### PR TITLE
Audit and schema browser component linting and misc cleanup after move from Sample Manager app

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.76.0",
+  "version": "0.76.0-fb-auditSchemaBrowserLinting.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.77.0",
+  "version": "0.77.0-fb-auditSchemaBrowserLinting.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.76.0-fb-auditSchemaBrowserLinting.0",
+  "version": "0.76.0-fb-auditSchemaBrowserLinting.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.80.1
+*Released*: 27 July 2020
 * Audit and schema browser component linting and misc cleanup after move from Sample Manager app
 
 ### version 0.80.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Audit and schema browser component linting and misc cleanup after move from Sample Manager app
+
 ### version 0.76.0
 *Released*: 14 July 2020
 * Updates FileTree to support new Module Editor functionality.

--- a/packages/components/src/components/auditlog/actions.ts
+++ b/packages/components/src/components/auditlog/actions.ts
@@ -10,7 +10,6 @@ export function getAuditDetail(auditRowId: number, auditEventType: string): Prom
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('audit', 'GetDetailedAuditChanges.api'),
-            method: 'GET',
             params: { auditRowId, auditEventType },
             success: Utils.getCallbackWrapper(response => {
                 resolve(AuditDetailsModel.create(response));

--- a/packages/components/src/components/auditlog/models.ts
+++ b/packages/components/src/components/auditlog/models.ts
@@ -27,16 +27,22 @@ export class AuditDetailsModel extends Record({
         });
     }
 
-    getActionLabel = (): string => {
+    getActionLabel(): string {
         if (this.isUpdate()) return 'Updated';
         else if (this.isInsert()) return 'Created';
         else if (this.isDelete()) return 'Deleted';
         else return 'Updated';
-    };
+    }
 
-    isDelete = (): boolean => this.oldData && this.newData && this.oldData.size > 0 && this.newData.size === 0;
+    isUpdate(): boolean {
+        return this.oldData && this.newData && this.oldData.size > 0 && this.newData.size > 0;
+    }
 
-    isInsert = (): boolean => this.oldData && this.newData && this.oldData.size === 0 && this.newData.size > 0;
+    isInsert(): boolean {
+        return this.oldData && this.newData && this.oldData.size === 0 && this.newData.size > 0;
+    }
 
-    isUpdate = (): boolean => this.oldData && this.newData && this.oldData.size > 0 && this.newData.size > 0;
+    isDelete(): boolean {
+        return this.oldData && this.newData && this.oldData.size > 0 && this.newData.size === 0;
+    }
 }

--- a/packages/components/src/components/auditlog/models.ts
+++ b/packages/components/src/components/auditlog/models.ts
@@ -19,10 +19,6 @@ export class AuditDetailsModel extends Record({
     oldData?: Map<string, string>;
     newData?: Map<string, string>;
 
-    constructor(values?: { [key: string]: any }) {
-        super(values);
-    }
-
     static create(raw: any): AuditDetailsModel {
         return new AuditDetailsModel({
             ...raw,
@@ -31,22 +27,16 @@ export class AuditDetailsModel extends Record({
         });
     }
 
-    isUpdate() {
-        return this.oldData && this.newData && this.oldData.size > 0 && this.newData.size > 0;
-    }
-
-    isInsert() {
-        return this.oldData && this.newData && this.oldData.size === 0 && this.newData.size > 0;
-    }
-
-    isDelete() {
-        return this.oldData && this.newData && this.oldData.size > 0 && this.newData.size === 0;
-    }
-
-    getActionLabel() {
+    getActionLabel = (): string => {
         if (this.isUpdate()) return 'Updated';
         else if (this.isInsert()) return 'Created';
         else if (this.isDelete()) return 'Deleted';
         else return 'Updated';
-    }
+    };
+
+    isDelete = (): boolean => this.oldData && this.newData && this.oldData.size > 0 && this.newData.size === 0;
+
+    isInsert = (): boolean => this.oldData && this.newData && this.oldData.size === 0 && this.newData.size > 0;
+
+    isUpdate = (): boolean => this.oldData && this.newData && this.oldData.size > 0 && this.newData.size > 0;
 }

--- a/packages/components/src/components/auditlog/utils.ts
+++ b/packages/components/src/components/auditlog/utils.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { List } from 'immutable';
 import { Query } from '@labkey/api';
 
@@ -15,7 +15,47 @@ import {
 } from '../../internal/app';
 import { AppURL } from '../../url/AppURL';
 
-export function getEventDataValueDisplay(d: any, showLink = true) {
+export type AuditQuery = {
+    containerFilter?: Query.ContainerFilter;
+    hasDetail?: boolean;
+    label: string;
+    value: string;
+};
+
+export function getAuditQueries(): AuditQuery[] {
+    const auditQueries = [];
+    if (isSampleManagerEnabled()) {
+        auditQueries.push(
+            { value: 'attachmentauditevent', label: 'Attachment Events' },
+            { value: 'experimentauditevent', label: 'Assay Events' },
+            { value: 'domainauditevent', label: 'Domain Events' },
+            { value: 'domainpropertyauditevent', label: 'Domain Property Events' },
+            { value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true }
+        );
+    }
+    if (isFreezerManagementEnabled()) {
+        auditQueries.push({ value: 'inventoryauditevent', label: 'Freezer Management Events', hasDetail: true });
+    }
+    if (isSampleManagerEnabled()) {
+        auditQueries.push(
+            { value: 'listauditevent', label: 'List Events' },
+            {
+                value: 'groupauditevent',
+                label: 'Roles and Assignment Events',
+                containerFilter: Query.ContainerFilter.allFolders,
+            },
+            { value: 'samplesetauditevent', label: 'Sample Type Events' },
+            { value: 'sampletimelineevent', label: 'Sample Timeline Events', hasDetail: true },
+            { value: 'samplesworkflowauditevent', label: 'Sample Workflow Events', hasDetail: true },
+            { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true },
+            { value: 'userauditevent', label: 'User Events', containerFilter: Query.ContainerFilter.allFolders }
+        );
+    }
+
+    return auditQueries;
+}
+
+export function getEventDataValueDisplay(d: any, showLink = true): ReactNode {
     let display = null;
     if (d) {
         if (typeof d === 'string' || typeof d === 'number') {
@@ -83,38 +123,5 @@ export function getTimelineEntityUrl(d: any): string {
         }
     }
 
-    return url !== undefined ? url.toHref() : undefined;
-}
-
-export function getAuditQueries(): Array<{ [key: string]: any }> {
-    const auditQueries = [];
-    if (isSampleManagerEnabled()) {
-        auditQueries.push(
-            { value: 'attachmentauditevent', label: 'Attachment Events' },
-            { value: 'experimentauditevent', label: 'Assay Events' },
-            { value: 'domainauditevent', label: 'Domain Events' },
-            { value: 'domainpropertyauditevent', label: 'Domain Property Events' },
-            { value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true }
-        );
-    }
-    if (isFreezerManagementEnabled()) {
-        auditQueries.push({ value: 'inventoryauditevent', label: 'Freezer Management Events', hasDetail: true });
-    }
-    if (isSampleManagerEnabled()) {
-        auditQueries.push(
-            { value: 'listauditevent', label: 'List Events' },
-            {
-                value: 'groupauditevent',
-                label: 'Roles and Assignment Events',
-                containerFilter: Query.ContainerFilter.allFolders,
-            },
-            { value: 'samplesetauditevent', label: 'Sample Type Events' },
-            { value: 'sampletimelineevent', label: 'Sample Timeline Events', hasDetail: true },
-            { value: 'samplesworkflowauditevent', label: 'Sample Workflow Events', hasDetail: true },
-            { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true },
-            { value: 'userauditevent', label: 'User Events', containerFilter: Query.ContainerFilter.allFolders }
-        );
-    }
-
-    return auditQueries;
+    return url?.toHref();
 }

--- a/packages/components/src/components/base/models/schemas.ts
+++ b/packages/components/src/components/base/models/schemas.ts
@@ -102,7 +102,7 @@ export function fetchSchemas(schemaName?: string): Promise<List<Map<string, Sche
         Query.getSchemas({
             apiVersion: 9.3,
             schemaName,
-            success: function (schemas) {
+            success: schemas => {
                 resolve(
                     processSchemas(schemas)
                         .filter(schema => {
@@ -113,7 +113,7 @@ export function fetchSchemas(schemaName?: string): Promise<List<Map<string, Sche
                         .toList()
                 );
             },
-            failure: function (error) {
+            failure: error => {
                 reject(error);
             },
         });

--- a/packages/components/src/components/listing/QueriesListing.tsx
+++ b/packages/components/src/components/listing/QueriesListing.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { Component, ReactNode } from 'react';
 import { Link } from 'react-router';
 import { List } from 'immutable';
 
@@ -55,7 +55,11 @@ interface QueriesListingState {
     error: string;
 }
 
-export class QueriesListing extends React.Component<QueriesListingProps, QueriesListingState> {
+export class QueriesListing extends Component<QueriesListingProps, QueriesListingState> {
+    static defaultProps = {
+        title: 'Queries',
+    };
+
     constructor(props: QueriesListingProps) {
         super(props);
 
@@ -65,18 +69,18 @@ export class QueriesListing extends React.Component<QueriesListingProps, Queries
         };
     }
 
-    componentWillMount() {
-        const { schemaName } = this.props;
-        this.loadQueries(schemaName);
-    }
+    componentDidMount = (): void => {
+        this.loadQueries();
+    };
 
-    componentWillReceiveProps(nextProps) {
-        if (this.props.schemaName !== nextProps.schemaName) {
-            this.loadQueries(nextProps.schemaName);
+    componentDidUpdate = (prevProps: Readonly<QueriesListingProps>): void => {
+        if (prevProps.schemaName !== this.props.schemaName) {
+            this.loadQueries();
         }
-    }
+    };
 
-    loadQueries(schemaName: string) {
+    loadQueries = (): void => {
+        const { schemaName } = this.props;
         fetchGetQueries(schemaName)
             .then(queries => {
                 this.setState(() => ({ queries }));
@@ -85,9 +89,9 @@ export class QueriesListing extends React.Component<QueriesListingProps, Queries
                 console.error(error);
                 this.setState(() => ({ error: error.exception }));
             });
-    }
+    };
 
-    render() {
+    render = (): ReactNode => {
         const { schemaName, hideEmpty, asPanel, title } = this.props;
         const { queries, error } = this.state;
 
@@ -97,7 +101,7 @@ export class QueriesListing extends React.Component<QueriesListingProps, Queries
                     <SchemaListing schemaName={schemaName} hideEmpty={true} asPanel={true} title="Nested Schemas" />
                     {hideEmpty && queries.count() === 0 ? null : asPanel ? (
                         <div className="panel panel-default">
-                            <div className="panel-heading">{title || 'Queries'}</div>
+                            <div className="panel-heading">{title}</div>
                             <div className="panel-body">
                                 <Grid data={queries} columns={columns} />
                             </div>
@@ -114,5 +118,5 @@ export class QueriesListing extends React.Component<QueriesListingProps, Queries
         }
 
         return <LoadingSpinner />;
-    }
+    };
 }

--- a/packages/components/src/components/listing/SchemaListing.tsx
+++ b/packages/components/src/components/listing/SchemaListing.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { Component, ReactNode } from 'react';
 import { Link } from 'react-router';
 import { List, Map } from 'immutable';
 
@@ -56,7 +56,11 @@ interface SchemaListingState {
     schemas: List<Map<string, SchemaDetails>>;
 }
 
-export class SchemaListing extends React.Component<SchemaListingProps, SchemaListingState> {
+export class SchemaListing extends Component<SchemaListingProps, SchemaListingState> {
+    static defaultProps = {
+        title: 'Schemas',
+    };
+
     constructor(props: SchemaListingProps) {
         super(props);
 
@@ -65,24 +69,23 @@ export class SchemaListing extends React.Component<SchemaListingProps, SchemaLis
         };
     }
 
-    componentWillMount() {
-        const { schemaName } = this.props;
-        this.loadSchemas(schemaName);
-    }
+    componentDidMount = (): void => {
+        this.loadSchemas();
+    };
 
-    componentWillReceiveProps(nextProps) {
-        if (this.props.schemaName !== nextProps.schemaName) {
-            this.loadSchemas(nextProps.schemaName);
+    componentDidUpdate = (prevProps: Readonly<SchemaListingProps>): void => {
+        if (prevProps.schemaName !== this.props.schemaName) {
+            this.loadSchemas();
         }
-    }
+    };
 
-    loadSchemas(schemaName: string) {
-        fetchSchemas(schemaName).then(schemas => {
-            this.setState(() => ({ schemas }));
+    loadSchemas = (): void => {
+        fetchSchemas(this.props.schemaName).then(schemas => {
+            this.setState({ schemas });
         });
-    }
+    };
 
-    render() {
+    render = (): ReactNode => {
         const { hideEmpty, asPanel, title } = this.props;
         const { schemas } = this.state;
 
@@ -91,31 +94,20 @@ export class SchemaListing extends React.Component<SchemaListingProps, SchemaLis
                 return null;
             }
 
+            const grid = <Grid data={schemas} columns={columns} />;
+
             if (asPanel) {
                 return (
                     <div className="panel panel-default">
-                        <div className="panel-heading">{title || 'Schemas'}</div>
-                        <div className="panel-body">
-                            <SchemaListingDisplay schemas={schemas} />
-                        </div>
+                        <div className="panel-heading">{title}</div>
+                        <div className="panel-body">{grid}</div>
                     </div>
                 );
             }
 
-            return <SchemaListingDisplay schemas={schemas} />;
+            return grid;
         }
 
         return <LoadingSpinner />;
-    }
-}
-
-interface SchemaListingDisplayProps {
-    schemas: List<Map<string, SchemaDetails>>;
-}
-
-export class SchemaListingDisplay extends React.PureComponent<SchemaListingDisplayProps, any> {
-    render() {
-        const { schemas } = this.props;
-        return <Grid data={schemas} columns={columns} />;
-    }
+    };
 }

--- a/packages/components/src/components/listing/pages/QueriesListingPage.tsx
+++ b/packages/components/src/components/listing/pages/QueriesListingPage.tsx
@@ -2,18 +2,14 @@
  * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import * as React from 'react';
-import { Link } from 'react-router';
+import React, { Component, ReactNode } from 'react';
+import { Link, WithRouterProps } from 'react-router';
 
 import { AppURL, Breadcrumb, Page, PageHeader } from '../../..';
 import { QueriesListing } from '../QueriesListing';
 
-interface OwnProps {
-    params: any;
-}
-
-export class QueriesListingPage extends React.Component<OwnProps, any> {
-    render() {
+export class QueriesListingPage extends Component<WithRouterProps> {
+    render = (): ReactNode => {
         const { schema } = this.props.params;
 
         return (
@@ -25,5 +21,5 @@ export class QueriesListingPage extends React.Component<OwnProps, any> {
                 <QueriesListing schemaName={schema} asPanel={true} hideEmpty={true} />
             </Page>
         );
-    }
+    };
 }

--- a/packages/components/src/components/listing/pages/QueryDetailPage.tsx
+++ b/packages/components/src/components/listing/pages/QueryDetailPage.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import * as React from 'react';
-import { Link } from 'react-router';
+import React, { Component, ReactNode } from 'react';
+import { Link, WithRouterProps } from 'react-router';
 
 import {
     getStateQueryGridModel,
@@ -21,26 +21,22 @@ import {
     LoadingSpinner,
 } from '../../..';
 
-interface OwnProps {
-    params?: any;
-}
+export class QueryDetailPage extends Component<WithRouterProps> {
+    componentDidMount = (): void => {
+        this.initModel();
+    };
 
-export class QueryDetailPage extends React.Component<OwnProps, any> {
-    componentWillMount() {
-        this.initModel(this.props);
-    }
+    componentDidUpdate = (): void => {
+        this.initModel();
+    };
 
-    componentWillReceiveProps(nextProps: OwnProps) {
-        this.initModel(nextProps);
-    }
+    initModel = (): void => {
+        gridInit(this.getQueryGridModel(), true, this);
+    };
 
-    initModel(props: OwnProps) {
-        const model = this.getQueryGridModel(props);
-        gridInit(model, true, this);
-    }
-
-    getQueryGridModel(props: OwnProps): QueryGridModel {
-        const { schema, query, id } = props.params;
+    getQueryGridModel = (): QueryGridModel => {
+        const { params } = this.props;
+        const { schema, query, id } = params;
         const model = getStateQueryGridModel(
             'querydetail',
             SchemaQuery.create(schema, query),
@@ -52,10 +48,10 @@ export class QueryDetailPage extends React.Component<OwnProps, any> {
         );
 
         return getQueryGridModel(model.getId()) || model;
-    }
+    };
 
-    title(row: any): string {
-        const model = this.getQueryGridModel(this.props);
+    title = (row: any): string => {
+        const model = this.getQueryGridModel();
         const queryInfo = model.queryInfo;
         let title: string;
 
@@ -83,10 +79,10 @@ export class QueryDetailPage extends React.Component<OwnProps, any> {
         }
 
         return title;
-    }
+    };
 
-    render() {
-        const model = this.getQueryGridModel(this.props);
+    render = (): ReactNode => {
+        const model = this.getQueryGridModel();
 
         if (model && model.isLoaded) {
             const queryInfo = model.queryInfo;
@@ -110,5 +106,5 @@ export class QueryDetailPage extends React.Component<OwnProps, any> {
         }
 
         return <LoadingSpinner />;
-    }
+    };
 }

--- a/packages/components/src/components/listing/pages/QueryDetailPage.tsx
+++ b/packages/components/src/components/listing/pages/QueryDetailPage.tsx
@@ -26,8 +26,10 @@ export class QueryDetailPage extends Component<WithRouterProps> {
         this.initModel();
     };
 
-    componentDidUpdate = (): void => {
-        this.initModel();
+    componentDidUpdate = (prevProps: Readonly<WithRouterProps>): void => {
+        if (prevProps.location?.pathname !== this.props.location?.pathname) {
+            this.initModel();
+        }
     };
 
     initModel = (): void => {

--- a/packages/components/src/components/listing/pages/QueryListingPage.tsx
+++ b/packages/components/src/components/listing/pages/QueryListingPage.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import * as React from 'react';
-import { Link } from 'react-router';
+import React, { Component, ReactNode } from 'react';
+import { Link, WithRouterProps } from 'react-router';
 import { Query } from '@labkey/api';
 
 import {
@@ -17,41 +17,34 @@ import {
     PageHeader,
     AppURL,
     QueryGridPanel,
-    Location,
 } from '../../..';
 
-interface OwnProps {
-    params: any;
-    location: Location;
-}
+export class QueryListingPage extends Component<WithRouterProps> {
+    componentDidMount = (): void => {
+        this.initModel();
+    };
 
-export class QueryListingPage extends React.Component<OwnProps, any> {
-    componentWillMount() {
-        this.initModel(this.props);
-    }
+    componentDidUpdate = (): void => {
+        this.initModel();
+    };
 
-    componentWillReceiveProps(nextProps: OwnProps) {
-        this.initModel(nextProps);
-    }
+    initModel = (): void => {
+        gridInit(this.getQueryGridModel(), true, this);
+    };
 
-    initModel(props: OwnProps) {
-        const model = this.getQueryGridModel(props);
-        gridInit(model, true, this);
-    }
+    getQueryGridModel = (): QueryGridModel => {
+        const { location, params } = this.props;
+        const { schema, query } = params;
 
-    getQueryGridModel(props: OwnProps): QueryGridModel {
-        const { schema, query } = props.params;
-        const { containerFilter } = props.location.query;
-
-        const model = getStateQueryGridModel('querylisting', SchemaQuery.create(schema, query), {
-            containerFilter: Query.ContainerFilter[containerFilter],
+        const model = getStateQueryGridModel('querylisting', SchemaQuery.create(schema, query), () => ({
+            containerFilter: Query.ContainerFilter[location.query.containerFilter as string],
             isPaged: true,
-        });
+        }));
         return getQueryGridModel(model.getId()) || model;
-    }
+    };
 
-    render() {
-        const model = this.getQueryGridModel(this.props);
+    render = (): ReactNode => {
+        const model = this.getQueryGridModel();
         const queryInfo = model.queryInfo;
 
         const schemaTitle = queryInfo ? queryInfo.schemaLabel : model.schema;
@@ -69,5 +62,5 @@ export class QueryListingPage extends React.Component<OwnProps, any> {
                 <QueryGridPanel model={model} />
             </Page>
         );
-    }
+    };
 }

--- a/packages/components/src/components/listing/pages/QueryListingPage.tsx
+++ b/packages/components/src/components/listing/pages/QueryListingPage.tsx
@@ -24,8 +24,10 @@ export class QueryListingPage extends Component<WithRouterProps> {
         this.initModel();
     };
 
-    componentDidUpdate = (): void => {
-        this.initModel();
+    componentDidUpdate = (prevProps: Readonly<WithRouterProps>): void => {
+        if (prevProps.location?.pathname !== this.props.location?.pathname) {
+            this.initModel();
+        }
     };
 
     initModel = (): void => {

--- a/packages/components/src/components/listing/pages/SchemaListingPage.tsx
+++ b/packages/components/src/components/listing/pages/SchemaListingPage.tsx
@@ -2,18 +2,18 @@
  * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import * as React from 'react';
+import React, { Component, ReactNode } from 'react';
 
 import { Page, PageHeader } from '../../..';
 import { SchemaListing } from '../SchemaListing';
 
-export class SchemaListingPage extends React.Component<any, any> {
-    render() {
+export class SchemaListingPage extends Component {
+    render = (): ReactNode => {
         return (
             <Page title="Schema Browser" hasHeader={true}>
                 <PageHeader title="Schema Browser" />
                 <SchemaListing />
             </Page>
         );
-    }
+    };
 }


### PR DESCRIPTION
#### Rationale
Misc linting and cleanup of the audit log and schema browser related components that were factored out of the Sample Manager app so that they could be shared between that app and the Freezer Manager app, and maybe Biologics in the future.

Author: @labkey-nicka 

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/56
* https://github.com/LabKey/sampleManagement/pull/326