### PR TITLE
Fb fm freezer delete

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.2",
+  "version": "0.69.3-fb-fmFreezerDelete.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.3-fb-fmFreezerDelete.0",
+  "version": "0.69.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Expose QueryConfig type
+
 ### version 0.69.2
 *Released*: 10 June 2020
 * Issue 39206: OmniBox should not restrict results with filters against target column

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.69.3
+*Released*: 11 June 2020
 * Expose QueryConfig type
 
 ### version 0.69.2

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -338,7 +338,7 @@ import { SampleTypeDataType, DataClassDataType } from './components/entities/con
 import { SampleTypeModel } from './components/domainproperties/samples/models';
 import { SampleTypeDesigner } from './components/domainproperties/samples/SampleTypeDesigner';
 
-import { QueryModel } from './QueryModel/QueryModel';
+import { QueryConfig, QueryModel } from './QueryModel/QueryModel';
 import { QueryModelLoader } from './QueryModel/QueryModelLoader';
 import {
     withQueryModels,
@@ -743,6 +743,7 @@ export {
     IGridResponse,
     // QueryModel
     QueryModel,
+    QueryConfig,
     QueryConfigMap,
     QueryModelMap,
     QueryModelLoader,


### PR DESCRIPTION
#### Rationale
The addModel method from withQueryModels expects the QueryConfig type, so this exposes that type

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/273

#### Changes
* Add QueryConfig type to index.ts
