### PR TITLE
Issue 40026: Change doc link from Advanced List Settings popup

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.0-fb-Issue40026-docLink.1",
+  "version": "0.64.0-fb-Issue40026-docLink.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.0-fb-Issue40026-docLink",
+  "version": "0.64.0-fb-Issue40026-docLink.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.0-fb-Issue40026-docLink.2",
+  "version": "0.64.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.0",
+  "version": "0.64.0-fb-Issue40026-docLink",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-## version TBD
-*Released*: TBD
+## version 0.64.1
+*Released*: 1 June 2020
 * Issue 40026: Change doc link from Advanced List Settings popup - Update text and topic for Advance Settings help link
 
 ## version 0.64.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+## version TBD
+*Released*: TBD
+* Issue 40026: Change doc link from Advanced List Settings popup - Update text and topic for Advance Settings help link
+
 ## version 0.64.0
 *Released*: 29 May 2020
 * Merge AssayReimportRunButton from Biologics and SampleManager and move here for common use

--- a/packages/components/src/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
+++ b/packages/components/src/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
@@ -635,9 +635,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                                 className="domain-adv-footer domain-adv-cancel-btn"
                             >
                                 Cancel
-                            </Button>https://www.labkey.org/Documentation/20.3/wiki-page.view?name=createListOptions#advanced
+                            </Button>
 
-                            {helpLinkNode('lists', 'Get help with list settings', 'domain-adv-footer domain-adv-link')}
+                            {helpLinkNode('createListOptions#advanced', 'Get help with list settings', 'domain-adv-footer domain-adv-link')}
 
                             <Button
                                 onClick={this.applyChanges}

--- a/packages/components/src/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
+++ b/packages/components/src/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
@@ -635,9 +635,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                                 className="domain-adv-footer domain-adv-cancel-btn"
                             >
                                 Cancel
-                            </Button>
+                            </Button>https://www.labkey.org/Documentation/20.3/wiki-page.view?name=createListOptions#advanced
 
-                            {helpLinkNode('lists', 'Learn more about using lists', 'domain-adv-footer domain-adv-link')}
+                            {helpLinkNode('lists', 'Get help with list settings', 'domain-adv-footer domain-adv-link')}
 
                             <Button
                                 onClick={this.applyChanges}


### PR DESCRIPTION
#### Rationale
Help link under Advanced Settings takes user to List create doc instead of advanced setting section.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1245

#### Changes
Update text and topic for Advance Settings help link.