### PR TITLE
Issue 39263 - PermissionAssignments.tsx update to include display of root assignments in Effective Roles listing

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -148,6 +148,9 @@
         "container": {
           "path": ""
         },
+        "project": {
+          "rootId": "ROOTID"
+        },
         "user": {
           "id": 1004
         },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.3-fb-issue39263EffectiveRolesList.0",
+  "version": "0.70.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.3",
+  "version": "0.70.3-fb-issue39263EffectiveRolesList.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 39263 - PermissionAssignments.tsx update to include display of root assignments in Effective Roles listing
+
 ### version 0.70.3
 *Released*: 24 June 2020
 * Issue 40555: QC state conditional formats work but are not viewable/editable in Query Metadata editor

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.70.4
+*Released*: 25 June 2020
 * Issue 39263 - PermissionAssignments.tsx update to include display of root assignments in Effective Roles listing
 
 ### version 0.70.3

--- a/packages/components/src/components/permissions/EffectiveRolesList.spec.tsx
+++ b/packages/components/src/components/permissions/EffectiveRolesList.spec.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
 
 import { JEST_SITE_ADMIN_USER_ID } from '../../test/data/constants';
 
 import policyJSON from '../../test/data/security-getPolicy.json';
-
+import rootPolicyJSON from '../../test/data/security-getPolicyRoot.json';
 import rolesJSON from '../../test/data/security-getRoles.json';
 
 import { EffectiveRolesList } from './EffectiveRolesList';
@@ -13,6 +12,7 @@ import { SecurityPolicy } from './models';
 import { getRolesByUniqueName, processGetRolesResponse } from './actions';
 
 const POLICY = SecurityPolicy.create(policyJSON);
+const ROOT_POLICY = SecurityPolicy.create(rootPolicyJSON);
 const ROLES = processGetRolesResponse(rolesJSON.roles);
 const ROLES_BY_NAME = getRolesByUniqueName(ROLES);
 
@@ -51,6 +51,20 @@ describe('<EffectiveRolesList/>', () => {
             <EffectiveRolesList
                 userId={1} // user doesn't have an assignment
                 policy={POLICY}
+                rolesByUniqueName={ROLES_BY_NAME}
+            />
+        );
+
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('with root policy', () => {
+        const component = (
+            <EffectiveRolesList
+                userId={1004}
+                policy={POLICY}
+                rootPolicy={ROOT_POLICY}
                 rolesByUniqueName={ROLES_BY_NAME}
             />
         );

--- a/packages/components/src/components/permissions/EffectiveRolesList.tsx
+++ b/packages/components/src/components/permissions/EffectiveRolesList.tsx
@@ -17,12 +17,15 @@ interface Props {
 export class EffectiveRolesList extends React.PureComponent<Props, any> {
     render() {
         const { userId, policy, rootPolicy, rolesByUniqueName } = this.props;
-        let assignments = policy && rolesByUniqueName
+        let assignments =
+            policy && rolesByUniqueName
                 ? policy.assignments.filter(assignment => assignment.userId === userId).toList()
                 : List<SecurityAssignment>();
 
         if (rootPolicy && rolesByUniqueName) {
-            assignments = assignments.concat(rootPolicy.assignments.filter(assignment => assignment.userId === userId)).toList();
+            assignments = assignments
+                .concat(rootPolicy.assignments.filter(assignment => assignment.userId === userId))
+                .toList();
         }
 
         if (assignments.size === 0) {

--- a/packages/components/src/components/permissions/EffectiveRolesList.tsx
+++ b/packages/components/src/components/permissions/EffectiveRolesList.tsx
@@ -10,16 +10,20 @@ import { SecurityAssignment, SecurityPolicy, SecurityRole } from './models';
 interface Props {
     userId: number;
     policy?: SecurityPolicy;
+    rootPolicy?: SecurityPolicy;
     rolesByUniqueName?: Map<string, SecurityRole>;
 }
 
 export class EffectiveRolesList extends React.PureComponent<Props, any> {
     render() {
-        const { userId, policy, rolesByUniqueName } = this.props;
-        const assignments =
-            policy && rolesByUniqueName
+        const { userId, policy, rootPolicy, rolesByUniqueName } = this.props;
+        let assignments = policy && rolesByUniqueName
                 ? policy.assignments.filter(assignment => assignment.userId === userId).toList()
                 : List<SecurityAssignment>();
+
+        if (rootPolicy && rolesByUniqueName) {
+            assignments = assignments.concat(rootPolicy.assignments.filter(assignment => assignment.userId === userId)).toList();
+        }
 
         if (assignments.size === 0) {
             return null;

--- a/packages/components/src/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/components/permissions/PermissionAssignments.tsx
@@ -16,7 +16,7 @@ import { UserDetailsPanel } from '../user/UserDetailsPanel';
 import { PermissionsProviderProps, Principal, SecurityPolicy, SecurityRole } from './models';
 import { PermissionsRole } from './PermissionsRole';
 import { GroupDetailsPanel } from './GroupDetailsPanel';
-import { fetchContainerSecurityPolicy } from "./actions";
+import { fetchContainerSecurityPolicy } from './actions';
 
 interface Props extends PermissionsProviderProps {
     title?: string;
@@ -59,10 +59,11 @@ export class PermissionAssignments extends React.PureComponent<Props, State> {
     componentDidMount(): void {
         const rootId = getServerContext().project.rootId;
         if (this.props.containerId !== rootId) {
-            fetchContainerSecurityPolicy(rootId, this.props.principalsById, this.props.inactiveUsersById)
-                .then((rootPolicy) => {
+            fetchContainerSecurityPolicy(rootId, this.props.principalsById, this.props.inactiveUsersById).then(
+                rootPolicy => {
                     this.setState(() => ({ rootPolicy }));
-                });
+                }
+            );
         }
     }
 

--- a/packages/components/src/components/permissions/__snapshots__/EffectiveRolesList.spec.tsx.snap
+++ b/packages/components/src/components/permissions/__snapshots__/EffectiveRolesList.spec.tsx.snap
@@ -57,4 +57,42 @@ Array [
 ]
 `;
 
+exports[`<EffectiveRolesList/> with root policy 1`] = `
+Array [
+  <hr
+    className="principal-hr"
+  />,
+  <div
+    className="principal-detail-label"
+  >
+    Effective Roles:
+  </div>,
+  <ul
+    className="permissions-ul"
+  >
+    <li>
+      Editor
+    </li>
+    <li>
+      Folder Administrator
+    </li>
+    <li>
+      Project Administrator
+    </li>
+    <li>
+      Reader
+    </li>
+    <li>
+      Restricted Reader
+    </li>
+    <li>
+      Submitter
+    </li>
+    <li>
+      Application Admin
+    </li>
+  </ul>,
+]
+`;
+
 exports[`<EffectiveRolesList/> without policy 1`] = `null`;

--- a/packages/components/src/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/components/user/UserDetailsPanel.tsx
@@ -22,6 +22,7 @@ import { UserResetPasswordConfirmModal } from './UserResetPasswordConfirmModal';
 interface Props {
     userId: number;
     policy?: SecurityPolicy;
+    rootPolicy?: SecurityPolicy;
     rolesByUniqueName?: Map<string, SecurityRole>;
     allowDelete?: boolean;
     allowResetPassword?: boolean;

--- a/packages/components/src/test/data/security-getPolicyRoot.json
+++ b/packages/components/src/test/data/security-getPolicyRoot.json
@@ -1,0 +1,18 @@
+{
+  "relevantRoles" : [ "org.labkey.api.security.roles.SiteAdminRole", "org.labkey.api.security.roles.ApplicationAdminRole", "org.labkey.api.security.roles.TroubleshooterRole", "org.labkey.api.security.roles.SeeUserAndGroupDetailsRole", "org.labkey.api.security.roles.CanSeeAuditLogRole", "org.labkey.api.security.roles.EmailNonUsersRole", "org.labkey.api.security.roles.SeeFilePathsRole", "org.labkey.api.security.roles.CanUseSendMessageApi", "org.labkey.api.security.roles.PlatformDeveloperRole", "org.labkey.api.security.roles.TrustedAnalystRole", "org.labkey.api.security.roles.AnalystRole" ],
+  "policy" : {
+    "resourceId" : "3BCE26D4-1622-1035-AF26-843B99F37724",
+    "assignments" : [ {
+      "role" : "org.labkey.api.security.roles.ApplicationAdminRole",
+      "userId" : 1004
+    }, {
+      "role" : "org.labkey.api.security.roles.TroubleshooterRole",
+      "userId" : 2300
+    }, {
+      "role" : "org.labkey.api.security.roles.SeeUserAndGroupDetailsRole",
+      "userId" : 4971
+    } ],
+    "modifiedMillis" : 1593118537147,
+    "modified" : "2020-06-25 15:55:37.147"
+  }
+}


### PR DESCRIPTION
#### Rationale
Issue [39263](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=39263) - in the Sample Manager app, the permissions page allows for a user to click on a role assignment to view details about the selected user. This user details shows a listing of the "Effective Roles" for that user in the current container. To date, that listing is only the roles assigned to that user in the current container (i.e. in the Sample Manager project). It does not include the roles assigned to that user at the root level (i.e. Application Admin).

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/307

#### Changes
* PermissionAssignments.tsx update to include display of root assignments in Effective Roles listing
