### PR TITLE
Issue 40329: Sample Manager source samples: limit to 1st generation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.2.2",
+    "@labkey/api": "0.2.6",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.55.1-fb-issue-40329.1",
+  "version": "0.55.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.55.0",
+  "version": "0.55.1-fb-issue-40329.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.55.1
+*Released*: 6 May 2020
+* `@labkey/api` dependency update.
+* allow using separate singleFilterValue for createQueryGridModelFilteredBySample
+
 ## version 0.55.0
 *Released*: 30 April 2020
 * Issue 39633: Choosing to cancel navigating away from a page when using react-router's setRouteLeaveHook will leave

--- a/packages/components/src/actions.ts
+++ b/packages/components/src/actions.ts
@@ -2759,13 +2759,14 @@ export function createQueryGridModelFilteredBySample(
     singleFilter: Filter.IFilterType,
     whereClausePart: (fieldKey, value) => string,
     useLsid?: boolean,
-    omitSampleCols?: boolean
+    omitSampleCols?: boolean,
+    singleFilterValue?: any
 ): QueryGridModel {
     const schemaQuery = SchemaQuery.create(model.protocolSchemaName, 'Data');
     const sampleColumns = model.getSampleColumnFieldKeys();
 
     if (sampleColumns && !sampleColumns.isEmpty()) {
-        const filter = model.createSampleFilter(sampleColumns, value, singleFilter, whereClausePart, useLsid);
+        const filter = model.createSampleFilter(sampleColumns, value, singleFilter, whereClausePart, useLsid, singleFilterValue);
         return getStateQueryGridModel(gridId, schemaQuery, () => ({
             baseFilters: List([filter]),
             isPaged: true,

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -1470,13 +1470,14 @@ export class AssayDefinitionModel extends Record({
         value,
         singleFilter: Filter.IFilterType,
         whereClausePart: (fieldKey, value) => string,
-        useLsid?: boolean
+        useLsid?: boolean,
+        singleFilterValue?: any
     ) {
         const keyCol = useLsid ? '/LSID' : '/RowId';
         if (sampleColumns.size == 1) {
             // generate simple equals filter
             const sampleColumn = sampleColumns.get(0);
-            return Filter.create(sampleColumn + keyCol, value, singleFilter);
+            return Filter.create(sampleColumn + keyCol, singleFilterValue ? singleFilterValue : value, singleFilter);
         } else {
             // generate an OR filter to include all sample columns
             const whereClause =

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1553,10 +1553,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.2.2":
-  version "0.2.2"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2.tgz#deeb617dfbf2be83eb76e3c44c27807c691c6a9d"
-  integrity sha1-3uthffvyvoPrduPETCeAfGkcap0=
+"@labkey/api@0.2.6":
+  version "0.2.6"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.6.tgz#3040827aa4f78e07de041daffee67ec8c5b0ae0d"
+  integrity sha1-MECCeqT3jgfeBB2v/uZ+yMWwrg0=
 
 "@labkey/eslint-config-base@0.0.7":
   version "0.0.7"


### PR DESCRIPTION
#### Rationale
hot fix to allow lineage query to limit to 1st generation only for sample manager 20.5

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1118
* https://github.com/LabKey/labkey-ui-components/pull/239
* https://github.com/LabKey/sampleManagement/pull/258
* https://github.com/LabKey/labkey-api-js/pull/57

Changes
* labkey/api dependency update
* allow using separate singleFilterValue for createQueryGridModelFilteredBySample