### PR TITLE
Issue39813: Metadata settings in new Designer don't align with old Designer

### DIFF
--- a/packages/components/src/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
+++ b/packages/components/src/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
@@ -116,10 +116,13 @@ class MetadataIndexField extends React.PureComponent<MetadataIndexFieldProps> {
     render() {
         const { indexSetting, name, onRadioChange } = this.props;
 
+        // Note: Currently the radio values go from high to low in order to correspond with the previous
+        // designer's order of radio options. Once the old designer is deprecated, we could change these to
+        // count from low to high.
         return (
             <div>
                 <FormGroup>
-                    <Radio name={name} value={0} checked={indexSetting == 0} onChange={onRadioChange}>
+                    <Radio name={name} value={2} checked={indexSetting == 2} onChange={onRadioChange}>
                         Include both metadata and data
                         <LabelHelpTip title="Warning" body={() => {return <> {DATA_INDEXING_TIP} </>;}}/>
                     </Radio>
@@ -127,7 +130,7 @@ class MetadataIndexField extends React.PureComponent<MetadataIndexFieldProps> {
                         Include data only
                         <LabelHelpTip title="Warning" body={() => {return <> {DATA_INDEXING_TIP} </>;}}/>
                     </Radio>
-                    <Radio name={name} value={2} checked={indexSetting == 2} onChange={onRadioChange}>
+                    <Radio name={name} value={0} checked={indexSetting == 0} onChange={onRadioChange}>
                         Include metadata only (name and description of list and fields)
                     </Radio>
                 </FormGroup>


### PR DESCRIPTION
Because the new designer lists the relevant options as, in order,

- Both metadata and data
- Data only
- Metadata only

and the old designer had, in order,

- Metadata only
- Data only
- Both metadata and data

and both sets and values were from 0 increasing to 2, the old designer and new designer radio selections weren't aligning. Talked to Binal and we decided to flip the client values for now, and put them right-side-up if we want to upon deprecating the old list designer.