### PR TITLE
Item 7565: Box display, Putting Samples in a Box

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.78.1-fb-fmAddSampleToBox",
+  "version": "0.78.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.78.0",
+  "version": "0.78.1-fb-fmAddSampleToBox",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Support custom gridColumnRenderer for AuditDetails
+
 ### version 0.78.0
 *Released*: 16 July 2020
 * Item 7563: SampleTypeDesigner update to add "Label Color" property to Sample Manager

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 0.78.1
+*Released*: 20 July 2020
 * Support custom gridColumnRenderer for AuditDetails
 
 ### version 0.78.0

--- a/packages/components/src/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/components/auditlog/AuditDetails.tsx
@@ -225,13 +225,10 @@ export class AuditDetails extends React.Component<Props, State> {
                 showHeader: false,
                 cell: (data, row) => {
                     let display;
-                    if (row.get('isUser'))
-                        display = this.getUserDisplay(data, user.isAdmin);
-                    else
-                        display = getEventDataValueDisplay(data, user.isAdmin);
+                    if (row.get('isUser')) display = this.getUserDisplay(data, user.isAdmin);
+                    else display = getEventDataValueDisplay(data, user.isAdmin);
 
-                    if (gridColumnRenderer)
-                        display = gridColumnRenderer(data, row, display);
+                    if (gridColumnRenderer) display = gridColumnRenderer(data, row, display);
 
                     return display;
                 },

--- a/packages/components/src/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/components/auditlog/AuditDetails.tsx
@@ -22,6 +22,7 @@ interface Props {
     gridData?: List<Map<string, any>>;
     changeDetails?: AuditDetailsModel;
     fieldValueRenderer?: (label, value, displayValue) => any;
+    gridColumnRenderer?: (data: any, row: any, displayValue: any) => any;
 }
 
 interface State {
@@ -211,7 +212,7 @@ export class AuditDetails extends React.Component<Props, State> {
     }
 
     getGridColumns(): List<GridColumn> {
-        const { user } = this.props;
+        const { user, gridColumnRenderer } = this.props;
         return List<GridColumn>([
             new GridColumn({
                 index: 'field',
@@ -223,11 +224,16 @@ export class AuditDetails extends React.Component<Props, State> {
                 title: 'Value',
                 showHeader: false,
                 cell: (data, row) => {
-                    if (row.get('isUser')) {
-                        return this.getUserDisplay(data, user.isAdmin);
-                    }
+                    let display;
+                    if (row.get('isUser'))
+                        display = this.getUserDisplay(data, user.isAdmin);
+                    else
+                        display = getEventDataValueDisplay(data, user.isAdmin);
 
-                    return getEventDataValueDisplay(data, user.isAdmin);
+                    if (gridColumnRenderer)
+                        display = gridColumnRenderer(data, row, display);
+
+                    return display;
                 },
             }),
         ]);


### PR DESCRIPTION
#### Rationale
We want to show the location event on Sample's timeline when a sample is added to a storage location in freezer. A gridColumnRenderer is added to AuditDetaiils so that box can link to its freezermanager page from sample manager. When we work on the future story to supporting routing between LKSM and LKFM in a more general way, we can then re-consider the approach. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/300
* https://github.com/LabKey/inventory/pull/58
* https://github.com/LabKey/sampleManagement/pull/327

#### Changes
* Support custom gridColumnRenderer for AuditDetails
