### PR TITLE
Update @labkey/api dependency.

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.28.2",
+  "version": "0.28.1-fb-update-api-js.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.0.33",
+    "@labkey/api": "0.0.34-fb-fix-selectRows-callback",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.28.1-fb-update-api-js.1",
+  "version": "0.28.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.0.34-fb-fix-selectRows-callback.1",
+    "@labkey/api": "0.0.34",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.28.1-fb-update-api-js.0",
+  "version": "0.28.1-fb-update-api-js.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.0.34-fb-fix-selectRows-callback",
+    "@labkey/api": "0.0.34-fb-fix-selectRows-callback.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.28.3
+*Released*: 26 February 2020
+* Bump @labkey/api dependency to 0.0.34
+
 ### version 0.28.2
 *Released*: 25 February 2020
 * Issue 39788: Responses that have exceptions but not errors not showing messages in the UI

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -2051,10 +2051,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@labkey/api@0.0.34-fb-fix-selectRows-callback":
-  version "0.0.34-fb-fix-selectRows-callback"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.34-fb-fix-selectRows-callback.tgz#e5f8858f99e211a424d29a32b78c734f771635cf"
-  integrity sha1-5fiFj5niEaQk0poyt4xzT3cWNc8=
+"@labkey/api@0.0.34-fb-fix-selectRows-callback.1":
+  version "0.0.34-fb-fix-selectRows-callback.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.34-fb-fix-selectRows-callback.1.tgz#8acd60caf9d32d0beae9578e8fb9e7cd5517b182"
+  integrity sha1-is1gyvnTLQvq6VeOj7nnzVUXsYI=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -2051,10 +2051,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@labkey/api@0.0.34-fb-fix-selectRows-callback.1":
-  version "0.0.34-fb-fix-selectRows-callback.1"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.34-fb-fix-selectRows-callback.1.tgz#8acd60caf9d32d0beae9578e8fb9e7cd5517b182"
-  integrity sha1-is1gyvnTLQvq6VeOj7nnzVUXsYI=
+"@labkey/api@0.0.34":
+  version "0.0.34"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.34.tgz#00dcb8dba40e15ae9406283e88df61af3b84199c"
+  integrity sha1-ANy426QOFa6UBig+iN9hrzuEGZw=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -2051,10 +2051,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@labkey/api@0.0.33":
-  version "0.0.33"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.33.tgz#2b7f95f8ea31acdbda1b1f2b841d9dd9a3f5d7ab"
-  integrity sha1-K3+V+OoxrNvaGx8rhB2d2aP116s=
+"@labkey/api@0.0.34-fb-fix-selectRows-callback":
+  version "0.0.34-fb-fix-selectRows-callback"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.34-fb-fix-selectRows-callback.tgz#e5f8858f99e211a424d29a32b78c734f771635cf"
+  integrity sha1-5fiFj5niEaQk0poyt4xzT3cWNc8=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"


### PR DESCRIPTION
This PR doesn't do anything but bump the api-js dependency so we have the correct type signature for the selectRows failure callback.