### PR TITLE
Item 7417: BasePropertiesPanel - add to index.ts for use in Freezer Manager app

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.4",
+  "version": "0.69.4-fb-fmFreezerCreation2.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.5",
+  "version": "0.69.5-fb-fmFreezerCreation2.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.5-fb-fmFreezerCreation2.1",
+  "version": "0.70.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.5-fb-fmFreezerCreation2.0",
+  "version": "0.69.5-fb-fmFreezerCreation2.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -4,6 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Item 7417: BasePropertiesPanel - add to index.ts for use in Freezer Manager app
+* QueryInfo - add getColumnFieldKeys helper method to get fieldKeys for select columns
+* QueryModel - add parameter to getRow method to allow for a flattened key/value pair response object
 
 ### version 0.69.5
 *Released*: 15 June 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.70.0
+*Released*: 19 June 2020
 * Item 7417: BasePropertiesPanel - add to index.ts for use in Freezer Manager app
 * QueryInfo - add getColumnFieldKeys helper method to get fieldKeys for select columns
 * QueryModel - add parameter to getRow method to allow for a flattened key/value pair response object

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 7417: BasePropertiesPanel - add to index.ts for use in Freezer Manager app
+
 ### version 0.69.4
 *Released*: 15 June 2020
 * Item 7417: QueryModel - add getRow() helper for getting first row of QueryModel.rows object

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -14,7 +14,8 @@ import {
     ViewInfo,
 } from '..';
 import { GRID_SELECTION_INDEX } from '../components/base/models/constants';
-import { flattenValuesFromRow } from "./utils";
+
+import { flattenValuesFromRow } from './utils';
 
 /**
  * Creates a QueryModel ID for a given SchemaQuery. The id is just the SchemaQuery snake-cased as

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -14,6 +14,7 @@ import {
     ViewInfo,
 } from '..';
 import { GRID_SELECTION_INDEX } from '../components/base/models/constants';
+import { flattenValuesFromRow } from "./utils";
 
 /**
  * Creates a QueryModel ID for a given SchemaQuery. The id is just the SchemaQuery snake-cased as
@@ -281,8 +282,9 @@ export class QueryModel {
      * Returns the data for the specified key parameter on the QueryModel.rows object.
      * If no key parameter is provided, the first data row will be returned.
      * @param key
+     * @param flattenValues True to flatten the row object to just the key: value pairs
      */
-    getRow(key?: string): any {
+    getRow(key?: string, flattenValues = false): any {
         if (!this.rows) {
             return undefined;
         }
@@ -291,7 +293,8 @@ export class QueryModel {
             key = Object.keys(this.rows)[0];
         }
 
-        return this.rows[key];
+        const row = this.rows[key];
+        return flattenValues ? flattenValuesFromRow(row, this.queryInfo.getColumnFieldKeys()) : row;
     }
 
     get pageCount(): number {

--- a/packages/components/src/QueryModel/utils.spec.ts
+++ b/packages/components/src/QueryModel/utils.spec.ts
@@ -1,0 +1,25 @@
+import { flattenValuesFromRow } from "./utils";
+
+describe("flattenValuesFromRow", () => {
+    test("missing params", () => {
+        expect(JSON.stringify(flattenValuesFromRow(undefined, undefined))).toBe('{}');
+        expect(JSON.stringify(flattenValuesFromRow({test: {value: 123}}, undefined))).toBe('{}');
+        expect(JSON.stringify(flattenValuesFromRow(undefined, ['test']))).toBe('{}');
+    });
+
+    test("with values", () => {
+        const data = {
+            test1: {value: 123, displayValue: 'TEST123'},
+            test2: {value: 456},
+            test3: {value: null},
+            test4: undefined
+        };
+
+
+        expect(flattenValuesFromRow(data, Object.keys(data)).test0).toBe(undefined);
+        expect(flattenValuesFromRow(data, Object.keys(data)).test1).toBe(123);
+        expect(flattenValuesFromRow(data, Object.keys(data)).test2).toBe(456);
+        expect(flattenValuesFromRow(data, Object.keys(data)).test3).toBe(null);
+        expect(flattenValuesFromRow(data, Object.keys(data)).test4).toBe(undefined);
+    });
+});

--- a/packages/components/src/QueryModel/utils.spec.ts
+++ b/packages/components/src/QueryModel/utils.spec.ts
@@ -1,20 +1,19 @@
-import { flattenValuesFromRow } from "./utils";
+import { flattenValuesFromRow } from './utils';
 
-describe("flattenValuesFromRow", () => {
-    test("missing params", () => {
+describe('flattenValuesFromRow', () => {
+    test('missing params', () => {
         expect(JSON.stringify(flattenValuesFromRow(undefined, undefined))).toBe('{}');
-        expect(JSON.stringify(flattenValuesFromRow({test: {value: 123}}, undefined))).toBe('{}');
+        expect(JSON.stringify(flattenValuesFromRow({ test: { value: 123 } }, undefined))).toBe('{}');
         expect(JSON.stringify(flattenValuesFromRow(undefined, ['test']))).toBe('{}');
     });
 
-    test("with values", () => {
+    test('with values', () => {
         const data = {
-            test1: {value: 123, displayValue: 'TEST123'},
-            test2: {value: 456},
-            test3: {value: null},
-            test4: undefined
+            test1: { value: 123, displayValue: 'TEST123' },
+            test2: { value: 456 },
+            test3: { value: null },
+            test4: undefined,
         };
-
 
         expect(flattenValuesFromRow(data, Object.keys(data)).test0).toBe(undefined);
         expect(flattenValuesFromRow(data, Object.keys(data)).test1).toBe(123);

--- a/packages/components/src/QueryModel/utils.ts
+++ b/packages/components/src/QueryModel/utils.ts
@@ -45,3 +45,15 @@ export function sortArraysEqual(a: QuerySort[], b: QuerySort[]): boolean {
         .join(';');
     return aStr === bStr;
 }
+
+export function flattenValuesFromRow(row: any, keys: string[]): {[key:string]: any} {
+    let values = {};
+    if (row && keys) {
+        keys.forEach((key: string) => {
+            if (row[key]) {
+                values[key] = row[key].value;
+            }
+        });
+    }
+    return values;
+}

--- a/packages/components/src/QueryModel/utils.ts
+++ b/packages/components/src/QueryModel/utils.ts
@@ -46,7 +46,7 @@ export function sortArraysEqual(a: QuerySort[], b: QuerySort[]): boolean {
     return aStr === bStr;
 }
 
-export function flattenValuesFromRow(row: any, keys: string[]): {[key:string]: any} {
+export function flattenValuesFromRow(row: any, keys: string[]): { [key: string]: any } {
     let values = {};
     if (row && keys) {
         keys.forEach((key: string) => {

--- a/packages/components/src/components/base/models/QueryInfo.spec.ts
+++ b/packages/components/src/components/base/models/QueryInfo.spec.ts
@@ -15,21 +15,17 @@
  */
 import { QueryInfo } from './QueryInfo';
 
-describe("getColumnFieldKeys", () => {
-    test("missing params", () => {
+describe('getColumnFieldKeys', () => {
+    test('missing params', () => {
         const queryInfo = QueryInfo.create({});
 
         expect(JSON.stringify(queryInfo.getColumnFieldKeys(undefined))).toBe('[]');
         expect(JSON.stringify(queryInfo.getColumnFieldKeys(['test']))).toBe('[]');
     });
 
-    test("queryInfo with columns", () => {
+    test('queryInfo with columns', () => {
         const queryInfo = QueryInfo.fromJSON({
-            columns: [
-                {fieldKey: 'test1'},
-                {fieldKey: 'test2'},
-                {fieldKey: 'test3'},
-            ]
+            columns: [{ fieldKey: 'test1' }, { fieldKey: 'test2' }, { fieldKey: 'test3' }],
         });
 
         expect(JSON.stringify(queryInfo.getColumnFieldKeys(undefined))).toBe('["test1","test2","test3"]');

--- a/packages/components/src/components/base/models/QueryInfo.spec.ts
+++ b/packages/components/src/components/base/models/QueryInfo.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryInfo } from './QueryInfo';
+
+describe("getColumnFieldKeys", () => {
+    test("missing params", () => {
+        const queryInfo = QueryInfo.create({});
+
+        expect(JSON.stringify(queryInfo.getColumnFieldKeys(undefined))).toBe('[]');
+        expect(JSON.stringify(queryInfo.getColumnFieldKeys(['test']))).toBe('[]');
+    });
+
+    test("queryInfo with columns", () => {
+        const queryInfo = QueryInfo.fromJSON({
+            columns: [
+                {fieldKey: 'test1'},
+                {fieldKey: 'test2'},
+                {fieldKey: 'test3'},
+            ]
+        });
+
+        expect(JSON.stringify(queryInfo.getColumnFieldKeys(undefined))).toBe('["test1","test2","test3"]');
+        expect(JSON.stringify(queryInfo.getColumnFieldKeys(['test0']))).toBe('[]');
+        expect(JSON.stringify(queryInfo.getColumnFieldKeys(['test1']))).toBe('["test1"]');
+        expect(JSON.stringify(queryInfo.getColumnFieldKeys(['test1', 'test2']))).toBe('["test1","test2"]');
+        expect(JSON.stringify(queryInfo.getColumnFieldKeys(['test1', 'test2', 'test4']))).toBe('["test1","test2"]');
+    });
+});

--- a/packages/components/src/components/base/models/QueryInfo.ts
+++ b/packages/components/src/components/base/models/QueryInfo.ts
@@ -5,14 +5,7 @@ import { Filter } from '@labkey/api';
 
 import { toLowerSafe } from '../../../util/utils';
 
-import {
-    insertColumnFilter,
-    LastActionStatus,
-    QueryColumn,
-    QueryInfoStatus,
-    SchemaQuery,
-    ViewInfo,
-} from './model';
+import { insertColumnFilter, LastActionStatus, QueryColumn, QueryInfoStatus, SchemaQuery, ViewInfo } from './model';
 import { QuerySort } from './QuerySort';
 
 export class QueryInfo extends Record({
@@ -352,7 +345,7 @@ export class QueryInfo extends Record({
         if (this.columns) {
             return this.columns
                 .filter((col, key) => !keys || keys.indexOf(key) > -1)
-                .map((col) => col.fieldKey)
+                .map(col => col.fieldKey)
                 .toArray();
         }
 

--- a/packages/components/src/components/base/models/QueryInfo.ts
+++ b/packages/components/src/components/base/models/QueryInfo.ts
@@ -342,4 +342,20 @@ export class QueryInfo extends Record({
     getIconURL(): string {
         return this.iconURL;
     }
+
+    /**
+     * Get an array of fieldKeys for the column keys provided.
+     * Default to getting all column fieldKeys if no parameter provided
+     * @param keys The column keys to filter by
+     */
+    getColumnFieldKeys(keys?: string[]): string[] {
+        if (this.columns) {
+            return this.columns
+                .filter((col, key) => !keys || keys.indexOf(key) > -1)
+                .map((col) => col.fieldKey)
+                .toArray();
+        }
+
+        return [];
+    }
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -612,7 +612,7 @@ export {
     IFieldChange,
     IBannerMessage, // TODO remove usages of this in platform and remove from export list here
     IAppDomainHeader,
-    BasePropertiesPanel, // TODO this should probably be renamed as it can be used for non "properties" panels
+    BasePropertiesPanel,
     AssayPropertiesPanel,
     AssayDesignerPanels,
     saveAssayDesign,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -304,6 +304,7 @@ import {
     SAMPLE_TYPE,
 } from './components/domainproperties/models';
 import DomainForm from './components/domainproperties/DomainForm';
+import { BasePropertiesPanel } from './components/domainproperties/BasePropertiesPanel';
 import { DomainFieldsDisplay } from './components/domainproperties/DomainFieldsDisplay';
 import { fetchProtocol, saveAssayDesign } from './components/domainproperties/assay/actions';
 import { AssayProtocolModel } from './components/domainproperties/assay/models';
@@ -611,6 +612,7 @@ export {
     IFieldChange,
     IBannerMessage, // TODO remove usages of this in platform and remove from export list here
     IAppDomainHeader,
+    BasePropertiesPanel, // TODO this should probably be renamed as it can be used for non "properties" panels
     AssayPropertiesPanel,
     AssayDesignerPanels,
     saveAssayDesign,


### PR DESCRIPTION
#### Rationale
For the Freezer Creation story in the Freezer Manager app, there is a "domain designer" like page for the freezer creation / update form UI. Instead of reinvent the panel collapse/expand, status icon, error display, etc., this BasePropertiesPanel can be reused for the panels of this new freezer designer.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/39

#### Changes
* Add BasePropertiesPanel to the index.ts for use in apps
* QueryInfo - add getColumnFieldKeys helper method to get fieldKeys for select columns
* QueryModel - add parameter to getRow method to allow for a flattened key/value pair response object