### PR TITLE
Fix issues 39633, 38002, 40008, and do some more error translation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.53.0-fb-smOtherMiscFixes205.1",
+  "version": "0.53.0-fb-smOtherMiscFixes205.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.52.2",
+  "version": "0.53.0-fb-smOtherMiscFixes205.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.53.0-fb-smOtherMiscFixes205.0",
+  "version": "0.53.0-fb-smOtherMiscFixes205.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 39633: Choosing to cancel navigating away from a page when using react-router's setRouteLeaveHook will leave
 you on the page but the URL will have been updated to the page where you had originally intended to go, which means
 using that link again from the starting page will not work.
+* Issue 38002: Set isSubmitting to false after updateRows in EditableGridPanelForUpdate in case you stay on the page after updating
 
 ### version 0.52.2
 *Released*: 24 April 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -7,6 +7,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 you on the page but the URL will have been updated to the page where you had originally intended to go, which means
 using that link again from the starting page will not work.
 * Issue 38002: Set isSubmitting to false after updateRows in EditableGridPanelForUpdate in case you stay on the page after updating
+* Update resolveErrorMessage to strip off java.lang.IllegalArgumentException prefixes and detect "Bad SQL grammar" exceptions.
+
 
 ### version 0.52.2
 *Released*: 24 April 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -8,7 +8,7 @@ you on the page but the URL will have been updated to the page where you had ori
 using that link again from the starting page will not work.
 * Issue 38002: Set isSubmitting to false after updateRows in EditableGridPanelForUpdate in case you stay on the page after updating
 * Update resolveErrorMessage to strip off java.lang.IllegalArgumentException prefixes and detect "Bad SQL grammar" exceptions.
-
+* Issue 40008: Add optional property to LineageSummary to allow customization of the lineage group headings in the summary panel
 
 ### version 0.52.2
 *Released*: 24 April 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+## version TBD
+*Released*: TBD
+* Issue 39633: Choosing to cancel navigating away from a page when using react-router's setRouteLeaveHook will leave
+you on the page but the URL will have been updated to the page where you had originally intended to go, which means
+using that link again from the starting page will not work.
+
 ### version 0.52.2
 *Released*: 24 April 2020
 * Misc 20.5 issue fixes for Sample Manager
@@ -13,13 +19,13 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 20 April 2020
 * `@labkey/api` dependency update.
 
-### version 0.52.0
+## version 0.52.0
 *Released*: 18 April 2020
 * Item 7178: Prettier/ESLint bulk update
     - Initial Prettier/ESLint bulk update across packages/components/src directory.
     - yarn run lint-fix ./src/\*\*/\*
 
-### version 0.51.0
+## version 0.51.0
 *Released*: 17 April 2020
 * Item 6961: DataClassDesigner updates for LKS
     - update fetchDataClass function to work for either a data class name or rowId

--- a/packages/components/src/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/components/editable/EditableGridPanelForUpdate.tsx
@@ -57,7 +57,9 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
             if (updatedRows.length > 0) {
                 this.setState(() => ({ isSubmitting: true }));
             }
-            updateRows(model.queryInfo.schemaQuery, updatedRows).then(() => onComplete());
+            updateRows(model.queryInfo.schemaQuery, updatedRows).then(() => {
+                this.setState(() => ({isSubmitting: false}),  onComplete())
+            });
         }
     };
 

--- a/packages/components/src/components/lineage/LineageSummary.tsx
+++ b/packages/components/src/components/lineage/LineageSummary.tsx
@@ -4,7 +4,7 @@
  */
 import React, { ReactNode } from 'react';
 import ReactN from 'reactn';
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 
 import { LoadingSpinner } from '../..';
 
@@ -44,10 +44,6 @@ export class LineageSummary extends ReactN.Component<Props> {
         return this.global.QueryGrid_lineageResults.get(seed);
     }
 
-    private getTitleSuffix(direction: LINEAGE_DIRECTIONS): string {
-        return direction === LINEAGE_DIRECTIONS.Parent ? 'Parents' : 'Children';
-    }
-
     renderNodeList = (
         direction: LINEAGE_DIRECTIONS,
         lineage: LineageResult,
@@ -63,12 +59,13 @@ export class LineageSummary extends ReactN.Component<Props> {
         const nodesByType = createLineageNodeCollections(nodes, this.props.options);
         const groups = Object.keys(nodesByType).sort();
 
-        const title = direction === LINEAGE_DIRECTIONS.Parent ? 'Parents' : 'Children';
+        const defaultTitleSuffix = direction === LINEAGE_DIRECTIONS.Parent ? 'Parents' : 'Children';
+        const suffixes = this.props.options?.groupTitles?.get(direction) || Map<string, string>();
 
         return groups.map(groupName => (
             <LineageNodeList
                 key={groupName}
-                title={groupName + ' ' + title}
+                title={groupName + ' ' + (suffixes.has(groupName) ? suffixes.get(groupName) : defaultTitleSuffix)}
                 nodes={nodesByType[groupName]}
                 highlightNode={highlightNode}
             />

--- a/packages/components/src/components/lineage/LineageSummary.tsx
+++ b/packages/components/src/components/lineage/LineageSummary.tsx
@@ -44,6 +44,10 @@ export class LineageSummary extends ReactN.Component<Props> {
         return this.global.QueryGrid_lineageResults.get(seed);
     }
 
+    private getTitleSuffix(direction: LINEAGE_DIRECTIONS): string {
+        return direction === LINEAGE_DIRECTIONS.Parent ? 'Parents' : 'Children';
+    }
+
     renderNodeList = (
         direction: LINEAGE_DIRECTIONS,
         lineage: LineageResult,

--- a/packages/components/src/components/lineage/types.ts
+++ b/packages/components/src/components/lineage/types.ts
@@ -4,6 +4,7 @@
  */
 // DO NOT IMPORT ANYTHING IN HERE! ONLY MEANT FOR TOP-LEVEL LINEAGE TYPES
 // Can cause circular dependency
+import { Map } from 'immutable';
 
 export enum LINEAGE_DIRECTIONS {
     Children = 'children',
@@ -63,4 +64,5 @@ export interface LineageOptions {
     filters?: LineageFilter[];
     grouping?: LineageGroupingOptions;
     urlResolver?: LineageURLResolvers;
+    groupTitles?: Map<LINEAGE_DIRECTIONS, Map<string, string>>;
 }

--- a/packages/components/src/components/navigation/utils.ts
+++ b/packages/components/src/components/navigation/utils.ts
@@ -1,0 +1,26 @@
+import { AppURL } from '../..';
+import { Location } from "history";
+
+export const ON_LEAVE_DIRTY_STATE_MESSAGE = 'You have unsaved changes which will be lost. Are you sure you want to continue?';
+
+/**
+ * This function can be used as the callback for react-router's setRouteLeaveHook.  It should be preferred
+ * over a callback that simply returns the confirm message because with react-router v3.x, the URL route
+ * will have already been changed by the time this confirm is shown and will not be reset if the user does not confirm.
+ * If the user tries to click on the initial link again after canceling, nothing will happen because the URL
+ * in the browser will not change. (Issue 39633).  See also https://stackoverflow.com/questions/32841757/detecting-user-leaving-page-with-react-router
+ *
+ * @param currentLocation the location of the current page
+ */
+export function confirmLeaveWhenDirty(currentLocation: Location) {
+    const result = confirm(ON_LEAVE_DIRTY_STATE_MESSAGE);
+    if (result) {
+        // navigation confirmed
+        return true;
+    } else {
+        // navigation canceled, pushing the previous path
+        if (currentLocation)
+            window.history.pushState(null, null, AppURL.create(...currentLocation.pathname.substring(1).split("/")).toHref());
+        return false;
+    }
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -258,7 +258,7 @@ import {
     uploadAssayRunFiles,
 } from './components/assay/actions';
 import { ReportItemModal, ReportList, ReportListItem } from './components/report-list/ReportList';
-import { LineageFilter, LINEAGE_GROUPING_GENERATIONS, LineageURLResolvers } from './components/lineage/types';
+import { LineageFilter, LINEAGE_DIRECTIONS, LINEAGE_GROUPING_GENERATIONS, LineageURLResolvers } from './components/lineage/types';
 import { VisGraphNode } from './components/lineage/vis/VisGraphGenerator';
 import { LineageGraph } from './components/lineage/LineageGraph';
 import { LineageGrid } from './components/lineage/LineageGrid';
@@ -512,6 +512,7 @@ export {
     ReportList,
     // lineage
     LINEAGE_GROUPING_GENERATIONS,
+    LINEAGE_DIRECTIONS,
     LineageFilter,
     LineageGraph,
     LineageGrid,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -273,6 +273,7 @@ import { ITab, SubNav } from './components/navigation/SubNav';
 import { Breadcrumb } from './components/navigation/Breadcrumb';
 import { BreadcrumbCreate } from './components/navigation/BreadcrumbCreate';
 import { MenuItemModel, MenuSectionModel, ProductMenuModel } from './components/navigation/model';
+import { confirmLeaveWhenDirty } from './components/navigation/utils';
 import { UserSelectInput } from './components/forms/input/UserSelectInput';
 import { UserDetailHeader } from './components/user/UserDetailHeader';
 import { UserProfile } from './components/user/UserProfile';
@@ -547,6 +548,7 @@ export {
     SubNav,
     Breadcrumb,
     BreadcrumbCreate,
+    confirmLeaveWhenDirty,
     // DomainProperties
     DomainForm,
     DomainFieldsDisplay,

--- a/packages/components/src/stories/Lineage.tsx
+++ b/packages/components/src/stories/Lineage.tsx
@@ -16,13 +16,14 @@
 import React from 'react';
 import { Panel } from 'react-bootstrap';
 import { storiesOf } from '@storybook/react';
-import { withKnobs } from '@storybook/addon-knobs';
+import { text, withKnobs } from '@storybook/addon-knobs';
 
 import { LineageGraph } from '../components/lineage/LineageGraph';
 import { LineageGrid } from '../components/lineage/LineageGrid';
-import { LineageFilter, LINEAGE_GROUPING_GENERATIONS } from '../components/lineage/types';
+import { LineageFilter, LINEAGE_GROUPING_GENERATIONS, LINEAGE_DIRECTIONS } from '../components/lineage/types';
 
 import './stories.scss';
+import { fromJS } from 'immutable';
 
 storiesOf('Lineage', module)
     .addDecorator(withKnobs)
@@ -32,6 +33,7 @@ storiesOf('Lineage', module)
                 lsid="urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3"
                 grouping={{ generations: LINEAGE_GROUPING_GENERATIONS.Specific }}
                 filters={[new LineageFilter('type', ['Sample', 'Data'])]}
+                groupTitles={fromJS({[LINEAGE_DIRECTIONS.Parent]: {Hemoglobin: text('Hemoglobin parent suffix', 'Parents')}})}
             />
         );
     })

--- a/packages/components/src/util/messaging.tsx
+++ b/packages/components/src/util/messaging.tsx
@@ -18,6 +18,8 @@ export function getActionErrorMessage(
     );
 }
 
+const IllegalArgumentMessage = 'java.lang.illegalargumentexception:';
+
 export function resolveErrorMessage(error: any, noun: string = undefined, nounPlural?: string, verb?: string): string {
     let errorMsg;
     if (!error) {
@@ -39,6 +41,9 @@ export function resolveErrorMessage(error: any, noun: string = undefined, nounPl
             lcMessage.indexOf('violation of unique key constraint') >= 0
         )
             return 'There was a problem ' + (verb || 'creating') + ' your ' + noun + '.  Check the existing ' + (nounPlural || noun) + ' for possible duplicates and make sure any referenced ' + (nounPlural || noun) + ' are still valid.';
+        else if (lcMessage.indexOf('bad sql grammar') >= 0) {
+            return 'There was a problem ' + (verb || 'creating') + ' your ' + noun + '.  Check that the format of the data matches the expected type for each field.';
+        }
         else if (lcMessage.indexOf('existing row was not found') >= 0) {
             return (
                 'We could not find the ' +
@@ -54,6 +59,9 @@ export function resolveErrorMessage(error: any, noun: string = undefined, nounPl
             return 'There was a problem retrieving your ' + (noun || 'data') + '. Your session may have expired or the ' + (noun || 'data') + ' may no longer be valid.  Try refreshing your page.';
         } else if (lcMessage.indexOf('either rowid or lsid is required') >= 0) {
             return 'There was a problem retrieving or updating your ' + (noun || 'data') + '.  The request did not contain the proper identifiers.  Make sure the ' + (noun || 'data') + ' are still valid.';
+        } else if (lcMessage.indexOf(IllegalArgumentMessage) >= 0) {
+            const startIndex = lcMessage.indexOf(IllegalArgumentMessage);
+            return errorMsg.substring(startIndex + IllegalArgumentMessage.length);
         }
     }
     return errorMsg;


### PR DESCRIPTION
#### Rationale
Various issues need fixing

#### Related Pull Requests
* TBD

#### Changes
* Issue 39633: Better handling for cancel from the dirty-state-leave confirmation dialog
* Update resolveErrorMessage to strip off java.lang.IllegalArgumentException prefixes and detect "Bad SQL grammar" exceptions.
* Issue 38002: Set isSubmitting to false after updateRows in EditableGridPanelForUpdate in case you stay on the page after updating
* Issue 40008: Add optional property to LineageSummary to allow customization of the lineage group headings in the summary panel 

***N.B. The changes for 40008 are likely going to be reverted in favor of similar changes from the fb_runGraph_deets feature branch***
