### PR TITLE
Fix Issue 39719

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.25.0",
+  "version": "0.25.1-fb-fix-39719.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.25.1-fb-fix-39719.0",
+  "version": "0.25.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.??.??
-*Released*: ?? February 2020
+### version 0.25.1
+*Released*: 19 February 2020
 * Fix Issue 39719
     * No longer apply any base filters if a QueryGridModel has a keyValue and the view name is \~\~DETAILS\~\~
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.??.??
+*Released*: ?? February 2020
+* Fix Issue 39719
+    * No longer apply any base filters if a QueryGridModel has a keyValue and the view name is \~\~DETAILS\~\~
+
 ### version 0.25.0
 *Released*: 18 February 2020
 * Item 6835: Changes to support Data Class Designer in Sample Manager and LKS

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -785,8 +785,17 @@ export class QueryGridModel extends Record({
                 } else {
                     console.warn('Too many keys. Unable to filter for specific keyValue.', this.queryInfo.pkCols.toJS());
                 }
+
+                if (this.view === ViewInfo.DETAIL_NAME) {
+                    // Issue 39719:
+                    // We return here because we should never ever apply any filters other than on the PKCol for the
+                    // details view. If we were to apply any other filters then it's possible that we'll filter out the
+                    // PK we want, which our clients render as "Not Found", and/or can lead to other NPE errors in
+                    // our clients.
+                    return filterList;
+                }
             }
-            // if a keyValue if provided, we may still have baseFilters to apply in the case that the default
+            // if a keyValue is provided, we may still have baseFilters to apply in the case that the default
             // filter on a query view is a limiting filter and we want to expand the set of values returned (e.g., for assay runs
             // that may have been replaced)
             return filterList.concat(this.baseFilters.concat(this.queryInfo.getFilters(this.view)).concat(this.filterArray)).toList();


### PR DESCRIPTION
We have an issue in Biologics where if the user creates a view called `BiologicsDetails` on any item in the registry and it has a filter on it the view. If the filter removes a particular PK you are unable to view the details view for that item, It will also break the Molecule details view completely (white page error). The solution is to never apply base filters if we have a keyValue, and the view name is \~\~DETAILS\~\~.