### PR TITLE
Item #6862: Switch LineageNode to bind "id" instead of "rowId"

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.41.1-fb-lineage-rowid-id.0",
+  "version": "0.41.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.41.0",
+  "version": "0.41.1-fb-lineage-rowid-id.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.41.1
+*Released*: ## March 2020
+* Item 6862: Switch LineageNode to bind "id" instead of "rowId"
+
 ### version 0.41.0
 *Released*: 27 March 2020
 * Item 7002: Refactor domain designer components to share more with base components

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 0.41.1
-*Released*: ## March 2020
+*Released*: 29 March 2020
 * Item 6862: Switch LineageNode to bind "id" instead of "rowId"
 
 ### version 0.41.0

--- a/packages/components/src/components/lineage/models.ts
+++ b/packages/components/src/components/lineage/models.ts
@@ -184,7 +184,8 @@ export class LineageNode extends Record ({
             name:  values.name,
             parents: LineageLink.createList(values.parents),
             queryName: values.queryName,
-            rowId:values.rowId,
+            // "rowId" -> "id". See https://github.com/LabKey/platform/pull/1000
+            rowId:values.id,
             schemaName: values.schemaName,
             type: values.type,
             url: values.url,


### PR DESCRIPTION
The `experiment-lineage.api` changed the property "rowId" to "id". This is the corresponding change to fix the binding of `LineageNode` on the client.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1000