### PR TITLE
Update to latest @labkey/api

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.46.0",
+  "version": "0.47.0-fb-api-js-010.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.0.45",
+    "@labkey/api": "0.1.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.47.0-fb-api-js-010.0",
+  "version": "0.47.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.1.0",
+    "@labkey/api": "0.1.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.4#.#
+*Released*: 7 April 2020
+* `@labkey/api` dependency update.
+
 ### version 0.46.0
 *Released*: 7 April 2020
 * Add QueryModel model to replace QueryGridModel

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.4#.#
+### version 0.47.0
 *Released*: 7 April 2020
 * `@labkey/api` dependency update.
 

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.0":
-  version "0.1.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.0.tgz#8ee03f71e0205499aa2600a910529d70e4d3dee9"
-  integrity sha1-juA/ceAgVJmqJgCpEFKdcOTT3uk=
+"@labkey/api@0.1.1-fb-fix-perm-resp-type.0":
+  version "0.1.1-fb-fix-perm-resp-type.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1-fb-fix-perm-resp-type.0.tgz#e5358b14d63d5c6107473678831d7d1ce9759344"
+  integrity sha1-5TWLFNY9XGEHRzZ4gx19HOl1k0Q=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.1-fb-fix-perm-resp-type.0":
-  version "0.1.1-fb-fix-perm-resp-type.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1-fb-fix-perm-resp-type.0.tgz#e5358b14d63d5c6107473678831d7d1ce9759344"
-  integrity sha1-5TWLFNY9XGEHRzZ4gx19HOl1k0Q=
+"@labkey/api@0.1.1":
+  version "0.1.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1.tgz#38a0451dbccf31e902a8d5bbada12af85b41cce0"
+  integrity sha1-OKBFHbzPMekCqNW7raEq+FtBzOA=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.0.45":
-  version "0.0.45"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.45.tgz#1757abb6463012b27727843d6846a6fffd94b534"
-  integrity sha1-F1ertkYwErJ3J4Q9aEam//2UtTQ=
+"@labkey/api@0.1.0":
+  version "0.1.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.0.tgz#8ee03f71e0205499aa2600a910529d70e4d3dee9"
+  integrity sha1-juA/ceAgVJmqJgCpEFKdcOTT3uk=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"


### PR DESCRIPTION
#### Rationale
Want `@labkey/components` and our apps that transitively depend on `@labkey/api` to use the latest version.

#### Changes
* Bumps `@labkey/api` to version `0.1.1`.