### PR TITLE
Issue 40555: QC state conditional formats work but are not viewable/editable in Query Metadata editor

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.2",
+  "version": "0.70.3-fb-Issue40555-decodeFilters.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.3-fb-Issue40555-decodeFilters.0",
+  "version": "0.70.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.70.3-fb-Issue40555-decodeFilters.0
-*Released*: TBD June 2020
+### version 0.70.3
+*Released*: 24 June 2020
 * Issue 40555: QC state conditional formats work but are not viewable/editable in Query Metadata editor
 * Filters - decode correct part of Filter string
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.70.3-fb-Issue40555-decodeFilters.0
+*Released*: TBD June 2020
+* Issue 40555: QC state conditional formats work but are not viewable/editable in Query Metadata editor
+* Filters - decode correct part of Filter string
+
 ### version 0.70.2
 *Released*: 23 June 2020
 * Expose createApplicationUrl utility method

--- a/packages/components/src/components/domainproperties/validation/Filters.tsx
+++ b/packages/components/src/components/domainproperties/validation/Filters.tsx
@@ -174,7 +174,7 @@ export class Filters extends React.PureComponent<FiltersProps, FiltersState> {
         const returnVal = { type: undefined, value: undefined };
 
         if (parts.length > 0 && parts[0].length > 0) {
-            returnVal.type = decodeURIComponent(parts[0].substring(1 + (prefix ? prefix.length : 0))); // remove ~
+            returnVal.type = decodeURIComponent(parts[0]).substring(1 + (prefix ? prefix.length : 0)); // remove ~
         }
 
         if (parts.length > 1) {


### PR DESCRIPTION
#### Rationale
Decode the correct part of filter type string.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1339
