### PR TITLE
Misc 20.5 issue fixes for Sample Manager

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.1",
+  "version": "0.52.1-fb-smMiscFixes205.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.1-fb-smMiscFixes205.3",
+  "version": "0.52.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.1-fb-smMiscFixes205.2",
+  "version": "0.52.1-fb-smMiscFixes205.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.1-fb-smMiscFixes205.1",
+  "version": "0.52.1-fb-smMiscFixes205.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.1-fb-smMiscFixes205.0",
+  "version": "0.52.1-fb-smMiscFixes205.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     - Issue 40139: DetailEditing panel editing - updating time but not date does not recognize change
     - Issue 39328: Assay run should use renamed file name as its Assay Id when the same data file is being imported
     - Issue 40233: EntityInsertPanel columns for Sources should not include "Parents" in column name caption
+    - DetailEditing panel (i.e. QueryForm usage) boolean field checked state doesn't initialize correctly when formattedValue exists
 
 ### version 0.52.1
 *Released*: 20 April 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Misc 20.5 issue fixes for Sample Manager
+    - Issue 40139: DetailEditing panel editing - updating time but not date does not recognize change
+
 ### version 0.52.1
 *Released*: 20 April 2020
 * `@labkey/api` dependency update.

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.52.2
+*Released*: 24 April 2020
 * Misc 20.5 issue fixes for Sample Manager
     - Issue 40139: DetailEditing panel editing - updating time but not date does not recognize change
     - Issue 39328: Assay run should use renamed file name as its Assay Id when the same data file is being imported (for both re-import case and new import case)

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Misc 20.5 issue fixes for Sample Manager
     - Issue 40139: DetailEditing panel editing - updating time but not date does not recognize change
     - Issue 39328: Assay run should use renamed file name as its Assay Id when the same data file is being imported
+    - Issue 40233: EntityInsertPanel columns for Sources should not include "Parents" in column name caption
 
 ### version 0.52.1
 *Released*: 20 April 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Misc 20.5 issue fixes for Sample Manager
     - Issue 40139: DetailEditing panel editing - updating time but not date does not recognize change
+    - Issue 39328: Assay run should use renamed file name as its Assay Id when the same data file is being imported
 
 ### version 0.52.1
 *Released*: 20 April 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -5,7 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Misc 20.5 issue fixes for Sample Manager
     - Issue 40139: DetailEditing panel editing - updating time but not date does not recognize change
-    - Issue 39328: Assay run should use renamed file name as its Assay Id when the same data file is being imported
+    - Issue 39328: Assay run should use renamed file name as its Assay Id when the same data file is being imported (for both re-import case and new import case)
     - Issue 40233: EntityInsertPanel columns for Sources should not include "Parents" in column name caption
     - DetailEditing panel (i.e. QueryForm usage) boolean field checked state doesn't initialize correctly when formattedValue exists
 

--- a/packages/components/src/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/components/assay/RunDataPanel.tsx
@@ -35,7 +35,7 @@ import { FileSizeLimitProps } from '../files/models';
 import { getEditorModel, helpLinkNode, IMPORT_DATA_FORM_TYPES } from '../..';
 import { DATA_IMPORT_TOPIC } from '../../util/helpLinks';
 
-import { getRunPropertiesRow } from './actions';
+import { getRunPropertiesFileName, getRunPropertiesRow } from './actions';
 import { AssayWizardModel } from './models';
 
 const TABS = ['Upload Files', 'Copy-and-Paste Data', 'Enter Data Into Grid'];
@@ -130,7 +130,7 @@ export class RunDataPanel extends React.Component<Props, State> {
                                 previousRunData: {
                                     isLoaded: true,
                                     data: response,
-                                    fileName: outputs.getIn([0, 'displayValue']),
+                                    fileName: getRunPropertiesFileName(row),
                                 },
                             }));
                         })

--- a/packages/components/src/components/assay/actions.spec.ts
+++ b/packages/components/src/components/assay/actions.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List } from 'immutable';
+import { fromJS, List } from 'immutable';
 
 import { getStateQueryGridModel } from '../../models';
 import { initQueryGridState } from '../../global';
@@ -21,7 +21,7 @@ import { ASSAY_DEFINITION_MODEL } from '../../test/data/constants';
 import sampleSet2QueryInfo from '../../test/data/sampleSet2-getQueryDetails.json';
 import { AssayDefinitionModel, QueryInfo, SchemaQuery } from '../../index';
 
-import { getImportItemsForAssayDefinitions } from './actions';
+import { getImportItemsForAssayDefinitions, getRunPropertiesFileName } from './actions';
 
 beforeAll(() => {
     initQueryGridState();
@@ -50,5 +50,17 @@ describe('getImportItemsForAssayDefinitions', () => {
         sampleModel = getStateQueryGridModel('jestTest-2', queryInfo.schemaQuery, { queryInfo });
         items = getImportItemsForAssayDefinitions(assayDefs, sampleModel);
         expect(items.size).toBe(1);
+    });
+});
+
+describe('getRunPropertiesFileName', () => {
+    test('abc', () => {
+        expect(getRunPropertiesFileName(undefined)).toBe(undefined);
+        expect(getRunPropertiesFileName(fromJS({}))).toBe(undefined);
+        expect(getRunPropertiesFileName(fromJS({ DataOutputs: [] }))).toBe(undefined);
+        expect(
+            getRunPropertiesFileName(fromJS({ DataOutputs: [{ displayValue: 'test1' }, { displayValue: 'test2' }] }))
+        ).toBe(undefined);
+        expect(getRunPropertiesFileName(fromJS({ DataOutputs: [{ displayValue: 'test1' }] }))).toBe('test1');
     });
 });

--- a/packages/components/src/components/assay/actions.ts
+++ b/packages/components/src/components/assay/actions.ts
@@ -248,6 +248,11 @@ export function getRunPropertiesModel(assayDefinition: AssayDefinitionModel, run
     return getQueryGridModel(model.getId()) || model;
 }
 
+export function getRunPropertiesFileName(row: Map<string, any>): string {
+    const dataOutputs = row && row.has('DataOutputs') ? row.get('DataOutputs') : undefined;
+    return dataOutputs && dataOutputs.size === 1 ? dataOutputs.getIn([0, 'displayValue']) : undefined;
+}
+
 export function getRunPropertiesRow(assayDefinition: AssayDefinitionModel, runId: string): Map<string, any> {
     const model = getRunPropertiesModel(assayDefinition, runId);
     return model.isLoaded ? model.getRow() : undefined;

--- a/packages/components/src/components/assay/actions.ts
+++ b/packages/components/src/components/assay/actions.ts
@@ -249,7 +249,7 @@ export function getRunPropertiesModel(assayDefinition: AssayDefinitionModel, run
 }
 
 export function getRunPropertiesFileName(row: Map<string, any>): string {
-    const dataOutputs = row && row.has('DataOutputs') ? row.get('DataOutputs') : undefined;
+    const dataOutputs = row?.get('DataOutputs');
     return dataOutputs && dataOutputs.size === 1 ? dataOutputs.getIn([0, 'displayValue']) : undefined;
 }
 

--- a/packages/components/src/components/assay/models.spec.ts
+++ b/packages/components/src/components/assay/models.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List, Map } from 'immutable';
+import { fromJS, List, Map } from 'immutable';
 import { Utils } from '@labkey/api';
 
 import { ASSAY_WIZARD_MODEL } from '../../test/data/constants';
@@ -54,13 +54,22 @@ describe('AssayWizardModel', () => {
     test('getRunName', () => {
         let model = ASSAY_WIZARD_MODEL;
 
-        // if runName is not set, use the generateNameWithTimestamp function
-        const runName = model.getRunName(AssayUploadTabs.Files);
-        expect(runName.indexOf(model.assayDef.name) === 0).toBeTruthy();
+        // if runName is not set and no file selected, use the generateNameWithTimestamp function
+        expect(model.getRunName(AssayUploadTabs.Files).indexOf(model.assayDef.name) === 0).toBeTruthy();
+        expect(model.getRunName(AssayUploadTabs.Copy).indexOf(model.assayDef.name) === 0).toBeTruthy();
+        expect(model.getRunName(AssayUploadTabs.Grid).indexOf(model.assayDef.name) === 0).toBeTruthy();
+
+        // if runName is not set but we have a file selected, the value should be undefined (which means the server will set it)
+        model = model.set('attachedFiles', fromJS({ file1: new File([], 'file1') })) as AssayWizardModel;
+        expect(model.getRunName(AssayUploadTabs.Files)).toBe(undefined);
+        expect(model.getRunName(AssayUploadTabs.Copy).indexOf(model.assayDef.name) === 0).toBeTruthy();
+        expect(model.getRunName(AssayUploadTabs.Grid).indexOf(model.assayDef.name) === 0).toBeTruthy();
 
         // if runName is set, use that
         model = model.set('runName', 'testing') as AssayWizardModel;
         expect(model.getRunName(AssayUploadTabs.Files)).toBe('testing');
+        expect(model.getRunName(AssayUploadTabs.Copy)).toBe('testing');
+        expect(model.getRunName(AssayUploadTabs.Grid)).toBe('testing');
     });
 
     test('prepareFormData Files tab', () => {

--- a/packages/components/src/components/assay/models.ts
+++ b/packages/components/src/components/assay/models.ts
@@ -118,10 +118,11 @@ export class AssayWizardModel
         }
 
         if (this.isFilesTab(currentStep)) {
-            // using file upload tab
+            // Issue 39328: set assay run to 'undefined' so that the server will fill it in based on the file name
+            // note that in the "file already exists so it will be renamed" case, that renamed file name will be used.
             const file = this.getAttachedFiles().first();
             if (file) {
-                return file.name;
+                return undefined;
             }
         }
 

--- a/packages/components/src/components/assay/models.ts
+++ b/packages/components/src/components/assay/models.ts
@@ -121,7 +121,7 @@ export class AssayWizardModel
             // Issue 39328: set assay run to 'undefined' so that the server will fill it in based on the file name
             // note that in the "file already exists so it will be renamed" case, that renamed file name will be used.
             const file = this.getAttachedFiles().first();
-            if (file) {
+            if (file || this.usePreviousRunFile) {
                 return undefined;
             }
         }

--- a/packages/components/src/components/entities/models.spec.ts
+++ b/packages/components/src/components/entities/models.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SCHEMAS } from '../..';
+
+import { EntityParentType } from './models';
+
+describe('EntityParentType', () => {
+    test('generateColumn captionSuffix', () => {
+        let col = EntityParentType.create({ query: 'dataclass' }).generateColumn('Display Column');
+        expect(col.caption).toBe('Dataclass Parents');
+
+        col = EntityParentType.create({ schema: SCHEMAS.DATA_CLASSES.SCHEMA, query: 'dataclass' }).generateColumn(
+            'Display Column'
+        );
+        expect(col.caption).toBe('Dataclass');
+
+        col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column');
+        expect(col.caption).toBe('Sampletype Parents');
+
+        col = EntityParentType.create({ schema: SCHEMAS.SAMPLE_SETS.SCHEMA, query: 'sampletype' }).generateColumn(
+            'Display Column'
+        );
+        expect(col.caption).toBe('Sampletype Parents');
+    });
+});

--- a/packages/components/src/components/entities/models.ts
+++ b/packages/components/src/components/entities/models.ts
@@ -103,6 +103,9 @@ export class EntityParentType extends Record({
         // Issue 33653: query name is case-sensitive for some data inputs (sample parents), so leave it
         // capitalized here and we lower it where needed
         const parentColName = [encodePart(parentInputType), encodePart(formattedQueryName)].join('/');
+        // Issue 40233: SM app allows for two types of parents, sources and samples, and its confusing if both use
+        // the "Parents" suffix in the editable grid header
+        const captionSuffix = this.schema !== SCHEMAS.DATA_CLASSES.SCHEMA ? ' Parents' : '';
 
         // 32671: Sample import and edit grid key ingredients on scientific name
         if (
@@ -115,7 +118,7 @@ export class EntityParentType extends Record({
         }
 
         return QueryColumn.create({
-            caption: formattedQueryName + ' Parents',
+            caption: formattedQueryName + captionSuffix,
             description: 'Contains optional parent entity for this ' + formattedQueryName,
             fieldKeyArray: [parentColName],
             fieldKey: parentColName,

--- a/packages/components/src/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/components/forms/detail/DetailEditRenderer.tsx
@@ -101,6 +101,9 @@ export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boole
 
         switch (col.jsonType) {
             case 'boolean':
+                // boolean checkbox state needs to be based off of the data value (not formattedValue)
+                value = resolveDetailFieldValue(data, false, true);
+
                 return (
                     <Checkbox
                         name={col.name}

--- a/packages/components/src/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/components/forms/detail/DetailEditing.tsx
@@ -130,11 +130,10 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
                 // A date field needs to be checked specially
                 if (column && column.jsonType === 'date') {
                     // Ensure dates have same formatting
-                    // If submitted value is same as existing date, do not update
-                    if (
-                        new Date(values[field]).setUTCHours(0, 0, 0, 0) ===
-                        new Date(queryData.getIn([field, 'value'])).setUTCHours(0, 0, 0, 0)
-                    ) {
+                    // If submitted value is same as existing date down to the minute (issue 40139), do not update
+                    const newDateValue = new Date(values[field]).setUTCSeconds(0, 0);
+                    const origDateValue = new Date(queryData.getIn([field, 'value'])).setUTCSeconds(0, 0);
+                    if (newDateValue === origDateValue) {
                         return false;
                     }
                 }

--- a/packages/components/src/components/forms/renderers.spec.tsx
+++ b/packages/components/src/components/forms/renderers.spec.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fromJS } from 'immutable';
+
+import { resolveDetailFieldValue } from './renderers';
+
+describe('resolveDetailFieldValue', () => {
+    test('data value undefined', () => {
+        expect(resolveDetailFieldValue(undefined)).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: undefined }))).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: undefined, displayValue: undefined }))).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: null, displayValue: null }))).toBe(undefined);
+    });
+
+    test('data value defined', () => {
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: undefined }))).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }))).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }))).toBe('Test Display');
+    });
+
+    test('lookup prop', () => {
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: undefined }), false)).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), false)).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }), false)).toBe(
+            'Test Display'
+        );
+
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: undefined }), true)).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true)).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }), true)).toBe('test1');
+    });
+
+    test('ignoreFormattedValue prop', () => {
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: undefined, formattedValue: undefined }),
+                false,
+                false
+            )
+        ).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), false, false)).toBe('test1');
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
+                false,
+                false
+            )
+        ).toBe('Test Formatted');
+
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: undefined, formattedValue: undefined }),
+                true,
+                true
+            )
+        ).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true, true)).toBe('test1');
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
+                true,
+                true
+            )
+        ).toBe('test1');
+    });
+});

--- a/packages/components/src/components/forms/renderers.tsx
+++ b/packages/components/src/components/forms/renderers.tsx
@@ -85,14 +85,18 @@ function findValue(data: Map<string, any>, lookup?: boolean) {
     return data.has('displayValue') && lookup !== true ? data.get('displayValue') : data.get('value');
 }
 
-export function resolveDetailFieldValue(data: any, lookup?: boolean): string | string[] {
+export function resolveDetailFieldValue(
+    data: any,
+    lookup?: boolean,
+    ignoreFormattedValue?: boolean
+): string | string[] {
     let value;
 
     if (data) {
         if (List.isList(data) && data.size) {
             value = data
                 .map(d => {
-                    if (d.has('formattedValue')) {
+                    if (!ignoreFormattedValue && d.has('formattedValue')) {
                         return d.get('formattedValue');
                     }
 
@@ -100,7 +104,7 @@ export function resolveDetailFieldValue(data: any, lookup?: boolean): string | s
                     return o !== null && o !== undefined ? o : undefined;
                 })
                 .toArray();
-        } else if (data.has('formattedValue')) {
+        } else if (!ignoreFormattedValue && data.has('formattedValue')) {
             value = data.get('formattedValue');
         } else {
             const o = findValue(data, lookup);

--- a/packages/components/src/components/lineage/actions.ts
+++ b/packages/components/src/components/lineage/actions.ts
@@ -75,6 +75,12 @@ function fetchNodeMetadata(lineage: LineageResult): Array<Promise<ISelectRowsRes
     // Node metadata does not support nodes with multiple primary keys. These could be supported, however,
     // each node would require it's own request for the unique keys combination. Also, nodes without any primary
     // keys cannot be filtered upon and thus are also not supported.
+    const filteredNodes = lineage.nodes.filter(n => n.schemaName !== undefined && n.queryName !== undefined && n.pkFilters.size === 1);
+    console.log(lineage.nodes.size, filteredNodes.size);
+    if (lineage.nodes.size !== filteredNodes.size) {
+        lineage.nodes.map(node => console.error(JSON.stringify(node.toJS())));
+    }
+
     return lineage.nodes
         .filter(n => n.schemaName !== undefined && n.queryName !== undefined && n.pkFilters.size === 1)
         .groupBy(n => SchemaQuery.create(n.schemaName, n.queryName))

--- a/packages/components/src/components/lineage/actions.ts
+++ b/packages/components/src/components/lineage/actions.ts
@@ -75,12 +75,6 @@ function fetchNodeMetadata(lineage: LineageResult): Array<Promise<ISelectRowsRes
     // Node metadata does not support nodes with multiple primary keys. These could be supported, however,
     // each node would require it's own request for the unique keys combination. Also, nodes without any primary
     // keys cannot be filtered upon and thus are also not supported.
-    const filteredNodes = lineage.nodes.filter(n => n.schemaName !== undefined && n.queryName !== undefined && n.pkFilters.size === 1);
-    console.log(lineage.nodes.size, filteredNodes.size);
-    if (lineage.nodes.size !== filteredNodes.size) {
-        lineage.nodes.map(node => console.error(JSON.stringify(node.toJS())));
-    }
-
     return lineage.nodes
         .filter(n => n.schemaName !== undefined && n.queryName !== undefined && n.pkFilters.size === 1)
         .groupBy(n => SchemaQuery.create(n.schemaName, n.queryName))


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/248

#### Changes
* Issue [40139](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40139): DetailEditing panel editing - updating time but not date does not recognize change
* Issue [39328](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39328): Assay run should use renamed file name as its Assay Id when the same data file is being imported
* Issue [40233](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40233): EntityInsertPanel columns for Sources should not include "Parents" in column name caption
* DetailEditing panel (i.e. QueryForm usage) boolean field checked state doesn't initialize correctly when formattedValue exists
