### PR TITLE
Fix getLocation url decoding

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.3",
+  "version": "0.32.0-fb-fix-getLocation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.3?.0
+*Released*: ?? March 2020
+* Use decodeURIComponent in getLocation
+
 ### version 0.31.3
 *Released*: 28 February 2020
 * Fix for Sample Manager QueryGridModel use case that passes in undefined as baseFilters

--- a/packages/components/src/util/URL.ts
+++ b/packages/components/src/util/URL.ts
@@ -29,8 +29,6 @@ export type Location = {
     state?: any // {[key:string]: string}
 }
 
-// FIXME: the return type for getLocation is incorrect since we modify the object to be something rather different.
-//  we convert several parts of the location object to immutable objects which is not in the spec.
 export function getLocation() : Location {
     let location : Location = getBrowserHistory().location;
     let query =  Map<string, string>(location.query).asMutable();

--- a/packages/components/src/util/URL.ts
+++ b/packages/components/src/util/URL.ts
@@ -30,7 +30,11 @@ export type Location = {
 }
 
 export function getLocation() : Location {
+    // FIXME: Instead of manipulating the location object like we do here (which has side effects) we should return a
+    //  new object every time.
     let location : Location = getBrowserHistory().location;
+    // FIXME: Side effect! location.query is only ever available after the first time this function is called becuase we
+    //  manipulate the object in place.
     let query =  Map<string, string>(location.query).asMutable();
     const parseParams = (p => {
         const keyVal = p.split('=');


### PR DESCRIPTION
We are incorrectly decoding query params in the URL. This is causing an issue in Biologics when trying to fix issue 37293. The change is small, but the impact may be large. I'll be opening branches in SM and Biologics. @cnathe please see the comments I added, I am a little confused by this method.