### PR TITLE
Item 7563: SampleTypeDesigner update to add "Label Color" property to Sample Manager

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.77.0",
+  "version": "0.77.0-fb-sampleTypeLabelColor.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.75.0-fb-sampleTypeLabelColor.0",
+  "version": "0.75.0-fb-sampleTypeLabelColor.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.75.0",
+  "version": "0.75.0-fb-sampleTypeLabelColor.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.75.0-fb-sampleTypeLabelColor.4",
+  "version": "0.75.0-fb-sampleTypeLabelColor.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.75.0-fb-sampleTypeLabelColor.3",
+  "version": "0.75.0-fb-sampleTypeLabelColor.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.76.0",
+  "version": "0.76.0-fb-sampleTypeLabelColor.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.75.0-fb-sampleTypeLabelColor.1",
+  "version": "0.75.0-fb-sampleTypeLabelColor.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.77.0-fb-sampleTypeLabelColor.1",
+  "version": "0.78.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.77.0-fb-sampleTypeLabelColor.0",
+  "version": "0.77.0-fb-sampleTypeLabelColor.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.75.0-fb-sampleTypeLabelColor.2",
+  "version": "0.75.0-fb-sampleTypeLabelColor.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 7563: SampleTypeDesigner update to add "Label Color" property to Sample Manager
+    - ColorPickerInput updates to support showing color chip within dropdown button when label text not provided
+    - ColorPickerInput update to handle value=#ffffff (display as white background with black border)
+    - SampleTypePropertiesPanel addition of ColorPickerInput, conditional based on appPropertiesOnly prop
+    - SampleTypeModel addition of labelColor prop
+
 ### version 0.75.0
 *Released*: 9 July 2020
 * [Issue 36916](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=36916): Remove `toLowerCase()` when constructing `AppURL`s base parts.

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.78.0
+*Released*: 16 July 2020
 * Item 7563: SampleTypeDesigner update to add "Label Color" property to Sample Manager
     - ColorPickerInput updates to support showing color chip within dropdown button when label text not provided
     - ColorPickerInput update to handle value=#ffffff (display as white background with black border)

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -8,7 +8,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     - ColorPickerInput update to handle value=#ffffff (display as white background with black border)
     - SampleTypePropertiesPanel addition of ColorPickerInput, conditional based on appPropertiesOnly prop
     - SampleTypeModel addition of labelColor prop
-    - Add ColorIcon display component to use in Sample Manager and Freezer Manager
+    - Add ColorIcon display component and LabelColorRenderer to use in Sample Manager and Freezer Manager
 
 ### version 0.75.0
 *Released*: 9 July 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -8,6 +8,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     - ColorPickerInput update to handle value=#ffffff (display as white background with black border)
     - SampleTypePropertiesPanel addition of ColorPickerInput, conditional based on appPropertiesOnly prop
     - SampleTypeModel addition of labelColor prop
+    - Add ColorIcon display component to use in Sample Manager and Freezer Manager
 
 ### version 0.75.0
 *Released*: 9 July 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,9 +1,5 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
-### version 0.77.0
-*Released*: 15 July 2020
-* Update URLResolvers to handle URLs that may go to a separate application
-* Add StorageStatusRenderer for showing the storage status of a sample
 
 ### version TBD
 *Released*: TBD
@@ -13,6 +9,11 @@ Components, models, actions, and utility functions for LabKey applications and p
     - SampleTypePropertiesPanel addition of ColorPickerInput, conditional based on appPropertiesOnly prop
     - SampleTypeModel addition of labelColor prop
     - Add ColorIcon display component and LabelColorRenderer to use in Sample Manager and Freezer Manager
+
+### version 0.77.0
+*Released*: 15 July 2020
+* Update URLResolvers to handle URLs that may go to a separate application
+* Add StorageStatusRenderer for showing the storage status of a sample
 
 ### version 0.76.0
 *Released*: 14 July 2020

--- a/packages/components/src/components/base/ColorIcon.spec.tsx
+++ b/packages/components/src/components/base/ColorIcon.spec.tsx
@@ -4,16 +4,10 @@ import { mount } from 'enzyme';
 import { ColorIcon } from './ColorIcon';
 
 describe('ColorIcon', () => {
-    function verifyIconDisplay(wrapper: any, color: string, asSquare = false, label?: string): void {
+    function verifyIconDisplay(wrapper: any, color: string, label?: string): void {
         expect(wrapper.find('i')).toHaveLength(1);
         const icon = wrapper.find('i').first();
-        expect(icon.props().style['color']).toBe(asSquare ? undefined : color);
-        expect(icon.props().style['backgroundColor']).toBe(asSquare ? color : undefined);
-        if (color.toLowerCase() === '#ffffff') {
-            expect(icon.props().style['border']).not.toBe(undefined);
-        } else {
-            expect(icon.props().style['border']).toBe(undefined);
-        }
+        expect(icon.props().style['backgroundColor']).toBe(color);
 
         const spans = wrapper.find('span');
         if (label) {
@@ -38,12 +32,12 @@ describe('ColorIcon', () => {
     test('asSquare prop', () => {
         let color = '#000000';
         const wrapper = mount(<ColorIcon value={color} asSquare={true} />);
-        verifyIconDisplay(wrapper, color, true);
+        verifyIconDisplay(wrapper, color);
 
         // handling of color white
         color = '#ffffff';
         wrapper.setProps({ value: color });
-        verifyIconDisplay(wrapper, color, true);
+        verifyIconDisplay(wrapper, color);
 
         wrapper.unmount();
     });
@@ -52,10 +46,10 @@ describe('ColorIcon', () => {
         let color = '#000000';
         const label = 'Color Label';
         const wrapper = mount(<ColorIcon value={color} label={label} />);
-        verifyIconDisplay(wrapper, color, false, label);
+        verifyIconDisplay(wrapper, color, label);
 
         color = '#ffffff';
         wrapper.setProps({ asSquare: true, value: color });
-        verifyIconDisplay(wrapper, color, true, label);
+        verifyIconDisplay(wrapper, color, label);
     });
 });

--- a/packages/components/src/components/base/ColorIcon.spec.tsx
+++ b/packages/components/src/components/base/ColorIcon.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { mount } from "enzyme";
-import { ColorIcon } from "./ColorIcon";
+import { mount } from 'enzyme';
+
+import { ColorIcon } from './ColorIcon';
 
 describe('ColorIcon', () => {
     function verifyIconDisplay(wrapper: any, color: string, asSquare = false, label?: string): void {
@@ -24,11 +25,11 @@ describe('ColorIcon', () => {
     }
 
     test('value prop', () => {
-        const wrapper = mount(<ColorIcon value={undefined}/>);
+        const wrapper = mount(<ColorIcon value={undefined} />);
         expect(wrapper.find('i')).toHaveLength(0);
 
         const color = '#000000';
-        wrapper.setProps({value: color});
+        wrapper.setProps({ value: color });
         verifyIconDisplay(wrapper, color);
 
         wrapper.unmount();
@@ -36,12 +37,12 @@ describe('ColorIcon', () => {
 
     test('asSquare prop', () => {
         let color = '#000000';
-        const wrapper = mount(<ColorIcon value={color} asSquare={true}/>);
+        const wrapper = mount(<ColorIcon value={color} asSquare={true} />);
         verifyIconDisplay(wrapper, color, true);
 
         // handling of color white
         color = '#ffffff';
-        wrapper.setProps({value: color});
+        wrapper.setProps({ value: color });
         verifyIconDisplay(wrapper, color, true);
 
         wrapper.unmount();
@@ -50,11 +51,11 @@ describe('ColorIcon', () => {
     test('with label prop', () => {
         let color = '#000000';
         const label = 'Color Label';
-        const wrapper = mount(<ColorIcon value={color} label={label}/>);
+        const wrapper = mount(<ColorIcon value={color} label={label} />);
         verifyIconDisplay(wrapper, color, false, label);
 
         color = '#ffffff';
-        wrapper.setProps({asSquare: true, value: color});
+        wrapper.setProps({ asSquare: true, value: color });
         verifyIconDisplay(wrapper, color, true, label);
     });
 });

--- a/packages/components/src/components/base/ColorIcon.spec.tsx
+++ b/packages/components/src/components/base/ColorIcon.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { mount } from "enzyme";
+import { ColorIcon } from "./ColorIcon";
+
+describe('ColorIcon', () => {
+    function verifyIconDisplay(wrapper: any, color: string, asSquare = false, label?: string): void {
+        expect(wrapper.find('i')).toHaveLength(1);
+        const icon = wrapper.find('i').first();
+        expect(icon.props().style['color']).toBe(asSquare ? undefined : color);
+        expect(icon.props().style['backgroundColor']).toBe(asSquare ? color : undefined);
+        if (color.toLowerCase() === '#ffffff') {
+            expect(icon.props().style['border']).not.toBe(undefined);
+        } else {
+            expect(icon.props().style['border']).toBe(undefined);
+        }
+
+        const spans = wrapper.find('span');
+        if (label) {
+            expect(spans).toHaveLength(1);
+            expect(spans.first().text()).toBe(label);
+        } else {
+            expect(spans).toHaveLength(0);
+        }
+    }
+
+    test('value prop', () => {
+        const wrapper = mount(<ColorIcon value={undefined}/>);
+        expect(wrapper.find('i')).toHaveLength(0);
+
+        const color = '#000000';
+        wrapper.setProps({value: color});
+        verifyIconDisplay(wrapper, color);
+
+        wrapper.unmount();
+    });
+
+    test('asSquare prop', () => {
+        let color = '#000000';
+        const wrapper = mount(<ColorIcon value={color} asSquare={true}/>);
+        verifyIconDisplay(wrapper, color, true);
+
+        // handling of color white
+        color = '#ffffff';
+        wrapper.setProps({value: color});
+        verifyIconDisplay(wrapper, color, true);
+
+        wrapper.unmount();
+    });
+
+    test('with label prop', () => {
+        let color = '#000000';
+        const label = 'Color Label';
+        const wrapper = mount(<ColorIcon value={color} label={label}/>);
+        verifyIconDisplay(wrapper, color, false, label);
+
+        color = '#ffffff';
+        wrapper.setProps({asSquare: true, value: color});
+        verifyIconDisplay(wrapper, color, true, label);
+    });
+});

--- a/packages/components/src/components/base/ColorIcon.tsx
+++ b/packages/components/src/components/base/ColorIcon.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, ReactNode } from "react";
+import React, { PureComponent, ReactNode } from 'react';
 
 interface Props {
     cls?: string;

--- a/packages/components/src/components/base/ColorIcon.tsx
+++ b/packages/components/src/components/base/ColorIcon.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export class ColorIcon extends PureComponent<Props> {
-    private defaultProps = {
+    static defaultProps = {
         cls: 'color-picker__chip',
     };
 
@@ -19,13 +19,11 @@ export class ColorIcon extends PureComponent<Props> {
 
         let icon;
         if (value) {
-            icon = <i className="fa fa-circle" style={{ color: value }} />;
-        } else if (isWhite) {
-            icon = <i className="fa fa-circle-thin" />;
-        }
-
-        if (value && asSquare) {
-            icon = <i className={cls} style={{ backgroundColor: value, border }} />;
+            if (asSquare) {
+                icon = <i className={cls} style={{ backgroundColor: value, border }} />;
+            } else {
+                icon = <i className="fa fa-circle" style={{ color: value }} />;
+            }
         }
 
         return (

--- a/packages/components/src/components/base/ColorIcon.tsx
+++ b/packages/components/src/components/base/ColorIcon.tsx
@@ -4,22 +4,35 @@ interface Props {
     cls?: string;
     value: string;
     asSquare?: boolean;
+    label?: string;
 }
 
 export class ColorIcon extends PureComponent<Props> {
+    private defaultProps = {
+        cls: 'color-picker__chip',
+    };
+
     render(): ReactNode {
-        const { cls, value, asSquare } = this.props;
+        const { cls, value, asSquare, label } = this.props;
         const isWhite = value?.toLowerCase() === '#ffffff';
         const border = isWhite ? 'solid 1px #000000' : undefined;
 
-        if (asSquare) {
-            return <i className={cls} style={{ backgroundColor: value, border }} />;
+        let icon;
+        if (value) {
+            icon = <i className="fa fa-circle" style={{ color: value }} />;
+        } else if (isWhite) {
+            icon = <i className="fa fa-circle-thin" />;
         }
 
-        if (isWhite) {
-            return <i className="fa fa-circle-thin" />;
+        if (value && asSquare) {
+            icon = <i className={cls} style={{ backgroundColor: value, border }} />;
         }
 
-        return <i className="fa fa-circle" style={{ color: value }} />;
+        return (
+            <>
+                {icon}
+                {label && <span className={value ? 'spacer-left' : undefined}>{label}</span>}
+            </>
+        );
     }
 }

--- a/packages/components/src/components/base/ColorIcon.tsx
+++ b/packages/components/src/components/base/ColorIcon.tsx
@@ -14,15 +14,13 @@ export class ColorIcon extends PureComponent<Props> {
 
     render(): ReactNode {
         const { cls, value, asSquare, label } = this.props;
-        const isWhite = value?.toLowerCase() === '#ffffff';
-        const border = isWhite ? 'solid 1px #000000' : undefined;
 
         let icon;
         if (value) {
             if (asSquare) {
-                icon = <i className={cls} style={{ backgroundColor: value, border }} />;
+                icon = <i className={cls} style={{ backgroundColor: value }} />;
             } else {
-                icon = <i className="fa fa-circle" style={{ color: value }} />;
+                icon = <i className="color-icon__circle" style={{ backgroundColor: value }} />;
             }
         }
 

--- a/packages/components/src/components/base/ColorIcon.tsx
+++ b/packages/components/src/components/base/ColorIcon.tsx
@@ -1,0 +1,25 @@
+import React, { PureComponent, ReactNode } from "react";
+
+interface Props {
+    cls?: string;
+    value: string;
+    asSquare?: boolean;
+}
+
+export class ColorIcon extends PureComponent<Props> {
+    render(): ReactNode {
+        const { cls, value, asSquare } = this.props;
+        const isWhite = value?.toLowerCase() === '#ffffff';
+        const border = isWhite ? 'solid 1px #000000' : undefined;
+
+        if (asSquare) {
+            return <i className={cls} style={{ backgroundColor: value, border }} />;
+        }
+
+        if (isWhite) {
+            return <i className="fa fa-circle-thin" />;
+        }
+
+        return <i className="fa fa-circle" style={{ color: value }} />;
+    }
+}

--- a/packages/components/src/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -80,7 +80,7 @@ Array [
           className=""
         >
           <div
-            className="margin-bottom row"
+            className="margin-bottom margin-top row"
           >
             <div
               className="col-xs-2"
@@ -496,7 +496,7 @@ Array [
           className=""
         >
           <div
-            className="margin-bottom row"
+            className="margin-bottom margin-top row"
           >
             <div
               className="col-xs-2"
@@ -3039,11 +3039,11 @@ exports[`DataClassDesigner initModel 1`] = `
                                   >
                                     <Row
                                       bsClass="row"
-                                      className="margin-bottom"
+                                      className="margin-bottom margin-top"
                                       componentClass="div"
                                     >
                                       <div
-                                        className="margin-bottom row"
+                                        className="margin-bottom margin-top row"
                                       >
                                         <Col
                                           bsClass="col"

--- a/packages/components/src/components/domainproperties/dataclasses/__snapshots__/DataClassPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/components/domainproperties/dataclasses/__snapshots__/DataClassPropertiesPanel.spec.tsx.snap
@@ -75,7 +75,7 @@ exports[`DataClassPropertiesPanel custom properties 1`] = `
       className=""
     >
       <div
-        className="margin-bottom row"
+        className="margin-bottom margin-top row"
       >
         <div
           className="col-xs-2"
@@ -270,7 +270,7 @@ exports[`DataClassPropertiesPanel default properties 1`] = `
       className=""
     >
       <div
-        className="margin-bottom row"
+        className="margin-bottom margin-top row"
       >
         <div
           className="col-xs-2"

--- a/packages/components/src/components/domainproperties/entities/EntityDetailsForm.tsx
+++ b/packages/components/src/components/domainproperties/entities/EntityDetailsForm.tsx
@@ -46,7 +46,7 @@ export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, a
 
         return (
             <Form>
-                <Row className="margin-bottom">
+                <Row className="margin-bottom margin-top">
                     <Col xs={2}>
                         <DomainFieldLabel
                             label="Name"

--- a/packages/components/src/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
+++ b/packages/components/src/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`<EntityDetailsForm/> default properties 1`] = `
   className=""
 >
   <div
-    className="margin-bottom row"
+    className="margin-bottom margin-top row"
   >
     <div
       className="col-xs-2"
@@ -157,7 +157,7 @@ exports[`<EntityDetailsForm/> initial data 1`] = `
   className=""
 >
   <div
-    className="margin-bottom row"
+    className="margin-bottom margin-top row"
   >
     <div
       className="col-xs-2"
@@ -310,7 +310,7 @@ exports[`<EntityDetailsForm/> nameExpression properties 1`] = `
   className=""
 >
   <div
-    className="margin-bottom row"
+    className="margin-bottom margin-top row"
   >
     <div
       className="col-xs-2"
@@ -463,7 +463,7 @@ exports[`<EntityDetailsForm/> with formValues 1`] = `
   className=""
 >
   <div
-    className="margin-bottom row"
+    className="margin-bottom margin-top row"
   >
     <div
       className="col-xs-2"

--- a/packages/components/src/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List, Map } from 'immutable';
+import { Map } from 'immutable';
 import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 import toJson from 'enzyme-to-json';

--- a/packages/components/src/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -470,6 +470,7 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
                     }
                     validate={validatePanel === PROPERTIES_PANEL_INDEX}
                     onToggle={(collapsed, callback) => onTogglePanel(PROPERTIES_PANEL_INDEX, collapsed, callback)}
+                    appPropertiesOnly={appPropertiesOnly}
                     useTheme={useTheme}
                 />
                 <DomainForm

--- a/packages/components/src/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -349,7 +349,7 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
     saveDomain = () => {
         const { beforeFinish, setSubmitting } = this.props;
         const { model } = this.state;
-        const { name, domain, description, nameExpression } = model;
+        const { name, domain, description, nameExpression, labelColor } = model;
 
         if (beforeFinish) {
             beforeFinish(model);
@@ -363,6 +363,7 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
         const details = {
             name,
             nameExpression,
+            labelColor,
             importAliases: this.getImportAliasesAsMap(model).toJS(),
         };
 

--- a/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
@@ -58,6 +58,26 @@ describe('<SampleTypePropertiesPanel/>', () => {
         });
     });
 
+    test('appPropertiesOnly', done => {
+        const tree = renderer.create(
+            <SampleTypePropertiesPanel
+                {...BASE_PROPS}
+                appPropertiesOnly={true}
+                model={SampleTypeModel.create()}
+                updateModel={jest.fn}
+                onAddParentAlias={jest.fn}
+                onRemoveParentAlias={jest.fn}
+                onParentAliasChange={jest.fn}
+                parentOptions={[]}
+            />
+        );
+
+        setTimeout(() => {
+            expect(tree.toJSON()).toMatchSnapshot();
+            done();
+        });
+    });
+
     test('nameExpressionInfoUrl', done => {
         const tree = renderer.create(
             <SampleTypePropertiesPanel

--- a/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -328,6 +328,7 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
                                     name={'labelColor'}
                                     value={model.labelColor}
                                     onChange={this.onFieldChange}
+                                    allowRemove={true}
                                 />
                             </Col>
                         </Row>

--- a/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -320,7 +320,7 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
                             <Col xs={2}>
                                 <DomainFieldLabel
                                     label="Label Color"
-                                    helpTipBody={() => `TODO: put text here...`}
+                                    helpTipBody={() => 'The label color will be used to distinguish this sample type in various views in the application.'}
                                 />
                             </Col>
                             <Col xs={10}>

--- a/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { OrderedMap } from 'immutable';
-
 import { Col, Row } from 'react-bootstrap';
 
 import { getFormNameFromId } from '../entities/actions';
 import { IParentOption } from '../../entities/models';
 import { EntityDetailsForm } from '../entities/EntityDetailsForm';
-import { AddEntityButton, generateId, getHelpLink, helpLinkNode, SCHEMAS } from '../../..';
+import { AddEntityButton, ColorPickerInput, generateId, getHelpLink, helpLinkNode, SCHEMAS } from '../../..';
 import { PARENT_ALIAS_HELPER_TEXT, SAMPLE_SET_DISPLAY_TEXT } from '../../../constants';
 import { DERIVE_SAMPLES_ALIAS_TOPIC, DEFINE_SAMPLE_TYPE_TOPIC } from '../../../util/helpLinks';
 import { SampleSetParentAliasRow } from '../../samples/SampleSetParentAliasRow';
@@ -16,8 +15,9 @@ import {
 } from '../DomainPropertiesPanelCollapse';
 import { BasePropertiesPanel, BasePropertiesPanelProps } from '../BasePropertiesPanel';
 import { HelpTopicURL } from '../HelpTopicURL';
-
 import { IParentAlias, SampleTypeModel } from './models';
+import { DomainFieldLabel } from "../DomainFieldLabel";
+import { SectionHeading } from "../SectionHeading";
 
 const PROPERTIES_HEADER_ID = 'sample-type-properties-hdr';
 
@@ -114,10 +114,14 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
     };
 
     onFormChange = (evt: any): void => {
-        const { model } = this.props;
         const id = evt.target.id;
         const value = evt.target.value;
-        const newModel = model.set(getFormNameFromId(id), value) as SampleTypeModel;
+        this.onFieldChange(getFormNameFromId(id), value);
+    };
+
+    onFieldChange = (key: string, value: any): void => {
+        const { model } = this.props;
+        const newModel = model.set(key, value) as SampleTypeModel;
         this.updateValidStatus(newModel);
     };
 
@@ -220,14 +224,14 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
         this.updateValidStatus();
     };
 
-    containsDataClassOptions = () => {
+    containsDataClassOptions() {
         const { parentOptions } = this.props;
         if (!parentOptions || parentOptions.length === 0) return false;
 
         return parentOptions.filter(dataClassOptionFilterFn).length > 0;
-    };
+    }
 
-    render = () => {
+    render() {
         const {
             model,
             parentOptions,
@@ -242,6 +246,7 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
             dataClassAliasCaption,
             sampleAliasCaption,
             dataClassParentageLabel,
+            appPropertiesOnly,
         } = this.props;
         const { isValid } = this.state;
 
@@ -265,6 +270,7 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
                         <HelpTopicURL helpTopic={helpTopic} nounPlural={nounPlural} />
                     </Col>
                 </Row>
+                {appPropertiesOnly && <SectionHeading title="General Properties" />}
                 <EntityDetailsForm
                     noun={nounSingular}
                     onFormChange={this.onFormChange}
@@ -307,9 +313,29 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
                         </Col>
                     </Row>
                 )}
+                {appPropertiesOnly &&
+                    <>
+                        <SectionHeading title="Appearance Settings" />
+                        <Row className="margin-top">
+                            <Col xs={2}>
+                                <DomainFieldLabel
+                                    label="Label Color"
+                                    helpTipBody={() => `TODO: put text here...`}
+                                />
+                            </Col>
+                            <Col xs={10}>
+                                <ColorPickerInput
+                                    name={'labelColor'}
+                                    value={model.labelColor}
+                                    onChange={this.onFieldChange}
+                                />
+                            </Col>
+                        </Row>
+                    </>
+                }
             </BasePropertiesPanel>
         );
-    };
+    }
 }
 
 export const SampleTypePropertiesPanel = withDomainPropertiesPanelCollapse<Props>(SampleTypePropertiesPanelImpl);

--- a/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -15,9 +15,11 @@ import {
 } from '../DomainPropertiesPanelCollapse';
 import { BasePropertiesPanel, BasePropertiesPanelProps } from '../BasePropertiesPanel';
 import { HelpTopicURL } from '../HelpTopicURL';
+
+import { DomainFieldLabel } from '../DomainFieldLabel';
+import { SectionHeading } from '../SectionHeading';
+
 import { IParentAlias, SampleTypeModel } from './models';
-import { DomainFieldLabel } from "../DomainFieldLabel";
-import { SectionHeading } from "../SectionHeading";
 
 const PROPERTIES_HEADER_ID = 'sample-type-properties-hdr';
 
@@ -313,19 +315,21 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
                         </Col>
                     </Row>
                 )}
-                {appPropertiesOnly &&
+                {appPropertiesOnly && (
                     <>
                         <SectionHeading title="Appearance Settings" />
                         <Row className="margin-top">
                             <Col xs={2}>
                                 <DomainFieldLabel
                                     label="Label Color"
-                                    helpTipBody={() => 'The label color will be used to distinguish this sample type in various views in the application.'}
+                                    helpTipBody={() =>
+                                        'The label color will be used to distinguish this sample type in various views in the application.'
+                                    }
                                 />
                             </Col>
                             <Col xs={10}>
                                 <ColorPickerInput
-                                    name={'labelColor'}
+                                    name="labelColor"
                                     value={model.labelColor}
                                     onChange={this.onFieldChange}
                                     allowRemove={true}
@@ -333,7 +337,7 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
                             </Col>
                         </Row>
                     </>
-                }
+                )}
             </BasePropertiesPanel>
         );
     }

--- a/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -2711,6 +2711,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                       className="col-xs-10"
                                     >
                                       <ColorPickerInput
+                                        allowRemove={true}
                                         name="labelColor"
                                         onChange={[Function]}
                                       >

--- a/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -80,7 +80,7 @@ Array [
           className=""
         >
           <div
-            className="margin-bottom row"
+            className="margin-bottom margin-top row"
           >
             <div
               className="col-xs-2"
@@ -492,11 +492,16 @@ Array [
             </div>
           </div>
         </div>
+        <div
+          className="domain-field-section-heading"
+        >
+          General Properties
+        </div>
         <form
           className=""
         >
           <div
-            className="margin-bottom row"
+            className="margin-bottom margin-top row"
           >
             <div
               className="col-xs-2"
@@ -642,6 +647,70 @@ Array [
             </div>
           </div>
         </form>
+        <div
+          className="domain-field-section-heading"
+        >
+          Appearance Settings
+        </div>
+        <div
+          className="margin-top row"
+        >
+          <div
+            className="col-xs-2"
+          >
+            Label 
+            <span
+              className="domain-no-wrap"
+            >
+              Color
+              <span
+                className="label-help-target"
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                  data-icon="question-circle"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              
+            </span>
+          </div>
+          <div
+            className="col-xs-10"
+          >
+            <div
+              className="color-picker"
+            >
+              <button
+                className="color-picker__button btn btn-default"
+                onClick={[Function]}
+                type="button"
+              >
+                None
+                <i
+                  className="fa fa-caret-down"
+                />
+              </button>
+              <div
+                className="color-picker__picker"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>,
@@ -1214,6 +1283,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
       visitedPanels={Immutable.List []}
     >
       <ComponentWithDomainPropertiesPanelCollapse
+        appPropertiesOnly={true}
         controlledCollapse={true}
         includeDataClasses={false}
         initCollapsed={false}
@@ -1224,6 +1294,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
             "nameReadOnly": true,
             "nameExpression": undefined,
             "description": undefined,
+            "labelColor": undefined,
             "parentAliases": undefined,
             "importAliases": Immutable.Map {},
             "domainId": undefined,
@@ -1341,7 +1412,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
         validate={false}
       >
         <SampleTypePropertiesPanelImpl
-          appPropertiesOnly={false}
+          appPropertiesOnly={true}
           collapsed={false}
           controlledCollapse={true}
           dataClassAliasCaption="Data Class Alias"
@@ -1356,6 +1427,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
               "nameReadOnly": true,
               "nameExpression": undefined,
               "description": undefined,
+              "labelColor": undefined,
               "parentAliases": undefined,
               "importAliases": Immutable.Map {},
               "domainId": undefined,
@@ -1479,7 +1551,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
           validate={false}
         >
           <BasePropertiesPanel
-            appPropertiesOnly={false}
+            appPropertiesOnly={true}
             collapsed={false}
             controlledCollapse={true}
             dataClassAliasCaption="Data Class Alias"
@@ -1496,6 +1568,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                 "nameReadOnly": true,
                 "nameExpression": undefined,
                 "description": undefined,
+                "labelColor": undefined,
                 "parentAliases": undefined,
                 "importAliases": Immutable.Map {},
                 "domainId": undefined,
@@ -1810,6 +1883,15 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                   </Col>
                                 </div>
                               </Row>
+                              <SectionHeading
+                                title="General Properties"
+                              >
+                                <div
+                                  className="domain-field-section-heading"
+                                >
+                                  General Properties
+                                </div>
+                              </SectionHeading>
                               <EntityDetailsForm
                                 data={
                                   Immutable.Record {
@@ -1818,6 +1900,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                     "nameReadOnly": true,
                                     "nameExpression": undefined,
                                     "description": undefined,
+                                    "labelColor": undefined,
                                     "parentAliases": undefined,
                                     "importAliases": Immutable.Map {},
                                     "domainId": undefined,
@@ -1940,11 +2023,11 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                   >
                                     <Row
                                       bsClass="row"
-                                      className="margin-bottom"
+                                      className="margin-bottom margin-top"
                                       componentClass="div"
                                     >
                                       <div
-                                        className="margin-bottom row"
+                                        className="margin-bottom margin-top row"
                                       >
                                         <Col
                                           bsClass="col"
@@ -2463,6 +2546,196 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                   </form>
                                 </Form>
                               </EntityDetailsForm>
+                              <SectionHeading
+                                title="Appearance Settings"
+                              >
+                                <div
+                                  className="domain-field-section-heading"
+                                >
+                                  Appearance Settings
+                                </div>
+                              </SectionHeading>
+                              <Row
+                                bsClass="row"
+                                className="margin-top"
+                                componentClass="div"
+                              >
+                                <div
+                                  className="margin-top row"
+                                >
+                                  <Col
+                                    bsClass="col"
+                                    componentClass="div"
+                                    xs={2}
+                                  >
+                                    <div
+                                      className="col-xs-2"
+                                    >
+                                      <DomainFieldLabel
+                                        helpTipBody={[Function]}
+                                        label="Label Color"
+                                      >
+                                        Label 
+                                        <span
+                                          className="domain-no-wrap"
+                                        >
+                                          Color
+                                          <LabelHelpTip
+                                            body={[Function]}
+                                            customStyle={Object {}}
+                                            id="tooltip"
+                                            size="1x"
+                                            title="Label Color"
+                                          >
+                                            <span
+                                              className="label-help-target"
+                                              onMouseOut={[Function]}
+                                              onMouseOver={[Function]}
+                                            >
+                                              <FontAwesomeIcon
+                                                border={false}
+                                                className="label-help-icon"
+                                                fixedWidth={false}
+                                                flip={null}
+                                                icon={
+                                                  Object {
+                                                    "icon": Array [
+                                                      512,
+                                                      512,
+                                                      Array [],
+                                                      "f059",
+                                                      "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                    ],
+                                                    "iconName": "question-circle",
+                                                    "prefix": "fas",
+                                                  }
+                                                }
+                                                inverse={false}
+                                                listItem={false}
+                                                mask={null}
+                                                pull={null}
+                                                pulse={false}
+                                                rotation={null}
+                                                size="1x"
+                                                spin={false}
+                                                style={Object {}}
+                                                symbol={false}
+                                                title=""
+                                                transform={null}
+                                              >
+                                                <svg
+                                                  aria-hidden="true"
+                                                  className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                  data-icon="question-circle"
+                                                  data-prefix="fas"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={Object {}}
+                                                  viewBox="0 0 512 512"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                    fill="currentColor"
+                                                    style={Object {}}
+                                                  />
+                                                </svg>
+                                              </FontAwesomeIcon>
+                                              <Overlay
+                                                animation={[Function]}
+                                                placement="right"
+                                                rootClose={false}
+                                                show={false}
+                                                target={
+                                                  <span
+                                                    class="label-help-target"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                      data-icon="question-circle"
+                                                      data-prefix="fas"
+                                                      focusable="false"
+                                                      role="img"
+                                                      viewBox="0 0 512 512"
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                        fill="currentColor"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                }
+                                              >
+                                                <Overlay
+                                                  placement="right"
+                                                  rootClose={false}
+                                                  show={false}
+                                                  target={
+                                                    <span
+                                                      class="label-help-target"
+                                                    >
+                                                      <svg
+                                                        aria-hidden="true"
+                                                        class="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                        data-icon="question-circle"
+                                                        data-prefix="fas"
+                                                        focusable="false"
+                                                        role="img"
+                                                        viewBox="0 0 512 512"
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                          fill="currentColor"
+                                                        />
+                                                      </svg>
+                                                    </span>
+                                                  }
+                                                  transition={[Function]}
+                                                />
+                                              </Overlay>
+                                            </span>
+                                          </LabelHelpTip>
+                                        </span>
+                                      </DomainFieldLabel>
+                                    </div>
+                                  </Col>
+                                  <Col
+                                    bsClass="col"
+                                    componentClass="div"
+                                    xs={10}
+                                  >
+                                    <div
+                                      className="col-xs-10"
+                                    >
+                                      <ColorPickerInput
+                                        name="labelColor"
+                                        onChange={[Function]}
+                                      >
+                                        <div
+                                          className="color-picker"
+                                        >
+                                          <button
+                                            className="color-picker__button btn btn-default"
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            None
+                                            <i
+                                              className="fa fa-caret-down"
+                                            />
+                                          </button>
+                                          <div
+                                            className="color-picker__picker"
+                                          />
+                                        </div>
+                                      </ColorPickerInput>
+                                    </div>
+                                  </Col>
+                                </div>
+                              </Row>
                             </div>
                           </div>
                         </Transition>

--- a/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -45,7 +45,7 @@ exports[`<SampleTypePropertiesPanel/> default props 1`] = `
       className=""
     >
       <div
-        className="margin-bottom row"
+        className="margin-bottom margin-top row"
       >
         <div
           className="col-xs-2"
@@ -293,7 +293,7 @@ exports[`<SampleTypePropertiesPanel/> include dataclass and use custom labels 1`
       className=""
     >
       <div
-        className="margin-bottom row"
+        className="margin-bottom margin-top row"
       >
         <div
           className="col-xs-2"
@@ -593,7 +593,7 @@ exports[`<SampleTypePropertiesPanel/> nameExpressionInfoUrl 1`] = `
       className=""
     >
       <div
-        className="margin-bottom row"
+        className="margin-bottom margin-top row"
       >
         <div
           className="col-xs-2"

--- a/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -1,5 +1,322 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<SampleTypePropertiesPanel/> appPropertiesOnly 1`] = `
+<div
+  className="domain-form-panel domain-panel-no-theme panel panel-default"
+>
+  <div
+    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    id="sample-type-properties-hdr"
+    onClick={[Function]}
+  >
+    <span
+      className="domain-panel-title"
+    >
+      Sample Type Properties
+    </span>
+  </div>
+  <div
+    className="panel-body"
+  >
+    <div
+      className="margin-bottom row"
+    >
+      <div
+        className="col-xs-12"
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-xs-12"
+          >
+            <a
+              className="domain-field-float-right"
+              href="https://www.labkey.org/Documentation/wiki-page.view?name=createSampleSet"
+              target="_blank"
+            >
+              Learn more about designing sample types
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="domain-field-section-heading"
+    >
+      General Properties
+    </div>
+    <form
+      className=""
+    >
+      <div
+        className="margin-bottom margin-top row"
+      >
+        <div
+          className="col-xs-2"
+        >
+          <span
+            className="domain-no-wrap"
+          >
+            Name
+            <span
+              className="label-help-target"
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                data-icon="question-circle"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+             *
+          </span>
+        </div>
+        <div
+          className="col-xs-10"
+        >
+          <input
+            className="form-control"
+            disabled={false}
+            id="entity-name"
+            onChange={[Function]}
+            placeholder="Enter a name for this sample type"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="margin-bottom row"
+      >
+        <div
+          className="col-xs-2"
+        >
+          <span
+            className="domain-no-wrap"
+          >
+            Description
+            <span
+              className="label-help-target"
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                data-icon="question-circle"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+            
+          </span>
+        </div>
+        <div
+          className="col-xs-10"
+        >
+          <textarea
+            className="form-control textarea-noresize"
+            id="entity-description"
+            onChange={[Function]}
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="margin-bottom row"
+      >
+        <div
+          className="col-xs-2"
+        >
+          Naming 
+          <span
+            className="domain-no-wrap"
+          >
+            Pattern
+            <span
+              className="label-help-target"
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                data-icon="question-circle"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+            
+          </span>
+        </div>
+        <div
+          className="col-xs-10"
+        >
+          <input
+            className="form-control"
+            id="entity-nameExpression"
+            onChange={[Function]}
+            placeholder="Enter a naming pattern (e.g., S-\${now:date}-\${dailySampleCount})"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+    </form>
+    <div
+      className="row"
+    >
+      <div
+        className="col-xs-2"
+      />
+      <div
+        className="col-xs-10"
+      >
+        <span>
+          <div
+            className="form-group"
+          >
+            <div>
+              <span
+                className="container--action-button btn btn-default"
+                onClick={[Function]}
+              >
+                <i
+                  className="fa fa-plus-circle container--addition-icon"
+                />
+                 Add 
+                Parent Alias
+              </span>
+              <span
+                className="label-help-target"
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                  data-icon="question-circle"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      className="domain-field-section-heading"
+    >
+      Appearance Settings
+    </div>
+    <div
+      className="margin-top row"
+    >
+      <div
+        className="col-xs-2"
+      >
+        Label 
+        <span
+          className="domain-no-wrap"
+        >
+          Color
+          <span
+            className="label-help-target"
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+              data-icon="question-circle"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </span>
+          
+        </span>
+      </div>
+      <div
+        className="col-xs-10"
+      >
+        <div
+          className="color-picker"
+        >
+          <button
+            className="color-picker__button btn btn-default"
+            onClick={[Function]}
+            type="button"
+          >
+            None
+            <i
+              className="fa fa-caret-down"
+            />
+          </button>
+          <div
+            className="color-picker__picker"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<SampleTypePropertiesPanel/> default props 1`] = `
 <div
   className="domain-form-panel domain-panel-no-theme panel panel-default"

--- a/packages/components/src/components/domainproperties/samples/models.spec.ts
+++ b/packages/components/src/components/domainproperties/samples/models.spec.ts
@@ -89,9 +89,17 @@ describe('SampleTypeModel', () => {
 
     test('labelColor value', () => {
         expect(SampleTypeModel.create({ options: fromJS({}) } as DomainDetails, undefined).labelColor).toBe(undefined);
-        expect(SampleTypeModel.create({ options: fromJS({labelColor: undefined}) } as DomainDetails, undefined).labelColor).toBe(undefined);
-        expect(SampleTypeModel.create({ options: fromJS({labelColor: null}) } as DomainDetails, undefined).labelColor).toBe(undefined);
-        expect(SampleTypeModel.create({ options: fromJS({labelColor: '#000000'}) } as DomainDetails, undefined).labelColor).toBe('#000000');
+        expect(
+            SampleTypeModel.create({ options: fromJS({ labelColor: undefined }) } as DomainDetails, undefined)
+                .labelColor
+        ).toBe(undefined);
+        expect(
+            SampleTypeModel.create({ options: fromJS({ labelColor: null }) } as DomainDetails, undefined).labelColor
+        ).toBe(undefined);
+        expect(
+            SampleTypeModel.create({ options: fromJS({ labelColor: '#000000' }) } as DomainDetails, undefined)
+                .labelColor
+        ).toBe('#000000');
     });
 
     // TODO add tests for getDuplicateAlias

--- a/packages/components/src/components/domainproperties/samples/models.spec.ts
+++ b/packages/components/src/components/domainproperties/samples/models.spec.ts
@@ -87,5 +87,12 @@ describe('SampleTypeModel', () => {
         ).toBeTruthy();
     });
 
+    test('labelColor value', () => {
+        expect(SampleTypeModel.create({ options: fromJS({}) } as DomainDetails, undefined).labelColor).toBe(undefined);
+        expect(SampleTypeModel.create({ options: fromJS({labelColor: undefined}) } as DomainDetails, undefined).labelColor).toBe(undefined);
+        expect(SampleTypeModel.create({ options: fromJS({labelColor: null}) } as DomainDetails, undefined).labelColor).toBe(undefined);
+        expect(SampleTypeModel.create({ options: fromJS({labelColor: '#000000'}) } as DomainDetails, undefined).labelColor).toBe('#000000');
+    });
+
     // TODO add tests for getDuplicateAlias
 });

--- a/packages/components/src/components/domainproperties/samples/models.ts
+++ b/packages/components/src/components/domainproperties/samples/models.ts
@@ -49,6 +49,7 @@ export class SampleTypeModel extends Record({
             name,
             nameReadOnly: raw.nameReadOnly,
             importAliases,
+            labelColor: options.get('labelColor') || undefined, // helps to convert null to undefined
             domain,
         });
     }

--- a/packages/components/src/components/domainproperties/samples/models.ts
+++ b/packages/components/src/components/domainproperties/samples/models.ts
@@ -9,6 +9,7 @@ export class SampleTypeModel extends Record({
     nameReadOnly: false,
     nameExpression: undefined,
     description: undefined,
+    labelColor: undefined,
     parentAliases: undefined,
     importAliases: undefined,
     domainId: undefined,
@@ -20,6 +21,7 @@ export class SampleTypeModel extends Record({
     nameReadOnly?: boolean;
     nameExpression: string;
     description: string;
+    labelColor: string;
     parentAliases?: OrderedMap<string, IParentAlias>;
     importAliases?: Map<string, string>;
     domainId?: number;

--- a/packages/components/src/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/components/forms/detail/DetailEditRenderer.tsx
@@ -30,6 +30,7 @@ import { QueryColumn } from '../../base/models/model';
 import { getUnFormattedNumber } from '../../../util/Date';
 
 import { _defaultRenderer } from './DetailDisplay';
+import { LabelColorRenderer } from "../../../renderers/LabelColorRenderer";
 
 export function titleRenderer(col: QueryColumn): React.ReactNode {
     // If the column cannot be edited, return the label as is
@@ -173,6 +174,9 @@ export function resolveDetailRenderer(column: QueryColumn) {
                 break;
             case 'assayrunreference':
                 renderer = d => <AssayRunReferenceRenderer data={d} />;
+                break;
+            case 'labelcolorrenderer':
+                renderer = d => <LabelColorRenderer data={d} />;
                 break;
             default:
                 break;

--- a/packages/components/src/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/components/forms/detail/DetailEditRenderer.tsx
@@ -29,8 +29,9 @@ import { LookupSelectInput } from '../input/LookupSelectInput';
 import { QueryColumn } from '../../base/models/model';
 import { getUnFormattedNumber } from '../../../util/Date';
 
+import { LabelColorRenderer } from '../../../renderers/LabelColorRenderer';
+
 import { _defaultRenderer } from './DetailDisplay';
-import { LabelColorRenderer } from "../../../renderers/LabelColorRenderer";
 
 export function titleRenderer(col: QueryColumn): React.ReactNode {
     // If the column cannot be edited, return the label as is

--- a/packages/components/src/components/forms/input/ColorPickerInput.spec.tsx
+++ b/packages/components/src/components/forms/input/ColorPickerInput.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from "enzyme";
+import renderer from 'react-test-renderer';
+import { ColorPickerInput } from "../../..";
+
+describe('ColorPickerInput', () => {
+    test('default props', () => {
+        const component = <ColorPickerInput value={'#000000'} onChange={jest.fn}/>;
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('without value', () => {
+        const component = <ColorPickerInput value={undefined} onChange={jest.fn}/>;
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('with button text', () => {
+        const component = <ColorPickerInput value={'#000000'} text={'Select color...'} onChange={jest.fn}/>;
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('showPicker', () => {
+        const component = shallow(<ColorPickerInput value={'#000000'} onChange={jest.fn}/>);
+        component.setState({showPicker: true});
+        expect(component).toMatchSnapshot();
+    });
+});

--- a/packages/components/src/components/forms/input/ColorPickerInput.spec.tsx
+++ b/packages/components/src/components/forms/input/ColorPickerInput.spec.tsx
@@ -1,35 +1,36 @@
 import React from 'react';
-import { shallow } from "enzyme";
+import { shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
-import { ColorPickerInput } from "../../..";
+
+import { ColorPickerInput } from '../../..';
 
 describe('ColorPickerInput', () => {
     test('default props', () => {
-        const component = <ColorPickerInput value={'#000000'} onChange={jest.fn}/>;
+        const component = <ColorPickerInput value="#000000" onChange={jest.fn} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('without value', () => {
-        const component = <ColorPickerInput value={undefined} onChange={jest.fn}/>;
+        const component = <ColorPickerInput value={undefined} onChange={jest.fn} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('with button text', () => {
-        const component = <ColorPickerInput value={'#000000'} text={'Select color...'} onChange={jest.fn}/>;
+        const component = <ColorPickerInput value="#000000" text="Select color..." onChange={jest.fn} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('showPicker', () => {
-        const component = shallow(<ColorPickerInput value={'#000000'} onChange={jest.fn}/>);
-        component.setState({showPicker: true});
+        const component = shallow(<ColorPickerInput value="#000000" onChange={jest.fn} />);
+        component.setState({ showPicker: true });
         expect(component).toMatchSnapshot();
     });
 
     test('allowRemove', () => {
-        const component = <ColorPickerInput value={'#000000'} onChange={jest.fn} allowRemove={true}/>;
+        const component = <ColorPickerInput value="#000000" onChange={jest.fn} allowRemove={true} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/components/src/components/forms/input/ColorPickerInput.spec.tsx
+++ b/packages/components/src/components/forms/input/ColorPickerInput.spec.tsx
@@ -27,4 +27,10 @@ describe('ColorPickerInput', () => {
         component.setState({showPicker: true});
         expect(component).toMatchSnapshot();
     });
+
+    test('allowRemove', () => {
+        const component = <ColorPickerInput value={'#000000'} onChange={jest.fn} allowRemove={true}/>;
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/packages/components/src/components/forms/input/ColorPickerInput.tsx
+++ b/packages/components/src/components/forms/input/ColorPickerInput.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 interface Props {
     name?: string;
     onChange: (name: string, value: string) => void;
-    text: string;
+    text?: string;
     value: string;
 }
 
@@ -31,15 +31,16 @@ export class ColorPickerInput extends PureComponent<Props, State> {
         const { text, value } = this.props;
         const { showPicker } = this.state;
         const iconClassName = classNames('fa', { 'fa-caret-up': showPicker, 'fa-caret-down': !showPicker });
+        const showChip = text !== undefined;
 
         return (
             <div className="color-picker">
                 <button type="button" className="color-picker__button btn btn-default" onClick={this.togglePicker}>
-                    {text}
+                    {text ? text : value ? <ColorChip cls="color-picker__chip-small" value={value} /> : 'None'}
                     <i className={iconClassName} />
                 </button>
 
-                <i className="color-picker__chip" style={{ backgroundColor: value }} />
+                {showChip && <ColorChip cls="color-picker__chip" value={value} />}
 
                 <div className="color-picker__picker">
                     {showPicker && (
@@ -51,5 +52,19 @@ export class ColorPickerInput extends PureComponent<Props, State> {
                 </div>
             </div>
         );
+    }
+}
+
+interface ColorChipProps {
+    cls: string;
+    value: string;
+}
+
+class ColorChip extends PureComponent<ColorChipProps> {
+    render(): ReactNode {
+        const { cls, value } = this.props;
+        const border = value?.toLowerCase() === '#ffffff' ? 'solid 1px #000000' : undefined;
+
+        return <i className={cls} style={{ backgroundColor: value, border }} />;
     }
 }

--- a/packages/components/src/components/forms/input/ColorPickerInput.tsx
+++ b/packages/components/src/components/forms/input/ColorPickerInput.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, ReactNode } from 'react';
 import { ColorResult, CompactPicker } from 'react-color';
 import classNames from 'classnames';
+import { ColorIcon } from "../../../components/base/ColorIcon";
 
 interface Props {
     name?: string;
@@ -36,11 +37,11 @@ export class ColorPickerInput extends PureComponent<Props, State> {
         return (
             <div className="color-picker">
                 <button type="button" className="color-picker__button btn btn-default" onClick={this.togglePicker}>
-                    {text ? text : value ? <ColorChip cls="color-picker__chip-small" value={value} /> : 'None'}
+                    {text ? text : value ? <ColorIcon cls="color-picker__chip-small" asSquare={true} value={value} /> : 'None'}
                     <i className={iconClassName} />
                 </button>
 
-                {showChip && <ColorChip cls="color-picker__chip" value={value} />}
+                {showChip && <ColorIcon cls="color-picker__chip" asSquare={true} value={value} />}
 
                 <div className="color-picker__picker">
                     {showPicker && (
@@ -52,19 +53,5 @@ export class ColorPickerInput extends PureComponent<Props, State> {
                 </div>
             </div>
         );
-    }
-}
-
-interface ColorChipProps {
-    cls: string;
-    value: string;
-}
-
-class ColorChip extends PureComponent<ColorChipProps> {
-    render(): ReactNode {
-        const { cls, value } = this.props;
-        const border = value?.toLowerCase() === '#ffffff' ? 'solid 1px #000000' : undefined;
-
-        return <i className={cls} style={{ backgroundColor: value, border }} />;
     }
 }

--- a/packages/components/src/components/forms/input/ColorPickerInput.tsx
+++ b/packages/components/src/components/forms/input/ColorPickerInput.tsx
@@ -1,13 +1,15 @@
 import React, { PureComponent, ReactNode } from 'react';
 import { ColorResult, CompactPicker } from 'react-color';
 import classNames from 'classnames';
-import { ColorIcon } from "../../../components/base/ColorIcon";
+
+import { ColorIcon, RemoveEntityButton } from "../../..";
 
 interface Props {
     name?: string;
     onChange: (name: string, value: string) => void;
     text?: string;
     value: string;
+    allowRemove?: boolean;
 }
 
 interface State {
@@ -19,9 +21,11 @@ export class ColorPickerInput extends PureComponent<Props, State> {
         showPicker: false,
     };
 
-    onChange = (color: ColorResult): void => {
-        this.props.onChange(this.props.name, color.hex);
-        this.togglePicker();
+    onChange = (color?: ColorResult): void => {
+        this.props.onChange(this.props.name, color?.hex);
+        if (color) {
+            this.togglePicker();
+        }
     };
 
     togglePicker = (): void => {
@@ -29,7 +33,7 @@ export class ColorPickerInput extends PureComponent<Props, State> {
     };
 
     render(): ReactNode {
-        const { text, value } = this.props;
+        const { text, value, allowRemove } = this.props;
         const { showPicker } = this.state;
         const iconClassName = classNames('fa', { 'fa-caret-up': showPicker, 'fa-caret-down': !showPicker });
         const showChip = text !== undefined;
@@ -42,6 +46,8 @@ export class ColorPickerInput extends PureComponent<Props, State> {
                 </button>
 
                 {showChip && <ColorIcon cls="color-picker__chip" asSquare={true} value={value} />}
+
+                {allowRemove && value && <RemoveEntityButton onClick={() => this.onChange()} labelClass={'color-picker__remove'}/>}
 
                 <div className="color-picker__picker">
                     {showPicker && (

--- a/packages/components/src/components/forms/input/ColorPickerInput.tsx
+++ b/packages/components/src/components/forms/input/ColorPickerInput.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactNode } from 'react';
 import { ColorResult, CompactPicker } from 'react-color';
 import classNames from 'classnames';
 
-import { ColorIcon, RemoveEntityButton } from "../../..";
+import { ColorIcon, RemoveEntityButton } from '../../..';
 
 interface Props {
     name?: string;
@@ -41,13 +41,21 @@ export class ColorPickerInput extends PureComponent<Props, State> {
         return (
             <div className="color-picker">
                 <button type="button" className="color-picker__button btn btn-default" onClick={this.togglePicker}>
-                    {text ? text : value ? <ColorIcon cls="color-picker__chip-small" asSquare={true} value={value} /> : 'None'}
+                    {text ? (
+                        text
+                    ) : value ? (
+                        <ColorIcon cls="color-picker__chip-small" asSquare={true} value={value} />
+                    ) : (
+                        'None'
+                    )}
                     <i className={iconClassName} />
                 </button>
 
                 {showChip && <ColorIcon cls="color-picker__chip" asSquare={true} value={value} />}
 
-                {allowRemove && value && <RemoveEntityButton onClick={() => this.onChange()} labelClass={'color-picker__remove'}/>}
+                {allowRemove && value && (
+                    <RemoveEntityButton onClick={() => this.onChange()} labelClass="color-picker__remove" />
+                )}
 
                 <div className="color-picker__picker">
                     {showPicker && (

--- a/packages/components/src/components/forms/input/__snapshots__/ColorPickerInput.spec.tsx.snap
+++ b/packages/components/src/components/forms/input/__snapshots__/ColorPickerInput.spec.tsx.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ColorPickerInput allowRemove 1`] = `
+<div
+  className="color-picker"
+>
+  <button
+    className="color-picker__button btn btn-default"
+    onClick={[Function]}
+    type="button"
+  >
+    <i
+      className="color-picker__chip-small"
+      style={
+        Object {
+          "backgroundColor": "#000000",
+          "border": undefined,
+        }
+      }
+    />
+    <i
+      className="fa fa-caret-down"
+    />
+  </button>
+  <div
+    className="color-picker__remove"
+  >
+    <span
+      className="container--action-button"
+      onClick={[Function]}
+    >
+      <i
+        className="fa fa-times container--removal-icon"
+      />
+      
+    </span>
+  </div>
+  <div
+    className="color-picker__picker"
+  />
+</div>
+`;
+
 exports[`ColorPickerInput default props 1`] = `
 <div
   className="color-picker"

--- a/packages/components/src/components/forms/input/__snapshots__/ColorPickerInput.spec.tsx.snap
+++ b/packages/components/src/components/forms/input/__snapshots__/ColorPickerInput.spec.tsx.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ColorPickerInput default props 1`] = `
+<div
+  className="color-picker"
+>
+  <button
+    className="color-picker__button btn btn-default"
+    onClick={[Function]}
+    type="button"
+  >
+    <i
+      className="color-picker__chip-small"
+      style={
+        Object {
+          "backgroundColor": "#000000",
+          "border": undefined,
+        }
+      }
+    />
+    <i
+      className="fa fa-caret-down"
+    />
+  </button>
+  <div
+    className="color-picker__picker"
+  />
+</div>
+`;
+
+exports[`ColorPickerInput showPicker 1`] = `
+<div
+  className="color-picker"
+>
+  <button
+    className="color-picker__button btn btn-default"
+    onClick={[Function]}
+    type="button"
+  >
+    <ColorIcon
+      asSquare={true}
+      cls="color-picker__chip-small"
+      value="#000000"
+    />
+    <i
+      className="fa fa-caret-up"
+    />
+  </button>
+  <div
+    className="color-picker__picker"
+  >
+    <div
+      className="color-picker__mask"
+      onClick={[Function]}
+    />
+    <ColorPicker
+      color="#000000"
+      colors={
+        Array [
+          "#4D4D4D",
+          "#999999",
+          "#FFFFFF",
+          "#F44E3B",
+          "#FE9200",
+          "#FCDC00",
+          "#DBDF00",
+          "#A4DD00",
+          "#68CCCA",
+          "#73D8FF",
+          "#AEA1FF",
+          "#FDA1FF",
+          "#333333",
+          "#808080",
+          "#cccccc",
+          "#D33115",
+          "#E27300",
+          "#FCC400",
+          "#B0BC00",
+          "#68BC00",
+          "#16A5A5",
+          "#009CE0",
+          "#7B64FF",
+          "#FA28FF",
+          "#000000",
+          "#666666",
+          "#B3B3B3",
+          "#9F0500",
+          "#C45100",
+          "#FB9E00",
+          "#808900",
+          "#194D33",
+          "#0C797D",
+          "#0062B1",
+          "#653294",
+          "#AB149E",
+        ]
+      }
+      onChangeComplete={[Function]}
+      styles={Object {}}
+    />
+  </div>
+</div>
+`;
+
+exports[`ColorPickerInput with button text 1`] = `
+<div
+  className="color-picker"
+>
+  <button
+    className="color-picker__button btn btn-default"
+    onClick={[Function]}
+    type="button"
+  >
+    Select color...
+    <i
+      className="fa fa-caret-down"
+    />
+  </button>
+  <i
+    className="color-picker__chip"
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "border": undefined,
+      }
+    }
+  />
+  <div
+    className="color-picker__picker"
+  />
+</div>
+`;
+
+exports[`ColorPickerInput without value 1`] = `
+<div
+  className="color-picker"
+>
+  <button
+    className="color-picker__button btn btn-default"
+    onClick={[Function]}
+    type="button"
+  >
+    None
+    <i
+      className="fa fa-caret-down"
+    />
+  </button>
+  <div
+    className="color-picker__picker"
+  />
+</div>
+`;

--- a/packages/components/src/components/forms/input/__snapshots__/ColorPickerInput.spec.tsx.snap
+++ b/packages/components/src/components/forms/input/__snapshots__/ColorPickerInput.spec.tsx.snap
@@ -14,7 +14,6 @@ exports[`ColorPickerInput allowRemove 1`] = `
       style={
         Object {
           "backgroundColor": "#000000",
-          "border": undefined,
         }
       }
     />
@@ -55,7 +54,6 @@ exports[`ColorPickerInput default props 1`] = `
       style={
         Object {
           "backgroundColor": "#000000",
-          "border": undefined,
         }
       }
     />
@@ -162,7 +160,6 @@ exports[`ColorPickerInput with button text 1`] = `
     style={
       Object {
         "backgroundColor": "#000000",
-        "border": undefined,
       }
     }
   />

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -359,11 +359,11 @@ import {
 import { GridPanel, GridPanelWithModel } from './QueryModel/GridPanel';
 import { DetailPanelWithModel } from './QueryModel/DetailPanel';
 import { Pagination, PaginationData } from './components/pagination/Pagination';
-import * as App from './internal/app/index';
 import { AuditDetailsModel } from './components/auditlog/models';
 import { AuditQueriesListingPage } from './components/auditlog/AuditQueriesListingPage';
 import { AuditDetails } from './components/auditlog/AuditDetails';
 import { getEventDataValueDisplay, getTimelineEntityUrl } from './components/auditlog/utils';
+import * as App from './internal/app';
 
 // See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 enableMapSet();

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -199,6 +199,7 @@ import { TextInput } from './components/forms/input/TextInput';
 import { TextAreaInput } from './components/forms/input/TextAreaInput';
 import { FieldEditForm, FieldEditProps } from './components/forms/input/FieldEditInput';
 import { ColorPickerInput } from './components/forms/input/ColorPickerInput';
+import { ColorIcon } from './components/base/ColorIcon';
 import { QuerySelect, QuerySelectOwnProps } from './components/forms/QuerySelect';
 import { PageDetailHeader } from './components/forms/PageDetailHeader';
 import { DetailEditing } from './components/forms/detail/DetailEditing';
@@ -458,6 +459,7 @@ export {
     TextAreaInput,
     TextInput,
     ColorPickerInput,
+    ColorIcon,
     FieldEditForm,
     FieldEditProps,
     QuerySelect,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -185,6 +185,7 @@ import { AppendUnits } from './renderers/AppendUnits';
 import { DefaultRenderer } from './renderers/DefaultRenderer';
 import { FileColumnRenderer } from './renderers/FileColumnRenderer';
 import { MultiValueRenderer } from './renderers/MultiValueRenderer';
+import { LabelColorRenderer } from './renderers/LabelColorRenderer';
 import { BulkAddUpdateForm } from './components/forms/BulkAddUpdateForm';
 import { BulkUpdateForm } from './components/forms/BulkUpdateForm';
 import { LabelOverlay } from './components/forms/LabelOverlay';
@@ -441,6 +442,7 @@ export {
     AppendUnits,
     DefaultRenderer,
     FileColumnRenderer,
+    LabelColorRenderer,
     MultiValueRenderer,
     resolveDetailEditRenderer,
     resolveDetailRenderer,

--- a/packages/components/src/renderers/LabelColorRenderer.spec.tsx
+++ b/packages/components/src/renderers/LabelColorRenderer.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { fromJS } from 'immutable';
+import renderer from 'react-test-renderer';
+import { LabelColorRenderer } from "..";
+
+describe('LabelColorRenderer', () => {
+    test('undefined data', () => {
+        const component = <LabelColorRenderer data={undefined}/>;
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('empty data', () => {
+        const component = <LabelColorRenderer data={fromJS({})}/>;
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('with data', () => {
+        const component = <LabelColorRenderer data={fromJS({value: '#000000'})}/>;
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/packages/components/src/renderers/LabelColorRenderer.spec.tsx
+++ b/packages/components/src/renderers/LabelColorRenderer.spec.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
 import { fromJS } from 'immutable';
 import renderer from 'react-test-renderer';
-import { LabelColorRenderer } from "..";
+
+import { LabelColorRenderer } from '..';
 
 describe('LabelColorRenderer', () => {
     test('undefined data', () => {
-        const component = <LabelColorRenderer data={undefined}/>;
+        const component = <LabelColorRenderer data={undefined} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('empty data', () => {
-        const component = <LabelColorRenderer data={fromJS({})}/>;
+        const component = <LabelColorRenderer data={fromJS({})} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('with data', () => {
-        const component = <LabelColorRenderer data={fromJS({value: '#000000'})}/>;
+        const component = <LabelColorRenderer data={fromJS({ value: '#000000' })} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/components/src/renderers/LabelColorRenderer.tsx
+++ b/packages/components/src/renderers/LabelColorRenderer.tsx
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { PureComponent } from 'react';
+import React, { PureComponent, ReactNode } from 'react';
 import { Map } from 'immutable';
-import { ColorIcon } from "../components/base/ColorIcon";
+
+import { ColorIcon } from '../components/base/ColorIcon';
 
 interface Props {
     data: Map<any, any>;
 }
 
 export class LabelColorRenderer extends PureComponent<Props> {
-    render() {
+    render(): ReactNode {
         const { data } = this.props;
-        return <ColorIcon value={data?.get('value')}/>;
+        return <ColorIcon value={data?.get('value')} />;
     }
 }

--- a/packages/components/src/renderers/LabelColorRenderer.tsx
+++ b/packages/components/src/renderers/LabelColorRenderer.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { PureComponent } from 'react';
+import { Map } from 'immutable';
+import { ColorIcon } from "../components/base/ColorIcon";
+
+interface Props {
+    data: Map<any, any>;
+}
+
+export class LabelColorRenderer extends PureComponent<Props> {
+    render() {
+        const { data } = this.props;
+        return <ColorIcon value={data?.get('value')}/>;
+    }
+}

--- a/packages/components/src/renderers/__snapshots__/LabelColorRenderer.spec.tsx.snap
+++ b/packages/components/src/renderers/__snapshots__/LabelColorRenderer.spec.tsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LabelColorRenderer empty data 1`] = `null`;
+
+exports[`LabelColorRenderer undefined data 1`] = `null`;
+
+exports[`LabelColorRenderer with data 1`] = `
+<i
+  className="fa fa-circle"
+  style={
+    Object {
+      "color": "#000000",
+    }
+  }
+/>
+`;

--- a/packages/components/src/renderers/__snapshots__/LabelColorRenderer.spec.tsx.snap
+++ b/packages/components/src/renderers/__snapshots__/LabelColorRenderer.spec.tsx.snap
@@ -6,10 +6,10 @@ exports[`LabelColorRenderer undefined data 1`] = `null`;
 
 exports[`LabelColorRenderer with data 1`] = `
 <i
-  className="fa fa-circle"
+  className="color-icon__circle"
   style={
     Object {
-      "color": "#000000",
+      "backgroundColor": "#000000",
     }
   }
 />

--- a/packages/components/src/stories/ColorIcon.tsx
+++ b/packages/components/src/stories/ColorIcon.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+import React, { FC, useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+
+import { ColorIcon } from "..";
+import './stories.scss';
+
+storiesOf('ColorIcon', module)
+    .addDecorator(withKnobs)
+    .add('with knobs', () => {
+        return <ColorIcon
+            label={text('label', 'Color Label')}
+            value={text('value', '#009ce0')}
+            asSquare={boolean('asSquare', false)}
+        />;
+    });

--- a/packages/components/src/stories/ColorIcon.tsx
+++ b/packages/components/src/stories/ColorIcon.tsx
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
-import React, { FC, useState } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 

--- a/packages/components/src/stories/ColorIcon.tsx
+++ b/packages/components/src/stories/ColorIcon.tsx
@@ -7,15 +7,17 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 
-import { ColorIcon } from "..";
+import { ColorIcon } from '..';
 import './stories.scss';
 
 storiesOf('ColorIcon', module)
     .addDecorator(withKnobs)
     .add('with knobs', () => {
-        return <ColorIcon
-            label={text('label', 'Color Label')}
-            value={text('value', '#009ce0')}
-            asSquare={boolean('asSquare', false)}
-        />;
+        return (
+            <ColorIcon
+                label={text('label', 'Color Label')}
+                value={text('value', '#009ce0')}
+                asSquare={boolean('asSquare', false)}
+            />
+        );
     });

--- a/packages/components/src/stories/ColorPickerInput.tsx
+++ b/packages/components/src/stories/ColorPickerInput.tsx
@@ -7,16 +7,16 @@ import React, { FC, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 
-import { ColorPickerInput } from "..";
+import { ColorPickerInput } from '..';
 import './stories.scss';
 
-const WrappedColorPickerInput: FC<any> = (props) => {
+const WrappedColorPickerInput: FC<any> = props => {
     const [selected, setSelected] = useState<string>('#009ce0');
     const showLabel = boolean('showLabel', true);
 
     return (
         <ColorPickerInput
-            name={'color-input-value'}
+            name="color-input-value"
             text={showLabel ? text('text', 'Select color') : undefined}
             allowRemove={boolean('allowRemove', true)}
             value={selected}
@@ -28,5 +28,5 @@ const WrappedColorPickerInput: FC<any> = (props) => {
 storiesOf('ColorPickerInput', module)
     .addDecorator(withKnobs)
     .add('with knobs', () => {
-        return <WrappedColorPickerInput/>;
+        return <WrappedColorPickerInput />;
     });

--- a/packages/components/src/stories/ColorPickerInput.tsx
+++ b/packages/components/src/stories/ColorPickerInput.tsx
@@ -18,6 +18,7 @@ const WrappedColorPickerInput: FC<any> = (props) => {
         <ColorPickerInput
             name={'color-input-value'}
             text={showLabel ? text('text', 'Select color') : undefined}
+            allowRemove={boolean('allowRemove', true)}
             value={selected}
             onChange={(name, value) => setSelected(value)}
         />

--- a/packages/components/src/stories/ColorPickerInput.tsx
+++ b/packages/components/src/stories/ColorPickerInput.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+import React, { FC, useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+
+import { ColorPickerInput } from "..";
+import './stories.scss';
+
+const WrappedColorPickerInput: FC<any> = (props) => {
+    const [selected, setSelected] = useState<string>('#009ce0');
+    const showLabel = boolean('showLabel', true);
+
+    return (
+        <ColorPickerInput
+            name={'color-input-value'}
+            text={showLabel ? text('text', 'Select color') : undefined}
+            value={selected}
+            onChange={(name, value) => setSelected(value)}
+        />
+    );
+};
+
+storiesOf('ColorPickerInput', module)
+    .addDecorator(withKnobs)
+    .add('with knobs', () => {
+        return <WrappedColorPickerInput/>;
+    });

--- a/packages/components/src/stories/SampleTypeDesigner.tsx
+++ b/packages/components/src/stories/SampleTypeDesigner.tsx
@@ -35,6 +35,7 @@ storiesOf('SampleTypeDesigner', module)
     .add('for create', () => {
         return (
             <SampleTypeDesigner
+                appPropertiesOnly={boolean('appPropertiesOnly', true)}
                 includeDataClasses={boolean('includeDataClasses', true)}
                 useSeparateDataClassesAliasMenu={boolean('useSeparateDataClasses', true)}
                 isValidParentOptionFn={isValidParentOption}
@@ -63,6 +64,7 @@ storiesOf('SampleTypeDesigner', module)
                 )}
                 onCancel={() => console.log('Cancel clicked')}
                 onComplete={() => console.log('Create clicked')}
+                appPropertiesOnly={boolean('appPropertiesOnly', false)}
                 nameExpressionInfoUrl={text('nameExpressionInfoUrl', 'https://wwDodomw.labkey.org')}
                 nameExpressionPlaceholder={text('nameExpressionPlaceholder', undefined)}
                 helpTopic={text('helpTopic', undefined)}
@@ -77,6 +79,7 @@ storiesOf('SampleTypeDesigner', module)
                 initModel={design}
                 onCancel={() => console.log('Cancel clicked')}
                 onComplete={() => console.log('Create clicked')}
+                appPropertiesOnly={boolean('appPropertiesOnly', false)}
                 nameExpressionInfoUrl={text('nameExpressionInfoUrl', undefined)}
                 nameExpressionPlaceholder={text('nameExpressionPlaceholder', undefined)}
                 headerText="Sample types help you organize samples in your lab and allow you to add properties for easy tracking of data."
@@ -90,7 +93,8 @@ storiesOf('SampleTypeDesigner', module)
         return (
             <SampleTypeDesigner
                 initModel={design}
-                includeDataClasses={true}
+                appPropertiesOnly={boolean('appPropertiesOnly', true)}
+                includeDataClasses={boolean('includeDataClasses', true)}
                 useSeparateDataClassesAliasMenu={boolean('useSeparateDataClassesAliasMenu', true)}
                 isValidParentOptionFn={isValidParentOption}
                 sampleAliasCaption="Parent Alias"

--- a/packages/components/src/test/data/property-getDomain-sampleType.json
+++ b/packages/components/src/test/data/property-getDomain-sampleType.json
@@ -4,6 +4,7 @@
     "name": "Sample Set 2",
     "nameExpression": "S-${now:date}-${dailySampleCount}",
     "description": "tacocat",
+    "labelColor": "#009ce0",
     "importAliases": {
       "a": "materialInputs/Fruits",
       "b": "dataInputs/Source 1",

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -215,6 +215,7 @@ div.react-datepicker__current-month {
     height: 32px;
     margin-left: 2em;
     border-radius: 4px;
+    border: solid 1px $gray;
     width: 32px;
     vertical-align: middle;
 }
@@ -223,6 +224,7 @@ div.react-datepicker__current-month {
     height: 16px;
     margin-left: 1em;
     border-radius: 2px;
+    border: solid 1px $gray;
     width: 16px;
     vertical-align: middle;
 }
@@ -241,4 +243,11 @@ div.react-datepicker__current-month {
 .color-picker__remove {
     display: inline-block;
     padding-left: 4px;
+}
+.color-icon__circle {
+    display: inline-block;
+    border-radius: 50%;
+    border: solid 1px $gray;
+    height: 12px;
+    width: 12px;
 }

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -218,6 +218,14 @@ div.react-datepicker__current-month {
     width: 32px;
     vertical-align: middle;
 }
+.color-picker__chip-small {
+    display: inline-block;
+    height: 16px;
+    margin-left: 1em;
+    border-radius: 2px;
+    width: 16px;
+    vertical-align: middle;
+}
 .color-picker__picker {
     position: absolute;
     top: 48px;

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -238,3 +238,7 @@ div.react-datepicker__current-month {
     bottom: 0;
     left: 0;
 }
+.color-picker__remove {
+    display: inline-block;
+    padding-left: 4px;
+}


### PR DESCRIPTION
#### Rationale
There are expectations that there will be several sample types used in the Sample Manager and Freezer Manager apps. To distinguish them quickly in various parts of the UI, we are adding a "Label Color" property to the Sample Type so that it can be tagged with a color to be used in things like the Freezer box display and grid.

This PR adds or updates some shared components related to showing a color icon in various places. The existing ColorPickerInput, used by ELN, was updated for use with the SampleTypeDesigner and a ColorIcon component was added for display purposes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1389
* https://github.com/LabKey/sampleManagement/pull/324
* https://github.com/LabKey/inventory/pull/54

#### Changes
* ColorPickerInput updates to support showing color chip within dropdown button when label text not provided
* ColorPickerInput update to handle value=#ffffff (display as white background with black border)
* SampleTypePropertiesPanel addition of ColorPickerInput, conditional based on appPropertiesOnly prop
* SampleTypeModel addition of labelColor prop
* Add ColorIcon display component and LabelColorRenderer to use in Sample Manager and Freezer Manager
