### PR TITLE
Item 6646: Issues List Def support for shared domain

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.59.3-fb-issuesListDefTestConversion.0",
+  "version": "0.60.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.59.3",
+  "version": "0.59.3-fb-issuesListDefTestConversion.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,12 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.60.0
+*Released*: 20 May 2020
 * Item 6646: IssuesListDefDesignerPanels fix for shared domain scenario
-    - Add helpers to DomainDesign model to getDomainContainer and isSharedDomain
+    - Add helpers to DomainDesign model to getDomainContainer() and isSharedDomain()
     - Allow for a shared def to be used in another container where only the top level properties can be saved via saveIssueListDefOptions
     - Show alert if the current container is using a shared domain with link to get to source container
+    - Disable field re-order and add field for a shared domain (read only display)
 
 ### version 0.59.3
 *Released*: 18 May 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 6646: IssuesListDefDesignerPanels fix for shared domain scenario
+    - Add helpers to DomainDesign model to getDomainContainer and isSharedDomain
+    - Allow for a shared def to be used in another container where only the top level properties can be saved via saveIssueListDefOptions
+    - Show alert if the current container is using a shared domain with link to get to source container
+
 ### version 0.59.3
 *Released*: 18 May 2020
 * Item 7207: DatasetColumnMappingPanel fix to allow for numeric and text fields to be used for timepoint/visit column mapping

--- a/packages/components/src/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
+++ b/packages/components/src/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
@@ -203,6 +203,10 @@ class IssuesDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseD
                     }}
                     useTheme={useTheme}
                     successBsStyle={successBsStyle}
+                    domainFormDisplayOptions={{
+                        isDragDisabled: model.domain.isSharedDomain(),
+                        hideAddFieldsButton: model.domain.isSharedDomain(),
+                    }}
                 />
             </BaseDomainDesigner>
         );

--- a/packages/components/src/components/domainproperties/issues/actions.ts
+++ b/packages/components/src/components/domainproperties/issues/actions.ts
@@ -2,9 +2,11 @@ import { ActionURL, Ajax, Domain, getServerContext, Utils } from '@labkey/api';
 
 import { List } from 'immutable';
 
-import { Principal } from '../../..';
+import { buildURL, Principal } from '../../..';
 
-import { IssuesListDefModel } from './models';
+import { DuplicateFilesResponse } from '../../assay/actions';
+
+import { IssuesListDefModel, IssuesListDefOptionsConfig } from './models';
 
 export function fetchIssuesListDefDesign(issueDefName: string): Promise<IssuesListDefModel> {
     return new Promise((resolve, reject) => {
@@ -62,6 +64,23 @@ export function getProjectGroups(): Promise<List<Principal>> {
             }),
             failure: Utils.getCallbackWrapper(error => {
                 reject(error);
+            }),
+        });
+    });
+}
+
+export function saveIssueListDefOptions(options: IssuesListDefOptionsConfig): Promise<DuplicateFilesResponse> {
+    return new Promise((resolve, reject) => {
+        Ajax.request({
+            url: buildURL('issues', 'admin.api'),
+            method: 'POST',
+            params: options,
+            success: Utils.getCallbackWrapper(res => {
+                resolve(res);
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                console.error(response);
+                reject(response);
             }),
         });
     });

--- a/packages/components/src/components/domainproperties/issues/models.spec.ts
+++ b/packages/components/src/components/domainproperties/issues/models.spec.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DomainDesign } from '../models';
-
 import getDomainDetailsJSON from '../../../test/data/issuesListDef-getDomainDetails.json';
 
 import { IssuesListDefModel } from './models';

--- a/packages/components/src/components/domainproperties/issues/models.ts
+++ b/packages/components/src/components/domainproperties/issues/models.ts
@@ -13,13 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Draft, immerable, produce } from 'immer';
-
-import { Record } from 'immutable';
+import { immerable } from 'immer';
 
 import { DomainDesign } from '../models';
 
-export class IssuesListDefModel {
+export interface IssuesListDefOptionsConfig {
+    entityId?: string;
+    issueDefName: string;
+    singularItemName: string;
+    pluralItemName: string;
+    commentSortDirection: string;
+    assignedToGroup: number;
+    assignedToUser: number;
+}
+
+interface IssuesListDefModelConfig extends IssuesListDefOptionsConfig {
+    exception: string;
+    domain: DomainDesign;
+    domainId: number;
+    domainKindName: string;
+}
+
+export class IssuesListDefModel implements IssuesListDefModelConfig {
     [immerable] = true;
 
     readonly exception: string;
@@ -34,8 +49,8 @@ export class IssuesListDefModel {
     readonly assignedToUser: number;
     readonly domainKindName: string;
 
-    constructor(issuesListDefModel: IssuesListDefModel) {
-        Object.assign(this, issuesListDefModel);
+    constructor(values?: Partial<IssuesListDefModelConfig>) {
+        Object.assign(this, values);
     }
 
     static create(raw: any, defaultSettings = null): IssuesListDefModel {
@@ -60,10 +75,15 @@ export class IssuesListDefModel {
         return this.issueDefName !== undefined && this.issueDefName !== null && this.issueDefName.trim().length > 0;
     }
 
-    getOptions(): Record<string, any> {
-        return produce(this, (draft: Draft<IssuesListDefModel>) => {
-            delete draft.exception;
-            delete draft.domain;
-        });
+    getOptions(): IssuesListDefOptionsConfig {
+        return {
+            entityId: this.entityId,
+            issueDefName: this.issueDefName,
+            singularItemName: this.singularItemName,
+            pluralItemName: this.pluralItemName,
+            commentSortDirection: this.commentSortDirection,
+            assignedToGroup: this.assignedToGroup,
+            assignedToUser: this.assignedToUser,
+        };
     }
 }

--- a/packages/components/src/components/domainproperties/models.spec.ts
+++ b/packages/components/src/components/domainproperties/models.spec.ts
@@ -150,6 +150,22 @@ describe('DomainDesign', () => {
         expect(domain.hasInvalidNameField({ name: 'abc' })).toBeTruthy();
         expect(domain.hasInvalidNameField({ name: 'ABC' })).toBeTruthy();
     });
+
+    test('getDomainContainer', () => {
+        const domain = DomainDesign.create({ name: 'Test Container' });
+        expect(domain.getDomainContainer()).toBe(undefined);
+
+        const domain2 = DomainDesign.create({ name: 'Test Container', container: 'SOMETHINGELSE' });
+        expect(domain2.getDomainContainer()).toBe('SOMETHINGELSE');
+    });
+
+    test('isSharedDomain', () => {
+        const domain = DomainDesign.create({ name: 'Test Container' });
+        expect(domain.isSharedDomain()).toBeFalsy();
+
+        const domain2 = DomainDesign.create({ name: 'Test Container', container: 'SOMETHINGELSE' });
+        expect(domain2.isSharedDomain()).toBeTruthy();
+    });
 });
 
 describe('DomainField', () => {

--- a/packages/components/src/components/domainproperties/models.ts
+++ b/packages/components/src/components/domainproperties/models.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { fromJS, List, Map, Record } from 'immutable';
-import { Domain } from '@labkey/api';
+import { Domain, getServerContext } from '@labkey/api';
 
 import { SCHEMAS } from '../base/models/schemas';
 
@@ -463,6 +463,16 @@ export class DomainDesign
         }
 
         return false;
+    }
+
+    getDomainContainer(): string {
+        const currentContainer = getServerContext().container.id;
+        return this.container || currentContainer;
+    }
+
+    isSharedDomain(): boolean {
+        const currentContainer = getServerContext().container.id;
+        return this.getDomainContainer() !== currentContainer;
     }
 }
 


### PR DESCRIPTION
#### Rationale
During the automated test conversion for the issues list def designer, a few tests failed because they were trying to save an issues list def when the fields for the def were coming from a shared domain (i.e. Shared container). This update allows for that scenario by saving just the issues list def options for the given container when the domain is shared. This fixes the RlabkeyTest, FilterTest, and IssueDomainSharingTest failures.

#### Related Pull Requests
* https://github.com/LabKey/assayRequest/pull/27
* https://github.com/LabKey/biologics/pull/588
* https://github.com/LabKey/platform/pull/1184
* https://github.com/LabKey/testAutomation/pull/333

#### Changes
* Add helpers to DomainDesign model to getDomainContainer and isSharedDomain
* Allow for a shared def to be used in another container where only the top level properties can be saved via saveIssueListDefOptions
* Show alert if the current container is using a shared domain with link to get to source container
