### PR TITLE
Recommend installing lerna via npm instead of yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Yarn should now be available on the command line.
 
 #### 2. Install lerna
 
-[Lerna](https://lerna.js.org/) is a tool for managing JavaScript projects with multiple packages. Our build is configured for a specific verison so you'll want to specify that when installing. It can also be installed via npm:
+[Lerna](https://lerna.js.org/) is a tool for managing JavaScript projects with multiple packages. Our build is configured for a specific verison so you'll want to specify that when installing. It can be installed via npm:
 
 ```sh
-npm install -g lerna@3.14.1
+npm install lerna@3.14.1 -g
 ```
 
 Lerna should now be available on the command line.


### PR DESCRIPTION
Installing lerna via yarn didn't get it added to my path (I'm on Windows if that matters). Marty recommended using npm, which worked for me. Since it sounds like others have hit the same problem, it seemed reasonable to update the docs.