### PR TITLE
Fix 37776

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.29.0-fb-fix-37776.0",
+  "version": "0.29.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.28.3",
+  "version": "0.29.0-fb-fix-37776.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 0.29.0
-*Released*: ??? February 2020
+*Released*: 26 February 2020
 * Issue 37776: updateUrl in custom assay does not get used in Biologics UI
 * Added two new attributes to QueryGridModel
     * includeDetailsColumn

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.29.0
+*Released*: ??? February 2020
+* Issue 37776: updateUrl in custom assay does not get used in Biologics UI
+* Added two new attributes to QueryGridModel
+    * includeDetailsColumn
+    * includeUpdateColumn
+    * simplify getStateQueryGridModel
+    * remove IStateModelProps interface used by getStateQueryGridModel
+
 ### version 0.28.3
 *Released*: 26 February 2020
 * Bump @labkey/api dependency to 0.0.34

--- a/packages/components/src/components/GridLoader.tsx
+++ b/packages/components/src/components/GridLoader.tsx
@@ -35,7 +35,9 @@ class GridLoader implements IGridLoader {
                 columns: model.getRequestColumnsString(),
                 offset: model.getOffset(),
                 maxRows: model.getMaxRows(),
-                parameters: model.queryParameters
+                parameters: model.queryParameters,
+                includeDetailsColumn: model.includeDetailsColumn,
+                includeUpdateColumn: model.includeUpdateColumn,
             }).then(response => {
                 const { models, orderedModels, totalRows, messages } = response;
 

--- a/packages/components/src/components/QueryGridPanel.spec.tsx
+++ b/packages/components/src/components/QueryGridPanel.spec.tsx
@@ -45,7 +45,7 @@ describe("QueryGridPanel render", () => {
             schemaName: "assay.General.Amino Acids",
             queryName: "Data"
         });
-       const model = getStateQueryGridModel(modelId, schemaQuery, {});
+       const model = getStateQueryGridModel(modelId, schemaQuery);
        const tree = renderer.create(<QueryGridPanel model={model}/>).toJSON();
        expect(tree).toMatchSnapshot();
     });
@@ -56,7 +56,7 @@ describe("QueryGridPanel render", () => {
             schemaName: "i.dont.exist",
             queryName: "shouldFourOhFour"
         });
-        const model = getStateQueryGridModel(modelId, schemaQuery, {});
+        const model = getStateQueryGridModel(modelId, schemaQuery);
 
         const tree = renderer.create(<QueryGridPanel model={model}/>);
         setTimeout(() => {
@@ -71,7 +71,7 @@ describe("QueryGridPanel render", () => {
             schemaName: "assay.General.Amino Acids",
             queryName: "Data"
         });
-        const model = getStateQueryGridModel(modelId, schemaQuery, {});
+        const model = getStateQueryGridModel(modelId, schemaQuery);
         const tree = renderer.create(
             <QueryGridPanel
                 model={model}
@@ -89,7 +89,7 @@ describe("QueryGridPanel render", () => {
             schemaName: "assay.General.ImageFieldAssay",
             queryName: "Runs"
         });
-        const model = getStateQueryGridModel(modelId, schemaQuery, {});
+        const model = getStateQueryGridModel(modelId, schemaQuery);
         const tree = renderer.create(<QueryGridPanel model={model} showAllTabs={true}/>);
         expect(tree).toMatchSnapshot();
     });

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -452,6 +452,8 @@ export interface IQueryGridModel {
     editable?: boolean
     editing?: boolean
     filterArray?: List<Filter.IFilter>
+    includeDetailsColumn?: boolean,
+    includeUpdateColumn?: boolean,
     isError?: boolean
     isLoaded?: boolean
     isLoading?: boolean
@@ -519,6 +521,8 @@ export class QueryGridModel extends Record({
     editable: false,
     editing: false,
     filterArray: List<Filter.IFilter>(),
+    includeDetailsColumn: false,
+    includeUpdateColumn: false,
     isError: false,
     isLoaded: false,
     isLoading: false,
@@ -571,6 +575,8 @@ export class QueryGridModel extends Record({
     editable: boolean;
     editing: boolean;
     filterArray: List<Filter.IFilter>;
+    includeDetailsColumn?: boolean;
+    includeUpdateColumn?: boolean;
     isError: boolean;
     isLoaded: boolean;
     isLoading: boolean;

--- a/packages/components/src/components/gridbar/QueryGridBar.spec.tsx
+++ b/packages/components/src/components/gridbar/QueryGridBar.spec.tsx
@@ -20,7 +20,7 @@ beforeAll(() => {
 describe("<QueryGridBar/>", () => {
 
     test("default props", (done) => {
-        const model = getStateQueryGridModel("QueryGridBarDefaultProps", SQ, {});
+        const model = getStateQueryGridModel("QueryGridBarDefaultProps", SQ);
         gridInit(model);
 
         window.setTimeout(() => {

--- a/packages/components/src/components/user/SiteUsersGridPanel.tsx
+++ b/packages/components/src/components/user/SiteUsersGridPanel.tsx
@@ -101,10 +101,16 @@ export class SiteUsersGridPanel extends React.PureComponent<Props, State> {
     getUsersModel(): QueryGridModel {
         const { usersView } = this.state;
         const gridId = 'user-management-users-' + usersView;
+        let baseFilters = List<Filter.IFilter>([Filter.create('active', usersView === 'active')]);
+
+        if (usersView === 'all') {
+            baseFilters = List<Filter.IFilter>();
+        }
+
         const model = getStateQueryGridModel(gridId, SCHEMAS.CORE_TABLES.USERS, {
             containerPath: '/',
             omittedColumns: OMITTED_COLUMNS,
-            baseFilters: usersView === 'all' ? undefined : List<Filter.IFilter>([Filter.create('active', usersView === 'active')]),
+            baseFilters: baseFilters,
             bindURL: true,
             isPaged: true
         });

--- a/packages/components/src/stories/QueryGrid.tsx
+++ b/packages/components/src/stories/QueryGrid.tsx
@@ -60,7 +60,7 @@ storiesOf('QueryGrid', module)
             schemaName: "exp.data",
             queryName: "mixtures"
         });
-        const model = getStateQueryGridModel(modelId, schemaQuery, {});
+        const model = getStateQueryGridModel(modelId, schemaQuery);
 
         return <QueryGrid model={model}/>
     })
@@ -70,6 +70,6 @@ storiesOf('QueryGrid', module)
             schemaName: "assay.General.Amino Acids",
             queryName: "Runs"
         });
-        const model = getStateQueryGridModel(modelId, schemaQuery, {});
+        const model = getStateQueryGridModel(modelId, schemaQuery);
         return <QueryGrid model={model}/>
     });

--- a/packages/components/src/stories/QueryGridPanel.tsx
+++ b/packages/components/src/stories/QueryGridPanel.tsx
@@ -103,7 +103,7 @@ class QueryGridPanelWithMessagesWrapper extends React.Component {
             queryName: "Runs"
         });
 
-        return getStateQueryGridModel(modelId, schemaQuery, {});
+        return getStateQueryGridModel(modelId, schemaQuery);
     }
 
     render() {
@@ -137,7 +137,7 @@ class QueryGridPanelWithImagesWrapper extends React.Component {
             queryName: "Runs"
         });
 
-        return getStateQueryGridModel(modelId, schemaQuery, {});
+        return getStateQueryGridModel(modelId, schemaQuery);
     }
 
     render() {
@@ -173,7 +173,7 @@ class QueryGridPanelWithRenamedColumnsWrapper extends React.Component {
             queryName: "LabBookExperiment"
         });
 
-        return getStateQueryGridModel(modelId, schemaQuery, {});
+        return getStateQueryGridModel(modelId, schemaQuery);
     }
 
     render() {
@@ -205,15 +205,15 @@ class QueryGridPanelMultiTab extends React.Component<any, any> {
             getStateQueryGridModel("gridPanelWithData", new SchemaQuery({
                 schemaName: "exp.data",
                 queryName: "mixtures"
-            }), {}),
+            })),
             getStateQueryGridModel("gridPanelWithImages", new SchemaQuery({
                 schemaName: "assay.General.ImageFieldAssay",
                 queryName: "Runs"
-            }), {}),
+            })),
             getStateQueryGridModel("gridPanelWithRenamedColumns",  new SchemaQuery({
                 schemaName: "labbook",
                 queryName: "LabBookExperiment"
-            }), {})
+            }))
         ]);
     }
 
@@ -242,7 +242,7 @@ class QueryGridPanelWithSampleComparisonWrapper extends React.Component {
             queryName: "Data"
         });
 
-        return getStateQueryGridModel(modelId, schemaQuery, {});
+        return getStateQueryGridModel(modelId, schemaQuery);
     }
 
     render() {


### PR DESCRIPTION
This PR adds two fields to QueryGridModel (includeDetailsColumn, includeUpdateColumn, so I can fix Issue 37776. These props are also passed to the server via the GridLoader.

I also took the time to simplify getStateQueryGridModel by removing the giant block of `if (prop !== undefined)`, removing duplicated default values, and removing the `IStateModelProps` interface. This makes it easier for us to add new fields to the QueryGridModel that we want at init time (like @labkey-martyp is doing in Provenance).

It's worth noting that I discovered the `IStateModelProps` interface is/was not being type checked at compile time. I implemented these changes without removing the interface, and Biologics still compiled. It also still compiled after I added any other arbitrary attribute that does not exist on the interface to the initProps object. I am not sure why that is happening.