### PR TITLE
QueryModel URL Binding

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.79.0-fb-url-binding.4",
+  "version": "0.79.0-fb-url-binding.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.78.3",
+  "version": "0.79.0-fb-url-binding.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.3.4",
+    "@labkey/api": "1.0.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.9.0",
     "@fortawesome/react-fontawesome": "0.1.4",
-    "@labkey/api": "0.3.2",
+    "@labkey/api": "0.3.4",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.79.0-fb-url-binding.3",
+  "version": "0.79.0-fb-url-binding.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.79.0-fb-url-binding.5",
+  "version": "0.79.0-fb-url-binding.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.79.0-fb-url-binding.6",
+  "version": "0.79.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.??.0
-*Released*: ?? July 2020
+### version 0.79.0
+*Released*: 23 July 2020
 * Implement URL Binding for QueryModel/withQueryModels
     * For this feature to work your usage of withQueryModels must be a child of a configured React Router (see
     packages/components/src/stories/QueryModel.tsx for an example)

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -14,6 +14,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     * selectedReportId
 * QueryModel: Added urlQueryParams getter
 * Removed unused getter methods from DataViewInfo
+* Added toString() to SchemaQuery class
 
 ### version 0.78.3
 *Released*: 22 July 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -12,7 +12,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * QueryModel: Added fields
     * bindURL
     * selectedReportId
-* QueryModel: Added urlQueryParams and hasRows getters
+* QueryModel: Added urlQueryParams, attributesForURLQueryParams, and hasRows getters
 * QueryModel: Default to Details View if keyValue is set
 * Removed unused getter methods from DataViewInfo
 * Added toString() to SchemaQuery class

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -18,6 +18,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Added toString() to SchemaQuery class
 * Added (and exported) DetailPanel component
     - Same as DetailPanelWithModel except it is not wrapped in withQueryModels
+* DetailPanelWithModel: changed props signature. Props are now `QueryConfig & DetailDisplaySharedProps`
 
 ### version 0.78.3
 *Released*: 22 July 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,22 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.??.0
+*Released*: ?? July 2020
+* Add option to Bind QueryModels to URL
+    * When a model is configured with bindURL set to true we will persist some model state to the URL, and read model
+    state from the URL. This allows users to share pages with filters/sorts/etc.
+        * For this feature to work your usage of withQueryModels must be a child of a configured React Router (see
+        packages/components/src/stories/QueryModel.tsx for an example)
+    * QueryModel: charts has been changed from IDataViewInfo to DataViewInfo
+        * QueryModelLoader has been updated to support this
+    * Fixed an issue in DefaultQueryModelLoader where loadCharts was returning unsupported charts.
+    * QueryModel: Added fields
+        * bindURL
+        * selectedReportId
+    * QueryModel: Added urlQueryParams getter
+    * Removed unused getter methods from DataViewInfo
+
 ### version 0.78.3
 *Released*: 22 July 2020
 * AppModel: initialUserId set from `User` model instead of directly from `getServerContext()`.

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -12,7 +12,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * QueryModel: Added fields
     * bindURL
     * selectedReportId
-* QueryModel: Added urlQueryParams getter
+* QueryModel: Added urlQueryParams and hasRows getters
 * Removed unused getter methods from DataViewInfo
 * Added toString() to SchemaQuery class
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -13,6 +13,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     * bindURL
     * selectedReportId
 * QueryModel: Added urlQueryParams and hasRows getters
+* QueryModel: Default to Details View if keyValue is set
 * Removed unused getter methods from DataViewInfo
 * Added toString() to SchemaQuery class
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -3,19 +3,17 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 0.??.0
 *Released*: ?? July 2020
-* Add option to Bind QueryModels to URL
-    * When a model is configured with bindURL set to true we will persist some model state to the URL, and read model
-    state from the URL. This allows users to share pages with filters/sorts/etc.
-        * For this feature to work your usage of withQueryModels must be a child of a configured React Router (see
-        packages/components/src/stories/QueryModel.tsx for an example)
-    * QueryModel: charts has been changed from IDataViewInfo to DataViewInfo
-        * QueryModelLoader has been updated to support this
-    * Fixed an issue in DefaultQueryModelLoader where loadCharts was returning unsupported charts.
-    * QueryModel: Added fields
-        * bindURL
-        * selectedReportId
-    * QueryModel: Added urlQueryParams getter
-    * Removed unused getter methods from DataViewInfo
+* Implement URL Binding for QueryModel/withQueryModels
+    * For this feature to work your usage of withQueryModels must be a child of a configured React Router (see
+    packages/components/src/stories/QueryModel.tsx for an example)
+* QueryModel: charts has been changed from IDataViewInfo to DataViewInfo
+    * QueryModelLoader has been updated to support this
+* Fixed an issue in DefaultQueryModelLoader where loadCharts was returning unsupported charts.
+* QueryModel: Added fields
+    * bindURL
+    * selectedReportId
+* QueryModel: Added urlQueryParams getter
+* Removed unused getter methods from DataViewInfo
 
 ### version 0.78.3
 *Released*: 22 July 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -16,6 +16,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 * QueryModel: Default to Details View if keyValue is set
 * Removed unused getter methods from DataViewInfo
 * Added toString() to SchemaQuery class
+* Added (and exported) DetailPanel component
+    - Same as DetailPanelWithModel except it is not wrapped in withQueryModels
 
 ### version 0.78.3
 *Released*: 22 July 2020

--- a/packages/components/src/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/QueryModel/ChartMenu.tsx
@@ -16,17 +16,7 @@ interface Props extends RequiresModelAndActions {
     showSampleComparisonReports: boolean;
 }
 
-interface State {
-    selectedChart?: DataViewInfo;
-}
-
-export class ChartMenu extends PureComponent<Props, State> {
-    constructor(props) {
-        super(props);
-
-        // TODO: move this state to QueryModel for URL Binding purposes.
-        this.state = { selectedChart: undefined };
-    }
+export class ChartMenu extends PureComponent<Props> {
     componentDidMount(): void {
         const { model, actions, showSampleComparisonReports } = this.props;
         actions.loadCharts(model.id, showSampleComparisonReports);
@@ -41,20 +31,21 @@ export class ChartMenu extends PureComponent<Props, State> {
         }
     };
 
-    chartClicked = (chart): void => {
-        const { onChartClicked } = this.props;
+    chartClicked = (chart: DataViewInfo): void => {
+        const { actions, onChartClicked, model } = this.props;
 
         blurActiveElement();
 
         // If the user supplies a click handler then we use the response from that to determine if we should render the
         // chart modal. This is needed so Biologics and redirect to Sample Comparison Reports.
         if (onChartClicked === undefined || onChartClicked(chart)) {
-            this.setState({ selectedChart: chart });
+            actions.selectReport(model.id, chart.reportId);
         }
     };
 
     clearChart = (): void => {
-        this.setState({ selectedChart: undefined });
+        const { actions, model } = this.props;
+        actions.selectReport(model.id, undefined);
     };
 
     chartMapper = (chart): ReactNode => (
@@ -63,14 +54,26 @@ export class ChartMenu extends PureComponent<Props, State> {
 
     render(): ReactNode {
         const { model, showSampleComparisonReports } = this.props;
-        const { charts, chartsError, hasCharts, id, isLoading, isLoadingCharts, rowsError, queryInfoError } = model;
+        const {
+            charts,
+            chartsError,
+            hasCharts,
+            id,
+            isLoading,
+            isLoadingCharts,
+            rowsError,
+            selectedReportId,
+            queryInfo,
+            queryInfoError,
+        } = model;
         const privateCharts = hasCharts ? charts.filter(chart => !chart.shared) : [];
         const publicCharts = hasCharts ? charts.filter(chart => chart.shared) : [];
         const title = isLoadingCharts ? <span className="fa fa-spinner fa-pulse" /> : 'Charts';
         const noCharts = hasCharts && charts.length === 0 && !showSampleComparisonReports;
         const hasError = queryInfoError !== undefined || rowsError !== undefined;
         const disabled = isLoading || isLoadingCharts || noCharts || hasError;
-        const { selectedChart } = this.state;
+        const selectedChart = charts?.find(chart => chart.reportId === selectedReportId);
+        const showChartModal = queryInfo !== undefined && selectedChart !== undefined;
 
         return (
             <div className="chart-menu">
@@ -99,7 +102,7 @@ export class ChartMenu extends PureComponent<Props, State> {
                     {publicCharts.length > 0 && publicCharts.map(this.chartMapper)}
                 </DropdownButton>
 
-                {selectedChart !== undefined && (
+                {showChartModal && (
                     <ChartModal selectedChart={selectedChart} filters={model.filters} onHide={this.clearChart} />
                 )}
             </div>

--- a/packages/components/src/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/QueryModel/ChartMenu.tsx
@@ -24,6 +24,7 @@ export class ChartMenu extends PureComponent<Props, State> {
     constructor(props) {
         super(props);
 
+        // TODO: move this state to QueryModel for URL Binding purposes.
         this.state = { selectedChart: undefined };
     }
     componentDidMount(): void {

--- a/packages/components/src/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/QueryModel/DetailPanel.tsx
@@ -55,19 +55,13 @@ interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
 }
 
 class DetailPanelWithModelBodyImpl extends PureComponent<DetailPanelWithModelProps & InjectedQueryModels> {
-    componentDidMount(): void {
-        const { actions, queryModels } = this.props;
-        actions.loadModel(queryModels.model.id);
-    }
-
     render(): ReactNode {
         const { queryModels, ...rest } = this.props;
-
         return <DetailPanel {...rest} model={queryModels.model} />;
     }
 }
 
-export const DetailPanelWithModelBody = withQueryModels<DetailPanelWithModelProps>(DetailPanelWithModelBodyImpl);
+const DetailPanelWithModelBody = withQueryModels<DetailPanelWithModelProps>(DetailPanelWithModelBodyImpl);
 
 export class DetailPanelWithModel extends PureComponent<QueryConfig & DetailDisplaySharedProps> {
     render(): ReactNode {
@@ -80,6 +74,7 @@ export class DetailPanelWithModel extends PureComponent<QueryConfig & DetailDisp
         return (
             <DetailPanelWithModelBody
                 asPanel={asPanel}
+                autoLoad
                 detailRenderer={detailRenderer}
                 editingMode={editingMode}
                 key={key}

--- a/packages/components/src/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/QueryModel/DetailPanel.tsx
@@ -17,38 +17,21 @@ import React, { PureComponent, ReactNode } from 'react';
 import { fromJS, List } from 'immutable';
 import { Alert } from 'react-bootstrap';
 
-import { LoadingSpinner, QueryColumn } from '..';
+import { LoadingSpinner, QueryColumn, QueryModel, RequiresModelAndActions } from '..';
 
 import { DetailDisplay, DetailDisplaySharedProps } from '../components/forms/detail/DetailDisplay';
 
-import { QueryModel } from './QueryModel';
 import { InjectedQueryModels, withQueryModels } from './withQueryModels';
 
-interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
+interface DetailPanelProps extends DetailDisplaySharedProps, RequiresModelAndActions {
     queryColumns?: List<QueryColumn>;
 }
 
-class DetailPanelWithModelImpl extends PureComponent<DetailPanelWithModelProps & InjectedQueryModels> {
-    componentDidMount(): void {
-        const { actions } = this.props;
-        actions.loadModel(this.getModel().id);
-    }
-
-    getModel(): QueryModel {
-        const { queryModels } = this.props;
-        return queryModels[Object.keys(queryModels)[0]];
-    }
-
-    get detailDisplayProps(): DetailDisplaySharedProps {
-        // Purposely not using queryColumns, queryModels, do not want to pass to DetailDisplay
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { queryColumns, queryModels, ...detailDisplayProps } = this.props;
-        return detailDisplayProps;
-    }
-
+export class DetailPanel extends PureComponent<DetailPanelProps> {
     render(): ReactNode {
-        const { editingMode, queryColumns } = this.props;
-        const model = this.getModel();
+        // ignoring actions so we don't pass to DetailDisplay
+        const { actions, model, queryColumns, ...detailDisplayProps } = this.props;
+        const { editingMode } = detailDisplayProps;
         const error = model.queryInfoError ?? model.rowsError;
 
         if (error !== undefined) {
@@ -59,11 +42,33 @@ class DetailPanelWithModelImpl extends PureComponent<DetailPanelWithModelProps &
 
         return (
             <DetailDisplay
-                {...this.detailDisplayProps}
+                {...detailDisplayProps}
                 data={fromJS(model.gridData)}
                 displayColumns={queryColumns ?? List(editingMode ? model.updateColumns : model.detailColumns)}
             />
         );
+    }
+}
+
+interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
+    queryColumns?: List<QueryColumn>;
+}
+
+class DetailPanelWithModelImpl extends PureComponent<DetailPanelWithModelProps & InjectedQueryModels> {
+    componentDidMount(): void {
+        const { actions } = this.props;
+        actions.loadModel(this.model.id);
+    }
+
+    get model(): QueryModel {
+        return this.props.queryModels[Object.keys(this.props.queryModels)[0]]
+    }
+
+    render(): ReactNode {
+        // Don't pass QueryModels to DetailPanel.
+        const { queryModels, ...rest } = this.props;
+
+        return <DetailPanel {...rest} model={this.model} />;
     }
 }
 

--- a/packages/components/src/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/QueryModel/GridPanel.spec.tsx
@@ -225,6 +225,8 @@ describe('GridPanel', () => {
         expectError(wrapper, selectionsError);
     });
 
+    const omniBoxTextMapper = (av): string => av.displayValue ?? av.value;
+
     const expectFilterState = (
         wrapper: GridPanelWrapper,
         actionValue: ActionValue,
@@ -238,7 +240,7 @@ describe('GridPanel', () => {
             .filter(
                 av => av.valueObject === valueObject || av.valueObject.getColumnName() !== valueObject.getColumnName()
             )
-            .map(av => av.value)
+            .map(omniBoxTextMapper)
             .join('');
         expect(wrapper.find(OMNIBOX_SELECTOR).text()).toEqual(expectedOmniText);
         expect(actions.setFilters).toHaveBeenCalledWith(model.id, expectedFilters, grid.props.allowSelections);
@@ -258,7 +260,7 @@ describe('GridPanel', () => {
         const { valueObject } = actionValue;
         const expectedOmniText = actionValues
             .filter(av => av.valueObject === valueObject || av.valueObject.fieldKey !== valueObject.fieldKey)
-            .map(av => av.value)
+            .map(omniBoxTextMapper)
             .join('');
         expect(wrapper.find(OMNIBOX_SELECTOR).text()).toEqual(expectedOmniText);
         expect(actions.setSorts).toHaveBeenCalledWith(model.id, expectedSorts);
@@ -342,7 +344,7 @@ describe('GridPanel', () => {
         // Omnibox filters out existing view actions for us because they are singletons.
         let values = grid.state.actionValues.filter(v => v.action.keyword !== 'view');
         // GridPanel converts viewName to label
-        const expectedOmniText = values.map(v => v.value).join('') + viewLabel;
+        const expectedOmniText = values.map(v => v.displayValue ?? v.value).join('') + viewLabel;
         values = values.concat([
             {
                 action: grid.omniBoxActions.view,
@@ -363,31 +365,31 @@ describe('GridPanel', () => {
         const filter1 = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
         const filterAction1 = {
             action: grid.omniBoxActions.filter,
-            value: 'Name=DMXP',
+            value: '"Name" = DMXP',
             valueObject: filter1,
         };
         const filter2 = Filter.create('expirationTime', '1', Filter.Types.EQUAL);
         const filterAction2 = {
             action: grid.omniBoxActions.filter,
-            value: 'expirationTime=1',
+            value: '"Expiration Time" = 1',
             valueObject: filter2,
         };
         const filter3 = Filter.create('expirationTime', '2', Filter.Types.EQUAL);
         const filterAction3 = {
             action: grid.omniBoxActions.filter,
-            value: 'expirationTime=2',
+            value: '"Expiration Time" = 2',
             valueObject: filter3,
         };
         const filter4 = Filter.create('expirationTime', '10', Filter.Types.EQUAL);
         const filterAction4 = {
             action: grid.omniBoxActions.filter,
-            value: 'expirationTime=10',
+            value: '"Expiration Time" = 10',
             valueObject: filter4,
         };
         const filter5 = Filter.create('Name', 'PBS', Filter.Types.EQUAL);
         const filterAction5 = {
             action: grid.omniBoxActions.filter,
-            value: 'Name=PBS',
+            value: '"Name" = PBS',
             valueObject: filter5,
         };
         const search1 = Filter.create('*', 'foo', Filter.Types.Q);
@@ -411,19 +413,22 @@ describe('GridPanel', () => {
         const sort1 = new QuerySort({ fieldKey: 'Name' });
         const sortAction1 = {
             action: grid.omniBoxActions.sort,
-            value: 'Name',
+            displayValue: 'Name',
+            value: 'Name ASC',
             valueObject: sort1,
         };
         const sort2 = new QuerySort({ fieldKey: 'expirationTime' });
         const sortAction2 = {
             action: grid.omniBoxActions.sort,
-            value: 'expirationTime',
+            displayValue: 'Expiration Time',
+            value: 'expirationTime ASC',
             valueObject: sort2,
         };
         const sort3 = new QuerySort({ fieldKey: 'Name', dir: '-' });
         const sortAction3 = {
             action: grid.omniBoxActions.sort,
-            value: '-Name',
+            displayValue: 'Name',
+            value: 'Name DESC',
             valueObject: sort3,
         };
 
@@ -469,7 +474,7 @@ describe('GridPanel', () => {
         // Emulate remove view
         const values = grid.state.actionValues.filter(v => v.action.keyword !== 'view');
         grid.omniBoxChange(values, { type: ChangeType.remove, index: grid.state.actionValues.length - 1 });
-        expect(wrapper.find(OMNIBOX_SELECTOR).text()).toEqual(values.map(v => v.value).join(''));
+        expect(wrapper.find(OMNIBOX_SELECTOR).text()).toEqual(values.map(omniBoxTextMapper).join(''));
         expect(actions.setView).toHaveBeenCalledWith('model', undefined, false);
     });
 

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -205,30 +205,20 @@ export class GridPanel extends PureComponent<Props, State> {
         const actionValues = [];
 
         if (model.viewName) {
-            const viewLabel = queryInfo.views.get(viewName.toLowerCase())?.label ?? viewName;
-            actionValues.push({ value: viewLabel, action: this.omniBoxActions.view });
+            const view = queryInfo.views.get(viewName.toLowerCase())?.label ?? viewName;
+            actionValues.push(this.omniBoxActions.view.actionValueFromView(view));
         }
 
         sorts.forEach((sort): void => {
-            const { dir, fieldKey } = sort;
-            const column = model.getColumn(fieldKey);
-            actionValues.push({
-                value: `${fieldKey} ${dir === '-' ? 'DESC' : 'ASC'}`,
-                displayValue: column?.shortCaption ?? sort.fieldKey,
-                valueObject: sort,
-                action: this.omniBoxActions.sort,
-            });
+            const column = model.getColumn(sort.fieldKey);
+            actionValues.push(this.omniBoxActions.sort.actionValueFromSort(sort, column?.shortCaption));
         });
 
         filterArray.forEach((filter): void => {
             const column = model.getColumn(filter.getColumnName());
 
             if (filter.getColumnName() === '*') {
-                actionValues.push({
-                    value: filter.getValue(),
-                    valueObject: filter,
-                    action: this.omniBoxActions.search,
-                });
+                actionValues.push(this.omniBoxActions.search.actionValueFromFilter(filter));
             } else {
                 actionValues.push(this.omniBoxActions.filter.actionValueFromFilter(filter, column?.shortCaption));
             }

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -88,9 +88,9 @@ class ButtonBar extends PureComponent<GridBarProps> {
             showViewMenu,
         } = this.props;
 
-        const { hasData, queryInfo, queryInfoError, rowsError, selectionsError } = model;
+        const { hasRows, queryInfo, queryInfoError, rowsError, selectionsError } = model;
         const hasError = queryInfoError !== undefined || rowsError !== undefined || selectionsError !== undefined;
-        const paginate = showPagination && hasData && !hasError;
+        const paginate = showPagination && hasRows && !hasError;
         const canExport = showExport && !hasError;
         // Don't disable view selection when there is an error because it's possible the error may be caused by the view
         const canSelectView = showViewMenu && queryInfo !== undefined;
@@ -498,8 +498,8 @@ export class GridPanel extends PureComponent<Props, State> {
 
     headerCell = (column: GridColumn, index: number, columnCount?: number): ReactNode => {
         const { allowSelections, allowSorting, model } = this.props;
-        const { isLoading, isLoadingSelections, hasData, rowCount } = model;
-        const disabled = isLoadingSelections || isLoading || (hasData && rowCount === 0);
+        const { isLoading, isLoadingSelections, hasRows, rowCount } = model;
+        const disabled = isLoadingSelections || isLoading || (hasRows && rowCount === 0);
 
         if (column.index === GRID_SELECTION_INDEX) {
             return headerSelectionCell(this.selectPage, model.selectedState, disabled, 'grid-panel__page-checkbox');

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -396,8 +396,18 @@ export class QueryModel {
         return this.queryInfo?.views.sortBy(v => v.label, naturalSort).toArray() || [];
     }
 
+    /**
+     * True if data has been loaded, even if no rows were returned.
+     */
     get hasData(): boolean {
         return this.rows !== undefined;
+    }
+
+    /**
+     * True if the model has > 0 rows.
+     */
+    get hasRows(): boolean {
+        return this.hasData && Object.keys(this.rows).length > 0;
     }
 
     get hasCharts(): boolean {

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -37,6 +37,7 @@ export interface GridMessage {
     content: string;
 }
 
+// Note: if you add/remove fields on QueryConfig make sure to update utils.hashQueryConfig
 export interface QueryConfig {
     baseFilters?: Filter.IFilter[];
     bindURL?: boolean;

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -5,7 +5,6 @@ import { Filter, Query } from '@labkey/api';
 import {
     GRID_CHECKBOX_OPTIONS,
     LoadingState,
-    IDataViewInfo,
     naturalSort,
     QueryColumn,
     QueryInfo,
@@ -15,6 +14,7 @@ import {
 } from '..';
 import { GRID_SELECTION_INDEX } from '../components/base/models/constants';
 import { PaginationData } from '../components/pagination/Pagination';
+import { DataViewInfo } from '../models';
 
 import { flattenValuesFromRow } from './utils';
 
@@ -99,10 +99,11 @@ export class QueryModel {
     readonly rowCount?: number;
     readonly rowsError?: string;
     readonly rowsLoadingState: LoadingState;
+    readonly selectedReportId: string;
     readonly selections?: Set<string>; // Note: ES6 Set is being used here, not Immutable Set
     readonly selectionsError?: string;
     readonly selectionsLoadingState: LoadingState;
-    readonly charts: IDataViewInfo[];
+    readonly charts: DataViewInfo[];
     readonly chartsError: string;
     readonly chartsLoadingState: LoadingState;
 
@@ -141,6 +142,7 @@ export class QueryModel {
         this.rowCount = undefined;
         this.rowsError = undefined;
         this.rowsLoadingState = LoadingState.INITIALIZED;
+        this.selectedReportId = undefined;
         this.selections = undefined;
         this.selectionsError = undefined;
         this.selectionsLoadingState = LoadingState.INITIALIZED;
@@ -293,7 +295,7 @@ export class QueryModel {
      * true.
      */
     get urlQueryParams(): { [key: string]: string } {
-        const { currentPage, urlPrefix, filterArray, sortString, viewName } = this;
+        const { currentPage, urlPrefix, filterArray, selectedReportId, sortString, viewName } = this;
         const filters = filterArray.filter(f => f.getColumnName() !== '*');
         const searches = filterArray.filter(f => f.getColumnName() === '*').map(f => f.getValue()).join(';')
         // ReactRouter location.query is typed as any.
@@ -315,7 +317,9 @@ export class QueryModel {
             modelParams[`${urlPrefix}.q`] = searches;
         }
 
-        // TODO: reportId for Chart Modal
+        if (selectedReportId) {
+            modelParams[`${urlPrefix}.reportId`] = selectedReportId;
+        }
 
         filters.forEach((filter): void => {
             modelParams[filter.getURLParameterName(urlPrefix)] = filter.getURLParameterValue();

--- a/packages/components/src/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/QueryModel/QueryModelLoader.ts
@@ -73,7 +73,7 @@ export interface QueryModelLoader {
      * reports in the results. If false loads DataViewInfos via getReportInfos and does not include SampleComparison
      * reports.
      */
-    loadCharts: (model: QueryModel, includeSampleComparison: boolean) => Promise<IDataViewInfo[]>;
+    loadCharts: (model: QueryModel, includeSampleComparison: boolean) => Promise<DataViewInfo[]>;
 }
 
 export const DefaultQueryModelLoader: QueryModelLoader = {
@@ -142,10 +142,14 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
                     const isSampleComparison = type === DataViewInfoTypes.SampleComparison;
                     return matchingSq && (isVisualization || isSampleComparison);
                 })
-                .sort(sortByName);
+                .sort(sortByName)
+                .map(obj => new DataViewInfo(obj));
         } else {
             const charts = await fetchCharts(schemaQuery, containerPath);
-            return charts.toArray().sort(sortByName);
+            return charts
+                .toArray()
+                .sort(sortByName)
+                .filter(report => VISUALIZATION_REPORTS.contains(report.type));
         }
     },
 };

--- a/packages/components/src/QueryModel/testUtils.ts
+++ b/packages/components/src/QueryModel/testUtils.ts
@@ -61,6 +61,7 @@ export const makeTestActions = (): Actions => {
         selectAllRows: jest.fn(),
         selectRow: jest.fn(),
         selectPage: jest.fn(),
+        selectReport: jest.fn(),
         setFilters: jest.fn(),
         setMaxRows: jest.fn(),
         setOffset: jest.fn(),

--- a/packages/components/src/QueryModel/utils.ts
+++ b/packages/components/src/QueryModel/utils.ts
@@ -5,7 +5,7 @@
  */
 import { Filter } from '@labkey/api';
 
-import { QueryConfig, QuerySort } from '..';
+import { QuerySort } from '..';
 import { ActionValue } from '../components/omnibox/actions/Action';
 
 export function filterToString(filter: Filter.IFilter): string {
@@ -64,4 +64,35 @@ export function actionValuesToString(actionValues: ActionValue[]): string {
         .map(actionValue => actionValue.value.toString())
         .sort()
         .join(';');
+}
+
+export function offsetFromString(rowsPerPage: number, pageStr: string): number {
+    if (pageStr === undefined) {
+        return undefined;
+    }
+
+    let offset = 0;
+    const page = parseInt(pageStr, 10);
+
+    if (!isNaN(page)) {
+        offset = (page - 1) * rowsPerPage;
+    }
+
+    return offset >= 0 ? offset : 0;
+}
+
+export function querySortFromString(sortStr: string): QuerySort {
+    if (sortStr.startsWith('-')) {
+        return new QuerySort({ dir: '-', fieldKey: sortStr.slice(1) });
+    } else {
+        return new QuerySort({ fieldKey: sortStr });
+    }
+}
+
+export function querySortsFromString(sortsStr: string): QuerySort[] {
+    return sortsStr?.split(',').map(querySortFromString);
+}
+
+export function searchFiltersFromString(searchStr: string): Filter.IFilter[] {
+    return searchStr?.split(';').map(search => Filter.create('*', search, Filter.Types.Q));
 }

--- a/packages/components/src/QueryModel/utils.ts
+++ b/packages/components/src/QueryModel/utils.ts
@@ -65,32 +65,3 @@ export function actionValuesToString(actionValues: ActionValue[]): string {
         .sort()
         .join(';');
 }
-
-// Produces a stable string representation of an object.
-export function recordToString(record: Record<string, any>): string {
-    return Object.keys(record)
-        .sort()
-        .map(key => `${key}=${record[key]}`)
-        .join('_');
-}
-
-export function hashQueryConfig(config: QueryConfig): string {
-    return [
-        config.baseFilters?.map(filterToString).join('_'),
-        config.containerFilter,
-        config.containerPath,
-        config.id,
-        config.includeDetailsColumn,
-        config.includeUpdateColumn,
-        config.keyValue,
-        config.omittedColumns?.join('_'),
-        recordToString(config.queryParameters ?? {}),
-        config.requiredColumns?.join('_'),
-        config.schemaQuery.toString(),
-        config.sorts?.map(sort => sort.toRequestString()).join('_'),
-    ].join(';');
-}
-
-export function queryConfigsEqual(a: QueryConfig, b: QueryConfig): boolean {
-    return hashQueryConfig(a) === hashQueryConfig(b);
-}

--- a/packages/components/src/QueryModel/utils.ts
+++ b/packages/components/src/QueryModel/utils.ts
@@ -5,7 +5,7 @@
  */
 import { Filter } from '@labkey/api';
 
-import { naturalSort, QuerySort } from '..';
+import { QueryConfig, QuerySort } from '..';
 import { ActionValue } from '../components/omnibox/actions/Action';
 
 export function filterToString(filter: Filter.IFilter): string {
@@ -21,8 +21,8 @@ export function filterArraysEqual(a: Filter.IFilter[], b: Filter.IFilter[]): boo
         return false;
     }
 
-    const aStr = a.map(filterToString).sort(naturalSort).join(';');
-    const bStr = b.map(filterToString).sort(naturalSort).join(';');
+    const aStr = a.map(filterToString).sort().join(';');
+    const bStr = b.map(filterToString).sort().join(';');
 
     return aStr === bStr;
 }
@@ -38,11 +38,11 @@ export function sortArraysEqual(a: QuerySort[], b: QuerySort[]): boolean {
 
     const aStr = a
         .map(qs => qs.toRequestString())
-        .sort(naturalSort)
+        .sort()
         .join(';');
     const bStr = b
         .map(qs => qs.toRequestString())
-        .sort(naturalSort)
+        .sort()
         .join(';');
     return aStr === bStr;
 }
@@ -62,6 +62,35 @@ export function flattenValuesFromRow(row: any, keys: string[]): { [key: string]:
 export function actionValuesToString(actionValues: ActionValue[]): string {
     return actionValues
         .map(actionValue => actionValue.value.toString())
-        .sort(naturalSort)
+        .sort()
         .join(';');
+}
+
+// Produces a stable string representation of an object.
+export function recordToString(record: Record<string, any>): string {
+    return Object.keys(record)
+        .sort()
+        .map(key => `${key}=${record[key]}`)
+        .join('_');
+}
+
+export function hashQueryConfig(config: QueryConfig): string {
+    return [
+        config.baseFilters?.map(filterToString).join('_'),
+        config.containerFilter,
+        config.containerPath,
+        config.id,
+        config.includeDetailsColumn,
+        config.includeUpdateColumn,
+        config.keyValue,
+        config.omittedColumns?.join('_'),
+        recordToString(config.queryParameters ?? {}),
+        config.requiredColumns?.join('_'),
+        config.schemaQuery.toString(),
+        config.sorts?.map(sort => sort.toRequestString()).join('_'),
+    ].join(';');
+}
+
+export function queryConfigsEqual(a: QueryConfig, b: QueryConfig): boolean {
+    return hashQueryConfig(a) === hashQueryConfig(b);
 }

--- a/packages/components/src/QueryModel/utils.ts
+++ b/packages/components/src/QueryModel/utils.ts
@@ -6,6 +6,7 @@
 import { Filter } from '@labkey/api';
 
 import { naturalSort, QuerySort } from '..';
+import { ActionValue } from '../components/omnibox/actions/Action';
 
 export function filterToString(filter: Filter.IFilter): string {
     return `${filter.getColumnName()}-${filter.getFilterType().getURLSuffix()}-${filter.getValue()}`;
@@ -56,4 +57,11 @@ export function flattenValuesFromRow(row: any, keys: string[]): { [key: string]:
         });
     }
     return values;
+}
+
+export function actionValuesToString(actionValues: ActionValue[]): string {
+    return actionValues
+        .map(actionValue => actionValue.value.toString())
+        .sort(naturalSort)
+        .join(';');
 }

--- a/packages/components/src/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.spec.tsx
@@ -22,6 +22,14 @@ import aminoAcidsQuery from '../test/data/assayAminoAcidsData-getQuery.json';
 
 import { RowsResponse } from './QueryModelLoader';
 
+/**
+ * Note: All of the tests in this file look a tad weird. We create a component that resets local variables on render
+ * instead of grabbing props or state from the wrapper variable. This is because no matter what I tried I could not
+ * get the wrapper to return the updated model via props(), but for some reason the weird render hack works. It also
+ * works consistently, and lets us have fine grained control over the lifecycle via calls to sleep. If you have a
+ * better idea by all means try it.
+ */
+
 const MIXTURES_SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
 let MIXTURES_QUERY_INFO: QueryInfo;
 let MIXTURES_DATA: RowsResponse;

--- a/packages/components/src/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.spec.tsx
@@ -1,7 +1,17 @@
 import React, { ReactElement } from 'react';
 import { mount } from 'enzyme';
+import { createMemoryHistory, InjectedRouter, Route, Router } from 'react-router';
+import { Filter } from '@labkey/api';
 
-import { Actions, LoadingState, QueryInfo, QueryModel, QueryModelMap, SchemaQuery, withQueryModels } from '..';
+import {
+    Actions,
+    LoadingState,
+    QueryInfo,
+    QueryModel,
+    QueryModelMap, QuerySort,
+    SchemaQuery,
+    withQueryModels,
+} from '..';
 
 import { initUnitTests, makeQueryInfo, makeTestData, sleep } from '../testHelpers';
 import { MockQueryModelLoader } from '../test/MockQueryModelLoader';
@@ -238,6 +248,156 @@ describe('withQueryModels', () => {
         expect(model3.rowsLoadingState).toEqual(LoadingState.LOADED);
 
         // Due to the async nature of this test we need to call done() to ensure the test does not fail due to timeout.
+        done();
+    });
+
+    test('Bind from URL', async done => {
+        const modelLoader = new MockQueryModelLoader(MIXTURES_QUERY_INFO, MIXTURES_DATA);
+        const history = createMemoryHistory();
+        const queryConfigs = { model: { schemaQuery: MIXTURES_SCHEMA_QUERY, bindURL: true } };
+        const queryParams: Record<string, string> = {};
+        let injectedModel: QueryModel;
+        let injectedRouter: InjectedRouter;
+        let injectedLocation;
+        const TestComponentImpl = ({ actions, location, queryModels, router }): ReactElement => {
+            injectedModel = queryModels.model;
+            injectedRouter = router;
+            injectedLocation = location;
+            return <div />;
+        };
+        const WrappedComponent = withQueryModels<{}>(TestComponentImpl);
+        const wrapper = mount(
+            <Router history={history}>
+                <Route
+                    path="/"
+                    component={() => (
+                        <WrappedComponent autoLoad modelLoader={modelLoader} queryConfigs={queryConfigs} />
+                    )}
+                />
+            </Router>
+        );
+        await sleep(); // Sleep so QueryInfo gets loaded.
+        await sleep(); // Sleep so Rows get loaded.
+
+        queryParams['query.p'] = '2';
+        injectedRouter.replace({ ...injectedLocation, query: { ...queryParams } });
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADING);
+        expect(injectedModel.offset).toEqual(20);
+        await sleep(); // Load Rows
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADED);
+
+        queryParams['query.view'] = 'noMixtures';
+        injectedRouter.replace({ ...injectedLocation, query: { ...queryParams } });
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADING);
+        expect(injectedModel.schemaQuery.viewName).toEqual('noMixtures');
+        await sleep(); // Load Rows
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADED);
+
+        queryParams['query.Name~eq'] = 'DMXP';
+        injectedRouter.replace({ ...injectedLocation, query: { ...queryParams } });
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADING);
+        expect(injectedModel.filterArray.length).toEqual(1);
+        const filter = injectedModel.filterArray[0];
+        expect(filter.getColumnName()).toEqual('Name');
+        expect(filter.getValue()).toEqual('DMXP');
+        expect(filter.getFilterType()).toEqual(Filter.Types.EQUAL);
+        await sleep(); // Load Rows
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADED);
+
+        queryParams['query.sort'] = 'Name';
+        injectedRouter.replace({ ...injectedLocation, query: { ...queryParams } });
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADING);
+        expect(injectedModel.sorts.length).toEqual(1);
+        let sort = injectedModel.sorts[0];
+        expect(sort.fieldKey).toEqual('Name');
+        expect(sort.dir).toEqual('');
+        await sleep(); // Load Rows
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADED);
+
+        queryParams['query.sort'] = 'Name,-expirationTime';
+        injectedRouter.replace({ ...injectedLocation, query: { ...queryParams } });
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADING);
+        expect(injectedModel.sorts.length).toEqual(2);
+        sort = injectedModel.sorts[1];
+        expect(sort.fieldKey).toEqual('expirationTime');
+        expect(sort.dir).toEqual('-');
+        await sleep(); // Load Rows
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADED);
+
+        queryParams['query.reportId'] = 'db:1';
+        injectedRouter.replace({ ...injectedLocation, query: { ...queryParams } });
+        // Selecting a report doesn't trigger loading rows.
+        expect(injectedModel.rowsLoadingState).toEqual(LoadingState.LOADING);
+        expect(injectedModel.selectedReportId).toEqual('db:1');
+
+        done();
+    });
+
+    test('Bind to URL', async done => {
+        const modelLoader = new MockQueryModelLoader(MIXTURES_QUERY_INFO, MIXTURES_DATA);
+        const history = createMemoryHistory();
+        const queryConfigs = { model: { schemaQuery: MIXTURES_SCHEMA_QUERY, bindURL: true } };
+        let injectedModel: QueryModel;
+        let injectedActions: Actions;
+        let injectedLocation;
+        const TestComponentImpl = ({ actions, location, queryModels, router }): ReactElement => {
+            injectedModel = queryModels.model;
+            injectedActions = actions;
+            injectedLocation = location;
+            return <div />;
+        };
+        const WrappedComponent = withQueryModels<{}>(TestComponentImpl);
+        const wrapper = mount(
+            <Router history={history}>
+                <Route
+                    path="/"
+                    component={() => (
+                        <WrappedComponent autoLoad modelLoader={modelLoader} queryConfigs={queryConfigs} />
+                    )}
+                />
+            </Router>
+        );
+        await sleep(); // Sleep so QueryInfo gets loaded.
+        await sleep(); // Sleep so Rows get loaded.
+
+        let expectedQuery: Record<string, string> = { 'query.p': '34' };
+        injectedActions.loadLastPage(injectedModel.id);
+        await sleep();
+        expect(injectedLocation.query).toEqual(expectedQuery);
+
+        injectedActions.loadFirstPage(injectedModel.id);
+        await sleep();
+        // Setting the page to 1 removes the "p" param from the URL.
+        expect(injectedLocation.query).toEqual({});
+
+        expectedQuery['query.p'] = '2';
+        injectedActions.loadNextPage(injectedModel.id);
+        await sleep();
+        expect(injectedLocation.query).toEqual(expectedQuery);
+
+        // Setting a filter resets offset to 0, so we dont' expect "p" to stick around.
+        expectedQuery = { 'query.Name~eq': 'DMXP' };
+        injectedActions.setFilters(injectedModel.id, [Filter.create('Name', 'DMXP', Filter.Types.EQUAL)]);
+        await sleep();
+        expect(injectedLocation.query).toEqual(expectedQuery);
+
+        expectedQuery['query.sort'] = '-Name,expirationTime';
+        injectedActions.setSorts(injectedModel.id, [
+            new QuerySort({ fieldKey: 'Name', dir: '-' }),
+            new QuerySort({ fieldKey: 'expirationTime', dir: '' }),
+        ]);
+        await sleep();
+        expect(injectedLocation.query).toEqual(expectedQuery);
+
+        expectedQuery['query.view'] = 'noMixtures';
+        injectedActions.setView(injectedModel.id, 'noMixtures');
+        await sleep();
+        expect(injectedLocation.query).toEqual(expectedQuery);
+
+        expectedQuery['query.reportId'] = 'db:1';
+        injectedActions.selectReport(injectedModel.id, 'db:1');
+        expect(injectedLocation.query).toEqual(expectedQuery);
+
         done();
     });
 });

--- a/packages/components/src/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.tsx
@@ -285,8 +285,7 @@ export function withQueryModels<Props>(
                     loadSelections = model.hasSelections || model.selectionsError !== undefined;
                 }),
                 () => {
-                    // load selections?
-                    this.maybeLoad(id, false, true, false);
+                    this.maybeLoad(id, false, true, loadSelections);
                 }
             );
         };

--- a/packages/components/src/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.tsx
@@ -225,10 +225,8 @@ export function withQueryModels<Props>(
         componentDidUpdate(prevProps: Readonly<Props & MakeQueryModels & WithRouterProps>): void {
             const curLoc = this.props.location;
             const prevLoc = prevProps.location;
-            if (curLoc !== prevLoc) {
-                // iterate through all models, if any params changed (make a method to test this?) then call
-                // urlParamsForModel.
-                console.log('Location changed');
+
+            if (curLoc !== undefined && prevLoc !== undefined && curLoc !== prevLoc) {
                 const query = curLoc.query;
                 Object.values(this.state.queryModels).forEach(model => {
                     const modelParamsFromURL = Object.keys(query).reduce((result, key) => {
@@ -237,8 +235,6 @@ export function withQueryModels<Props>(
                         }
                         return result;
                     }, {});
-
-                    console.log(model.id, paramsEqual(modelParamsFromURL, model.urlQueryParams));
 
                     if (!paramsEqual(modelParamsFromURL, model.urlQueryParams)) {
                         // The params for the model have changed on the URL, so update the model.

--- a/packages/components/src/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.tsx
@@ -256,11 +256,9 @@ export function withQueryModels<Props>(
 
                     if (currConfig === undefined) {
                         // The queryConfig was removed, so remove the model.
-                        console.log('config for', id, 'was removed, removing model');
                         modelsToRemove.push(id);
                     } else if (prevConfig === undefined || !queryConfigsEqual(prevConfig, currConfig)) {
                         // New or changed config, need to instantiate model.
-                        console.log('new/changed config for', id, 'adding/updating model');
                         modelsToUpdate[id] = initModel(id, currQueryConfigs[id], this.props.location);
                     }
                 });

--- a/packages/components/src/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.tsx
@@ -97,6 +97,10 @@ const resetSelectionState = (model: Draft<QueryModel>): void => {
 };
 
 const offsetFromString = (rowsPerPage, pageStr: string): number => {
+    if (pageStr === undefined) {
+        return undefined;
+    }
+
     let offset = 0;
     const page = parseInt(pageStr, 10);
 
@@ -116,11 +120,11 @@ const querySortFromString = (sortStr: string): QuerySort => {
 };
 
 const querySortsFromString = (sortsStr: string): QuerySort[] => {
-    return sortsStr?.split(',').map(querySortFromString) ?? [];
+    return sortsStr?.split(',').map(querySortFromString);
 };
 
 const searchFiltersFromString = (searchStr: string): Filter.IFilter[] => {
-    return searchStr?.split(';').map(search => Filter.create('*', search, Filter.Types.Q)) ?? [];
+    return searchStr?.split(';').map(search => Filter.create('*', search, Filter.Types.Q));
 };
 
 type QueryModelURLState = Pick<QueryModel, 'filterArray' | 'offset' | 'schemaQuery' | 'sorts'>;
@@ -139,9 +143,9 @@ const urlParamsForModel = (queryParams, model: QueryModel | Draft<QueryModel>): 
 
     return {
         filterArray,
-        offset: offsetFromString(model.maxRows, queryParams[`${prefix}.p`]) || model.offset,
+        offset: offsetFromString(model.maxRows, queryParams[`${prefix}.p`]) ?? model.offset,
         schemaQuery: SchemaQuery.create(model.schemaName, model.queryName, viewName),
-        sorts: querySortsFromString(queryParams[`${prefix}.sort`]) || model.sorts,
+        sorts: querySortsFromString(queryParams[`${prefix}.sort`]) ?? model.sorts,
     };
 };
 

--- a/packages/components/src/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.tsx
@@ -488,7 +488,11 @@ export function withQueryModels<Props>(
                     const model = draft.queryModels[id];
                     model.selectedReportId = reportId;
                 }),
-                () => this.bindURL(id)
+                () => {
+                    if (this.state.queryModels[id].bindURL) {
+                        this.bindURL(id);
+                    }
+                }
             );
         };
 

--- a/packages/components/src/components/base/models/model.ts
+++ b/packages/components/src/components/base/models/model.ts
@@ -221,10 +221,7 @@ export class SchemaQuery extends Record({
 
     isEqual(sq: SchemaQuery): boolean {
         if (!sq) return false;
-        return (
-            [this.schemaName, this.queryName, this.viewName].join('|').toLowerCase() ===
-            [sq.schemaName, sq.queryName, sq.viewName].join('|').toLowerCase()
-        );
+        return this.toString().toLowerCase() === sq.toString().toLowerCase();
     }
 
     hasSchema(schemaName: string): boolean {
@@ -246,6 +243,10 @@ export class SchemaQuery extends Record({
 
     static createAppSelectionKey(targetSQ: SchemaQuery, keys: any[]): string {
         return [APP_SELECTION_PREFIX, resolveSchemaQuery(targetSQ), keys.join(';')].join('|');
+    }
+
+    toString(): string {
+        return [this.schemaName, this.queryName, this.viewName].join('|');
     }
 }
 

--- a/packages/components/src/components/chart/ChartMenuItem.tsx
+++ b/packages/components/src/components/chart/ChartMenuItem.tsx
@@ -15,7 +15,7 @@ export class ChartMenuItem extends PureComponent<ChartMenuItemProps> {
         return (
             <MenuItem onSelect={() => showChart(chart)}>
                 <i className={`chart-menu-icon ${chart.iconCls}`} />
-                <span className="chart-menu-label">{chart.getLabel()}</span>
+                <span className="chart-menu-label">{chart.name}</span>
             </MenuItem>
         );
     }

--- a/packages/components/src/components/chart/ChartModal.tsx
+++ b/packages/components/src/components/chart/ChartModal.tsx
@@ -9,7 +9,7 @@ import { Chart } from './Chart';
 interface ChartModalProps {
     selectedChart: DataViewInfo;
     filters: Filter.IFilter[];
-    onHide: Function;
+    onHide: () => void;
 }
 
 export class ChartModal extends PureComponent<ChartModalProps> {
@@ -27,9 +27,9 @@ export class ChartModal extends PureComponent<ChartModalProps> {
         }
 
         return (
-            <Modal bsSize="large" show={selectedChart !== undefined} keyboard={true} onHide={onHide}>
+            <Modal bsSize="large" show keyboard onHide={onHide}>
                 <Modal.Header closeButton={true} closeLabel="Close">
-                    <Modal.Title>{selectedChart.getLabel()}</Modal.Title>
+                    <Modal.Title>{selectedChart.name}</Modal.Title>
 
                     {description}
                 </Modal.Header>

--- a/packages/components/src/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/components/lineage/node/LineageDetail.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent, ReactNode } from 'react';
 import { Experiment, Filter } from '@labkey/api';
 
-import { DetailPanelWithModel, QueryConfigMap, SchemaQuery } from '../../..';
+import { DetailPanelWithModel, QueryConfig, QueryConfigMap, SchemaQuery } from '../../..';
 
 export interface LineageDetailProps {
     item: Experiment.LineageItemBase;
@@ -10,14 +10,13 @@ export interface LineageDetailProps {
 export class LineageDetail extends PureComponent<LineageDetailProps> {
     render(): ReactNode {
         const { item } = this.props;
-        const queryConfigs: QueryConfigMap = {
-            [item.lsid]: {
-                schemaQuery: SchemaQuery.create(item.schemaName, item.queryName),
-                baseFilters: item.pkFilters.map(pkFilter => Filter.create(pkFilter.fieldKey, pkFilter.value)),
-            },
-        };
-
-        // TODO: Without providing "key" the DetailPanelWithModel will stop updates
-        return <DetailPanelWithModel key={item.lsid} queryConfigs={queryConfigs} />;
+        // Without providing "key" the DetailPanelWithModel will stop updates
+        return (
+            <DetailPanelWithModel
+                baseFilters={item.pkFilters.map(pkFilter => Filter.create(pkFilter.fieldKey, pkFilter.value))}
+                key={item.lsid}
+                schemaQuery={SchemaQuery.create(item.schemaName, item.queryName)}
+            />
+        );
     }
 }

--- a/packages/components/src/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/components/lineage/node/LineageDetail.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent, ReactNode } from 'react';
 import { Experiment, Filter } from '@labkey/api';
 
-import { DetailPanelWithModel, QueryConfig, QueryConfigMap, SchemaQuery } from '../../..';
+import { DetailPanelWithModel, SchemaQuery } from '../../..';
 
 export interface LineageDetailProps {
     item: Experiment.LineageItemBase;

--- a/packages/components/src/components/omnibox/actions/Filter.ts
+++ b/packages/components/src/components/omnibox/actions/Filter.ts
@@ -484,4 +484,20 @@ export class FilterAction implements Action {
             param,
         };
     }
+
+    actionValueFromFilter(filter: Filter.IFilter, label: string): ActionValue {
+        const columnName = filter.getColumnName();
+        const filterType = filter.getFilterType();
+        const value = filter.getValue();
+        const operator = resolveSymbol(filter.getFilterType());
+        const { displayValue, isReadOnly } = this.getDisplayValue(label ?? columnName, filterType, value);
+
+        return {
+            action: this,
+            displayValue,
+            isReadOnly,
+            value: [columnName, operator, value].join(' '),
+            valueObject: filter,
+        };
+    }
 }

--- a/packages/components/src/components/omnibox/actions/Filter.ts
+++ b/packages/components/src/components/omnibox/actions/Filter.ts
@@ -496,7 +496,7 @@ export class FilterAction implements Action {
             action: this,
             displayValue,
             isReadOnly,
-            value: [columnName, operator, value].join(' '),
+            value: `"${label ?? columnName}" ${operator} ${value}`,
             valueObject: filter,
         };
     }

--- a/packages/components/src/components/omnibox/actions/Search.ts
+++ b/packages/components/src/components/omnibox/actions/Search.ts
@@ -82,4 +82,12 @@ export class SearchAction implements Action {
     parseParam(paramKey: string, paramValue: any, columns: List<QueryColumn>): string[] | Value[] {
         return paramValue.split(';');
     }
+
+    actionValueFromFilter(filter: Filter.IFilter): ActionValue {
+        return {
+            value: filter.getValue(),
+            valueObject: filter,
+            action: this,
+        };
+    }
 }

--- a/packages/components/src/components/omnibox/actions/Sort.ts
+++ b/packages/components/src/components/omnibox/actions/Sort.ts
@@ -180,4 +180,14 @@ export class SortAction implements Action {
             }
         });
     }
+
+    actionValueFromSort(sort: QuerySort, label: string): ActionValue {
+        const { dir, fieldKey } = sort;
+        return {
+            value: `${fieldKey} ${dir === '-' ? 'DESC' : 'ASC'}`,
+            displayValue: label ?? fieldKey,
+            valueObject: sort,
+            action: this,
+        };
+    }
 }

--- a/packages/components/src/components/omnibox/actions/View.ts
+++ b/packages/components/src/components/omnibox/actions/View.ts
@@ -127,4 +127,8 @@ export class ViewAction implements Action {
 
         return results;
     }
+
+    actionValueFromView(view: string): ActionValue {
+        return { value: view, action: this };
+    }
 }

--- a/packages/components/src/components/pagination/Pagination.tsx
+++ b/packages/components/src/components/pagination/Pagination.tsx
@@ -70,38 +70,41 @@ export class Pagination extends PureComponent<PaginationProps> {
             setPageSize,
         } = this.props;
         const showPageSizeMenu = rowCount > pageSizes[0];
+        const showPaginationButtons = rowCount > pageSize;
 
         // Use lk-pagination so we don't conflict with bootstrap pagination class.
         return (
             <div className="lk-pagination">
                 <div className="pagination-info">{this.paginationInfo}</div>
 
-                <ButtonGroup className="pagination-button-group">
-                    <PaginationButton
-                        disabled={disabled || isFirstPage}
-                        iconClass="fa-chevron-left"
-                        tooltip="Previous Page"
-                        onClick={loadPreviousPage}
-                    />
+                {showPaginationButtons && (
+                    <ButtonGroup className="pagination-button-group">
+                        <PaginationButton
+                            disabled={disabled || isFirstPage}
+                            iconClass="fa-chevron-left"
+                            tooltip="Previous Page"
+                            onClick={loadPreviousPage}
+                        />
 
-                    <PageMenu
-                        currentPage={currentPage}
-                        disabled={disabled || (isFirstPage && isLastPage)}
-                        id={id}
-                        isFirstPage={isFirstPage}
-                        isLastPage={isLastPage}
-                        pageCount={pageCount}
-                        loadFirstPage={loadFirstPage}
-                        loadLastPage={loadLastPage}
-                    />
+                        <PageMenu
+                            currentPage={currentPage}
+                            disabled={disabled || (isFirstPage && isLastPage)}
+                            id={id}
+                            isFirstPage={isFirstPage}
+                            isLastPage={isLastPage}
+                            pageCount={pageCount}
+                            loadFirstPage={loadFirstPage}
+                            loadLastPage={loadLastPage}
+                        />
 
-                    <PaginationButton
-                        disabled={disabled || isLastPage}
-                        iconClass="fa-chevron-right"
-                        tooltip="Next Page"
-                        onClick={loadNextPage}
-                    />
-                </ButtonGroup>
+                        <PaginationButton
+                            disabled={disabled || isLastPage}
+                            iconClass="fa-chevron-right"
+                            tooltip="Next Page"
+                            onClick={loadNextPage}
+                        />
+                    </ButtonGroup>
+                )}
 
                 {showPageSizeMenu && (
                     <PageSizeMenu

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -358,7 +358,7 @@ import {
     RequiresModelAndActions,
 } from './QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './QueryModel/GridPanel';
-import { DetailPanelWithModel } from './QueryModel/DetailPanel';
+import { DetailPanel, DetailPanelWithModel } from './QueryModel/DetailPanel';
 import { Pagination, PaginationData } from './components/pagination/Pagination';
 import { AuditDetailsModel } from './components/auditlog/models';
 import { AuditQueriesListingPage } from './components/auditlog/AuditQueriesListingPage';
@@ -779,6 +779,7 @@ export {
     InjectedQueryModels,
     GridPanel,
     GridPanelWithModel,
+    DetailPanel,
     DetailPanelWithModel,
     Pagination,
     PaginationData,

--- a/packages/components/src/models.ts
+++ b/packages/components/src/models.ts
@@ -133,7 +133,7 @@ export interface IDataViewInfo {
     appUrl?: AppURL; // This is a client side only attribute. Used to navigate within a Single Page App.
 }
 
-interface DataViewClientMetadata extends IDataViewInfo {
+export interface DataViewClientMetadata extends IDataViewInfo {
     // The attributes here are all specific to the DataViewInfo class and are not useful as part of IDataViewInfo
     isLoading?: boolean;
     isLoaded?: boolean;
@@ -196,23 +196,6 @@ export class DataViewInfo extends Record(DataViewInfoDefaultValues) {
 
     constructor(values?: DataViewClientMetadata) {
         super(values);
-    }
-
-    // TODO: remove the getters below, they're not necessary, consumers can safely access them via dot notation.
-    getLabel() {
-        return this.name;
-    }
-
-    isShared() {
-        return this.shared;
-    }
-
-    getIconCls() {
-        return this.iconCls;
-    }
-
-    isVisChartType() {
-        return VISUALIZATION_REPORTS.contains(this.type);
     }
 }
 

--- a/packages/components/src/stories/QueryModel.tsx
+++ b/packages/components/src/stories/QueryModel.tsx
@@ -1,4 +1,9 @@
-import React, { ChangeEvent, FunctionComponent, PureComponent, ReactElement, ReactNode } from 'react';
+import React, {
+    ChangeEvent,
+    FunctionComponent,
+    PureComponent,
+    ReactElement,
+} from 'react';
 import { storiesOf } from '@storybook/react';
 import { Button, MenuItem } from 'react-bootstrap';
 
@@ -13,7 +18,7 @@ import {
     withQueryModels,
 } from '..';
 import './QueryModel.scss';
-import { createMemoryHistory, Route, RouteComponent, Router, WithRouterProps } from 'react-router';
+import { createMemoryHistory, Route, Router, WithRouterProps } from 'react-router';
 
 class GridPanelButtonsExample extends PureComponent<RequiresModelAndActions> {
     render() {
@@ -124,7 +129,6 @@ storiesOf('QueryModel', module)
                 .map(key => {
                     const value = location.query[key];
                     return key + '=' + value;
-                    // return encodeURIComponent(key) + '=' + encodeURIComponent(value);
                 })
                 .join('&');
             const queryConfigs: QueryConfigMap = {
@@ -147,6 +151,7 @@ storiesOf('QueryModel', module)
             return (
                 <div className="query-model-example">
                     <div>
+                        <label>URL Query Params: </label>
                         <input style={{ width: '800px' }} value={queryString} onChange={onQueryChange} />
                     </div>
                     <GridPanelWithModel

--- a/packages/components/src/stories/QueryModel.tsx
+++ b/packages/components/src/stories/QueryModel.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { ChangeEvent, FunctionComponent, PureComponent, ReactElement, ReactNode } from 'react';
 import { storiesOf } from '@storybook/react';
 import { Button, MenuItem } from 'react-bootstrap';
 
@@ -8,12 +8,12 @@ import {
     InjectedQueryModels,
     ManageDropdownButton,
     QueryConfigMap,
-    QueryModel,
     RequiresModelAndActions,
     SchemaQuery,
     withQueryModels,
 } from '..';
 import './QueryModel.scss';
+import { createMemoryHistory, Route, RouteComponent, Router, WithRouterProps } from 'react-router';
 
 class GridPanelButtonsExample extends PureComponent<RequiresModelAndActions> {
     render() {
@@ -116,20 +116,52 @@ const ChangeableSchemaQuery = withQueryModels<{}>(ChangeableSchemaQueryImpl);
 
 storiesOf('QueryModel', module)
     .add('GridPanel', () => {
-        const queryConfigs: QueryConfigMap = {
-            mixtures: {
-                schemaQuery: SchemaQuery.create('exp.data', 'mixturespaging'),
-            },
+        const history = createMemoryHistory();
+
+        const ExampleGrid: FunctionComponent<WithRouterProps> = (props: WithRouterProps): ReactElement => {
+            const { location, router } = props;
+            const queryString = Object.keys(location.query)
+                .map(key => {
+                    const value = location.query[key];
+                    return key + '=' + value;
+                    // return encodeURIComponent(key) + '=' + encodeURIComponent(value);
+                })
+                .join('&');
+            const queryConfigs: QueryConfigMap = {
+                mixtures: {
+                    bindURL: true,
+                    schemaQuery: SchemaQuery.create('exp.data', 'mixturespaging'),
+                    urlPrefix: 'mixtures',
+                },
+            };
+
+            const onQueryChange = (evt: ChangeEvent<HTMLInputElement>): void => {
+                const query = {};
+                evt.target.value.split('&').forEach(segment => {
+                    const [ key, value ] = segment.split('=');
+                    query[key] = value;
+                    router.replace({...location, query });
+                });
+            };
+
+            return (
+                <div className="query-model-example">
+                    <div>
+                        <input style={{ width: '800px' }} value={queryString} onChange={onQueryChange} />
+                    </div>
+                    <GridPanelWithModel
+                        ButtonsComponent={GridPanelButtonsExample}
+                        title="Mixtures"
+                        queryConfigs={queryConfigs}
+                    />
+                </div>
+            );
         };
 
         return (
-            <div className="query-model-example">
-                <GridPanelWithModel
-                    ButtonsComponent={GridPanelButtonsExample}
-                    title="Mixtures"
-                    queryConfigs={queryConfigs}
-                />
-            </div>
+            <Router history={history}>
+                <Route path="/" component={ExampleGrid} />
+            </Router>
         );
     })
     .add('Minimal GridPanel', () => {

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1553,10 +1553,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.3.4":
-  version "0.3.4"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.4.tgz#3ad5911026311b8fa3a3564b26a0d90e087b5032"
-  integrity sha1-OtWRECYxG4+jo1ZLJqDZDgh7UDI=
+"@labkey/api@1.0.1":
+  version "1.0.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.0.1.tgz#92de4294dd2381b407659a15bc88a82efd9bca6a"
+  integrity sha1-kt5ClN0jgbQHZZoVvIioLv2bymo=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1553,10 +1553,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@labkey/api@0.3.2":
-  version "0.3.2"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz#6e08bc86731c5d6dd0356c7ee8e1ae3cd6bc58b8"
-  integrity sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg=
+"@labkey/api@0.3.4":
+  version "0.3.4"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.4.tgz#3ad5911026311b8fa3a3564b26a0d90e087b5032"
+  integrity sha1-OtWRECYxG4+jo1ZLJqDZDgh7UDI=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"


### PR DESCRIPTION
#### Rationale
We need QueryModel and withQueryModels to support URL binding so we can begin to replace existing usages of QueryGridModel in Biologics and Sample Manager that persist some model state to the URL.

#### Related Pull Requests
* n/a at the moment but will be needed in Biologics and Sample Manager

#### Changes
* Implement URL Binding for QueryModel/withQueryModels
    * For this feature to work your usage of withQueryModels must be a child of a configured React Router (see
    packages/components/src/stories/QueryModel.tsx for an example)
* QueryModel: charts has been changed from IDataViewInfo to DataViewInfo
    * QueryModelLoader has been updated to support this
* Fixed an issue in DefaultQueryModelLoader where loadCharts was returning unsupported charts.
* QueryModel: Added fields
    * bindURL
    * selectedReportId
* QueryModel: Added urlQueryParams, attributesForURLQueryParams, and hasRows getters
* QueryModel: Default to Details View if keyValue is set
* Removed unused getter methods from DataViewInfo
* Added toString() to SchemaQuery class
* Added (and exported) DetailPanel component
    - Same as DetailPanelWithModel except it is not wrapped in withQueryModels
* DetailPanelWithModel: changed props signature. Props are now `QueryConfig & DetailDisplaySharedProps`


Note: The GridPanel Omnibox tests are now failing, likely because the test is triggering a mismatch between the QueryModel and Omnibox state which we assume is an upstream/external change causing is to repopulate the Omnibox. I am not quite sure what the appropriate fix is at the moment, may need to change how we test the Omnibox for GridPanel.