### PR TITLE
Add .git-blame-ignore-revs for bulk lint update

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+ # lint and prettier bulk updates
+ 73cb79f1d4d15f3cfa8c3abb61b88f1ae5fc64fd
+ 9e1a60d5dc90941c5199b1b6f30933218cb0ade8


### PR DESCRIPTION
#### Rationale
Don't show bulk lint update in git blame or IntelliJ annotate.

#### Changes
- Add .git-blame-ignore-revs file which removes these two commits from blame history (annotate)
- To add this file, git config blame.ignoreRevsFile ./.git-blame-ignore-revs
