### PR TITLE
Issue 39803: signOut action support for a redirectUrl in the response, for the CAS identity provider logout case

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.42.0",
+  "version": "0.41.5-fb-20-4-signOutRedirect.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.41.5-fb-20-4-signOutRedirect.0",
+  "version": "0.41.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -5,6 +5,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 31 March 2020
 * SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)
 
+### version 0.41.6
+*Released*: TBD
+* Issue 39803: signOut action support for a redirectUrl in the response, for the CAS identity provider logout case
+
 ### version 0.41.3
 *Released*: 30 March 2020
 * Issue 40084: Add property to exclude unique field key from bulk update modal

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -6,7 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * SiteUsersGridPanel and UserDetails panel prop to hide/show 'Reset Password' button (i.e. allowResetPassword)
 
 ### version 0.41.6
-*Released*: TBD
+*Released*: 8 April 2020
 * Issue 39803: signOut action support for a redirectUrl in the response, for the CAS identity provider logout case
 
 ### version 0.41.3

--- a/packages/components/src/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/components/navigation/NavigationBar.tsx
@@ -33,6 +33,7 @@ interface NavigationBarProps {
     searchPlaceholder?: string
     user?: User
     showSwitchToLabKey: boolean
+    signOutUrl?: string
 }
 
 export class NavigationBar extends React.Component<NavigationBarProps, any> {
@@ -42,10 +43,10 @@ export class NavigationBar extends React.Component<NavigationBarProps, any> {
     };
 
     render() {
-        const { brand, menuSectionConfigs, model, projectName, showSearchBox, onSearch, searchPlaceholder, user, showSwitchToLabKey } = this.props;
+        const { brand, menuSectionConfigs, model, projectName, showSearchBox, onSearch, searchPlaceholder, user, showSwitchToLabKey, signOutUrl } = this.props;
         const productMenu = model ? <ProductMenu model={model} sectionConfigs={menuSectionConfigs}/> : null;
         const searchBox = showSearchBox ? <SearchBox onSearch={onSearch} placeholder={searchPlaceholder}/> : null;
-        const userMenu = user ? <UserMenu model={model} user={user} showSwitchToLabKey={showSwitchToLabKey}/> : null;
+        const userMenu = user ? <UserMenu model={model} user={user} showSwitchToLabKey={showSwitchToLabKey} signOutUrl={signOutUrl}/> : null;
 
         return (
             <nav className="navbar navbar-container test-loc-nav-header">

--- a/packages/components/src/components/navigation/UserMenu.tsx
+++ b/packages/components/src/components/navigation/UserMenu.tsx
@@ -29,12 +29,13 @@ interface UserMenuProps {
     showSwitchToLabKey: boolean
     extraDevItems?: any
     extraUserItems?: any
+    signOutUrl?: string
 }
 
 export class UserMenu extends React.Component<UserMenuProps, any> {
 
     render() {
-        const { extraDevItems, extraUserItems, model, user, showSwitchToLabKey } = this.props;
+        const { extraDevItems, extraUserItems, model, user, showSwitchToLabKey, signOutUrl } = this.props;
         const menuSection = model.getSection("user");
 
         if (menuSection) {
@@ -83,7 +84,7 @@ export class UserMenu extends React.Component<UserMenuProps, any> {
                         ) : null}
                         <MenuItem divider/>
                         {user.isSignedIn
-                            ? <MenuItem onClick={signOut}>Sign Out</MenuItem>
+                            ? <MenuItem onClick={() => signOut(signOutUrl)}>Sign Out</MenuItem>
                             : <MenuItem onClick={signIn}>Sign In</MenuItem>
                         }
                     </Dropdown.Menu>

--- a/packages/components/src/components/navigation/actions.ts
+++ b/packages/components/src/components/navigation/actions.ts
@@ -1,18 +1,21 @@
-import { Ajax, Utils } from '@labkey/api';
+import { Ajax, Utils, ActionURL } from '@labkey/api';
 import { buildURL } from "../../url/ActionURL";
 
 export function signOut(navigateUrl?: string) {
     const startUrl = buildURL('project', 'start', undefined, {returnURL: false});
 
+    // for the redirectUrl to work in the case of CAS logout provider redirect, this URL needs to include the host (Issue 39803)
+    const returnUrl = ActionURL.getBaseURL(true) + navigateUrl || startUrl;
+
     Ajax.request({
-        url: buildURL('login', 'logoutAPI.api'),
+        url: buildURL('login', 'logoutAPI.api', undefined, {returnURL: returnUrl}),
         method: 'POST',
         success: Utils.getCallbackWrapper((response) => {
-            window.location.href = navigateUrl || startUrl;
+            window.location.href = response.redirectUrl ? response.redirectUrl : returnUrl;
         }),
         failure: Utils.getCallbackWrapper((response) => {
             console.error(response);
-            window.location.href = navigateUrl || startUrl;
+            window.location.href = returnUrl;
         }, false)
     });
 }

--- a/packages/components/src/components/navigation/actions.ts
+++ b/packages/components/src/components/navigation/actions.ts
@@ -1,18 +1,18 @@
 import { Ajax, Utils } from '@labkey/api';
 import { buildURL } from "../../url/ActionURL";
 
-export function signOut() {
+export function signOut(navigateUrl?: string) {
     const startUrl = buildURL('project', 'start', undefined, {returnURL: false});
 
     Ajax.request({
         url: buildURL('login', 'logoutAPI.api'),
         method: 'POST',
         success: Utils.getCallbackWrapper((response) => {
-            window.location.href = startUrl;
+            window.location.href = navigateUrl || startUrl;
         }),
         failure: Utils.getCallbackWrapper((response) => {
             console.error(response);
-            window.location.href = startUrl;
+            window.location.href = navigateUrl || startUrl;
         }, false)
     });
 }

--- a/packages/components/src/components/navigation/actions.ts
+++ b/packages/components/src/components/navigation/actions.ts
@@ -5,13 +5,13 @@ export function signOut(navigateUrl?: string) {
     const startUrl = buildURL('project', 'start', undefined, {returnURL: false});
 
     // for the redirectUrl to work in the case of CAS logout provider redirect, this URL needs to include the host (Issue 39803)
-    const returnUrl = ActionURL.getBaseURL(true) + navigateUrl || startUrl;
+    const returnUrl = ActionURL.getBaseURL(true) + (navigateUrl || startUrl);
 
     Ajax.request({
         url: buildURL('login', 'logoutAPI.api', undefined, {returnURL: returnUrl}),
         method: 'POST',
         success: Utils.getCallbackWrapper((response) => {
-            window.location.href = response.redirectUrl ? response.redirectUrl : returnUrl;
+            window.location.href = response.redirectUrl || returnUrl;
         }),
         failure: Utils.getCallbackWrapper((response) => {
             console.error(response);


### PR DESCRIPTION
#### Rationale
For the LKSM trial logout issue 39803, changes were made in platform, cas, and other related modules to support calling the Authentication Identity Provider logout protocol when a user logs out. For the logoutApi action case, this involves a redirectUrl in the response object of that API call with the URL to call to hit the identity provider server /logout action and return accordingly. To support this, we need to handle that redirectUrl property in our signOut action which is called by the SM UserMenu "Sign Out" menu item.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1036
* https://github.com/LabKey/cas/pull/21
* https://github.com/LabKey/sampleManagement/pull/230

#### Changes
* NavigationBar optional property for an alternate url to go to after sign out
* signOut action updates to support redirectUrl from response object on login-logoutApi call