### PR TITLE
Fix dependencies in omnibox package.

### DIFF
--- a/packages/omnibox/package.json
+++ b/packages/omnibox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glass/omnibox",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A LabKey component that takes a set of actions (like filter, sort, search) and exposes them as a single input for applying those actions to a QueryGrid.",
   "main": "dist/omnibox.cjs.js",
   "module": "dist/omnibox.es.js",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/LabKey/glass-components#readme",
   "dependencies": {
-    "@glass/base": "0.10.0-fb-add-assay-qc-workflow.2",
+    "@glass/base": "0.10.0",
     "react-input-autosize": "2.2.1"
   },
   "peerDependencies": {

--- a/packages/querygrid/package.json
+++ b/packages/querygrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glass/querygrid",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Query Grid for LabKey schema/query data views",
   "main": "dist/querygrid.cjs.js",
   "module": "dist/querygrid.es.js",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/LabKey/glass-components#readme",
   "dependencies": {
     "@glass/base": "0.10.0",
-    "@glass/omnibox": "0.1.24",
+    "@glass/omnibox": "0.1.25",
     "formsy-react": "1.1.5",
     "formsy-react-components": "1.1.0",
     "history": "4.7.2",


### PR DESCRIPTION
Also requires a version bump in querygrid.

This will fix the build problems for 19.2 release branches.