### PR TITLE
Lineage: improve caching, allow non-default distance

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.59.2-fb-lineage-fixes-duex.0",
+  "version": "0.59.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.59.1",
+  "version": "0.59.2-fb-lineage-fixes-duex.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.59.2
+*Released*: 16 May 2020
+* Lineage: improve caching, allow non-default distance
+
 ### version 0.59.1
 *Released*: 15 May 2020
 * Merge forward changes from release20.5-SNAPSHOT branch

--- a/packages/components/src/components/lineage/SampleTypeLineageCounts.tsx
+++ b/packages/components/src/components/lineage/SampleTypeLineageCounts.tsx
@@ -40,7 +40,7 @@ class CountsWithLineageImpl extends PureComponent<InjectedLineage> {
     }
 }
 
-const CountsWithLineage = withLineage<{}>(CountsWithLineageImpl, false, true);
+const CountsWithLineage = withLineage<{}>(CountsWithLineageImpl, false, true, false);
 
 // Don't expose props from withLineage in public component
 export const SampleTypeLineageCounts: FunctionComponent<{ seed: string }> = props => {

--- a/packages/components/src/components/lineage/actions.ts
+++ b/packages/components/src/components/lineage/actions.ts
@@ -212,9 +212,15 @@ export function loadLineageResult(
         lsid: seed,
     };
 
+    const currentContainerId = getServerContext().container.id;
+
+    if (!container) {
+        container = currentContainerId;
+    }
+
     // Lineage API currently responds with the container's entity ID.
     // Only apply container if it doesn't match the current container.
-    if (container !== getServerContext().container.id) {
+    if (container !== currentContainerId) {
         fetchOptions.containerPath = container;
     }
 

--- a/packages/components/src/components/lineage/withLineage.tsx
+++ b/packages/components/src/components/lineage/withLineage.tsx
@@ -29,7 +29,8 @@ interface State {
 export function withLineage<Props>(
     ComponentToWrap: ComponentType<Props & InjectedLineage>,
     allowSeedPrefetch = true,
-    allowLoadSampleStats = false
+    allowLoadSampleStats = false,
+    applyDefaultDistance = true
 ): ComponentType<Props & WithLineageOptions> {
     class ComponentWithLineage extends PureComponent<Props & WithLineageOptions, State> {
         static defaultProps;
@@ -157,7 +158,7 @@ export function withLineage<Props>(
     }
 
     ComponentWithLineage.defaultProps = {
-        distance: DEFAULT_LINEAGE_DISTANCE,
+        distance: applyDefaultDistance ? DEFAULT_LINEAGE_DISTANCE : undefined,
         prefetchSeed: true,
     };
 


### PR DESCRIPTION
#### Rationale
This PR addresses two issues with lineage.
1. I'd originally thought that all lineage usages used the `DEFAULT_LINEAGE_DISTANCE` when none was specified, however, this isn't what was expected for `SampleTypeLineageCounts`. It expects the lineage request to not be constrained by distance/depth. This is fixed by allowing components to opt-out of defaulting to `DEFAULT_LINEAGE_DISTANCE`.
1. Lineage requests cache key include the container's id. If a container wasn't specified it was presumed to default to the current container (like all of our APIs), however, this resulted in different cache keys for the same result.  This is fixed by consistently specifying the container id for computing the cache key.

#### Changes
* `withLineage` allows callers to opt-out of defaulting to `DEFAULT_LINEAGE_DISTANCE`. This was causing `SampleTypeLineageCounts` to make all lineage requests with a `depth=6` (`DEFAULT_LINEAGE_DISTANCE` x 2).
* Lineage request caching fixed to make requests in current container equivalent to not specifying a container.