### PR TITLE
39206: Remove filters against selected column in OmniBox

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.1",
+  "version": "0.69.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.69.2
+*Released*: 10 June 2020
+* Issue 39206: OmniBox should not restrict results with filters against target column
+
 ### version 0.69.1
 *Released*: 10 June 2020
 * Issue 39468: QueryGridPanel button bar / paging component layout fixes for narrow windows

--- a/packages/components/src/components/omnibox/OmniBox.tsx
+++ b/packages/components/src/components/omnibox/OmniBox.tsx
@@ -373,8 +373,22 @@ export class OmniBox extends React.Component<OmniBoxProps, OmniBoxState> {
 
         this.setState({ distinctValuesLoading: true, distinctValuesFieldKey: fieldKey });
 
+        const options = getSelectDistinctOptions(fieldKey);
+
+        // 39206: Remove filters on the specified fieldKey so that the distinct results are not overly
+        // restricted by previous filtering.
+        if (options.filterArray?.length > 0) {
+            const lowerFieldKey = fieldKey.toLowerCase();
+            options.filterArray = options.filterArray.reduce((filterArray, filter) => {
+                if (filter.getColumnName().toLowerCase() !== lowerFieldKey) {
+                    filterArray.push(filter);
+                }
+                return filterArray;
+            }, []);
+        }
+
         Query.selectDistinctRows({
-            ...getSelectDistinctOptions(fieldKey),
+            ...options,
             success: result => {
                 if (!this.state.activeAction) {
                     // The user closed the action menu, do nothing.

--- a/packages/components/src/components/omnibox/OmniBox.tsx
+++ b/packages/components/src/components/omnibox/OmniBox.tsx
@@ -202,7 +202,7 @@ export class OmniBox extends React.Component<OmniBoxProps, OmniBoxState> {
 
     componentWillReceiveProps(nextProps: OmniBoxProps) {
         this.setState({
-            actionValues: nextProps.values ? [ ...nextProps.values ] : [],
+            actionValues: nextProps.values ? [...nextProps.values] : [],
         });
     }
 
@@ -259,7 +259,7 @@ export class OmniBox extends React.Component<OmniBoxProps, OmniBoxState> {
         let actionValue: ActionValue;
 
         if (value && action) {
-            let newActionValues = [ ...actionValues ];
+            let newActionValues = [...actionValues];
             const newInputValue = OmniBox.stripKeyword(value, action).trim();
             const tokenize = this.resolveTokenizer(action);
 
@@ -325,10 +325,7 @@ export class OmniBox extends React.Component<OmniBoxProps, OmniBoxState> {
 
                 if (changeType !== ChangeType.none) {
                     // Only fire the change handler if the user changed the omnibox values.
-                    this.fireOnChange(
-                        newActionValues,
-                        { type: changeType, index: activeValueIndex }
-                    );
+                    this.fireOnChange(newActionValues, { type: changeType, index: activeValueIndex });
                 }
 
                 if (!this.props.closeOnComplete) {
@@ -658,10 +655,7 @@ export class OmniBox extends React.Component<OmniBoxProps, OmniBoxState> {
         });
 
         if (requireOnChange) {
-            this.fireOnChange(
-                this.state.actionValues,
-                { type: ChangeType.remove, index: activeValueIndex }
-            );
+            this.fireOnChange(this.state.actionValues, { type: ChangeType.remove, index: activeValueIndex });
         }
 
         this.fetchOptions(matches.matchingActions, newInputValue);
@@ -818,10 +812,7 @@ export class OmniBox extends React.Component<OmniBoxProps, OmniBoxState> {
                 actionValues: newActionValues,
             });
 
-            this.fireOnChange(
-                newActionValues,
-                { type: ChangeType.remove, index: actionValueIndex }
-            );
+            this.fireOnChange(newActionValues, { type: ChangeType.remove, index: actionValueIndex });
         }
     };
 

--- a/packages/components/src/components/omnibox/OmniBox.tsx
+++ b/packages/components/src/components/omnibox/OmniBox.tsx
@@ -379,12 +379,9 @@ export class OmniBox extends React.Component<OmniBoxProps, OmniBoxState> {
         // restricted by previous filtering.
         if (options.filterArray?.length > 0) {
             const lowerFieldKey = fieldKey.toLowerCase();
-            options.filterArray = options.filterArray.reduce((filterArray, filter) => {
-                if (filter.getColumnName().toLowerCase() !== lowerFieldKey) {
-                    filterArray.push(filter);
-                }
-                return filterArray;
-            }, []);
+            options.filterArray = options.filterArray.filter(
+                filter => filter.getColumnName().toLowerCase() !== lowerFieldKey
+            );
         }
 
         Query.selectDistinctRows({


### PR DESCRIPTION
#### Rationale
This PR fixes [Issue 39206](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39206) by removing filters against the selected column prior to making the `Query.selectDistinctRows` call to fetch results for that column. As a result, when a user activates a previously defined OmniBox filter they will get the same behavior as composing a new one.

#### Changes
* Strip filters against the selected column from the `Query.selectDistinctRows` options in `OmniBox`.
