### PR TITLE
Item 7373: Move base user permission check helpers from Sample Manager to User model

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.0-fb-appRoutesAndPagesSetup.0",
+  "version": "0.64.0-fb-appRoutesAndPagesSetup.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.64.0",
+  "version": "0.64.0-fb-appRoutesAndPagesSetup.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ## version TBD
 *Released*: TBD
 * Item 7373: Move base user permission check helpers from Sample Manager to User model
+* Fix for NavigationBar.tsx to not show the search icon in the narrow window case when showSearchBox is false
 
 ## version 0.64.0
 *Released*: 29 May 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-## version TBD
-*Released*: TBD
+## version 0.64.3
+*Released*: 2 June 2020
 * Item 7373: Move base user permission check helpers from Sample Manager to User model
 * Fix for NavigationBar.tsx to not show the search icon in the narrow window case when showSearchBox is false
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+## version TBD
+*Released*: TBD
+* Item 7373: Move base user permission check helpers from Sample Manager to User model
+
 ## version 0.64.0
 *Released*: 29 May 2020
 * Merge AssayReimportRunButton from Biologics and SampleManager and move here for common use

--- a/packages/components/src/components/base/models/model.spec.ts
+++ b/packages/components/src/components/base/models/model.spec.ts
@@ -21,9 +21,10 @@ import sampleSetQueryInfo from '../../../test/data/sampleSet-getQueryDetails.jso
 import nameExpSetQueryColumn from '../../../test/data/NameExprParent-QueryColumn.json';
 import sampleSet3QueryColumn from '../../../test/data/SampleSet3Parent-QueryColumn.json';
 
+import { GUEST, READER, AUTHOR, EDITOR, ASSAYDESIGNER, FOLDER_ADMIN, APP_ADMIN } from '../../../test/data/users';
+
 import { AssayDefinitionModel, AssayDomainTypes, QueryColumn, QueryGridModel, SchemaQuery } from './model';
 import { QueryInfo } from './QueryInfo';
-import { GUEST, READER, AUTHOR, EDITOR, ASSAYDESIGNER, FOLDER_ADMIN, APP_ADMIN } from "../../../test/data/users";
 
 describe('QueryGridModel', () => {
     test('createParam no prefix', () => {
@@ -451,7 +452,6 @@ describe('Sample Lookup', () => {
 });
 
 describe('User permissions', () => {
-
     test('hasInsertPermission', () => {
         expect(GUEST.hasInsertPermission()).toBeFalsy();
         expect(READER.hasInsertPermission()).toBeFalsy();

--- a/packages/components/src/components/base/models/model.spec.ts
+++ b/packages/components/src/components/base/models/model.spec.ts
@@ -23,6 +23,7 @@ import sampleSet3QueryColumn from '../../../test/data/SampleSet3Parent-QueryColu
 
 import { AssayDefinitionModel, AssayDomainTypes, QueryColumn, QueryGridModel, SchemaQuery } from './model';
 import { QueryInfo } from './QueryInfo';
+import { GUEST, READER, AUTHOR, EDITOR, ASSAYDESIGNER, FOLDER_ADMIN, APP_ADMIN } from "../../../test/data/users";
 
 describe('QueryGridModel', () => {
     test('createParam no prefix', () => {
@@ -446,5 +447,78 @@ describe('Sample Lookup', () => {
 
     test('test lookup with different casing for query, schema and table names', () => {
         expect(materialSamplesWithAllCapsColumn.isSampleLookup()).toBe(true);
+    });
+});
+
+describe('User permissions', () => {
+
+    test('hasInsertPermission', () => {
+        expect(GUEST.hasInsertPermission()).toBeFalsy();
+        expect(READER.hasInsertPermission()).toBeFalsy();
+        expect(AUTHOR.hasInsertPermission()).toBeTruthy();
+        expect(EDITOR.hasInsertPermission()).toBeTruthy();
+        expect(ASSAYDESIGNER.hasInsertPermission()).toBeFalsy();
+        expect(FOLDER_ADMIN.hasInsertPermission()).toBeTruthy();
+        expect(APP_ADMIN.hasInsertPermission()).toBeTruthy();
+    });
+
+    test('hasUpdatePermission', () => {
+        expect(GUEST.hasUpdatePermission()).toBeFalsy();
+        expect(READER.hasUpdatePermission()).toBeFalsy();
+        expect(AUTHOR.hasUpdatePermission()).toBeFalsy();
+        expect(EDITOR.hasUpdatePermission()).toBeTruthy();
+        expect(ASSAYDESIGNER.hasUpdatePermission()).toBeFalsy();
+        expect(FOLDER_ADMIN.hasUpdatePermission()).toBeTruthy();
+        expect(APP_ADMIN.hasUpdatePermission()).toBeTruthy();
+    });
+
+    test('hasDeletePermission', () => {
+        expect(GUEST.hasDeletePermission()).toBeFalsy();
+        expect(READER.hasDeletePermission()).toBeFalsy();
+        expect(AUTHOR.hasDeletePermission()).toBeFalsy();
+        expect(EDITOR.hasDeletePermission()).toBeTruthy();
+        expect(ASSAYDESIGNER.hasDeletePermission()).toBeFalsy();
+        expect(FOLDER_ADMIN.hasDeletePermission()).toBeTruthy();
+        expect(APP_ADMIN.hasDeletePermission()).toBeTruthy();
+    });
+
+    test('hasDesignAssaysPermission', () => {
+        expect(GUEST.hasDesignAssaysPermission()).toBeFalsy();
+        expect(READER.hasDesignAssaysPermission()).toBeFalsy();
+        expect(AUTHOR.hasDesignAssaysPermission()).toBeFalsy();
+        expect(EDITOR.hasDesignAssaysPermission()).toBeFalsy();
+        expect(ASSAYDESIGNER.hasDesignAssaysPermission()).toBeTruthy();
+        expect(FOLDER_ADMIN.hasDesignAssaysPermission()).toBeTruthy();
+        expect(APP_ADMIN.hasDesignAssaysPermission()).toBeTruthy();
+    });
+
+    test('hasDesignSampleSetsPermission', () => {
+        expect(GUEST.hasDesignSampleSetsPermission()).toBeFalsy();
+        expect(READER.hasDesignSampleSetsPermission()).toBeFalsy();
+        expect(AUTHOR.hasDesignSampleSetsPermission()).toBeFalsy();
+        expect(EDITOR.hasDesignSampleSetsPermission()).toBeFalsy();
+        expect(ASSAYDESIGNER.hasDesignSampleSetsPermission()).toBeFalsy();
+        expect(FOLDER_ADMIN.hasDesignSampleSetsPermission()).toBeTruthy();
+        expect(APP_ADMIN.hasDesignSampleSetsPermission()).toBeTruthy();
+    });
+
+    test('hasManageUsersPermission', () => {
+        expect(GUEST.hasManageUsersPermission()).toBeFalsy();
+        expect(READER.hasManageUsersPermission()).toBeFalsy();
+        expect(AUTHOR.hasManageUsersPermission()).toBeFalsy();
+        expect(EDITOR.hasManageUsersPermission()).toBeFalsy();
+        expect(ASSAYDESIGNER.hasManageUsersPermission()).toBeFalsy();
+        expect(FOLDER_ADMIN.hasManageUsersPermission()).toBeFalsy();
+        expect(APP_ADMIN.hasManageUsersPermission()).toBeTruthy();
+    });
+
+    test('isAppAdmin', () => {
+        expect(GUEST.isAppAdmin()).toBeFalsy();
+        expect(READER.isAppAdmin()).toBeFalsy();
+        expect(AUTHOR.isAppAdmin()).toBeFalsy();
+        expect(EDITOR.isAppAdmin()).toBeFalsy();
+        expect(ASSAYDESIGNER.isAppAdmin()).toBeFalsy();
+        expect(FOLDER_ADMIN.isAppAdmin()).toBeFalsy();
+        expect(APP_ADMIN.isAppAdmin()).toBeTruthy();
     });
 });

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -16,11 +16,18 @@
 import { fromJS, List, Map, OrderedMap, OrderedSet, Record } from 'immutable';
 import { ActionURL, Filter, Query, Utils } from '@labkey/api';
 
-import { getSchemaQuery, intersect, resolveKey, resolveSchemaQuery, toLowerSafe } from '../../../util/utils';
+import {
+    getSchemaQuery,
+    hasAllPermissions,
+    intersect,
+    resolveKey,
+    resolveSchemaQuery,
+    toLowerSafe
+} from '../../../util/utils';
 import { AppURL } from '../../../url/AppURL';
 import { WHERE_FILTER_TYPE } from '../../../url/WhereFilterType';
 
-import { GRID_CHECKBOX_OPTIONS, GRID_EDIT_INDEX, GRID_SELECTION_INDEX } from './constants';
+import { GRID_CHECKBOX_OPTIONS, GRID_EDIT_INDEX, GRID_SELECTION_INDEX, PermissionTypes } from './constants';
 import { QueryInfo } from './QueryInfo';
 import { QuerySort } from './QuerySort';
 
@@ -150,6 +157,34 @@ export class User extends Record(defaultUser) implements IUserProps {
 
     constructor(values?: { [key: string]: any }) {
         super(values);
+    }
+
+    hasUpdatePermission(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.Update]);
+    }
+
+    hasInsertPermission(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.Insert]);
+    }
+
+    hasDeletePermission(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.Delete]);
+    }
+
+    hasDesignAssaysPermission(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.DesignAssay]);
+    }
+
+    hasDesignSampleSetsPermission(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.DesignSampleSet]);
+    }
+
+    hasManageUsersPermission(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.UserManagement], false);
+    }
+
+    isAppAdmin(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.ApplicationAdmin], false);
     }
 }
 

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -22,7 +22,7 @@ import {
     intersect,
     resolveKey,
     resolveSchemaQuery,
-    toLowerSafe
+    toLowerSafe,
 } from '../../../util/utils';
 import { AppURL } from '../../../url/AppURL';
 import { WHERE_FILTER_TYPE } from '../../../url/WhereFilterType';

--- a/packages/components/src/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/components/navigation/NavigationBar.tsx
@@ -81,7 +81,9 @@ export class NavigationBar extends React.Component<NavigationBarProps, any> {
                             <div className="navbar-item pull-right">{userMenu}</div>
                             <div className="navbar-item pull-right hidden-xs">{searchBox}</div>
                             <div className="navbar-item pull-right visible-xs">
-                                {showSearchBox && <i className="fa fa-search navbar__xs-search-icon" onClick={() => onSearch('')} />}
+                                {showSearchBox && (
+                                    <i className="fa fa-search navbar__xs-search-icon" onClick={() => onSearch('')} />
+                                )}
                             </div>
                         </div>
                     </div>

--- a/packages/components/src/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/components/navigation/NavigationBar.tsx
@@ -81,7 +81,7 @@ export class NavigationBar extends React.Component<NavigationBarProps, any> {
                             <div className="navbar-item pull-right">{userMenu}</div>
                             <div className="navbar-item pull-right hidden-xs">{searchBox}</div>
                             <div className="navbar-item pull-right visible-xs">
-                                <i className="fa fa-search navbar__xs-search-icon" onClick={() => onSearch('')} />
+                                {showSearchBox && <i className="fa fa-search navbar__xs-search-icon" onClick={() => onSearch('')} />}
                             </div>
                         </div>
                     </div>

--- a/packages/components/src/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
+++ b/packages/components/src/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
@@ -31,12 +31,7 @@ exports[`<NavigationBar/> default props 1`] = `
         />
         <div
           className="navbar-item pull-right visible-xs"
-        >
-          <i
-            className="fa fa-search navbar__xs-search-icon"
-            onClick={[Function]}
-          />
-        </div>
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### Rationale
As part of the freezer manager app foundations work, there were some user permissions check helper functions in the SM module that, if moved to the User model, would be easier to re-use / share.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/282
* https://github.com/LabKey/inventory/pull/33

#### Changes
* Move base user permission check helpers from Sample Manager to User model
* Move related jest tests for User permission check functions to ui-components
