### PR TITLE
SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.41.2",
+  "version": "0.41.2-fb-smPasswordButtons.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)
+
 ### version 0.41.2
 *Released*: 30 March 2020
 * Update canSubmit check for ParentEntityEditPanel to check for actual differences and allow submission when all parents have been removed

--- a/packages/components/src/components/user/SiteUsersGridPanel.tsx
+++ b/packages/components/src/components/user/SiteUsersGridPanel.tsx
@@ -37,8 +37,9 @@ interface Props {
     // note that the createNewUser action will not use this value but it will be passed back to the onCreateComplete
     newUserRoleOptions?: Array<any>
 
-    // option to disable the delete UI pieces for this component
+    // option to disable the delete and reset password UI pieces for this component
     allowDelete?: boolean
+    allowResetPassword?: boolean
 }
 
 interface State {
@@ -51,7 +52,8 @@ interface State {
 export class SiteUsersGridPanel extends React.PureComponent<Props, State> {
 
     static defaultProps = {
-        allowDelete: true
+        allowDelete: true,
+        allowResetPassword: true
     };
 
     constructor(props: Props) {

--- a/packages/components/src/components/user/UserDetailsPanel.spec.tsx
+++ b/packages/components/src/components/user/UserDetailsPanel.spec.tsx
@@ -41,7 +41,6 @@ describe("<UserDetailsPanel/>", () => {
                 userId={JEST_SITE_ADMIN_USER_ID} // see components/package.json "jest" config for the setting of self's userId
                 policy={POLICY}
                 rolesByUniqueName={ROLES_BY_NAME}
-                allowDelete={true}
                 onUsersStateChangeComplete={jest.fn()}
             />
         );
@@ -59,7 +58,6 @@ describe("<UserDetailsPanel/>", () => {
                 userId={1005} // self is JEST_SITE_ADMIN_USER_ID which will prevent buttons from rendering
                 policy={POLICY}
                 rolesByUniqueName={ROLES_BY_NAME}
-                allowDelete={true}
                 onUsersStateChangeComplete={jest.fn()}
             />
         );
@@ -71,13 +69,14 @@ describe("<UserDetailsPanel/>", () => {
         });
     });
 
-    test("with principal and buttons not allowDelete", (done) => {
+    test("with principal and buttons not allowDelete or allowResetPassword", (done) => {
         const component = (
             <UserDetailsPanel
                 userId={1005} // self is JEST_SITE_ADMIN_USER_ID which will prevent buttons from rendering
                 policy={POLICY}
                 rolesByUniqueName={ROLES_BY_NAME}
                 allowDelete={false}
+                allowResetPassword={false}
                 onUsersStateChangeComplete={jest.fn()}
             />
         );

--- a/packages/components/src/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/components/user/UserDetailsPanel.tsx
@@ -22,6 +22,7 @@ interface Props {
     policy?: SecurityPolicy
     rolesByUniqueName?: Map<string, SecurityRole>
     allowDelete?: boolean
+    allowResetPassword?: boolean
     onUsersStateChangeComplete?: (response: any, resetSelection: boolean) => any
 }
 
@@ -34,6 +35,7 @@ interface State {
 export class UserDetailsPanel extends React.PureComponent<Props, State> {
     static defaultProps = {
         allowDelete: true,
+        allowResetPassword: true,
         onUsersStateChangeComplete: undefined
     };
 
@@ -107,13 +109,13 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
     }
 
     renderButtons() {
-        const { allowDelete } = this.props;
+        const { allowDelete, allowResetPassword } = this.props;
         const isActive = caseInsensitive(this.state.userProperties, 'active');
 
         return (
             <>
                 <hr className={'principal-hr'}/>
-                {isActive &&
+                {allowResetPassword && isActive &&
                     <Button onClick={() => this.toggleDialog('reset')}>
                         Reset Password
                     </Button>
@@ -181,7 +183,7 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
     }
 
     render() {
-        const { userId, allowDelete } = this.props;
+        const { userId, allowDelete, allowResetPassword } = this.props;
         const { showDialog, userProperties } = this.state;
 
         return (
@@ -191,7 +193,7 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
                 </Panel.Heading>
                 <Panel.Body>
                     {this.renderBody()}
-                    {showDialog === 'reset' &&
+                    {allowResetPassword && showDialog === 'reset' &&
                         <UserResetPasswordConfirmModal
                             email={caseInsensitive(userProperties, 'email')}
                             hasLogin={Utils.isString(caseInsensitive(userProperties, 'lastLogin'))}

--- a/packages/components/src/components/user/__snapshots__/UserDetailsPanel.spec.tsx.snap
+++ b/packages/components/src/components/user/__snapshots__/UserDetailsPanel.spec.tsx.snap
@@ -173,7 +173,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
 </div>
 `;
 
-exports[`<UserDetailsPanel/> with principal and buttons not allowDelete 1`] = `
+exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allowResetPassword 1`] = `
 <div
   className="panel panel-default"
 >
@@ -289,14 +289,6 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete 1`] = `
     <hr
       className="principal-hr"
     />
-    <button
-      className="btn btn-default"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Reset Password
-    </button>
     <button
       className="pull-right btn btn-default"
       disabled={false}

--- a/packages/components/src/stories/SiteUsersGridPanel.tsx
+++ b/packages/components/src/stories/SiteUsersGridPanel.tsx
@@ -23,6 +23,7 @@ const ROLE_OPTIONS = [
 
 interface Props {
     allowDelete: boolean
+    allowResetPassword: boolean
     showRoleOptions: boolean
 }
 
@@ -62,6 +63,7 @@ class SiteUsersGridPanelWrapper extends React.PureComponent<Props, State> {
                 onUsersStateChangeComplete={(response) => console.log(response)}
                 newUserRoleOptions={this.props.showRoleOptions ? ROLE_OPTIONS : undefined}
                 allowDelete={this.props.allowDelete}
+                allowResetPassword={this.props.allowResetPassword}
             />
         )
     }
@@ -73,14 +75,16 @@ storiesOf("SiteUsersGridPanel", module)
         return (
             <SiteUsersGridPanelWrapper
                 allowDelete={true}
+                allowResetPassword={true}
                 showRoleOptions={false}
             />
         )
     })
-    .add("without delete", () => {
+    .add("without delete or reset password", () => {
         return (
             <SiteUsersGridPanelWrapper
                 allowDelete={false}
+                allowResetPassword={false}
                 showRoleOptions={false}
             />
         )
@@ -89,6 +93,7 @@ storiesOf("SiteUsersGridPanel", module)
         return (
             <SiteUsersGridPanelWrapper
                 allowDelete={true}
+                allowResetPassword={true}
                 showRoleOptions={true}
             />
         )


### PR DESCRIPTION
#### Rationale
For LKS, we currently will hide the "Change Password" and "Reset Password" button options from the user accounts page when the server is configured to use an SSO auth configuration that is set to "auto redirect on login". We need to do the same in the SM app to conditionally hide those buttons.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1008
* https://github.com/LabKey/sampleManagement/pull/223

#### Changes
* SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)