### PR TITLE
Fix Issue 39947 - ﻿Omnibox doesn't show sorts when URLPrefix is used 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.4",
+  "version": "0.69.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 0.69.??
 *Released*: ?? June 2020
-* Issue 39947 - Omnibox doesn't show sorts when URLPrefix is used
+* Issue 39947 - Omnibox doesn't show sorts or views when URLPrefix is used
 
 ### version 0.69.4
 *Released*: 15 June 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.69.??
-*Released*: ?? June 2020
+### version 0.69.5
+*Released*: 15 June 2020
 * Issue 39947 - Omnibox doesn't show sorts or views when URLPrefix is used
 
 ### version 0.69.4

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.69.??
+*Released*: ?? June 2020
+* Issue 39947 - Omnibox doesn't show sorts when URLPrefix is used
+
 ### version 0.69.4
 *Released*: 15 June 2020
 * Item 7417: QueryModel - add getRow() helper for getting first row of QueryModel.rows object

--- a/packages/components/src/components/omnibox/actions/Search.ts
+++ b/packages/components/src/components/omnibox/actions/Search.ts
@@ -76,7 +76,7 @@ export class SearchAction implements Action {
     }
 
     matchParam(paramKey: string, paramValue: any): boolean {
-        return paramKey && paramKey.toLowerCase() === this.param.toLowerCase();
+        return paramKey && paramKey === this.param;
     }
 
     parseParam(paramKey: string, paramValue: any, columns: List<QueryColumn>): string[] | Value[] {

--- a/packages/components/src/components/omnibox/actions/Sort.ts
+++ b/packages/components/src/components/omnibox/actions/Sort.ts
@@ -154,7 +154,7 @@ export class SortAction implements Action {
     }
 
     matchParam(paramKey: string, paramValue: any): boolean {
-        return paramKey && paramKey.toLowerCase() === this.param;
+        return paramKey && paramKey === this.param;
     }
 
     parseParam(paramKey: string, paramValue: any, columns: List<QueryColumn>): string[] | Value[] {

--- a/packages/components/src/components/omnibox/actions/View.ts
+++ b/packages/components/src/components/omnibox/actions/View.ts
@@ -33,7 +33,10 @@ export class ViewAction implements Action {
 
     constructor(urlPrefix: string, getColumns: () => List<QueryColumn>, getQueryInfo: () => QueryInfo) {
         this.getQueryInfo = getQueryInfo;
-        this.urlPrefix = urlPrefix;
+
+        if (urlPrefix) {
+            this.param = [urlPrefix, this.param].join('.');
+        }
     }
 
     completeAction(tokens: string[]): Promise<Value> {
@@ -48,7 +51,7 @@ export class ViewAction implements Action {
                     found = true;
                     resolve({
                         isValid: true,
-                        param: this.getParamPrefix() + '=' + view.name,
+                        param: this.param + '=' + view.name,
                         value: view.name,
                     });
                 });
@@ -97,14 +100,6 @@ export class ViewAction implements Action {
         });
     }
 
-    getParamPrefix(): string {
-        if (this.urlPrefix) {
-            return [this.urlPrefix, this.param].join('.');
-        }
-
-        return this.param;
-    }
-
     buildParams(actionValues: ActionValue[]): Array<{ paramKey: string; paramValue: string }> {
         return actionValues.map(actionValue => {
             const [paramKey, paramValue] = actionValue.param.split('=');
@@ -117,7 +112,7 @@ export class ViewAction implements Action {
     }
 
     matchParam(paramKey: string, paramValue: any): boolean {
-        return paramKey && paramKey.toLowerCase() === this.param;
+        return paramKey && paramKey === this.param;
     }
 
     parseParam(paramKey: string, paramValue: any, columns: List<QueryColumn>): string[] | Value[] {


### PR DESCRIPTION
#### Rationale
The Omnibox doesn't show sorts when URLPrefix is used, Biologics uses the URL prefix often, specifically on the assay pages. Not seeing or being able to clear sorts from the URL is a usability problem.

#### Related Pull Requests
* n/a

#### Changes
* Don't toLowerCase compare the paramKey in Sort.matchParam
