### PR TITLE
Add TeamCity status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LabKey NPM Packages (@labkey)
+# LabKey NPM Packages (@labkey) [![Build Status](https://teamcity.labkey.org/app/rest/builds/buildType:(id:LabKey_Trunk_Premium_InternalSuites_GlassComponentsUnitTest)/statusIcon)](https://teamcity.labkey.org/viewType.html?buildTypeId=LabKey_Trunk_Premium_InternalSuites_GlassComponentsUnitTest)
 
 This repository defines all of the npm packages available in the @labkey scope.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LabKey NPM Packages (@labkey) [![Build Status](https://teamcity.labkey.org/app/rest/builds/buildType:(id:LabKey_Trunk_Premium_InternalSuites_GlassComponentsUnitTest)/statusIcon)](https://teamcity.labkey.org/viewType.html?buildTypeId=LabKey_Trunk_Premium_InternalSuites_GlassComponentsUnitTest)
+# LabKey NPM Packages (@labkey)
 
 This repository defines all of the npm packages available in the @labkey scope.
 
@@ -10,11 +10,11 @@ Once they're ready, we'll officially push the components as version 1.0.0.
 ## Package listing
 
 <!--- keep these alphabetical --->
-| Package | Description |
-| --- | --- |
-| [@labkey/components](packages/components/README.md) | All components, models, actions, and utility functions for LabKey applications and pages
-| [@labkey/eslint-config-base](packages/eslint-config-base/README.md) | Base ESLint configuration with TypeScript and Prettier support.
-| [@labkey/eslint-config-react](packages/eslint-config-react/README.md) | Extends the base configuration with React support.
+| Package | Status | Description |
+| --- | --- | --- |
+| [@labkey/components](packages/components/README.md) |  [![Build Status](https://teamcity.labkey.org/app/rest/builds/buildType:(id:LabKey_Trunk_Premium_InternalSuites_GlassComponentsUnitTest)/statusIcon)](https://teamcity.labkey.org/viewType.html?buildTypeId=LabKey_Trunk_Premium_InternalSuites_GlassComponentsUnitTest) | All components, models, actions, and utility functions for LabKey applications and pages
+| [@labkey/eslint-config-base](packages/eslint-config-base/README.md) | | Base ESLint configuration with TypeScript and Prettier support.
+| [@labkey/eslint-config-react](packages/eslint-config-react/README.md) | | Extends the base configuration with React support.
 
 
 ## Using @labkey npm packages


### PR DESCRIPTION
#### Rationale
Shows TeamCity status and gives an easy way for people to locate the test results for this repository.

#### Changes
* Add status icon to README:
![image](https://user-images.githubusercontent.com/5263798/88216325-d0558f80-cc11-11ea-95f9-44caeb701f02.png)
