### PR TITLE
Item 7493: Support for adding storage status columns in sample grids and resolving URLs to other applications 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.76.0-sampleGridLocations.0",
+  "version": "0.76.0-sampleGridLocations.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.77.0-sampleGridLocations.1",
+  "version": "0.77.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.75.0",
+  "version": "0.76.0-sampleGridLocations.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
-### version TBD
-*Released*: TBD
+### version 0.77.0
+*Released*: 15 July 2020
 * Update URLResolvers to handle URLs that may go to a separate application
 * Add StorageStatusRenderer for showing the storage status of a sample
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,5 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
+### version TBD
+*Released*: TBD
+* Update URLResolvers to handle URLs that may go to a separate application
+* Add StorageStatusRenderer for showing the storage status of a sample
 
 ### version 0.75.0
 *Released*: 9 July 2020

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -181,6 +181,7 @@ import { EditableColumnMetadata } from './components/editable/EditableGrid';
 import { CollapsiblePanel } from './components/CollapsiblePanel';
 import { ErrorBoundary } from './components/error/ErrorBoundary';
 import { AliasRenderer } from './renderers/AliasRenderer';
+import { StorageStatusRenderer } from './renderers/StorageStatusRenderer';
 import { AppendUnits } from './renderers/AppendUnits';
 import { DefaultRenderer } from './renderers/DefaultRenderer';
 import { FileColumnRenderer } from './renderers/FileColumnRenderer';
@@ -441,6 +442,7 @@ export {
     DefaultRenderer,
     FileColumnRenderer,
     MultiValueRenderer,
+    StorageStatusRenderer,
     resolveDetailEditRenderer,
     resolveDetailRenderer,
     titleRenderer,

--- a/packages/components/src/renderers/StorageStatusRenderer.tsx
+++ b/packages/components/src/renderers/StorageStatusRenderer.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Map } from 'immutable';
 
 interface StorageStatusProps {
-    data: any
+    data: Map<any, any>;
 }
 
 export class StorageStatusRenderer extends React.PureComponent<StorageStatusProps, any> {
@@ -9,10 +10,10 @@ export class StorageStatusRenderer extends React.PureComponent<StorageStatusProp
     render() {
         const { data } = this.props;
 
-        const value = data && data.get('value');
+        const value = data?.get('value');
 
-        if (value.toLowerCase() === 'not in storage') {
-            return data.get('value');
+        if (value?.toLowerCase() === 'not in storage') {
+            return value;
         }
         else {
             return <a href={data.get('url')}>{value}</a>

--- a/packages/components/src/renderers/StorageStatusRenderer.tsx
+++ b/packages/components/src/renderers/StorageStatusRenderer.tsx
@@ -6,7 +6,6 @@ interface StorageStatusProps {
 }
 
 export class StorageStatusRenderer extends React.PureComponent<StorageStatusProps, any> {
-
     render() {
         const { data } = this.props;
 
@@ -14,9 +13,8 @@ export class StorageStatusRenderer extends React.PureComponent<StorageStatusProp
 
         if (value?.toLowerCase() === 'not in storage') {
             return value;
-        }
-        else {
-            return <a href={data.get('url')}>{value}</a>
+        } else {
+            return <a href={data.get('url')}>{value}</a>;
         }
     }
 }

--- a/packages/components/src/renderers/StorageStatusRenderer.tsx
+++ b/packages/components/src/renderers/StorageStatusRenderer.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface StorageStatusProps {
+    data: any
+}
+
+export class StorageStatusRenderer extends React.PureComponent<StorageStatusProps, any> {
+
+    render() {
+        const { data } = this.props;
+
+        const value = data && data.get('value');
+
+        if (value.toLowerCase() === 'not in storage') {
+            return data.get('value');
+        }
+        else {
+            return <a href={data.get('url')}>{value}</a>
+        }
+    }
+}

--- a/packages/components/src/util/URLResolver.ts
+++ b/packages/components/src/util/URLResolver.ts
@@ -348,6 +348,7 @@ export class URLResolver {
                         );
                     }
                 }
+                return false;
             }),
 
             new ActionMapper('user', 'details', (row, column, schema, query) => {

--- a/packages/components/src/util/URLResolver.ts
+++ b/packages/components/src/util/URLResolver.ts
@@ -334,11 +334,18 @@ export class URLResolver {
                 if (url) {
                     const materialIdKey = 'query.MaterialId~eq';
                     const params = ActionURL.getParameters(url);
-                    if (params.schemaName && params.schemaName.toLowerCase() == 'inventory'
-                        && params.queryName && params.queryName.toLowerCase() == 'item'
-                        && params[materialIdKey] !== undefined
+                    if (
+                        params.schemaName &&
+                        params.schemaName.toLowerCase() == 'inventory' &&
+                        params.queryName &&
+                        params.queryName.toLowerCase() == 'item' &&
+                        params[materialIdKey] !== undefined
                     ) {
-                        return createProductUrl(FREEZER_MANAGER_PRODUCT_ID, undefined, AppURL.create("rd", "sampleItem", params[materialIdKey]))
+                        return createProductUrl(
+                            FREEZER_MANAGER_PRODUCT_ID,
+                            undefined,
+                            AppURL.create('rd', 'sampleItem', params[materialIdKey])
+                        );
                     }
                 }
             }),
@@ -570,7 +577,11 @@ class ActionMapper implements URLMapper {
     action: string;
     resolver: (row, column, schema, query) => AppURL | string | boolean;
 
-    constructor(controller: string, action: string, resolver: (row?, column?, schema?, query?) => AppURL | string | boolean) {
+    constructor(
+        controller: string,
+        action: string,
+        resolver: (row?, column?, schema?, query?) => AppURL | string | boolean
+    ) {
         this.controller = controller.toLowerCase();
         this.action = action.toLowerCase();
         this.resolver = resolver;

--- a/packages/components/src/util/URLResolver.ts
+++ b/packages/components/src/util/URLResolver.ts
@@ -19,6 +19,7 @@ import { ActionURL, Experiment, Filter } from '@labkey/api';
 import { AppURL } from '../url/AppURL';
 import { LineageLinkMetadata } from '../components/lineage/types';
 import { createProductUrl } from '../components/navigation/utils';
+import { FREEZER_MANAGER_PRODUCT_ID } from '../internal/app';
 
 interface MapURLOptions {
     column: any;
@@ -331,10 +332,13 @@ export class URLResolver {
             new ActionMapper('query', 'executeQuery', row => {
                 const url = row.get('url');
                 if (url) {
+                    const materialIdKey = 'query.MaterialId~eq';
                     const params = ActionURL.getParameters(url);
                     if (params.schemaName && params.schemaName.toLowerCase() == 'inventory'
-                        && params.queryName && params.queryName.toLowerCase() == 'item') {
-                        return createProductUrl("freezerManager", undefined, AppURL.create("rd", "sampleItem", params['query.MaterialId~eq']))
+                        && params.queryName && params.queryName.toLowerCase() == 'item'
+                        && params[materialIdKey] !== undefined
+                    ) {
+                        return createProductUrl(FREEZER_MANAGER_PRODUCT_ID, undefined, AppURL.create("rd", "sampleItem", params[materialIdKey]))
                     }
                 }
             }),

--- a/packages/components/src/util/URLResolver.ts
+++ b/packages/components/src/util/URLResolver.ts
@@ -18,6 +18,7 @@ import { ActionURL, Experiment, Filter } from '@labkey/api';
 
 import { AppURL } from '../url/AppURL';
 import { LineageLinkMetadata } from '../components/lineage/types';
+import { createProductUrl } from '../components/navigation/utils';
 
 interface MapURLOptions {
     column: any;
@@ -327,6 +328,17 @@ export class URLResolver {
                 }
             }),
 
+            new ActionMapper('query', 'executeQuery', row => {
+                const url = row.get('url');
+                if (url) {
+                    const params = ActionURL.getParameters(url);
+                    if (params.schemaName && params.schemaName.toLowerCase() == 'inventory'
+                        && params.queryName && params.queryName.toLowerCase() == 'item') {
+                        return createProductUrl("freezerManager", undefined, AppURL.create("rd", "sampleItem", params['query.MaterialId~eq']))
+                    }
+                }
+            }),
+
             new ActionMapper('user', 'details', (row, column, schema, query) => {
                 const url = row.get('url');
                 if (url) {
@@ -373,6 +385,10 @@ export class URLResolver {
 
         if (_url instanceof AppURL) {
             return _url.toHref();
+        }
+
+        if (typeof _url === 'string') {
+            return _url;
         }
 
         if (_url !== false && LABKEY.devMode) {
@@ -542,21 +558,21 @@ export class URLResolver {
 }
 
 interface URLMapper {
-    resolve(url, row, column, schema, query): AppURL | boolean;
+    resolve(url, row, column, schema, query): AppURL | string | boolean;
 }
 
 class ActionMapper implements URLMapper {
     controller: string;
     action: string;
-    resolver: (row, column, schema, query) => AppURL | boolean;
+    resolver: (row, column, schema, query) => AppURL | string | boolean;
 
-    constructor(controller: string, action: string, resolver: (row?, column?, schema?, query?) => AppURL | boolean) {
+    constructor(controller: string, action: string, resolver: (row?, column?, schema?, query?) => AppURL | string | boolean) {
         this.controller = controller.toLowerCase();
         this.action = action.toLowerCase();
         this.resolver = resolver;
     }
 
-    resolve(url, row, column, schema, query): AppURL | boolean {
+    resolve(url, row, column, schema, query): AppURL | string | boolean {
         if (url) {
             const parsed = parsePathName(url);
 


### PR DESCRIPTION
#### Rationale
We are adding columns in our samples grids for SampleManager that will show the storage status for each sample and link to the appropriate location in the FreezerManager application when a sample is in storage.  Thus our URLResolvers need to be able to handle linking outside the current application

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1388
* https://github.com/LabKey/sampleManagement/pull/325
* https://github.com/LabKey/inventory/pull/55
* https://github.com/LabKey/biologics/pull/632


#### Changes
* Update URLResolvers to handle URLs that may go to a separate application
* Add StorageStatusRenderer for showing the storage status of a sample