### PR TITLE
Fix for Sample Manager QueryGridModel use case that passes in undefined as baseFilters

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.1",
+  "version": "0.31.1-fb-fixUndefinedBaseFilters.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.1-fb-fixUndefinedBaseFilters.0",
+  "version": "0.31.1-fb-fixUndefinedBaseFilters.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Fix for Sample Manager QueryGridModel use case that passes in undefined as baseFilters
+    - make sure baseFilters is defined before doing a concat with the rest of the filters
+
 ### version 0.31.1
 *Released*: 27 February 2020
 * Issue 39813: Metadata settings in new Designer don't align with old Designer

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.31.3
+*Released*: 28 February 2020
 * Fix for Sample Manager QueryGridModel use case that passes in undefined as baseFilters
     - make sure baseFilters is defined before doing a concat with the rest of the filters
 

--- a/packages/components/src/actions.ts
+++ b/packages/components/src/actions.ts
@@ -511,7 +511,7 @@ export function gridLoad(model: QueryGridModel, connectedComponent?: React.Compo
             gridShowError(payload.model, payload.error, connectedComponent);
         }
         else {
-            console.error("No model available for loading.", payload.error);
+            console.error("No model available for loading.", payload.error || payload);
             setError(model, resolveErrorMessage(payload.error, "data"));
         }
     });

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -791,11 +791,14 @@ export class QueryGridModel extends Record({
     // Applying other base filters will be problematic (Issue 39719) in that they could possibly exclude the row you are trying
     // to get details for.
     getDetailFilters(): List<Filter.IFilter> {
-        return this.baseFilters.filter((filter) => (filter.getColumnName().toLowerCase() === 'replaced')).toList();
+        return this.baseFilters
+            ? this.baseFilters.filter((filter) => (filter.getColumnName().toLowerCase() === 'replaced')).toList()
+            : List<Filter.IFilter>();
     }
 
     getFilters(): List<Filter.IFilter> {
         const baseFilters = this.baseFilters || List<Filter.IFilter>();
+        const filterArray = this.filterArray || List<Filter.IFilter>();
         let filterList = List<Filter.IFilter>();
 
         if (this.queryInfo) {
@@ -811,10 +814,10 @@ export class QueryGridModel extends Record({
                 return filterList.concat(this.getDetailFilters()).toList();
 
             }
-            return filterList.concat(baseFilters.concat(this.queryInfo.getFilters(this.view)).concat(this.filterArray)).toList();
+            return filterList.concat(baseFilters.concat(this.queryInfo.getFilters(this.view)).concat(filterArray)).toList();
         }
 
-        return baseFilters.concat(this.filterArray).toList();
+        return baseFilters.concat(filterArray).toList();
     }
 
     getId(): string {

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -795,7 +795,9 @@ export class QueryGridModel extends Record({
     }
 
     getFilters(): List<Filter.IFilter> {
+        const baseFilters = this.baseFilters || List<Filter.IFilter>();
         let filterList = List<Filter.IFilter>();
+
         if (this.queryInfo) {
             if (this.keyValue !== undefined) {
                 if (this.queryInfo.pkCols.size === 1) {
@@ -809,10 +811,10 @@ export class QueryGridModel extends Record({
                 return filterList.concat(this.getDetailFilters()).toList();
 
             }
-            return filterList.concat(this.baseFilters.concat(this.queryInfo.getFilters(this.view)).concat(this.filterArray)).toList();
+            return filterList.concat(baseFilters.concat(this.queryInfo.getFilters(this.view)).concat(this.filterArray)).toList();
         }
 
-        return this.baseFilters.concat(this.filterArray).toList();
+        return baseFilters.concat(this.filterArray).toList();
     }
 
     getId(): string {


### PR DESCRIPTION
- make sure baseFilters is defined before doing a concat with the rest of the filters in the model's getFilters() function