### PR TITLE
Item 7513: Add support for parameterized queries and retrieving selected data with selection operations 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.78.3",
+  "version": "0.78.4-fmSampleDetails.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.78.4-fmSampleDetails.0",
+  "version": "0.79.0-fbSampleDetails.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.0-fbSampleDetails.1",
+  "version": "0.80.0-fbSampleDetails.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.0-fbSampleDetails.3",
+  "version": "0.80.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.0-fbSampleDetails.2",
+  "version": "0.80.0-fbSampleDetails.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add support for parameterized queries when getting and setting selections on a grid
+
 ### version 0.78.2
 *Released*: 20 July 2020
 * EntityInsertPanel: Ability to filter Sample Type Options without filtering Parent Options

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.80.0
+*Released*: 24 July 2020
 * Add support for parameterized queries when getting and setting selections on a grid
 * Export getSelectedData method
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Add support for parameterized queries when getting and setting selections on a grid
+* Export getSelectedData method
 
 ### version 0.78.3
 *Released*: 22 July 2020

--- a/packages/components/src/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/QueryModel/QueryModelLoader.ts
@@ -110,8 +110,8 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
     // The selection related methods may seem like overly simple passthroughs, but by putting them on QueryModelLoader,
     // instead of in withQueryModels, it allows us to easily mock them or provide alternate implementations.
     clearSelections(model) {
-        const { id, schemaName, queryName, filters, containerPath } = model;
-        return clearSelected(id, schemaName, queryName, List(filters), containerPath);
+        const { id, schemaName, queryName, filters, containerPath, queryParameters } = model;
+        return clearSelected(id, schemaName, queryName, List(filters), containerPath, queryParameters);
     },
     async loadSelections(model) {
         const { id, schemaName, queryName, filters, containerPath, queryParameters } = model;

--- a/packages/components/src/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/QueryModel/QueryModelLoader.ts
@@ -114,8 +114,8 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
         return clearSelected(id, schemaName, queryName, List(filters), containerPath);
     },
     async loadSelections(model) {
-        const { id, schemaName, queryName, filters, containerPath } = model;
-        const result = await getSelected(id, schemaName, queryName, List(filters), containerPath);
+        const { id, schemaName, queryName, filters, containerPath, queryParameters } = model;
+        const result = await getSelected(id, schemaName, queryName, List(filters), containerPath, queryParameters);
         return new Set(result.selected);
     },
     setSelections(model, checked: boolean, selections: string[]) {
@@ -123,8 +123,8 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
         return setSelected(id, checked, selections, containerPath);
     },
     async selectAllRows(model) {
-        const { id, schemaName, queryName, filters, containerPath } = model;
-        await selectAll(id, schemaName, queryName, List(filters), containerPath);
+        const { id, schemaName, queryName, filters, containerPath, queryParameters } = model;
+        await selectAll(id, schemaName, queryName, List(filters), containerPath, queryParameters);
         return DefaultQueryModelLoader.loadSelections(model);
     },
     async loadCharts(model, includeSampleComparison) {

--- a/packages/components/src/actions.ts
+++ b/packages/components/src/actions.ts
@@ -1018,7 +1018,8 @@ export function clearSelected(
     schemaName?: string,
     queryName?: string,
     filterList?: List<Filter.IFilter>,
-    containerPath?: string
+    containerPath?: string,
+    queryParameters?: { [key: string]: any }
 ): Promise<ISelectResponse> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
@@ -1026,7 +1027,7 @@ export function clearSelected(
                 container: containerPath,
             }),
             method: 'POST',
-            jsonData: getFilteredQueryParams(key, schemaName, queryName, filterList),
+            jsonData: getFilteredQueryParams(key, schemaName, queryName, filterList, queryParameters),
             success: Utils.getCallbackWrapper(response => {
                 resolve(response);
             }),

--- a/packages/components/src/actions.ts
+++ b/packages/components/src/actions.ts
@@ -204,7 +204,14 @@ export function gridSelectAll(
 
     selectAll(id, model.schema, model.query, model.getFilters(), model.containerPath).then(data => {
         if (data && data.count > 0) {
-            return getSelected(id, model.schema, model.query, model.getFilters(), model.containerPath, model.queryParameters)
+            return getSelected(
+                id,
+                model.schema,
+                model.query,
+                model.getFilters(),
+                model.containerPath,
+                model.queryParameters
+            )
                 .then(response => {
                     const updatedModel = updateSelections(model, { selectedIds: List(response.selected) });
 
@@ -924,7 +931,8 @@ function getFilteredQueryParams(
     schemaName: string,
     queryName: string,
     filterList: List<Filter.IFilter>,
-    queryParameters?: { [key: string]: any }): any {
+    queryParameters?: { [key: string]: any }
+): any {
     if (schemaName && queryName && filterList && !filterList.isEmpty()) {
         return getQueryParams(key, schemaName, queryName, filterList, queryParameters);
     } else {
@@ -934,18 +942,24 @@ function getFilteredQueryParams(
     }
 }
 
-function getQueryParams(key: string, schemaName: string, queryName: string, filterList: List<Filter.IFilter>, queryParameters?: { [key: string]: any }): any {
+function getQueryParams(
+    key: string,
+    schemaName: string,
+    queryName: string,
+    filterList: List<Filter.IFilter>,
+    queryParameters?: { [key: string]: any }
+): any {
     const filters = filterList.reduce((prev, next) => {
         return Object.assign(prev, { [next.getURLParameterName()]: next.getURLParameterValue() });
     }, {});
 
-    let params = {
+    const params = {
         schemaName,
         queryName,
         'query.selectionKey': key,
     };
     if (queryParameters) {
-        for (let propName in queryParameters) {
+        for (const propName in queryParameters) {
             if (queryParameters.hasOwnProperty(propName)) {
                 params['query.param.' + propName] = queryParameters[propName];
             }
@@ -972,7 +986,8 @@ export function getSelected(
     queryName?: string,
     filterList?: List<Filter.IFilter>,
     containerPath?: string,
-    queryParameters?: { [key: string]: any }): Promise<IGetSelectedResponse> {
+    queryParameters?: { [key: string]: any }
+): Promise<IGetSelectedResponse> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
             url: buildURL('query', 'getSelected.api', undefined, {
@@ -1171,7 +1186,14 @@ export function getSelection(location: any): Promise<ISelectionResponse> {
                 });
             }
 
-            return getSelected(key, schemaQuery.schemaName, schemaQuery.queryName, getFilterListFromQuery(location), undefined, undefined).then(response => {
+            return getSelected(
+                key,
+                schemaQuery.schemaName,
+                schemaQuery.queryName,
+                getFilterListFromQuery(location),
+                undefined,
+                undefined
+            ).then(response => {
                 resolve({
                     resolved: true,
                     schemaQuery,
@@ -1187,13 +1209,15 @@ export function getSelection(location: any): Promise<ISelectionResponse> {
     });
 }
 
-export function getSelectedData(schemaName?: string,
-                                queryName?: string,
-                                selections?: string[],
-                                columns?: string,
-                                sorts?: string,
-                                queryParameters?: { [key: string]: any }): Promise<IGridResponse>  {
-    let filterArray = [];
+export function getSelectedData(
+    schemaName?: string,
+    queryName?: string,
+    selections?: string[],
+    columns?: string,
+    sorts?: string,
+    queryParameters?: { [key: string]: any }
+): Promise<IGridResponse> {
+    const filterArray = [];
     filterArray.push(Filter.create('RowId', selections, Filter.Types.IN));
 
     return new Promise((resolve, reject) =>
@@ -1222,11 +1246,21 @@ export function getSelectedData(schemaName?: string,
     );
 }
 
-export function getSelectedDataWithQueryGridModel(model: QueryGridModel, columns?: List<QueryColumn>): Promise<IGridResponse> {
+export function getSelectedDataWithQueryGridModel(
+    model: QueryGridModel,
+    columns?: List<QueryColumn>
+): Promise<IGridResponse> {
     // If columns defined use those for the query columns else use the display columns
     const columnString = columns ? columns.map(c => c.fieldKey).join(',') : model.getRequestColumnsString();
 
-    return getSelectedData(model.schema, model.query, model.selectedIds.toArray(), columnString, model.getSorts() || '-RowId', model.queryParameters);
+    return getSelectedData(
+        model.schema,
+        model.query,
+        model.selectedIds.toArray(),
+        columnString,
+        model.getSorts() || '-RowId',
+        model.queryParameters
+    );
 }
 
 function getFilterParameters(filters: List<any>, remove = false): Map<string, string> {

--- a/packages/components/src/components/GridLoader.tsx
+++ b/packages/components/src/components/GridLoader.tsx
@@ -61,7 +61,14 @@ class GridLoader implements IGridLoader {
     fetchSelection(model: QueryGridModel): Promise<IGridSelectionResponse> {
         return new Promise((resolve, reject) => {
             // TODO: filterArray should be model.getFilters();
-            return getSelected(model.getId(), model.schema, model.query, model.filterArray, model.containerPath, model.queryParameters)
+            return getSelected(
+                model.getId(),
+                model.schema,
+                model.query,
+                model.filterArray,
+                model.containerPath,
+                model.queryParameters
+            )
                 .then(response => {
                     resolve({
                         selectedIds: List(response.selected),

--- a/packages/components/src/components/GridLoader.tsx
+++ b/packages/components/src/components/GridLoader.tsx
@@ -61,7 +61,7 @@ class GridLoader implements IGridLoader {
     fetchSelection(model: QueryGridModel): Promise<IGridSelectionResponse> {
         return new Promise((resolve, reject) => {
             // TODO: filterArray should be model.getFilters();
-            return getSelected(model.getId(), model.schema, model.query, model.filterArray, model.containerPath)
+            return getSelected(model.getId(), model.schema, model.query, model.filterArray, model.containerPath, model.queryParameters)
                 .then(response => {
                     resolve({
                         selectedIds: List(response.selected),

--- a/packages/components/src/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/components/auditlog/AuditQueriesListingPage.tsx
@@ -79,13 +79,18 @@ export class AuditQueriesListingPage extends React.PureComponent<Props, State> {
         if (model.selectedLoaded) {
             this.updateSelectedRowId(this.getLastSelectedId());
         } else {
-            getSelected(model.getId(), model.schema, model.query, model.getFilters(), model.containerPath, model.queryParameters).then(
-                response => {
-                    const selectedId =
-                        response.selected.length > 0 ? parseInt(List.of(...response.selected).last()) : undefined;
-                    this.updateSelectedRowId(selectedId);
-                }
-            );
+            getSelected(
+                model.getId(),
+                model.schema,
+                model.query,
+                model.getFilters(),
+                model.containerPath,
+                model.queryParameters
+            ).then(response => {
+                const selectedId =
+                    response.selected.length > 0 ? parseInt(List.of(...response.selected).last()) : undefined;
+                this.updateSelectedRowId(selectedId);
+            });
         }
     }
 
@@ -227,7 +232,7 @@ export class AuditQueriesListingPage extends React.PureComponent<Props, State> {
 
         const { eventUserId, eventDateFormatted } = detail;
 
-        let rows = [];
+        const rows = [];
         if (eventUserId) {
             rows.push({ field: detail.getActionLabel() + ' By', value: eventUserId, isUser: true });
         }

--- a/packages/components/src/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/components/auditlog/AuditQueriesListingPage.tsx
@@ -79,7 +79,7 @@ export class AuditQueriesListingPage extends React.PureComponent<Props, State> {
         if (model.selectedLoaded) {
             this.updateSelectedRowId(this.getLastSelectedId());
         } else {
-            getSelected(model.getId(), model.schema, model.query, model.getFilters(), model.containerPath).then(
+            getSelected(model.getId(), model.schema, model.query, model.getFilters(), model.containerPath, model.queryParameters).then(
                 response => {
                     const selectedId =
                         response.selected.length > 0 ? parseInt(List.of(...response.selected).last()) : undefined;

--- a/packages/components/src/components/editable/EditableGridLoaderFromSelection.tsx
+++ b/packages/components/src/components/editable/EditableGridLoaderFromSelection.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { List, Map } from 'immutable';
 
-import { getSelectedData } from '../../actions';
+import { getSelectedDataWithQueryGridModel } from '../../actions';
 import { EditorModel } from '../../models';
 import { IGridLoader, IGridResponse, QueryGridModel } from '../base/models/model';
 
@@ -38,7 +38,7 @@ export class EditableGridLoaderFromSelection implements IGridLoader {
             // N.B.  gridModel is the model backing the editable grid, which has no selection on it,
             // so we use this.model, the model for the original query grid with selection.
             this.model = this.model.set('requiredColumns', gridModel.get('requiredColumns')) as QueryGridModel;
-            return getSelectedData(this.model)
+            return getSelectedDataWithQueryGridModel(this.model)
                 .then(response => {
                     const { data, dataIds, totalRows } = response;
                     resolve({

--- a/packages/components/src/components/entities/actions.ts
+++ b/packages/components/src/components/entities/actions.ts
@@ -105,7 +105,7 @@ function initParents(initialParents: string[], selectionKey: string): Promise<Li
                     .then(response => resolve(response))
                     .catch(reason => reject(reason));
             } else {
-                return getSelected(selectionKey, undefined, undefined, undefined, undefined, undefined)
+                return getSelected(selectionKey)
                     .then(selectionResponse => {
                         return getSelectedParents(schemaQuery, [
                             Filter.create('RowId', selectionResponse.selected, Filter.Types.IN),

--- a/packages/components/src/components/entities/actions.ts
+++ b/packages/components/src/components/entities/actions.ts
@@ -105,7 +105,7 @@ function initParents(initialParents: string[], selectionKey: string): Promise<Li
                     .then(response => resolve(response))
                     .catch(reason => reject(reason));
             } else {
-                return getSelected(selectionKey)
+                return getSelected(selectionKey, undefined, undefined, undefined, undefined, undefined)
                     .then(selectionResponse => {
                         return getSelectedParents(schemaQuery, [
                             Filter.create('RowId', selectionResponse.selected, Filter.Types.IN),

--- a/packages/components/src/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/components/forms/BulkUpdateForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { List, Map } from 'immutable';
 import { Utils } from '@labkey/api';
 
-import { getSelectedData } from '../../actions';
+import { getSelectedDataWithQueryGridModel } from '../../actions';
 import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
 
 import { capitalizeFirstChar, getCommonDataValues, getUpdatedData } from '../../util/utils';
@@ -59,7 +59,7 @@ export class BulkUpdateForm extends React.Component<Props, State> {
             ? (model.getKeyColumns().concat(model.getUpdateColumns()) as List<QueryColumn>)
             : undefined;
 
-        getSelectedData(model, columns)
+        getSelectedDataWithQueryGridModel(model, columns)
             .then(response => {
                 const { data, dataIds } = response;
                 this.setState(() => ({

--- a/packages/components/src/components/user/SiteUsersGridPanel.tsx
+++ b/packages/components/src/components/user/SiteUsersGridPanel.tsx
@@ -197,13 +197,18 @@ export class SiteUsersGridPanel extends React.PureComponent<Props, State> {
         if (model.selectedLoaded) {
             this.updateSelectedUserId(this.getLastSelectedId());
         } else {
-            getSelected(model.getId(), model.schema, model.query, model.getFilters(), model.containerPath, model.queryParameters).then(
-                response => {
-                    const selectedUserId =
-                        response.selected.length > 0 ? parseInt(List.of(...response.selected).last()) : undefined;
-                    this.updateSelectedUserId(selectedUserId);
-                }
-            );
+            getSelected(
+                model.getId(),
+                model.schema,
+                model.query,
+                model.getFilters(),
+                model.containerPath,
+                model.queryParameters
+            ).then(response => {
+                const selectedUserId =
+                    response.selected.length > 0 ? parseInt(List.of(...response.selected).last()) : undefined;
+                this.updateSelectedUserId(selectedUserId);
+            });
         }
     }
 

--- a/packages/components/src/components/user/SiteUsersGridPanel.tsx
+++ b/packages/components/src/components/user/SiteUsersGridPanel.tsx
@@ -197,7 +197,7 @@ export class SiteUsersGridPanel extends React.PureComponent<Props, State> {
         if (model.selectedLoaded) {
             this.updateSelectedUserId(this.getLastSelectedId());
         } else {
-            getSelected(model.getId(), model.schema, model.query, model.getFilters(), model.containerPath).then(
+            getSelected(model.getId(), model.schema, model.query, model.getFilters(), model.containerPath, model.queryParameters).then(
                 response => {
                     const selectedUserId =
                         response.selected.length > 0 ? parseInt(List.of(...response.selected).last()) : undefined;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -119,6 +119,7 @@ import { EditorModel, getStateQueryGridModel, getStateModelId, IDataViewInfo } f
 import {
     createQueryGridModelFilteredBySample,
     getSelected,
+    getSelectedData,
     getSelection,
     gridIdInvalidate,
     gridInit,
@@ -389,6 +390,7 @@ export {
     schemaGridInvalidate,
     // grid functions
     getSelected,
+    getSelectedData,
     getSelection,
     gridInit,
     gridShowError,


### PR DESCRIPTION
#### Rationale
Freezer Management functionality uses parameterized queries for a number of its grids, so we need to add support for selecting and de-selecting items in such grids that are backed by parameterized queries.  We also need to be able to retrieve the records for all selected items, not just those on the current page in order to do certain operations, so we expose an action for doing that.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/59

#### Changes
* Add support for parameterized queries when getting and setting selections on a grid
* Export getSelectedData method