### PR TITLE
Item 7333 - List designer issue fix targeting release20.3

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.4",
+  "version": "0.31.4-20.3-fb-Issue40373.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.31.4-20.3-fb-Issue40373.1",
+  "version": "0.31.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TO ADD
+*Released*: TBD
+Fix for List Designer issues targeting LabKey release 20.3
+    - Issue 40373: List designer fails to save any changes after the list's name has been edited
+
 ### version 0.31.4
 *Released*: 6 March 2020
 * Fixes for List Designer issues targeting LabKey release 20.3

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,9 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TO ADD
-*Released*: TBD
-Fix for List Designer issues targeting LabKey release 20.3
+### version 0.31.5
+*Released*: 20 May 2020
+Fix for List Designer issues targeting LK release 20.3
     - Issue 40373: List designer fails to save any changes after the list's name has been edited
 
 ### version 0.31.4

--- a/packages/components/src/components/domainproperties/list/models.ts
+++ b/packages/components/src/components/domainproperties/list/models.ts
@@ -140,9 +140,9 @@ export class ListModel extends Record({
 
         // Note: keyName is primarily set using <SetKeyFieldNamePanel/>'s onSelectionChange()
         // Setting keyName here covers the use-case where a user sets a Key Field, and then changes its name
-        const keyFieldName = (this.domain.fields).find((field) => (field.isPrimaryKey)).name;
-        if (this.keyName !== keyFieldName) {
-            options.keyName = keyFieldName;
+        const keyField = (this.domain.fields).find((field) => (field.isPrimaryKey));
+        if (keyField && this.keyName !== keyField.name) {
+            options.keyName = keyField.name;
         }
 
         delete options.exception;


### PR DESCRIPTION
#### Rationale
Hot fix for @labkey/components targeting release20.3
- Issue 40373: List designer fails to save any changes after the list's name has been edited

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1198

#### Changes
- Update how key name is found and set when retrieving List options.