### PR TITLE
Update to latest @labkey/api

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -46,7 +46,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.2.0",
+    "@labkey/api": "0.2.2-fb-fix-req-version.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -46,7 +46,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.2.2-fb-fix-req-version.0",
+    "@labkey/api": "0.2.2",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.1-fb-fix-req-version.0",
+  "version": "0.52.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.0",
+  "version": "0.52.1-fb-fix-req-version.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.52.1
+*Released*: 20 April 2020
+* `@labkey/api` dependency update.
+
 ### version 0.52.0
 *Released*: 18 April 2020
 * Item 7178: Prettier/ESLint bulk update

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1553,10 +1553,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.2.0":
-  version "0.2.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz#1a310ce7910769e3bf502bcaf4ec62b63a424267"
-  integrity sha1-GjEM55EHaeO/UCvK9OxitjpCQmc=
+"@labkey/api@0.2.2-fb-fix-req-version.0":
+  version "0.2.2-fb-fix-req-version.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2-fb-fix-req-version.0.tgz#965c427f26b80c9265ff5eb81aa23db94c87469a"
+  integrity sha1-llxCfya4DJJl/164GqI9uUyHRpo=
 
 "@labkey/eslint-config-base@0.0.7":
   version "0.0.7"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1553,10 +1553,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.2.2-fb-fix-req-version.0":
-  version "0.2.2-fb-fix-req-version.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2-fb-fix-req-version.0.tgz#965c427f26b80c9265ff5eb81aa23db94c87469a"
-  integrity sha1-llxCfya4DJJl/164GqI9uUyHRpo=
+"@labkey/api@0.2.2":
+  version "0.2.2"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2.tgz#deeb617dfbf2be83eb76e3c44c27807c691c6a9d"
+  integrity sha1-3uthffvyvoPrduPETCeAfGkcap0=
 
 "@labkey/eslint-config-base@0.0.7":
   version "0.0.7"


### PR DESCRIPTION
#### Rationale
Updates dependency to latest version of `@labkey/api`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/54

#### Changes
* Bump version of `@labkey/api`.
