### PR TITLE
Item 7207: DatasetColumnMappingPanel change to allow for numeric and text fields to be used for timepoint/visit column mapping

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.59.2-fb-datasetFromFileTestMigration.0",
+  "version": "0.59.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.59.2",
+  "version": "0.59.2-fb-datasetFromFileTestMigration.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.59.3
+*Released*: 18 May 2020
 * Item 7207: DatasetColumnMappingPanel fix to allow for numeric and text fields to be used for timepoint/visit column mapping
     - Fix for StudyScheduleTest use case which uses the text visit values instead of Sequence Num during import
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 7207: DatasetColumnMappingPanel fix to allow for numeric and text fields to be used for timepoint/visit column mapping
+    - Fix for StudyScheduleTest use case which uses the text visit values instead of Sequence Num during import
+
 ### version 0.59.2
 *Released*: 16 May 2020
 * Lineage: improve caching, allow non-default distance

--- a/packages/components/src/components/domainproperties/dataset/DatasetColumnMappingPanel.tsx
+++ b/packages/components/src/components/domainproperties/dataset/DatasetColumnMappingPanel.tsx
@@ -24,9 +24,10 @@ import { SectionHeading } from '../SectionHeading';
 import { DomainFieldLabel } from '../DomainFieldLabel';
 import { DomainField, SelectInput } from '../../..';
 
+import { DATETIME_RANGE_URI } from '../constants';
+
 import { DatasetModel } from './models';
 import { getStudySubjectProp, getStudyTimepointLabel } from './actions';
-import { DATETIME_RANGE_URI } from "../constants";
 
 interface Props {
     model: DatasetModel;
@@ -109,11 +110,15 @@ export class DatasetColumnMappingPanel extends React.PureComponent<Props, State>
         const { model, timepointType } = this.props;
 
         if (timepointType === 'VISIT') {
-            return model.domain.fields.filter(field => field.dataType.isNumeric() || field.dataType.isString()).toList();
+            return model.domain.fields
+                .filter(field => field.dataType.isNumeric() || field.dataType.isString())
+                .toList();
         } else {
             // DATE or CONTINUOUS
             return model.domain.fields
-                .filter(field => field.rangeURI.toLowerCase() === 'xsd:datetime' || field.rangeURI === DATETIME_RANGE_URI)
+                .filter(
+                    field => field.rangeURI.toLowerCase() === 'xsd:datetime' || field.rangeURI === DATETIME_RANGE_URI
+                )
                 .toList();
         }
     }

--- a/packages/components/src/components/domainproperties/dataset/DatasetColumnMappingPanel.tsx
+++ b/packages/components/src/components/domainproperties/dataset/DatasetColumnMappingPanel.tsx
@@ -109,7 +109,7 @@ export class DatasetColumnMappingPanel extends React.PureComponent<Props, State>
         const { model, timepointType } = this.props;
 
         if (timepointType === 'VISIT') {
-            return model.domain.fields.filter(field => field.dataType.isNumeric()).toList();
+            return model.domain.fields.filter(field => field.dataType.isNumeric() || field.dataType.isString()).toList();
         } else {
             // DATE or CONTINUOUS
             return model.domain.fields

--- a/packages/components/src/components/domainproperties/dataset/models.spec.ts
+++ b/packages/components/src/components/domainproperties/dataset/models.spec.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BOOLEAN_TYPE, DATETIME_TYPE, DECIMAL_TYPE, FILE_TYPE, INTEGER_TYPE, TEXT_TYPE } from '../models';
+
+import { DatasetModel } from './models';
+
+describe('DatasetModel', () => {
+    test('isNew', () => {
+        expect(DatasetModel.create({ entityId: undefined }).isNew()).toBeTruthy();
+        expect(DatasetModel.create({ entityId: 0 }).isNew()).toBeTruthy();
+        expect(DatasetModel.create({ entityId: 1 }).isNew()).toBeFalsy();
+    });
+
+    test('hasValidProperties name', () => {
+        expect(DatasetModel.create({ name: undefined }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: null }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: '' }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: ' ' }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test' }).hasValidProperties()).toBeTruthy();
+    });
+
+    test('hasValidProperties label', () => {
+        expect(DatasetModel.create({ name: 'test', label: undefined }).hasValidProperties()).toBeTruthy();
+        expect(DatasetModel.create({ name: 'test', label: undefined, entityId: 1 }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', label: null, entityId: 1 }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', label: '', entityId: 1 }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', label: ' ', entityId: 1 }).hasValidProperties()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', label: 'test label' }).hasValidProperties()).toBeTruthy();
+    });
+
+    test('hasValidProperties dataRowSetting', () => {
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: true,
+                keyPropertyName: undefined,
+                useTimeKeyField: false,
+            }).hasValidProperties()
+        ).toBeTruthy();
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: undefined,
+                useTimeKeyField: false,
+            }).hasValidProperties()
+        ).toBeTruthy();
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: undefined,
+                useTimeKeyField: true,
+            }).hasValidProperties()
+        ).toBeTruthy();
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: 'test',
+                useTimeKeyField: true,
+            }).hasValidProperties()
+        ).toBeTruthy();
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: null,
+                useTimeKeyField: false,
+            }).hasValidProperties()
+        ).toBeTruthy();
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: '',
+                useTimeKeyField: false,
+            }).hasValidProperties()
+        ).toBeFalsy();
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: 'test',
+                useTimeKeyField: false,
+            }).hasValidProperties()
+        ).toBeTruthy();
+    });
+
+    test('dataRowSetting', () => {
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: true,
+                keyPropertyName: undefined,
+                useTimeKeyField: false,
+            }).getDataRowSetting()
+        ).toBe(0);
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: true,
+                keyPropertyName: undefined,
+                useTimeKeyField: true,
+            }).getDataRowSetting()
+        ).toBe(0);
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: undefined,
+                useTimeKeyField: false,
+            }).getDataRowSetting()
+        ).toBe(1);
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: null,
+                useTimeKeyField: false,
+            }).getDataRowSetting()
+        ).toBe(1);
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: null,
+                useTimeKeyField: true,
+            }).getDataRowSetting()
+        ).toBe(2);
+        expect(
+            DatasetModel.create({
+                name: 'test',
+                demographicData: false,
+                keyPropertyName: 'test',
+                useTimeKeyField: false,
+            }).getDataRowSetting()
+        ).toBe(2);
+    });
+
+    test('validManagedKeyField', () => {
+        const model = DatasetModel.create(null, {
+            options: { name: 'test' },
+            domainDesign: {
+                fields: [
+                    { name: 'text', rangeURI: TEXT_TYPE.rangeURI },
+                    { name: 'int', rangeURI: INTEGER_TYPE.rangeURI },
+                    { name: 'decimal', rangeURI: DECIMAL_TYPE.rangeURI },
+                    { name: 'boolean', rangeURI: BOOLEAN_TYPE.rangeURI },
+                    { name: 'date', rangeURI: DATETIME_TYPE.rangeURI },
+                    { name: 'file', rangeURI: FILE_TYPE.rangeURI },
+                ],
+            },
+        });
+
+        expect(model.domain.fields.size).toBe(6);
+        expect(model.validManagedKeyField()).toBeFalsy();
+        expect(model.validManagedKeyField('text')).toBeTruthy();
+        expect(model.validManagedKeyField('int')).toBeTruthy();
+        expect(model.validManagedKeyField('decimal')).toBeTruthy();
+        expect(model.validManagedKeyField('boolean')).toBeFalsy();
+        expect(model.validManagedKeyField('date')).toBeFalsy();
+        expect(model.validManagedKeyField('file')).toBeFalsy();
+    });
+
+    test('getDomainKind', () => {
+        // this is based on the setting in the package.json jest "timepointType"
+        expect(DatasetModel.create({ name: 'test' }).getDomainKind()).toBe('StudyDatasetVisit');
+    });
+
+    test('isFromAssay', () => {
+        expect(DatasetModel.create({ name: 'test' }).isFromAssay()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', sourceAssayName: undefined }).isFromAssay()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', sourceAssayName: null }).isFromAssay()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', sourceAssayName: 'test' }).isFromAssay()).toBeTruthy();
+    });
+});

--- a/packages/components/src/components/domainproperties/dataset/models.ts
+++ b/packages/components/src/components/domainproperties/dataset/models.ts
@@ -87,7 +87,7 @@ export class DatasetModel implements IDatasetModel {
         Object.assign(this, datasetModel);
     }
 
-    static create(newDataset = null, raw: any): DatasetModel {
+    static create(newDataset = null, raw?: any): DatasetModel {
         if (newDataset) {
             const domain = DomainDesign.create(undefined);
             return new DatasetModel({ ...newDataset, domain });


### PR DESCRIPTION
#### Rationale
Fix for StudyScheduleTest use case which uses the text visit values instead of Sequence Num during import.

#### Related Pull Requests
* coming soon for platform and testAutomation
