### PR TITLE
QueryGridPanel "initModelOnMount" prop

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.6-fb-component-will-mount.0",
+  "version": "0.70.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.70.5",
+  "version": "0.70.6-fb-component-will-mount.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.70.6
+*Released*: 29 June 2020
+* Add `initModelOnMount` prop to `QueryGridModel`. Defaults to `true` so the behavior is unchanged for all current usages.
+
 ### version 0.70.5
 *Released*: 26 June 2020
 * Issue 40591: Query metadata editor should allow editing type of field in user defined query

--- a/packages/components/src/components/QueryGridPanel.tsx
+++ b/packages/components/src/components/QueryGridPanel.tsx
@@ -34,6 +34,7 @@ interface Props {
     model: QueryGridModel | List<QueryGridModel>;
     buttons?: QueryGridBarButtons;
     header?: React.ReactNode;
+    initModelOnMount?: boolean;
     message?: any;
     asPanel?: boolean;
     showTabs?: boolean;
@@ -57,6 +58,7 @@ interface State {
 export class QueryGridPanel extends React.Component<Props, State> {
     static defaultProps = {
         asPanel: true,
+        initModelOnMount: true,
         showGridBar: true,
         showSampleComparisonReports: false,
     };
@@ -70,9 +72,11 @@ export class QueryGridPanel extends React.Component<Props, State> {
         };
     }
 
-    componentDidMount() {
-        this.initModel(this.props);
-    }
+    componentDidMount = (): void => {
+        if (this.props.initModelOnMount) {
+            this.initModel(this.props);
+        }
+    };
 
     componentWillReceiveProps(nextProps: Props) {
         this.initModel(nextProps);

--- a/packages/components/src/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -627,6 +627,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
     </table>
     <QueryGridPanel
       asPanel={false}
+      initModelOnMount={true}
       model={
         Immutable.Record {
           "id": "dataclasses-parent-data|exp$pdata/second source",


### PR DESCRIPTION
#### Rationale
This PR adds a new boolean prop to `QueryGridPanel` (QGP) called `initModelOnMount` which allows the user to elect to prevent the QGP from calling `gridInit()` when it mounts. This allows the `QueryGridModel` (QGM) to be initialized by components that initialize the model from `componentDidMount()`.

During investigation of switching components to use `componentDidMount()` in <Biologics PR> a subtle behavior became apparent when calling `gridInit()` from multiple components on the same model. In short, the highest level component that relies on the QGM's state should be responsible for calling `gridInit(model, true, this)`. Here is an example:

1. Parent component initializes a QGM and calls `gridInit(model, true, this)` via `componentDidMount()` and passes model to child QGP in `render()`.
1. Parent component additionally needs to reference additional state from the QGM (e.g. `model.getRow()`).
1. Child QGP mounts and calls `gridInit(model)`.

Next, take a look at the first few lines of `gridInit()`:

```ts
export function gridInit(model: QueryGridModel, shouldLoadData = true, connectedComponent?: React.Component): void {
    // return quickly if we don't have a model or if it is already loading
    if (!model || model.isLoading) {
        return;
    }

    // ...
```

In the scenario described the child QGP will call `gridInit()` first. The subsequent call by the parent component will hit the short-circuit statement above. The result is that the `connectedComponent` (the parent in this case) is ignored and subsequently not updated upon changes to the model. As a result, the parent's component reference to additional state is never updated resulting in inconsistent UI state with the model state.

By setting `initModelOnMount={false}` on the child QGP the parent component will receive updates and the component lifecycle will ensure any child components are updated.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/619

#### Changes
* Add `initModelOnMount` prop to `QueryGridModel`. Defaults to `true` so the behavior is unchanged for all current usages.
