### PR TITLE
Protect against redundant calls to get lookup options

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.73.0",
+  "version": "0.73.1-fb-workflowFixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.73.1-fb-workflowFixes.0",
+  "version": "0.73.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.73.1
+*Released*: 2 July 2020
 * Adjust LookupSelectInput to protect against loading the options more than once
 
 ### version 0.73.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Adjust LookupSelectInput to protect against loading the options more than once
+
 ### version 0.73.0
 *Released*: 1 July 2020
 * Item 7458: Update Sample Manager and Freezer Manager app product menus to respect isSampleManagerEnabled

--- a/packages/components/src/components/forms/input/LookupSelectInput.tsx
+++ b/packages/components/src/components/forms/input/LookupSelectInput.tsx
@@ -59,6 +59,7 @@ function formatLookupSelectInputOptions(
 }
 
 interface StateProps {
+    isLoading: boolean;
     options: LookupSelectOption[];
 }
 
@@ -79,12 +80,13 @@ export class LookupSelectInput extends React.Component<OwnProps, StateProps> {
         this._id = generateId('select-');
 
         this.state = {
+            isLoading: false,
             options: this.getOptionsFromSelectedRows(props, props.selectedRows),
         };
     }
 
     componentWillMount() {
-        if (!this.state.options) {
+        if (!this.state.options && !this.state.isLoading) {
             this.getOptions();
         }
     }
@@ -92,6 +94,7 @@ export class LookupSelectInput extends React.Component<OwnProps, StateProps> {
     componentWillReceiveProps(nextProps: OwnProps) {
         if (nextProps.selectedRows) {
             this.setState(() => ({
+                isLoading: false,
                 options: this.getOptionsFromSelectedRows(nextProps, nextProps.selectedRows),
             }));
         }
@@ -121,17 +124,19 @@ export class LookupSelectInput extends React.Component<OwnProps, StateProps> {
                 'querygrid forms/input/<LookupSelectInput> received lookup column that is explicitly set displayAsLookup = false'
             );
         }
+        this.setState(() => ({isLoading: true}));
 
         const { schemaName, queryName } = queryColumn.lookup;
         selectRows({ schemaName, queryName, filterArray, sort })
             .then(response => {
                 this.setState(() => ({
+                    isLoading: false,
                     options: this.getOptionsFromSelectedRows(this.props, response),
                 }));
             })
             .catch(reason => {
                 console.error(reason);
-                this.setState(() => ({ options: [] }));
+                this.setState(() => ({ isLoading: false, options: [] }));
             });
     }
 

--- a/packages/components/src/components/forms/input/LookupSelectInput.tsx
+++ b/packages/components/src/components/forms/input/LookupSelectInput.tsx
@@ -124,7 +124,7 @@ export class LookupSelectInput extends React.Component<OwnProps, StateProps> {
                 'querygrid forms/input/<LookupSelectInput> received lookup column that is explicitly set displayAsLookup = false'
             );
         }
-        this.setState(() => ({isLoading: true}));
+        this.setState(() => ({ isLoading: true }));
 
         const { schemaName, queryName } = queryColumn.lookup;
         selectRows({ schemaName, queryName, filterArray, sort })


### PR DESCRIPTION
#### Rationale
When we don't use an `isLoading` property, we will almost certainly make multiple calls to load the options for a LookupSelectInput (primarily used in the workflow components in SampleManager).

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/316

#### Changes
* Add isLoading property on LookupSelectInput
