### PR TITLE
Item 6640: Fixes for List Designer issues targeting LabKey release 20.3

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.3-fb-listDesignerTestConversion.0",
+  "version": "0.31.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.3",
+  "version": "0.31.3-fb-listDesignerTestConversion.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 0.31.4
-*Released*: TBD March 2020
+*Released*: 6 March 2020
 * Fixes for List Designer issues targeting LabKey release 20.3
     - Issue 39846: List designer - "Name" doesn't validate immediately
     - Issue 39879: Domain designer - lookup queries which only have container PK are filtered out of the select input

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Fix for List Designer issues targeting LabKey release 20.3
+    - Issue 39846: New list designer - "Name" doesn't validate immediately
+
 ### version 0.31.3
 *Released*: 28 February 2020
 * Fix for Sample Manager QueryGridModel use case that passes in undefined as baseFilters

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 0.31.4
 *Released*: TBD March 2020
-* Fix for List Designer issues targeting LabKey release 20.3
+* Fixes for List Designer issues targeting LabKey release 20.3
     - Issue 39846: List designer - "Name" doesn't validate immediately
     - Issue 39879: Domain designer - lookup queries which only have container PK are filtered out of the select input
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,10 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.31.4
+*Released*: TBD March 2020
 * Fix for List Designer issues targeting LabKey release 20.3
-    - Issue 39846: New list designer - "Name" doesn't validate immediately
+    - Issue 39846: List designer - "Name" doesn't validate immediately
+    - Issue 39879: Domain designer - lookup queries which only have container PK are filtered out of the select input
 
 ### version 0.31.3
 *Released*: 28 February 2020

--- a/packages/components/src/components/domainproperties/list/ListPropertiesPanel.tsx
+++ b/packages/components/src/components/domainproperties/list/ListPropertiesPanel.tsx
@@ -80,10 +80,11 @@ class ListPropertiesPanelImpl extends React.PureComponent<Props, State> {
         updateDomainPanelClassList(prevProps.useTheme, undefined, PROPERTIES_HEADER_ID);
     }
 
-    setIsValid(): void {
-        const { model } = this.props;
-        const isValid = model && model.hasValidProperties();
-        this.setState(() => ({isValid}));
+    setIsValid(newModel?: ListModel): void {
+        const { model, onChange } = this.props;
+        const updatedModel = newModel || model;
+        const isValid = updatedModel && updatedModel.hasValidProperties();
+        this.setState(() => ({isValid}), () => onChange(updatedModel));
     }
 
     toggleLocalPanel = (evt: any): void => {
@@ -106,7 +107,7 @@ class ListPropertiesPanelImpl extends React.PureComponent<Props, State> {
             domain: newDomain,
         }) as ListModel;
 
-        onChange(newModel);
+        this.setIsValid(newModel);
     };
 
     onCheckBoxChange = (name, checked): void => {
@@ -128,7 +129,7 @@ class ListPropertiesPanelImpl extends React.PureComponent<Props, State> {
     applyAdvancedProperties = (advancedSettingsForm: AdvancedSettingsForm) : void => {
         const { model, onChange } = this.props;
         const newModel = model.merge(advancedSettingsForm) as ListModel;
-        onChange(newModel);
+        this.setIsValid(newModel);
     };
 
     render() {

--- a/packages/components/src/components/domainproperties/models.ts
+++ b/packages/components/src/components/domainproperties/models.ts
@@ -1136,9 +1136,9 @@ export class QueryInfoLite extends Record({
 
     getLookupInfo(rangeURI?: string): List<{name: string, type: PropDescType}> {
         let infos = List<{name: string, type: PropDescType}>();
-        let pkCols = this.getPkColumns()
-            .filter(col => col.name.toLowerCase() !== 'container')
-            .toList();
+
+        // allow for queries with only 1 primary key or with 2 primary key columns when one of them is container (see Issue 39879)
+        let pkCols = this.getPkColumns().size > 1 ? this.getPkColumns().filter(col => col.name.toLowerCase() !== 'container').toList() : this.getPkColumns();
 
         if (pkCols.size === 1) {
 


### PR DESCRIPTION
Note that this is a hotfix for the latest @labkey/components version used in platform modules in LK release20.3 (which was @labkey/components version 0.31.3):
- Issue 39846: List designer - "Name" doesn't validate immediately
- Issue 39879: Domain designer - lookup queries which only have container PK are filtered out of the select input