### PR TITLE
PageDetailHeader no longer requires user

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+## version 0.64.2
+*Released*: 1 June 2020
+* `<PageDetailHeader/>` no longer requires `user` prop. Remove unused `content` prop.
+
 ## version 0.64.1
 *Released*: 1 June 2020
 * Issue 40026: Change doc link from Advanced List Settings popup - Update text and topic for Advance Settings help link

--- a/packages/components/src/components/forms/PageDetailHeader.tsx
+++ b/packages/components/src/components/forms/PageDetailHeader.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { PureComponent, ReactNode } from 'react';
 
 import { hasAllPermissions } from '../../util/utils';
 import { User } from '../base/models/model';
@@ -23,29 +23,29 @@ import { SVGIcon } from '../base/SVGIcon';
 import { FieldEditTrigger, FieldEditTriggerProps } from './FieldEditTrigger';
 
 interface Props {
-    user: User;
-    content?: any[];
-    description?: React.ReactNode;
+    description?: ReactNode;
     fieldTriggerProps?: FieldEditTriggerProps;
     iconAltText?: string;
     iconDir?: string;
     iconSrc?: string;
     iconUrl?: string;
     leftColumns?: number;
-    subTitle?: any;
-    title: any;
+    subTitle?: ReactNode;
+    title: ReactNode;
+    user?: User;
 }
 
-export class PageDetailHeader extends React.Component<Props, any> {
+export class PageDetailHeader extends PureComponent<Props> {
     static defaultProps = {
         leftColumns: 6,
     };
 
-    render() {
+    render(): ReactNode {
         const {
             children,
             description,
             fieldTriggerProps,
+            iconAltText,
             iconUrl,
             iconDir,
             iconSrc,
@@ -53,8 +53,11 @@ export class PageDetailHeader extends React.Component<Props, any> {
             subTitle,
             title,
             user,
-            iconAltText,
         } = this.props;
+
+        if (fieldTriggerProps && !user) {
+            throw Error('PageDetailHeader: If supplying "fieldTriggerProps", then "user" prop must be specified.');
+        }
 
         return (
             <div className="page-header">
@@ -85,9 +88,7 @@ export class PageDetailHeader extends React.Component<Props, any> {
                         </div>
                     )}
                 </div>
-
                 {children && <div className="pull-right">{children}</div>}
-
                 <div className="clearfix" />
             </div>
         );


### PR DESCRIPTION
#### Rationale
`PageDetailHeader` requires the user if a `FieldEditTrigger` is available. This PR makes it explicitly optional to include a user when `fieldTriggerProps` not supplied.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/597

#### Changes
* Make `user` prop optional.
* Remove unused `content` prop.
