### PR TITLE
QueryGrid fix to remove extra call to reloadQueryGridModel when it is being unmounted

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.6.0",
+  "version": "0.6.0-fb-queryGridReloadUnmountFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.6.0-fb-queryGridReloadUnmountFix.0",
+  "version": "0.6.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.5.0",
+  "version": "0.5.0-fb-queryGridReloadUnmountFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,8 +2,8 @@
 
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.6.1
+*Released*: 20 December 2019
 * QueryGrid fix to remove extra call to reloadQueryGridModel when it is being unmounted
 
 ### version 0.6.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,6 +2,10 @@
 
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* QueryGrid fix to remove extra call to reloadQueryGridModel when it is being unmounted
+
 ### version 0.5.0
 *Released*: 16 December 2019
 * add handleUpdateRows to FieldEditTrigger

--- a/packages/components/src/util/URL.ts
+++ b/packages/components/src/util/URL.ts
@@ -61,6 +61,19 @@ export function getLocation() : Location
     return location;
 }
 
+export function getRouteFromLocationHash(hash: string) {
+    if (hash) {
+        const index = hash.indexOf('?');
+        if (index > -1) {
+            return hash.substring(0, index);
+        }
+
+        return hash;
+    }
+
+    return undefined;
+}
+
 export function buildQueryString(params: Map<string, string | number>): string {
     let q = '', sep = '';
     params.forEach((v, k) => {


### PR DESCRIPTION
The URL listener was being called (which executed reloadQueryGridModel) before the unmount of the QueryGrid component had a chance to remove the listener. The fix here is in the listener to add a check to only call reloadQueryGridModel when the location.hash has not changed, i.e. not navigating.