### PR TITLE
Item 7417: QueryModel - add getRow() helper for getting first row of QueryModel.rows object

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.3-fb-fmFreezerCreation.1",
+  "version": "0.69.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.3-fb-fmFreezerCreation.0",
+  "version": "0.69.3-fb-fmFreezerCreation.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.3",
+  "version": "0.69.3-fb-fmFreezerCreation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 7417: QueryModel - add getRow() helper for getting first row of QueryModel.rows object
+
 ### version 0.69.3
 *Released*: 11 June 2020
 * Expose QueryConfig type

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.69.4
+*Released*: 15 June 2020
 * Item 7417: QueryModel - add getRow() helper for getting first row of QueryModel.rows object
 
 ### version 0.69.3

--- a/packages/components/src/QueryModel/QueryModel.spec.ts
+++ b/packages/components/src/QueryModel/QueryModel.spec.ts
@@ -103,8 +103,8 @@ describe('QueryModel', () => {
             rows: ROWS,
         });
         expect(model.getRow().RowId.value).toBe(0);
-        expect(model.getRow("0").RowId.value).toBe(0);
-        expect(model.getRow("1").RowId.value).toBe(1);
+        expect(model.getRow('0').RowId.value).toBe(0);
+        expect(model.getRow('1').RowId.value).toBe(1);
     });
 
     test('Sorts', () => {

--- a/packages/components/src/QueryModel/QueryModel.spec.ts
+++ b/packages/components/src/QueryModel/QueryModel.spec.ts
@@ -97,6 +97,16 @@ describe('QueryModel', () => {
         expect(model.hasData).toEqual(true);
     });
 
+    test('Data getRow', () => {
+        const model = new QueryModel({ schemaQuery: SCHEMA_QUERY }).mutate({
+            orderedRows: ORDERED_ROWS,
+            rows: ROWS,
+        });
+        expect(model.getRow().RowId.value).toBe(0);
+        expect(model.getRow("0").RowId.value).toBe(0);
+        expect(model.getRow("1").RowId.value).toBe(1);
+    });
+
     test('Sorts', () => {
         const sorts = [new QuerySort({ fieldKey: 'RowId', dir: '-' }), new QuerySort({ fieldKey: 'Data', dir: '+' })];
         let model = new QueryModel({ schemaQuery: SCHEMA_QUERY, sorts });

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -283,7 +283,11 @@ export class QueryModel {
      * @param key
      */
     getRow(key?: string): any {
-        if (key === undefined && this.rows) {
+        if (!this.rows) {
+            return undefined;
+        }
+
+        if (key === undefined) {
             key = Object.keys(this.rows)[0];
         }
 

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -1,4 +1,4 @@
-import { List, Map } from 'immutable';
+import { List } from 'immutable';
 import { Draft, immerable, produce } from 'immer';
 import { Filter, Query } from '@labkey/api';
 

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -277,6 +277,11 @@ export class QueryModel {
         });
     }
 
+    /**
+     * Returns the data for the specified key parameter on the QueryModel.rows object.
+     * If no key parameter is provided, the first data row will be returned.
+     * @param key
+     */
     getRow(key?: string): any {
         if (key === undefined && this.rows) {
             key = Object.keys(this.rows)[0];

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -1,4 +1,4 @@
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 import { Draft, immerable, produce } from 'immer';
 import { Filter, Query } from '@labkey/api';
 
@@ -275,6 +275,14 @@ export class QueryModel {
 
             return row;
         });
+    }
+
+    getRow(key?: string): any {
+        if (key === undefined && this.rows) {
+            key = Object.keys(this.rows)[0];
+        }
+
+        return this.rows[key];
     }
 
     get pageCount(): number {


### PR DESCRIPTION
#### Rationale
The QueryGridModel object has a getRow helper which allows access to a row of data in the model by key, or access to the first row if no key is provided. This helper is useful for the "single model row details" type of usage. This PR adds a similar getRow helper to the QueryModel object

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/38

#### Changes
* add getRow() helper for getting first row of QueryModel.rows object
