### PR TITLE
NavigationBar optional property for an alternate url to go to after sign out

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.42.0-fb-smPasswordButtons3.0",
+  "version": "0.41.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.42.0",
+  "version": "0.42.0-fb-smPasswordButtons3.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.42.1
-*Released*: 1 April 2020
+### version TBD
+*Released*: TBD
 * NavigationBar optional property for an alternate url to go to after sign out
 
 ### version 0.42.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.42.1
+*Released*: 1 April 2020
 * NavigationBar optional property for an alternate url to go to after sign out
 
 ### version 0.42.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,13 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
-* NavigationBar optional property for an alternate url to go to after sign out
-
-### version 0.42.0
-*Released*: 31 March 2020
+### version 0.41.4
+*Released*: 1 April 2020
 * SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)
+* NavigationBar optional property for an alternate url to go to after sign out
 
 ### version 0.41.3
 *Released*: 30 March 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* NavigationBar optional property for an alternate url to go to after sign out
+
 ### version 0.42.0
 *Released*: 31 March 2020
 * SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.41.4
+### version 0.41.5
 *Released*: 1 April 2020
 * SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)
 * NavigationBar optional property for an alternate url to go to after sign out

--- a/packages/components/src/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/components/navigation/NavigationBar.tsx
@@ -33,6 +33,7 @@ interface NavigationBarProps {
     searchPlaceholder?: string
     user?: User
     showSwitchToLabKey: boolean
+    signOutUrl?: string
 }
 
 export class NavigationBar extends React.Component<NavigationBarProps, any> {
@@ -42,10 +43,10 @@ export class NavigationBar extends React.Component<NavigationBarProps, any> {
     };
 
     render() {
-        const { brand, menuSectionConfigs, model, projectName, showSearchBox, onSearch, searchPlaceholder, user, showSwitchToLabKey } = this.props;
+        const { brand, menuSectionConfigs, model, projectName, showSearchBox, onSearch, searchPlaceholder, user, showSwitchToLabKey, signOutUrl } = this.props;
         const productMenu = model ? <ProductMenu model={model} sectionConfigs={menuSectionConfigs}/> : null;
         const searchBox = showSearchBox ? <SearchBox onSearch={onSearch} placeholder={searchPlaceholder}/> : null;
-        const userMenu = user ? <UserMenu model={model} user={user} showSwitchToLabKey={showSwitchToLabKey}/> : null;
+        const userMenu = user ? <UserMenu model={model} user={user} showSwitchToLabKey={showSwitchToLabKey} signOutUrl={signOutUrl}/> : null;
 
         return (
             <nav className="navbar navbar-container test-loc-nav-header">

--- a/packages/components/src/components/navigation/UserMenu.tsx
+++ b/packages/components/src/components/navigation/UserMenu.tsx
@@ -29,12 +29,13 @@ interface UserMenuProps {
     showSwitchToLabKey: boolean
     extraDevItems?: any
     extraUserItems?: any
+    signOutUrl?: string
 }
 
 export class UserMenu extends React.Component<UserMenuProps, any> {
 
     render() {
-        const { extraDevItems, extraUserItems, model, user, showSwitchToLabKey } = this.props;
+        const { extraDevItems, extraUserItems, model, user, showSwitchToLabKey, signOutUrl } = this.props;
         const menuSection = model.getSection("user");
 
         if (menuSection) {
@@ -83,7 +84,7 @@ export class UserMenu extends React.Component<UserMenuProps, any> {
                         ) : null}
                         <MenuItem divider/>
                         {user.isSignedIn
-                            ? <MenuItem onClick={signOut}>Sign Out</MenuItem>
+                            ? <MenuItem onClick={() => signOut(signOutUrl)}>Sign Out</MenuItem>
                             : <MenuItem onClick={signIn}>Sign In</MenuItem>
                         }
                     </Dropdown.Menu>

--- a/packages/components/src/components/navigation/actions.ts
+++ b/packages/components/src/components/navigation/actions.ts
@@ -1,18 +1,18 @@
 import { Ajax, Utils } from '@labkey/api';
 import { buildURL } from "../../url/ActionURL";
 
-export function signOut() {
+export function signOut(navigateUrl?: string) {
     const startUrl = buildURL('project', 'start', undefined, {returnURL: false});
 
     Ajax.request({
         url: buildURL('login', 'logoutAPI.api'),
         method: 'POST',
         success: Utils.getCallbackWrapper((response) => {
-            window.location.href = startUrl;
+            window.location.href = navigateUrl || startUrl;
         }),
         failure: Utils.getCallbackWrapper((response) => {
             console.error(response);
-            window.location.href = startUrl;
+            window.location.href = navigateUrl || startUrl;
         }, false)
     });
 }


### PR DESCRIPTION
#### Rationale
For the SM app, we currently redirect back to the project-start action after a user logs out. However in the trail instance case that means that the user is automatically redirected through the login loop (via the labkey.org CAS configuration on those instances). Instead we'd like to send the user to a "Sign Out Success" page after sign out of the SM app. This PR adds an optional URL for that post sign out navigation when using the UserMenu component via the NavigationBar.

#### Changes
* NavigationBar optional property for an alternate url to go to after sign out