### PR TITLE
Item 7445: Freezers on the Dashboard

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.0",
+  "version": "0.70.1-fb-fmDashboard.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.1-fb-fmDashboard.1",
+  "version": "0.70.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.5",
+  "version": "0.69.6-fb-fmDashboard.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.3",
+  "version": "0.69.4-fb-fmDashboard.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.69.4-fb-fmDashboard.1",
+  "version": "0.69.4-fb-fmDashboard.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* correct QueryModelLoader queryParameters to parameters
+* add onClick prop for ExpandableContainer
+
+
 ### version 0.69.3
 *Released*: 11 June 2020
 * Expose QueryConfig type
@@ -22,10 +28,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Move search results filtering and cardData processing from SearchResultsPanel to searchUsingIndex action.
 - Added emptyResultDisplay, hideHeader and hidePanelFrame props to SearchResultsPanel
 - Add useEmail to UserSelectInput
-
-### version XXX
-*Released*: XXX
-* correct QueryModelLoader queryParameters to parameters
 
 ### version 0.68.0
 *Released*: 9 June 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,12 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 0.70.1
+*Released*: 23 June 2020
 * correct QueryModelLoader queryParameters to parameters
 * add onClick prop for ExpandableContainer
 
-### version 0.70.0
+## version 0.70.0
 *Released*: 19 June 2020
 * Item 7417: BasePropertiesPanel - add to index.ts for use in Freezer Manager app
 * QueryInfo - add getColumnFieldKeys helper method to get fieldKeys for select columns

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -23,6 +23,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Added emptyResultDisplay, hideHeader and hidePanelFrame props to SearchResultsPanel
 - Add useEmail to UserSelectInput
 
+### version XXX
+*Released*: XXX
+* correct QueryModelLoader queryParameters to parameters
+
 ### version 0.68.0
 *Released*: 9 June 2020
 * Remove `IUser` interface in favor of direct use of `@labkey/api` `User` and `UserWithPermissions` interfaces.

--- a/packages/components/src/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/QueryModel/QueryModelLoader.ts
@@ -93,7 +93,7 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
             columns: model.columnString,
             maxRows: model.maxRows,
             offset: model.offset,
-            queryParameters: model.queryParameters,
+            parameters: model.queryParameters,
             includeDetailsColumn: model.includeDetailsColumn,
             includeUpdateColumn: model.includeUpdateColumn,
         });

--- a/packages/components/src/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/QueryModel/QueryModelLoader.ts
@@ -15,8 +15,9 @@ import { bindColumnRenderers } from '../renderers';
 import { clearSelected, fetchCharts, ISelectResponse, selectAll } from '../actions';
 import { VISUALIZATION_REPORTS } from '../constants';
 
-import { GridMessage, QueryModel } from './QueryModel';
 import { DataViewInfo } from '../models';
+
+import { GridMessage, QueryModel } from './QueryModel';
 
 export interface RowsResponse {
     messages: GridMessage[];

--- a/packages/components/src/components/ExpandableContainer.tsx
+++ b/packages/components/src/components/ExpandableContainer.tsx
@@ -33,10 +33,12 @@ export class ExpandableContainer extends React.PureComponent<Props, State> {
     }
 
     handleClick = () => {
-        if (this.props.onClick)
-            this.props.onClick(!this.state.visible);
-
-        this.setState(state => ({ visible: !state.visible }));
+        this.setState(state => ({ 
+             visible: !state.visible 
+        }), () = > {
+            if (this.props.onClick)
+                this.props.onClick(this.state.visible);        
+        });
     };
 
     handleMouseEnter = () => {

--- a/packages/components/src/components/ExpandableContainer.tsx
+++ b/packages/components/src/components/ExpandableContainer.tsx
@@ -33,11 +33,11 @@ export class ExpandableContainer extends React.PureComponent<Props, State> {
     }
 
     handleClick = () => {
-        this.setState(state => ({ 
-             visible: !state.visible 
-        }), () = > {
+        this.setState((state) => ({
+             visible: !state.visible
+        }), () => {
             if (this.props.onClick)
-                this.props.onClick(this.state.visible);        
+                this.props.onClick(this.state.visible);
         });
     };
 

--- a/packages/components/src/components/ExpandableContainer.tsx
+++ b/packages/components/src/components/ExpandableContainer.tsx
@@ -33,12 +33,14 @@ export class ExpandableContainer extends React.PureComponent<Props, State> {
     }
 
     handleClick = () => {
-        this.setState((state) => ({
-             visible: !state.visible
-        }), () => {
-            if (this.props.onClick)
-                this.props.onClick(this.state.visible);
-        });
+        this.setState(
+            state => ({
+                visible: !state.visible,
+            }),
+            () => {
+                if (this.props.onClick) this.props.onClick(this.state.visible);
+            }
+        );
     };
 
     handleMouseEnter = () => {

--- a/packages/components/src/components/ExpandableContainer.tsx
+++ b/packages/components/src/components/ExpandableContainer.tsx
@@ -14,6 +14,7 @@ interface Props {
     iconFaCls?: string;
     isExpandable: boolean;
     initExpanded?: boolean;
+    onClick?: (show: boolean) => any;
 }
 
 interface State {
@@ -32,6 +33,9 @@ export class ExpandableContainer extends React.PureComponent<Props, State> {
     }
 
     handleClick = () => {
+        if (this.props.onClick)
+            this.props.onClick(!this.state.visible);
+
         this.setState(state => ({ visible: !state.visible }));
     };
 


### PR DESCRIPTION
#### Rationale
This PR includes 2 small changes to support location list display for FM. In order to use ExpandableContainer for FM location listing, a onclick hook is needed to wire up action for expand/collapsing a row. Additionally, QueryModelLoader should use parameters instead of queryParameters. 

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/40

#### Changes
* change QueryModelLoader queryParameters to parameters
* add onClick prop for ExpandableContainer
