### PR TITLE
Incorporate @labkey/api updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.1.1",
+    "@labkey/api": "0.1.2-fb-10-query.2",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.1.2-fb-10-query.2",
+    "@labkey/api": "0.1.2-fb-10-query.4",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.1.2-fb-10-query.4",
+    "@labkey/api": "0.1.2-fb-10-query.6",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.1.2-fb-10-query.7",
+    "@labkey/api": "0.1.2-fb-10-query.8",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.1.2-fb-10-query.8",
+    "@labkey/api": "0.2.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.48.4-fb-10-query.0",
+  "version": "0.49.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.48.3",
+  "version": "0.48.4-fb-10-query.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.1.2-fb-10-query.6",
+    "@labkey/api": "0.1.2-fb-10-query.7",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+## version 0.49.0
+*Released*: 15 April 2020
+* `@labkey/api` dependency update.
+* Incorporate changes needed due to stricter typings.
+
 ## version 0.48.3
 *Released*: 14 April 2020
 * Bug fixes for ParentEntityEditPanel to better support editing of parent samples

--- a/packages/components/src/components/base/CreatedModified.tsx
+++ b/packages/components/src/components/base/CreatedModified.tsx
@@ -38,7 +38,7 @@ interface CreatedModifiedProps {
 }
 
 interface State {
-    serverDate: string
+    serverDate: Date
     loading: boolean
 }
 

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -223,6 +223,7 @@ export class SchemaQuery extends Record({
     }
 }
 
+// Consider having this implement Query.QueryColumn from @labkey/api
 // commented out attributes are not used in app
 export class QueryColumn extends Record({
     align: undefined,

--- a/packages/components/src/components/base/models/schemas.ts
+++ b/packages/components/src/components/base/models/schemas.ts
@@ -138,12 +138,12 @@ export function fetchGetQueries(schemaName: string): Promise<List<QueryInfo>> {
         Query.getQueries({
             schemaName,
             success: (data) => {
-                let queries = data.queries.map((getQueryResult) => {
-                    getQueryResult.schemaName = schemaName;
-                    return QueryInfo.create(getQueryResult);
-                });
-
-                queries = List<QueryInfo>(queries)
+                const queries = List<QueryInfo>(
+                    data.queries.map((getQueryResult) => QueryInfo.create({
+                            ...getQueryResult,
+                            schemaName
+                        })
+                    ))
                     .sort((a, b) => {
                         if (a.name && b.name) {
                             let aLower = a.name.toLowerCase();
@@ -153,7 +153,8 @@ export function fetchGetQueries(schemaName: string): Promise<List<QueryInfo>> {
                         }
 
                         return a.name === b.name ? 0 : (a.name > b.name ? 1 : -1);
-                    }).toList();
+                    })
+                    .toList();
 
                 resolve(queries);
             },

--- a/packages/components/src/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -652,7 +652,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                 "isDataValueRequired": [Function],
                 "isMultiValued": [Function],
                 "isTableWise": [Function],
-                "splitValue": [Function],
+                "parseValue": [Function],
                 "validate": [Function],
               },
               "value": Array [
@@ -749,7 +749,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                           "isDataValueRequired": [Function],
                           "isMultiValued": [Function],
                           "isTableWise": [Function],
-                          "splitValue": [Function],
+                          "parseValue": [Function],
                           "validate": [Function],
                         },
                         "value": Array [

--- a/packages/components/src/components/omnibox/actions/Filter.spec.tsx
+++ b/packages/components/src/components/omnibox/actions/Filter.spec.tsx
@@ -18,7 +18,7 @@ import { List, Map } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { ActionOption, Value } from './Action';
-import { FilterAction } from './Filter';
+import { FilterAction, getURLSuffix } from './Filter';
 
 import { createMockActionContext } from '../../../test/OmniboxMock';
 import { QueryColumn } from '../../base/models/model';
@@ -173,7 +173,7 @@ describe('FilterAction::fetchOptions', () => {
     test('filter options', () => {
         const getExpectedFilterTypes = (columnType: string): Array<Filter.IFilterType> => {
             return Filter.getFilterTypesForType(columnType as any /* jsonType */)
-                .filter(ft => !ft.isMultiValued() && (ft.getDisplaySymbol() || ft.getURLSuffix()))
+                .filter(ft => !ft.isMultiValued() && (ft.getDisplaySymbol() || getURLSuffix(ft)))
         };
 
         return Promise.all([

--- a/packages/components/src/components/samples/actions.ts
+++ b/packages/components/src/components/samples/actions.ts
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ActionURL, Ajax, Domain, Filter, Query, Utils} from '@labkey/api';
+import { ActionURL, Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
 import { fromJS, List, Map, OrderedMap } from 'immutable';
-import { IEntityTypeDetails, IParentOption, } from '../entities/models';
+import { IEntityTypeDetails } from '../entities/models';
 import { deleteEntityType } from "../entities/actions";
 import { getSelection } from '../../actions';
 import { SCHEMAS } from '../base/models/schemas';
 import { QueryColumn, SchemaQuery } from '../base/models/model';
 import { buildURL } from '../../url/ActionURL';
-import { naturalSort } from '../../util/utils';
 import { selectRows } from '../../query/api';
-import {DomainDetails} from "../domainproperties/models";
+import { DomainDetails } from "../domainproperties/models";
 
 export function initSampleSetSelects(isUpdate: boolean, ssName: string, includeDataClasses: boolean): Promise<any[]> {
     let promises = [];
@@ -75,9 +74,9 @@ export function getSampleSet(config: IEntityTypeDetails): Promise<any> {
     });
 }
 
-export function getSampleTypeDetails(query?: SchemaQuery, domainId?: number): Promise<any> {
-    return new Promise<DomainDetails>((resolve, reject) => {
-        const sampleSetConfig = {
+export function getSampleTypeDetails(query?: SchemaQuery, domainId?: number): Promise<DomainDetails> {
+    return new Promise((resolve, reject) => {
+        return Domain.getDomainDetails({
             domainId,
             containerPath: ActionURL.getContainer(),
             queryName: query ? query.getQuery() : undefined,
@@ -85,12 +84,10 @@ export function getSampleTypeDetails(query?: SchemaQuery, domainId?: number): Pr
             success: (response) => {
                 resolve(DomainDetails.create(Map(response)));
             },
-            failure:(response) => {
+            failure: (response) => {
                 reject(response);
             }
-        } as Domain.GetDomainOptions;
-
-        return Domain.getDomainDetails(sampleSetConfig);
+        });
     });
 }
 

--- a/packages/components/src/query/api.ts
+++ b/packages/components/src/query/api.ts
@@ -612,11 +612,12 @@ export class InsertRowsResponse extends Record({
 export function insertRows(options: InsertRowsOptions): Promise<InsertRowsResponse> {
     return new Promise((resolve, reject) => {
         const { fillEmptyFields, rows, schemaQuery } = options;
+        const _rows = fillEmptyFields === true ? ensureAllFieldsInAllRows(rows) : rows;
 
         Query.insertRows({
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
-            rows: fillEmptyFields === true ? ensureAllFieldsInAllRows(rows) : rows,
+            rows: _rows.toArray(),
             apiVersion: 13.2,
             success: (response) => {
                 resolve(new InsertRowsResponse( {

--- a/packages/components/src/url/WhereFilterType.ts
+++ b/packages/components/src/url/WhereFilterType.ts
@@ -43,7 +43,7 @@ class WhereFilterType implements Filter.IFilterType {
     getSingleValueFilter(): Filter.IFilterType {
         return null;
     }
-    splitValue(value: any) {
+    parseValue(value: any) {
         return value;
     }
     getURLParameterValue(value: any) {

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.1":
-  version "0.1.1"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1.tgz#38a0451dbccf31e902a8d5bbada12af85b41cce0"
-  integrity sha1-OKBFHbzPMekCqNW7raEq+FtBzOA=
+"@labkey/api@0.1.2-fb-10-query.2":
+  version "0.1.2-fb-10-query.2"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.2.tgz#311ccbc1785cb85601e28eacea2a26f2e713d4a1"
+  integrity sha1-MRzLwXhcuFYB4o6s6iom8ucT1KE=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.2-fb-10-query.2":
-  version "0.1.2-fb-10-query.2"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.2.tgz#311ccbc1785cb85601e28eacea2a26f2e713d4a1"
-  integrity sha1-MRzLwXhcuFYB4o6s6iom8ucT1KE=
+"@labkey/api@0.1.2-fb-10-query.4":
+  version "0.1.2-fb-10-query.4"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.4.tgz#f4098528cf4c0faa29ef294dfa478f61e1333148"
+  integrity sha1-9AmFKM9MD6op7ylN+kePYeEzMUg=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.2-fb-10-query.4":
-  version "0.1.2-fb-10-query.4"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.4.tgz#f4098528cf4c0faa29ef294dfa478f61e1333148"
-  integrity sha1-9AmFKM9MD6op7ylN+kePYeEzMUg=
+"@labkey/api@0.1.2-fb-10-query.6":
+  version "0.1.2-fb-10-query.6"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.6.tgz#40affb1896c229b4461697838941fb7b667d811c"
+  integrity sha1-QK/7GJbCKbRGFpeDiUH7e2Z9gRw=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.2-fb-10-query.6":
-  version "0.1.2-fb-10-query.6"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.6.tgz#40affb1896c229b4461697838941fb7b667d811c"
-  integrity sha1-QK/7GJbCKbRGFpeDiUH7e2Z9gRw=
+"@labkey/api@0.1.2-fb-10-query.7":
+  version "0.1.2-fb-10-query.7"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz#fef89c13048ba14541b2af68b4337cb3403c5ea9"
+  integrity sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.2-fb-10-query.8":
-  version "0.1.2-fb-10-query.8"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz#5f3d5a842246a16db024a20b9fcf0d33461548f0"
-  integrity sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA=
+"@labkey/api@0.2.0":
+  version "0.2.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz#1a310ce7910769e3bf502bcaf4ec62b63a424267"
+  integrity sha1-GjEM55EHaeO/UCvK9OxitjpCQmc=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1545,10 +1545,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.1.2-fb-10-query.7":
-  version "0.1.2-fb-10-query.7"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz#fef89c13048ba14541b2af68b4337cb3403c5ea9"
-  integrity sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk=
+"@labkey/api@0.1.2-fb-10-query.8":
+  version "0.1.2-fb-10-query.8"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz#5f3d5a842246a16db024a20b9fcf0d33461548f0"
+  integrity sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA=
 
 "@labkey/eslint-config-base@0.0.5":
   version "0.0.5"


### PR DESCRIPTION
#### Rationale
This PR incorporates updates for `@labkey/api`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/51

#### Changes
- Support empty string URL suffix for `HAS_ANY_VALUE` filter type in Omnibox filter action.
- `Filter` updated from `splitValue` to `parseValue`.
- Typings updates.