### PR TITLE
getServerContext().user may not be defined

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.78.2",
+  "version": "0.78.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.78.3
+*Released*: 22 July 2020
+* AppModel: initialUserId set from `User` model instead of directly from `getServerContext()`.
+
 ### version 0.78.2
 *Released*: 20 July 2020
 * EntityInsertPanel: Ability to filter Sample Type Options without filtering Parent Options

--- a/packages/components/src/internal/app/models.ts
+++ b/packages/components/src/internal/app/models.ts
@@ -7,14 +7,16 @@ import { ActionURL, getServerContext } from '@labkey/api';
 
 import { Container, User } from '../../components/base/models/model';
 
+const user = new User(getServerContext().user);
+
 export class AppModel extends Record({
     container: new Container(getServerContext().container),
     contextPath: ActionURL.getContextPath(),
-    initialUserId: getServerContext().user.id,
+    initialUserId: user.id,
     logoutReason: undefined,
     reloadRequired: false,
     requestPermissions: true,
-    user: new User(getServerContext().user),
+    user,
 }) {
     container: Container;
     contextPath: string;


### PR DESCRIPTION
#### Rationale
Our tests currently require that "LABKEY.user.id" be defined in the `jest` global configuration to avoid an undefined reference when setting the `AppModel.initialUserId`. This PR makes it so the `User` model is used to source the `initialUserId` which will now be fulfilled by the `defaultUser` properties for any property not defined via `getServerContext().user`.

![image](https://user-images.githubusercontent.com/3926239/88107973-e8b7a280-cb5c-11ea-9845-1956751964dc.png)

#### Changes
* Use default `User` model properties to populate `AppModel.initialUserId`.
