### PR TITLE
Item 7622: Updates to URL routing for better between-application routing

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.0",
+  "version": "0.81.0-fmUrlRouting.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.81.0-fmUrlRouting.2",
+  "version": "0.81.0-fmUrlRouting.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.0-fmUrlRouting.5",
+  "version": "0.82.0-fmUrlRouting.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.81.0-fmUrlRouting.1",
+  "version": "0.81.0-fmUrlRouting.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.0-fmUrlRouting.6",
+  "version": "0.82.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.0-fmUrlRouting.3",
+  "version": "0.82.0-fmUrlRouting.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.81.0-fmUrlRouting.0",
+  "version": "0.81.0-fmUrlRouting.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TDB
+*Release*: TBD
+* Add method for applications to register their URL Mappers so different applications can choose to route Server URLs differently.
+* Add a productId property to ActionMapper so it can be used to construct a URL to a separate application.
+
 ### version 0.80.0
 *Released*: 24 July 2020
 * Add support for parameterized queries when getting and setting selections on a grid

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TDB
-*Release*: TBD
+### version 0.82.0
+*Release*: 30 July 2020
 * Add method for applications to register their URL Mappers so different applications can choose to route Server URLs differently.
 * Add a productId property to ActionMapper so it can be used to construct a URL to a separate application.
 

--- a/packages/components/src/components/PreviewGrid.spec.tsx
+++ b/packages/components/src/components/PreviewGrid.spec.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { initUnitTestMocks } from '../testHelpers';
+import { initUnitTestMocks, registerDefaultURLMappers } from '../testHelpers';
 
 import { PreviewGrid } from './PreviewGrid';
 import { SchemaQuery } from './base/models/model';
 
 beforeAll(() => {
     initUnitTestMocks();
+    registerDefaultURLMappers();
 });
 
 const SQ = SchemaQuery.create('exp.data', 'mixtures', '~~default~~');

--- a/packages/components/src/components/QueryGridPanel.spec.tsx
+++ b/packages/components/src/components/QueryGridPanel.spec.tsx
@@ -24,7 +24,6 @@ import { initUnitTestMocks, registerDefaultURLMappers } from '../testHelpers';
 
 import { QueryGridModel, SchemaQuery } from './base/models/model';
 import { QueryGridPanel } from './QueryGridPanel';
-import { ASSAY_MAPPERS, DATA_CLASS_MAPPERS, SAMPLE_TYPE_MAPPERS, URLService } from '..';
 
 beforeAll(() => {
     initUnitTestMocks();

--- a/packages/components/src/components/QueryGridPanel.spec.tsx
+++ b/packages/components/src/components/QueryGridPanel.spec.tsx
@@ -20,13 +20,15 @@ import { List } from 'immutable';
 import { TESTS_ONLY_RESET_DOM_COUNT } from '../util/utils';
 
 import { getStateQueryGridModel } from '../models';
-import { initUnitTestMocks } from '../testHelpers';
+import { initUnitTestMocks, registerDefaultURLMappers } from '../testHelpers';
 
 import { QueryGridModel, SchemaQuery } from './base/models/model';
 import { QueryGridPanel } from './QueryGridPanel';
+import { ASSAY_MAPPERS, DATA_CLASS_MAPPERS, SAMPLE_TYPE_MAPPERS, URLService } from '..';
 
 beforeAll(() => {
     initUnitTestMocks();
+    registerDefaultURLMappers();
 });
 
 describe('QueryGridPanel render', () => {

--- a/packages/components/src/components/base/models/QueryInfo.ts
+++ b/packages/components/src/components/base/models/QueryInfo.ts
@@ -122,6 +122,7 @@ export class QueryInfo extends Record({
             Object.assign({}, queryInfoJson, {
                 columns,
                 schemaQuery,
+                views: Map<string, ViewInfo>() // need views to be a Map to avoid 'get is not defined' errors
             })
         );
     }

--- a/packages/components/src/components/base/models/QueryInfo.ts
+++ b/packages/components/src/components/base/models/QueryInfo.ts
@@ -122,7 +122,7 @@ export class QueryInfo extends Record({
             Object.assign({}, queryInfoJson, {
                 columns,
                 schemaQuery,
-                views: Map<string, ViewInfo>() // need views to be a Map to avoid 'get is not defined' errors
+                views: Map<string, ViewInfo>(), // need views to be a Map to avoid 'get is not defined' errors
             })
         );
     }

--- a/packages/components/src/components/lineage/grid/LineageGrid.spec.tsx
+++ b/packages/components/src/components/lineage/grid/LineageGrid.spec.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { initUnitTestMocks } from '../../../testHelpers';
+import { initUnitTestMocks, registerDefaultURLMappers } from '../../../testHelpers';
 
 import { LineageGrid } from './LineageGrid';
 
 beforeAll(() => {
     initUnitTestMocks();
+    registerDefaultURLMappers();
 });
 
 describe('<LineageGrid/>', () => {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -162,19 +162,7 @@ import {
     NO_UPDATES_MESSAGE,
 } from './constants';
 import { getLocation, Location, replaceParameter, replaceParameters, resetParameters } from './util/URL';
-import {
-    ASSAY_MAPPERS,
-    AUDIT_DETAILS_MAPPER,
-    DATA_CLASS_MAPPERS,
-    DETAILS_QUERY_ROW_MAPPER,
-    DOWNLOAD_FILE_LINK_MAPPER,
-    EXECUTE_QUERY_MAPPER,
-    LIST_MAPPERS,
-    LOOKUP_MAPPER,
-    SAMPLE_TYPE_MAPPERS,
-    URLResolver,
-    USER_DETAILS_MAPPER
-} from './util/URLResolver';
+import { URL_MAPPERS, URLResolver } from './util/URLResolver';
 import { ActionMapper, URLService } from './util/URLService';
 import { DATA_IMPORT_TOPIC, DELETE_SAMPLES_TOPIC, getHelpLink, helpLinkNode } from './util/helpLinks';
 import {
@@ -435,16 +423,7 @@ export {
     AppURL,
     Location,
     ActionMapper,
-    ASSAY_MAPPERS,
-    AUDIT_DETAILS_MAPPER,
-    DATA_CLASS_MAPPERS,
-    EXECUTE_QUERY_MAPPER,
-    DOWNLOAD_FILE_LINK_MAPPER,
-    LIST_MAPPERS,
-    LOOKUP_MAPPER,
-    DETAILS_QUERY_ROW_MAPPER,
-    SAMPLE_TYPE_MAPPERS,
-    USER_DETAILS_MAPPER,
+    URL_MAPPERS,
     URLResolver,
     URLService,
     AppRouteResolver,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -91,19 +91,19 @@ import { DEFAULT_FILE, FileAttachmentFormModel, IFile } from './components/files
 import { FilesListing } from './components/files/FilesListing';
 import { FilesListingForm } from './components/files/FilesListingForm';
 import { FileAttachmentEntry } from './components/files/FileAttachmentEntry';
-import { WebDavFile, getWebDavFiles, uploadWebDavFile } from './components/files/WebDav';
+import { getWebDavFiles, uploadWebDavFile, WebDavFile } from './components/files/WebDav';
 import { FileTree } from './components/files/FileTree';
 import { Notification } from './components/notifications/Notification';
 import { createNotification } from './components/notifications/actions';
-import { dismissNotifications, initNotificationsState, addNotification } from './components/notifications/global';
+import { addNotification, dismissNotifications, initNotificationsState } from './components/notifications/global';
 import { ConfirmModal } from './components/base/ConfirmModal';
 import { datePlaceholder, formatDate, formatDateTime, getDateFormat, getUnFormattedNumber } from './util/Date';
 import { SVGIcon, Theme } from './components/base/SVGIcon';
 import { CreatedModified } from './components/base/CreatedModified';
 import {
     MessageFunction,
-    NotificationItemProps,
     NotificationItemModel,
+    NotificationItemProps,
     Persistence,
 } from './components/notifications/model';
 import { PermissionAllowed, PermissionNotAllowed } from './components/base/Permissions';
@@ -115,7 +115,7 @@ import { ToggleButtons } from './components/buttons/ToggleButtons';
 import { Cards } from './components/base/Cards';
 import { Footer } from './components/base/Footer';
 
-import { EditorModel, getStateQueryGridModel, getStateModelId, IDataViewInfo } from './models';
+import { EditorModel, getStateModelId, getStateQueryGridModel, IDataViewInfo } from './models';
 import {
     createQueryGridModelFilteredBySample,
     getSelected,
@@ -153,17 +153,29 @@ import {
     selectRows,
     updateRows,
 } from './query/api';
-import { loadReports, flattenBrowseDataTreeResponse } from './query/reports';
+import { flattenBrowseDataTreeResponse, loadReports } from './query/reports';
 import {
+    DataViewInfoTypes,
     IMPORT_DATA_FORM_TYPES,
+    LoadingState,
     MAX_EDITABLE_GRID_ROWS,
     NO_UPDATES_MESSAGE,
-    DataViewInfoTypes,
-    LoadingState,
 } from './constants';
 import { getLocation, Location, replaceParameter, replaceParameters, resetParameters } from './util/URL';
-import { URLResolver } from './util/URLResolver';
-import { URLService } from './util/URLService';
+import {
+    ASSAY_MAPPERS,
+    AUDIT_DETAILS_MAPPER,
+    DATA_CLASS_MAPPERS,
+    DETAILS_QUERY_ROW_MAPPER,
+    DOWNLOAD_FILE_LINK_MAPPER,
+    EXECUTE_QUERY_MAPPER,
+    LIST_MAPPERS,
+    LOOKUP_MAPPER,
+    SAMPLE_TYPE_MAPPERS,
+    URLResolver,
+    USER_DETAILS_MAPPER
+} from './util/URLResolver';
+import { ActionMapper, URLService } from './util/URLService';
 import { DATA_IMPORT_TOPIC, DELETE_SAMPLES_TOPIC, getHelpLink, helpLinkNode } from './util/helpLinks';
 import {
     AppRouteResolver,
@@ -192,7 +204,7 @@ import { BulkAddUpdateForm } from './components/forms/BulkAddUpdateForm';
 import { BulkUpdateForm } from './components/forms/BulkUpdateForm';
 import { LabelOverlay } from './components/forms/LabelOverlay';
 import { resolveDetailFieldValue, resolveRenderer } from './components/forms/renderers';
-import { QueryFormInputs, getQueryFormLabelFieldName, isQueryFormLabelField } from './components/forms/QueryFormInputs';
+import { getQueryFormLabelFieldName, isQueryFormLabelField, QueryFormInputs } from './components/forms/QueryFormInputs';
 import { LookupSelectInput } from './components/forms/input/LookupSelectInput';
 import { SelectInput, SelectInputProps } from './components/forms/input/SelectInput';
 import { DatePickerInput } from './components/forms/input/DatePickerInput';
@@ -208,9 +220,9 @@ import { PageDetailHeader } from './components/forms/PageDetailHeader';
 import { DetailEditing } from './components/forms/detail/DetailEditing';
 
 import {
+    resolveDetailEditRenderer,
     resolveDetailRenderer,
     titleRenderer,
-    resolveDetailEditRenderer,
 } from './components/forms/detail/DetailEditRenderer';
 import { Detail } from './components/forms/detail/Detail';
 import { getUsersWithPermissions, handleInputTab, handleTabKeyOnTextArea } from './components/forms/actions';
@@ -227,20 +239,20 @@ import { addDateRangeFilter, last12Months, monthSort } from './components/heatma
 import { EntityInsertPanel } from './components/entities/EntityInsertPanel';
 import { EntityDeleteModal } from './components/entities/EntityDeleteModal';
 import { ParentEntityEditPanel } from './components/entities/ParentEntityEditPanel';
-import { createDeleteSuccessNotification, createDeleteErrorNotification } from './components/notifications/messaging';
+import { createDeleteErrorNotification, createDeleteSuccessNotification } from './components/notifications/messaging';
 import {
-    IParentOption,
+    EntityDataType,
     EntityInputProps,
+    GenerateEntityResponse,
     IDerivePayload,
     IEntityTypeOption,
+    IParentOption,
     MaterialOutput,
-    GenerateEntityResponse,
-    EntityDataType,
 } from './components/entities/models';
 import { SearchResultCard } from './components/search/SearchResultCard';
 import { SearchResultsPanel } from './components/search/SearchResultsPanel';
 import { searchUsingIndex } from './components/search/actions';
-import { SearchResultsModel, SearchResultCardData } from './components/search/models';
+import { SearchResultCardData, SearchResultsModel } from './components/search/models';
 import {
     deleteSampleSet,
     fetchSamples,
@@ -252,13 +264,13 @@ import { DataClassDesigner } from './components/domainproperties/dataclasses/Dat
 import { DataClassModel } from './components/domainproperties/dataclasses/models';
 import { deleteDataClass, fetchDataClass } from './components/domainproperties/dataclasses/actions';
 import { AssayImportPanels } from './components/assay/AssayImportPanels';
-import { AssayProvider, AssayProviderProps, AssayContextConsumer } from './components/assay/AssayProvider';
+import { AssayContextConsumer, AssayProvider, AssayProviderProps } from './components/assay/AssayProvider';
 import { AssayDesignDeleteConfirmModal } from './components/assay/AssayDesignDeleteConfirmModal';
 import { AssayResultDeleteConfirmModal } from './components/assay/AssayResultDeleteConfirmModal';
 import { AssayRunDeleteConfirmModal } from './components/assay/AssayRunDeleteConfirmModal';
 import { AssayImportSubMenuItem } from './components/assay/AssayImportSubMenuItem';
 import { AssayReimportRunButton } from './components/assay/AssayReimportRunButton';
-import { AssayUploadResultModel, AssayStateModel } from './components/assay/models';
+import { AssayStateModel, AssayUploadResultModel } from './components/assay/models';
 import {
     deleteAssayDesign,
     deleteAssayRuns,
@@ -275,9 +287,9 @@ import { RUN_PROPERTIES_GRID_ID, RUN_PROPERTIES_REQUIRED_COLUMNS } from './compo
 import { ReportItemModal, ReportList, ReportListItem } from './components/report-list/ReportList';
 import { invalidateLineageResults } from './components/lineage/actions';
 import {
-    LineageFilter,
     LINEAGE_DIRECTIONS,
     LINEAGE_GROUPING_GENERATIONS,
+    LineageFilter,
     LineageURLResolvers,
 } from './components/lineage/types';
 import { VisGraphNode } from './components/lineage/vis/VisGraphGenerator';
@@ -293,7 +305,7 @@ import { ITab, SubNav } from './components/navigation/SubNav';
 import { Breadcrumb } from './components/navigation/Breadcrumb';
 import { BreadcrumbCreate } from './components/navigation/BreadcrumbCreate';
 import { MenuItemModel, MenuSectionModel, ProductMenuModel } from './components/navigation/model';
-import { confirmLeaveWhenDirty, createProductUrlFromParts } from './components/navigation/utils';
+import { confirmLeaveWhenDirty, createProductUrl, createProductUrlFromParts } from './components/navigation/utils';
 import { UserSelectInput } from './components/forms/input/UserSelectInput';
 import { UserDetailHeader } from './components/user/UserDetailHeader';
 import { UserProfile } from './components/user/UserProfile';
@@ -303,11 +315,11 @@ import { SiteUsersGridPanel } from './components/user/SiteUsersGridPanel';
 import { createFormInputId, fetchDomain, saveDomain, setDomainFields } from './components/domainproperties/actions';
 import {
     DomainDesign,
+    DomainDetails,
     DomainField,
     IAppDomainHeader,
     IBannerMessage,
     IDomainField,
-    DomainDetails,
     IFieldChange,
     SAMPLE_TYPE,
 } from './components/domainproperties/models';
@@ -339,24 +351,24 @@ import { PermissionsPageContextProvider } from './components/permissions/Permiss
 import { PermissionsProviderProps, Principal, SecurityPolicy, SecurityRole } from './components/permissions/models';
 import { fetchContainerSecurityPolicy } from './components/permissions/actions';
 import {
+    extractEntityTypeOptionFromRow,
     getDataDeleteConfirmationData,
     getSampleDeleteConfirmationData,
-    extractEntityTypeOptionFromRow,
 } from './components/entities/actions';
-import { SampleTypeDataType, DataClassDataType } from './components/entities/constants';
+import { DataClassDataType, SampleTypeDataType } from './components/entities/constants';
 import { SampleTypeModel } from './components/domainproperties/samples/models';
 import { SampleTypeDesigner } from './components/domainproperties/samples/SampleTypeDesigner';
 
 import { QueryConfig, QueryModel } from './QueryModel/QueryModel';
 import { QueryModelLoader } from './QueryModel/QueryModelLoader';
 import {
-    withQueryModels,
-    MakeQueryModels,
-    InjectedQueryModels,
     Actions,
+    InjectedQueryModels,
+    MakeQueryModels,
     QueryConfigMap,
     QueryModelMap,
     RequiresModelAndActions,
+    withQueryModels,
 } from './QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './QueryModel/GridPanel';
 import { DetailPanel, DetailPanelWithModel } from './QueryModel/DetailPanel';
@@ -422,6 +434,17 @@ export {
     // url and location related items
     AppURL,
     Location,
+    ActionMapper,
+    ASSAY_MAPPERS,
+    AUDIT_DETAILS_MAPPER,
+    DATA_CLASS_MAPPERS,
+    EXECUTE_QUERY_MAPPER,
+    DOWNLOAD_FILE_LINK_MAPPER,
+    LIST_MAPPERS,
+    LOOKUP_MAPPER,
+    DETAILS_QUERY_ROW_MAPPER,
+    SAMPLE_TYPE_MAPPERS,
+    USER_DETAILS_MAPPER,
     URLResolver,
     URLService,
     AppRouteResolver,
@@ -439,6 +462,7 @@ export {
     imageURL,
     spliceURL,
     WHERE_FILTER_TYPE,
+    createProductUrl,
     createProductUrlFromParts,
     // renderers
     AliasRenderer,

--- a/packages/components/src/test/data/sampleSetSearchResult.json
+++ b/packages/components/src/test/data/sampleSetSearchResult.json
@@ -15,7 +15,7 @@
       },
       "id": "materialSource:1",
       "title": "Sample Set - Molecule",
-      "url": "/labkey/e686748d-817d-1037-bb53-9caba13ba4f1/experiment-showMaterialSource.view?rowId=1&_docid=materialSource%3A1"
+      "url": "/labkey/e686748d-817d-1037-bb53-9caba13ba4f1/experiment-showSampleType.view?rowId=1&_docid=materialSource%3A1"
     }
   ],
   "metaData": {

--- a/packages/components/src/testHelpers.ts
+++ b/packages/components/src/testHelpers.ts
@@ -3,19 +3,13 @@ import { LabKey, Query } from '@labkey/api';
 import mock, { proxy } from 'xhr-mock';
 
 import { initQueryGridState } from './global';
-import { initQueryGridMocks, initLineageMocks, initUserPropsMocks } from './stories/mock';
+import { initLineageMocks, initQueryGridMocks, initUserPropsMocks } from './stories/mock';
 import { QueryInfo } from './components/base/models/QueryInfo';
 import { applyQueryMetadata, handle132Response } from './query/api';
 import { bindColumnRenderers } from './renderers';
 import { RowsResponse } from './QueryModel/QueryModelLoader';
 import { URLService } from './util/URLService';
-import {
-    ASSAY_MAPPERS,
-    DATA_CLASS_MAPPERS,
-    LIST_MAPPERS,
-    LOOKUP_MAPPER,
-    SAMPLE_TYPE_MAPPERS, USER_DETAILS_MAPPER
-} from './util/URLResolver';
+import { URL_MAPPERS } from './util/URLResolver';
 
 declare let LABKEY: LabKey;
 
@@ -56,12 +50,12 @@ export function initUnitTestMocks(metadata?: Map<string, any>, columnRenderers?:
 
 export function registerDefaultURLMappers() {
     URLService.registerURLMappers(
-        ...ASSAY_MAPPERS,
-        ...DATA_CLASS_MAPPERS,
-        ...SAMPLE_TYPE_MAPPERS,
-        ...LIST_MAPPERS,
-        USER_DETAILS_MAPPER,
-        LOOKUP_MAPPER
+        ...URL_MAPPERS.ASSAY_MAPPERS,
+        ...URL_MAPPERS.DATA_CLASS_MAPPERS,
+        ...URL_MAPPERS.SAMPLE_TYPE_MAPPERS,
+        ...URL_MAPPERS.LIST_MAPPERS,
+        URL_MAPPERS.USER_DETAILS_MAPPER,
+        URL_MAPPERS.LOOKUP_MAPPER
     );
 }
 

--- a/packages/components/src/testHelpers.ts
+++ b/packages/components/src/testHelpers.ts
@@ -8,6 +8,14 @@ import { QueryInfo } from './components/base/models/QueryInfo';
 import { applyQueryMetadata, handle132Response } from './query/api';
 import { bindColumnRenderers } from './renderers';
 import { RowsResponse } from './QueryModel/QueryModelLoader';
+import { URLService } from './util/URLService';
+import {
+    ASSAY_MAPPERS,
+    DATA_CLASS_MAPPERS,
+    LIST_MAPPERS,
+    LOOKUP_MAPPER,
+    SAMPLE_TYPE_MAPPERS, USER_DETAILS_MAPPER
+} from './util/URLResolver';
 
 declare let LABKEY: LabKey;
 
@@ -44,6 +52,17 @@ export function initUnitTestMocks(metadata?: Map<string, any>, columnRenderers?:
     initLineageMocks();
     initUserPropsMocks();
     mock.use(proxy);
+}
+
+export function registerDefaultURLMappers() {
+    URLService.registerURLMappers(
+        ...ASSAY_MAPPERS,
+        ...DATA_CLASS_MAPPERS,
+        ...SAMPLE_TYPE_MAPPERS,
+        ...LIST_MAPPERS,
+        USER_DETAILS_MAPPER,
+        LOOKUP_MAPPER
+    );
 }
 
 /**

--- a/packages/components/src/testHelpers.ts
+++ b/packages/components/src/testHelpers.ts
@@ -54,7 +54,7 @@ export function registerDefaultURLMappers() {
         ...URL_MAPPERS.DATA_CLASS_MAPPERS,
         ...URL_MAPPERS.SAMPLE_TYPE_MAPPERS,
         ...URL_MAPPERS.LIST_MAPPERS,
-        URL_MAPPERS.USER_DETAILS_MAPPER,
+        ...URL_MAPPERS.USER_DETAILS_MAPPERS,
         URL_MAPPERS.LOOKUP_MAPPER
     );
 }

--- a/packages/components/src/util/AppURLResolver.spec.ts
+++ b/packages/components/src/util/AppURLResolver.spec.ts
@@ -17,14 +17,16 @@ import { fromJS, List, Map } from 'immutable';
 
 import { AppURL } from '../url/AppURL';
 
-import { initMockServerContext } from '../testHelpers';
+import { initMockServerContext, registerDefaultURLMappers } from '../testHelpers';
 
 import { AssayResolver, AssayRunResolver, ListResolver, SamplesResolver } from './AppURLResolver';
 import { URLResolver } from './URLResolver';
 
-describe('URL Resolvers', () => {
-    const resolver = new URLResolver();
+beforeAll(() => {
+    registerDefaultURLMappers();
+});
 
+describe('URL Resolvers', () => {
     const selectRowsResult = fromJS({
         schemaName: ['Go'],
         queryName: 'Mariners',
@@ -123,6 +125,7 @@ describe('URL Resolvers', () => {
     });
 
     test('Should remap URLs within SelectRowsResult', () => {
+        const resolver = new URLResolver();
         initMockServerContext({
             contextPath: 'labkeyTest',
         });

--- a/packages/components/src/util/URLResolver.spec.ts
+++ b/packages/components/src/util/URLResolver.spec.ts
@@ -4,37 +4,23 @@ import entitiesJSON from '../test/data/sampleSetSearchResult.json';
 import lineageJSON from '../test/data/experiment-lineage.json';
 import { LineageResult } from '../components/lineage/models';
 
-import { parsePathName, URLResolver } from './URLResolver';
+import { URLResolver } from './URLResolver';
+import { registerDefaultURLMappers } from '../testHelpers';
+
+beforeAll(() => {
+    registerDefaultURLMappers();
+});
 
 describe('resolveSearchUsingIndex', () => {
     test('resolve Sample Set url', () => {
         const resolver = new URLResolver();
+
         const testJson = fromJS(entitiesJSON);
         return resolver.resolveSearchUsingIndex(testJson).then(resolved => {
             expect(resolved).toHaveProperty(['hits']);
             expect(resolved).toHaveProperty(['hits', 0]);
             expect(resolved).toHaveProperty(['hits', 0, 'url'], '#/samples/Molecule');
             expect(resolved).toHaveProperty(['hits', 0, 'data', 'name'], 'Molecule'); // not sure if this is best place to check this...
-        });
-    });
-});
-
-describe('parsePathName', () => {
-    test('old style', () => {
-        const url = '/labkey/controller/my%20folder/my%20path/action.view?extra=123';
-        expect(parsePathName(url)).toEqual({
-            controller: 'controller',
-            action: 'action',
-            containerPath: '/my folder/my path',
-        });
-    });
-
-    test('new style', () => {
-        const url = '/labkey/my%20folder/my%20path/controller-action.view?extra=123';
-        expect(parsePathName(url)).toEqual({
-            controller: 'controller',
-            action: 'action',
-            containerPath: '/my folder/my path',
         });
     });
 });

--- a/packages/components/src/util/URLResolver.spec.ts
+++ b/packages/components/src/util/URLResolver.spec.ts
@@ -4,8 +4,9 @@ import entitiesJSON from '../test/data/sampleSetSearchResult.json';
 import lineageJSON from '../test/data/experiment-lineage.json';
 import { LineageResult } from '../components/lineage/models';
 
-import { URLResolver } from './URLResolver';
 import { registerDefaultURLMappers } from '../testHelpers';
+
+import { URLResolver } from './URLResolver';
 
 beforeAll(() => {
     registerDefaultURLMappers();

--- a/packages/components/src/util/URLResolver.ts
+++ b/packages/components/src/util/URLResolver.ts
@@ -282,7 +282,7 @@ export const LOOKUP_MAPPER =
 
 export class URLResolver {
     private mapURL = (mapper: MapURLOptions): string => {
-        const _url = URLService.urlMappers
+        const _url = URLService.getUrlMappers()
             .toSeq()
             .map(m => m.resolve(mapper.url, mapper.row, mapper.column, mapper.schema, mapper.query))
             .filter(v => v !== undefined)

--- a/packages/components/src/util/URLResolver.ts
+++ b/packages/components/src/util/URLResolver.ts
@@ -247,13 +247,17 @@ const DETAILS_QUERY_ROW_MAPPER = new ActionMapper('query', 'detailsQueryRow', ro
 
 const EXECUTE_QUERY_MAPPER = new ActionMapper('query', 'executeQuery', () => false);
 
-const USER_DETAILS_MAPPER = new ActionMapper('user', 'details', (row, column, schema, query) => {
-    const url = row.get('url');
-    if (url) {
-        const params = ActionURL.getParameters(url);
-        return AppURL.create('q', 'core', 'siteusers', params.userId);
-    }
-});
+const USER_DETAILS_MAPPERS = [
+    new ActionMapper('user', 'details', (row, column, schema, query) => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
+            return AppURL.create('q', 'core', 'siteusers', params.userId);
+        }
+    }),
+
+    new ActionMapper('user', 'attachmentDownload', () => false)
+];
 
 const DOWNLOAD_FILE_LINK_MAPPER = new ActionMapper('core', 'downloadFileLink', () => false);
 
@@ -279,7 +283,7 @@ export const URL_MAPPERS = {
     LIST_MAPPERS,
     DETAILS_QUERY_ROW_MAPPER,
     EXECUTE_QUERY_MAPPER,
-    USER_DETAILS_MAPPER,
+    USER_DETAILS_MAPPERS,
     DOWNLOAD_FILE_LINK_MAPPER,
     AUDIT_DETAILS_MAPPER,
     LOOKUP_MAPPER,

--- a/packages/components/src/util/URLResolver.ts
+++ b/packages/components/src/util/URLResolver.ts
@@ -18,8 +18,7 @@ import { ActionURL, Experiment, Filter } from '@labkey/api';
 
 import { AppURL } from '../url/AppURL';
 import { LineageLinkMetadata } from '../components/lineage/types';
-import { createProductUrl } from '../components/navigation/utils';
-import { FREEZER_MANAGER_PRODUCT_ID } from '../internal/app';
+import { ActionMapper, URLMapper, URLService } from './URLService';
 
 interface MapURLOptions {
     column: any;
@@ -29,351 +28,246 @@ interface MapURLOptions {
     schema?: string;
 }
 
-export class URLResolver {
-    mappers: List<URLMapper>;
 
-    constructor() {
-        this.mappers = List<URLMapper>([
-            new ActionMapper('experiment', 'showDataClass', (row, column) => {
-                let identifier: string;
+class LookupMapper implements URLMapper {
+    defaultPrefix: string;
+    lookupResolvers: any;
 
-                // TODO: Deal with junction lookup
-                if (row.has('data')) {
-                    // search link doesn't use the same url
-                    identifier = row.getIn(['data', 'name']);
-                } else if (column.has('lookup')) {
-                    identifier = row.get('displayValue').toString();
-                } else {
-                    identifier = row.get('value').toString();
+    constructor(defaultPrefix: string, lookupResolvers) {
+        this.defaultPrefix = defaultPrefix;
+        this.lookupResolvers = lookupResolvers;
+    }
+
+    resolve(url, row, column, schema, query): AppURL {
+        if (column.has('lookup')) {
+            var lookup = column.get('lookup'),
+                schema = lookup.get('schemaName'),
+                query = lookup.get('queryName'),
+                queryKey = [schema, query].join('-').toLowerCase(),
+                schemaKey = schema.toLowerCase();
+
+            if (this.lookupResolvers) {
+                if (this.lookupResolvers[queryKey]) {
+                    return this.lookupResolvers[queryKey](row, column, schema, query);
                 }
-                if (identifier !== undefined) {
-                    return AppURL.create('rd', 'dataclass', identifier);
+                if (this.lookupResolvers[schemaKey]) {
+                    return this.lookupResolvers[schemaKey](row, column, schema, query);
                 }
-            }),
+            }
 
-            new ActionMapper('experiment', 'showData', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
+            const parts = [
+                this.defaultPrefix,
+                lookup.get('schemaName'),
+                lookup.get('queryName'),
+                row.get('value').toString(),
+            ];
 
-                    const url = ['rd', 'expdata', params.rowId];
-                    return AppURL.create(...url);
-                }
-            }),
+            return AppURL.create(...parts);
+        }
+    }
+}
 
-            // @deprecated: showSampleType is the action we're using going forward. Remove this mapping.
-            new ActionMapper('experiment', 'showMaterialSource', (row, column) => {
-                let identifier: string;
+export const ASSAY_MAPPERS = [
 
-                if (row.has('data')) {
-                    // search link doesn't use the same url
-                    identifier = row.getIn(['data', 'name']);
-                } else if (column.has('lookup')) {
-                    identifier = row.get('displayValue').toString();
-                } else {
-                    identifier = row.get('value').toString();
-                }
+    new ActionMapper('assay', 'assayDetailRedirect', row => {
+        if (row.has('url')) {
+            const rowURL = row.get('url');
+            const params = ActionURL.getParameters(rowURL);
 
-                if (identifier !== undefined) {
-                    let url: string[];
+            // expecting a parameter of runId=<runId>
+            if (params.hasOwnProperty('runId')) {
+                const runId = params['runId'];
 
-                    if (isNaN(parseInt(identifier))) {
-                        // string -- assume sample set name
-                        url = ['samples', identifier];
-                    } else {
-                        // numeric -- assume rowId and use resolver
-                        url = ['rd', 'samples', identifier];
-                    }
+                const url = ['rd', 'assayrun', runId];
+                return AppURL.create(...url);
+            }
+        }
+    }),
 
-                    return AppURL.create(...url);
-                }
-            }),
+    new ActionMapper('assay', 'assayRuns', (row, column, schema) => {
+        if (row.has('url')) {
+            const url = row.get('url');
 
-            new ActionMapper('experiment', 'showSampleType', (row, column) => {
-                let identifier: string;
+            // expecting a filter on Batch/RowId~eq=<rowId>
+            const filters = Filter.getFiltersFromUrl(url, 'Runs');
+            if (filters.length > 0) {
+                for (let i = 0; i < filters.length; i++) {
+                    if (filters[i].getColumnName().toLowerCase() === 'batch/rowid') {
+                        const rowId = filters[i].getValue();
 
-                if (row.has('data')) {
-                    // search link doesn't use the same url
-                    identifier = row.getIn(['data', 'name']);
-                } else if (column.has('lookup')) {
-                    identifier = row.get('displayValue').toString();
-                } else {
-                    identifier = row.get('value').toString();
-                }
+                        // expecting a schema of assay.<provider>.<protocol>
+                        if (schema.indexOf('assay.') === 0) {
+                            const url = ['assays'].concat(schema.replace('assay.', '').split('.'));
+                            url.push('batches', rowId);
 
-                if (identifier !== undefined) {
-                    let url: string[];
-
-                    if (isNaN(parseInt(identifier))) {
-                        // string -- assume sample set name
-                        url = ['samples', identifier];
-                    } else {
-                        // numeric -- assume rowId and use resolver
-                        url = ['rd', 'samples', identifier];
-                    }
-
-                    return AppURL.create(...url);
-                }
-            }),
-
-            new ActionMapper('experiment', 'showMaterial', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
-                    const rowId = params.rowId;
-
-                    const url = ['rd', 'samples', rowId];
-
-                    if (rowId !== undefined) {
-                        return AppURL.create(...url);
-                    }
-                }
-            }),
-
-            new ActionMapper('experiment', 'showRunText', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
-                    const rowId = params.rowId;
-                    const url = ['workflow', rowId];
-                    if (rowId !== undefined) {
-                        return AppURL.create(...url);
-                    }
-                }
-            }),
-
-            // http://localhost:8080/labkey/Sam%20Man/experiment-protocolDetails.view?rowId=1424
-            new ActionMapper('experiment', 'protocolDetails', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
-                    const rowId = params.rowId;
-                    const url = ['workflow', 'template', rowId];
-                    if (rowId !== undefined) {
-                        return AppURL.create(...url);
-                    }
-                }
-            }),
-
-            // Fixme.  This is really sketchy since there is no corresponding URL in LKS
-            new ActionMapper('samplesworkflow', 'samples', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
-                    const jobId = params.jobId;
-                    const url = ['workflow', jobId, 'samples'];
-                    if (jobId !== undefined) {
-                        return AppURL.create(...url);
-                    }
-                }
-            }),
-
-            new ActionMapper('samplesworkflow', 'tasks', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
-                    const jobId = params.jobId;
-                    const url = ['workflow', jobId, 'tasks'];
-                    if (jobId !== undefined) {
-                        return AppURL.create(...url);
-                    }
-                }
-            }),
-
-            new ActionMapper('samplesworkflow', 'templateJobs', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
-                    const templateId = params.templateId;
-                    const url = ['workflow', 'template', templateId, 'jobs'];
-                    if (templateId !== undefined) {
-                        return AppURL.create(...url).addParam('tab', 'all');
-                    }
-                }
-            }),
-
-            new ActionMapper('samplemanager', 'downloadAttachments', row => {
-                const targetURL = row.get('url');
-                if (targetURL) {
-                    const params = ActionURL.getParameters(targetURL);
-                    const jobId = params.jobId;
-                    const url = ['workflow', jobId, 'files'];
-                    if (jobId !== undefined) {
-                        return AppURL.create(...url);
-                    }
-                }
-            }),
-
-            new ActionMapper('assay', 'assayDetailRedirect', row => {
-                if (row.has('url')) {
-                    const rowURL = row.get('url');
-                    const params = ActionURL.getParameters(rowURL);
-
-                    // expecting a parameter of runId=<runId>
-                    if (params.hasOwnProperty('runId')) {
-                        const runId = params['runId'];
-
-                        const url = ['rd', 'assayrun', runId];
-                        return AppURL.create(...url);
-                    }
-                }
-            }),
-
-            new ActionMapper('assay', 'assayRuns', (row, column, schema) => {
-                if (row.has('url')) {
-                    const url = row.get('url');
-
-                    // expecting a filter on Batch/RowId~eq=<rowId>
-                    const filters = Filter.getFiltersFromUrl(url, 'Runs');
-                    if (filters.length > 0) {
-                        for (let i = 0; i < filters.length; i++) {
-                            if (filters[i].getColumnName().toLowerCase() === 'batch/rowid') {
-                                const rowId = filters[i].getValue();
-
-                                // expecting a schema of assay.<provider>.<protocol>
-                                if (schema.indexOf('assay.') === 0) {
-                                    const url = ['assays'].concat(schema.replace('assay.', '').split('.'));
-                                    url.push('batches', rowId);
-
-                                    return AppURL.create(...url);
-                                }
-                            }
+                            return AppURL.create(...url);
                         }
                     }
                 }
-            }),
+            }
+        }
+    }),
 
-            new ActionMapper('assay', 'assayBegin', row => {
-                const url = row.get('url');
-                if (url) {
-                    const params = ActionURL.getParameters(url);
+    new ActionMapper('assay', 'assayBegin', row => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
 
-                    if (params.rowId) {
-                        return AppURL.create('assays', params.rowId);
-                    }
-                }
-            }),
+            if (params.rowId) {
+                return AppURL.create('assays', params.rowId);
+            }
+        }
+    }),
 
-            new ActionMapper('assay', 'assayResults', row => {
-                const url = row.get('url');
-                if (url) {
-                    const params = ActionURL.getParameters(url);
-                    const rowId = params.rowId;
+    new ActionMapper('assay', 'assayResults', row => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
+            const rowId = params.rowId;
 
-                    if (rowId) {
-                        delete params.rowId; // strip the rowId and pass through the remaining params
-                        return AppURL.create('assays', rowId, 'data').addParams(params);
-                    }
-                }
-            }),
+            if (rowId) {
+                delete params.rowId; // strip the rowId and pass through the remaining params
+                return AppURL.create('assays', rowId, 'data').addParams(params);
+            }
+        }
+    }),
+];
 
-            // 33680: Prevent remapping issues-details
-            new ActionMapper('issues', 'details', () => false),
+export const DATA_CLASS_MAPPERS = [
+    new ActionMapper('experiment', 'showDataClass', (row, column) => {
+        let identifier: string;
 
-            new ActionMapper('issues', 'list', row => {
-                const url = row.get('url');
-                if (url) {
-                    const params = ActionURL.getParameters(url);
-                    if (params.issueDefName) {
-                        return AppURL.create('workflow', params.issueDefName);
-                    }
-                }
-            }),
+        // TODO: Deal with junction lookup
+        if (row.has('data')) {
+            // search link doesn't use the same url
+            identifier = row.getIn(['data', 'name']);
+        } else if (column.has('lookup')) {
+            identifier = row.get('displayValue').toString();
+        } else {
+            identifier = row.get('value').toString();
+        }
+        if (identifier !== undefined) {
+            return AppURL.create('rd', 'dataclass', identifier);
+        }
+    }),
 
-            new ActionMapper('list', 'details', (row, column) => {
-                if (!column.has('lookup')) {
-                    const params = ActionURL.getParameters(row.get('url'));
+    new ActionMapper('experiment', 'showData', row => {
+        const targetURL = row.get('url');
+        if (targetURL) {
+            const params = ActionURL.getParameters(targetURL);
 
-                    const parts = ['q', 'lists', params.listId, params.pk];
+            const url = ['rd', 'expdata', params.rowId];
+            return AppURL.create(...url);
+        }
+    }),
+
+];
+
+export const SAMPLE_TYPE_MAPPERS = [
+    new ActionMapper('experiment', 'showSampleType', (row, column) => {
+        let identifier: string;
+
+        if (row.has('data')) {
+            // search link doesn't use the same url
+            identifier = row.getIn(['data', 'name']);
+        } else if (column.has('lookup')) {
+            identifier = row.get('displayValue').toString();
+        } else {
+            identifier = row.get('value').toString();
+        }
+
+        if (identifier !== undefined) {
+            let url: string[];
+
+            if (isNaN(parseInt(identifier))) {
+                // string -- assume sample set name
+                url = ['samples', identifier];
+            } else {
+                // numeric -- assume rowId and use resolver
+                url = ['rd', 'samples', identifier];
+            }
+
+            return AppURL.create(...url);
+        }
+    }),
+
+    new ActionMapper('experiment', 'showMaterial', row => {
+        const targetURL = row.get('url');
+        if (targetURL) {
+            const params = ActionURL.getParameters(targetURL);
+            const rowId = params.rowId;
+
+            const url = ['rd', 'samples', rowId];
+
+            if (rowId !== undefined) {
+                return AppURL.create(...url);
+            }
+        }
+    }),
+];
+
+export const LIST_MAPPERS = [
+    new ActionMapper('list', 'details', (row, column) => {
+        if (!column.has('lookup')) {
+            const params = ActionURL.getParameters(row.get('url'));
+
+            const parts = ['q', 'lists', params.listId, params.pk];
+
+            return AppURL.create(...parts);
+        }
+    }),
+
+    new ActionMapper('list', 'grid', (row, column) => {
+        if (!column.has('lookup')) {
+            const params = ActionURL.getParameters(row.get('url'));
+
+            const parts = ['q', 'lists', params.listId];
+
+            return AppURL.create(...parts);
+        }
+    }),
+];
+
+export const DETAILS_QUERY_ROW_MAPPER =
+    new ActionMapper('query', 'detailsQueryRow', row => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
+            const schemaName = params.schemaName;
+            const queryName = params['query.queryName'];
+
+            if (schemaName && queryName) {
+                const key = params.keyValue ? params.keyValue : params.RowId;
+
+                if (key !== undefined) {
+                    const parts = ['q', schemaName, queryName, key];
 
                     return AppURL.create(...parts);
                 }
-            }),
+            }
+        }
+    });
 
-            new ActionMapper('list', 'grid', (row, column) => {
-                if (!column.has('lookup')) {
-                    const params = ActionURL.getParameters(row.get('url'));
+export const EXECUTE_QUERY_MAPPER =
+    new ActionMapper('query', 'executeQuery', () => false);
 
-                    const parts = ['q', 'lists', params.listId];
+export const USER_DETAILS_MAPPER =
+    new ActionMapper('user', 'details', (row, column, schema, query) => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
+            return AppURL.create('q', 'core', 'siteusers', params.userId);
+        }
+    });
 
-                    return AppURL.create(...parts);
-                }
-            }),
+export const DOWNLOAD_FILE_LINK_MAPPER =
+    new ActionMapper('core', 'downloadFileLink', () => false);
 
-            new ActionMapper('query', 'detailsQueryRow', row => {
-                const url = row.get('url');
-                if (url) {
-                    const params = ActionURL.getParameters(url);
-                    const schemaName = params.schemaName;
-                    const queryName = params['query.queryName'];
+export const AUDIT_DETAILS_MAPPER =
+    new ActionMapper('audit', 'detailedAuditChanges', () => false);
 
-                    if (schemaName && queryName) {
-                        if (
-                            schemaName === 'labbook' &&
-                            queryName === 'LabBookExperiment' &&
-                            params.RowId !== undefined
-                        ) {
-                            const parts = ['experiments', params.RowId];
-
-                            return AppURL.create(...parts);
-                        }
-
-                        const key = params.keyValue ? params.keyValue : params.RowId;
-
-                        if (key !== undefined) {
-                            const parts = ['q', schemaName, queryName, key];
-
-                            return AppURL.create(...parts);
-                        }
-                    }
-                }
-            }),
-
-            new ActionMapper('query', 'executeQuery', row => {
-                const url = row.get('url');
-                if (url) {
-                    const materialIdKey = 'query.MaterialId~eq';
-                    const params = ActionURL.getParameters(url);
-                    if (
-                        params.schemaName &&
-                        params.schemaName.toLowerCase() == 'inventory' &&
-                        params.queryName &&
-                        params.queryName.toLowerCase() == 'item' &&
-                        params[materialIdKey] !== undefined
-                    ) {
-                        return createProductUrl(
-                            FREEZER_MANAGER_PRODUCT_ID,
-                            undefined,
-                            AppURL.create('rd', 'sampleItem', params[materialIdKey])
-                        );
-                    }
-                }
-                return false;
-            }),
-
-            new ActionMapper('user', 'details', (row, column, schema, query) => {
-                const url = row.get('url');
-                if (url) {
-                    const params = ActionURL.getParameters(url);
-                    return AppURL.create('q', 'core', 'siteusers', params.userId);
-                }
-            }),
-
-            new ActionMapper('labbook', 'experiment', row => {
-                const url = row.get('url');
-                if (url) {
-                    const params = ActionURL.getParameters(url);
-                    if (params.labBookId) {
-                        return AppURL.create('experiments', params.labBookId);
-                    }
-                }
-            }),
-
-            new ActionMapper('core', 'downloadFileLink', () => false),
-
-            new ActionMapper('audit', 'detailedAuditChanges', () => false),
-
-            new LookupMapper('q', {
+export const LOOKUP_MAPPER =
+    new LookupMapper('q', {
                 'exp-dataclasses': row =>
                     row.get('displayValue') ? AppURL.create('rd', 'dataclass', row.get('displayValue')) : undefined,
                 'exp-runs': row => {
@@ -384,12 +278,11 @@ export class URLResolver {
                     return false;
                 },
                 issues: () => false, // 33680: Prevent remapping issues lookup
-            }),
-        ]);
-    }
+            });
 
+export class URLResolver {
     private mapURL = (mapper: MapURLOptions): string => {
-        const _url = this.mappers
+        const _url = URLService.urlMappers
             .toSeq()
             .map(m => m.resolve(mapper.url, mapper.row, mapper.column, mapper.schema, mapper.query))
             .filter(v => v !== undefined)
@@ -567,110 +460,4 @@ export class URLResolver {
             resolve(resolved.toJS());
         });
     }
-}
-
-interface URLMapper {
-    resolve(url, row, column, schema, query): AppURL | string | boolean;
-}
-
-class ActionMapper implements URLMapper {
-    controller: string;
-    action: string;
-    resolver: (row, column, schema, query) => AppURL | string | boolean;
-
-    constructor(
-        controller: string,
-        action: string,
-        resolver: (row?, column?, schema?, query?) => AppURL | string | boolean
-    ) {
-        this.controller = controller.toLowerCase();
-        this.action = action.toLowerCase();
-        this.resolver = resolver;
-    }
-
-    resolve(url, row, column, schema, query): AppURL | string | boolean {
-        if (url) {
-            const parsed = parsePathName(url);
-
-            if (parsed.action === this.action && parsed.controller === this.controller) {
-                return this.resolver(row, column, schema, query);
-            }
-        }
-    }
-}
-
-class LookupMapper implements URLMapper {
-    defaultPrefix: string;
-    lookupResolvers: any;
-
-    constructor(defaultPrefix: string, lookupResolvers) {
-        this.defaultPrefix = defaultPrefix;
-        this.lookupResolvers = lookupResolvers;
-    }
-
-    resolve(url, row, column, schema, query): AppURL {
-        if (column.has('lookup')) {
-            var lookup = column.get('lookup'),
-                schema = lookup.get('schemaName'),
-                query = lookup.get('queryName'),
-                queryKey = [schema, query].join('-').toLowerCase(),
-                schemaKey = schema.toLowerCase();
-
-            if (this.lookupResolvers) {
-                if (this.lookupResolvers[queryKey]) {
-                    return this.lookupResolvers[queryKey](row, column, schema, query);
-                }
-                if (this.lookupResolvers[schemaKey]) {
-                    return this.lookupResolvers[schemaKey](row, column, schema, query);
-                }
-            }
-
-            const parts = [
-                this.defaultPrefix,
-                lookup.get('schemaName'),
-                lookup.get('queryName'),
-                row.get('value').toString(),
-            ];
-
-            return AppURL.create(...parts);
-        }
-    }
-}
-
-// TODO: This is copied from LABKEY.ActionURL -- make public?
-export function parsePathName(path: string) {
-    const qMarkIdx = path.indexOf('?');
-    if (qMarkIdx > -1) {
-        path = path.substring(0, qMarkIdx);
-    }
-    const start = ActionURL.getContextPath().length;
-    const end = path.lastIndexOf('/');
-    let action = path.substring(end + 1);
-    path = path.substring(start, end);
-
-    let controller = null;
-
-    const dash = action.indexOf('-');
-    if (dash > 0) {
-        controller = action.substring(0, dash);
-        action = action.substring(dash + 1);
-    } else {
-        const slash = path.indexOf('/', 1);
-        if (slash < 0)
-            // 21945: e.g. '/admin'
-            controller = path.substring(1);
-        else controller = path.substring(1, slash);
-        path = path.substring(slash);
-    }
-
-    const dot = action.indexOf('.');
-    if (dot > 0) {
-        action = action.substring(0, dot);
-    }
-
-    return {
-        controller: decodeURIComponent(controller).toLowerCase(),
-        action: decodeURIComponent(action).toLowerCase(),
-        containerPath: decodeURI(path),
-    };
 }

--- a/packages/components/src/util/URLService.spec.ts
+++ b/packages/components/src/util/URLService.spec.ts
@@ -1,0 +1,21 @@
+import { parsePathName } from './URLService';
+
+describe('parsePathName', () => {
+    test('old style', () => {
+        const url = '/labkey/controller/my%20folder/my%20path/action.view?extra=123';
+        expect(parsePathName(url)).toEqual({
+            controller: 'controller',
+            action: 'action',
+            containerPath: '/my folder/my path',
+        });
+    });
+
+    test('new style', () => {
+        const url = '/labkey/my%20folder/my%20path/controller-action.view?extra=123';
+        expect(parsePathName(url)).toEqual({
+            controller: 'controller',
+            action: 'action',
+            containerPath: '/my folder/my path',
+        });
+    });
+});

--- a/packages/components/src/util/URLService.ts
+++ b/packages/components/src/util/URLService.ts
@@ -34,7 +34,9 @@ export interface URLMapper {
 export namespace URLService {
     export let urlMappers: List<URLMapper> = List<URLMapper>();
 
-    export let productURLMappings: Map<string, any> = Map<string, string>();
+    export function getUrlMappers() : List<URLMapper> {
+        return this.urlMappers;
+    }
 
     export function registerAppRouteResolvers(...appRouteResolvers: AppRouteResolver[]): void {
         appRouteResolvers.forEach(resolver => {

--- a/packages/components/src/util/URLService.ts
+++ b/packages/components/src/util/URLService.ts
@@ -106,12 +106,6 @@ export namespace URLService {
     export function registerURLMappers(...mappers: URLMapper[]) : void {
         URLService.urlMappers = URLService.urlMappers.concat(mappers) as List<URLMapper>;
     }
-
-    // // key is a lowercase, hyphen-separated join of controller-action (e.g., experiment-showmaterial).
-    // // value is the id of the product a URL that matches that controller action should resolve to
-    // export function registerProductURLMappings(mappings: {[key: string]: string}) : void {
-    //     URLService.productURLMappings = Map<string, string>(mappings);
-    // }
 }
 
 // TODO: This is copied from LABKEY.ActionURL -- make public?

--- a/packages/components/src/util/URLService.ts
+++ b/packages/components/src/util/URLService.ts
@@ -15,11 +15,13 @@
  */
 import { List, Map, OrderedSet } from 'immutable';
 
+import { ActionURL } from '@labkey/api';
+
 import { AppURL } from '../url/AppURL';
 
-import { AppRouteResolver } from './AppURLResolver';
-import { ActionURL } from '@labkey/api';
 import { createProductUrl } from '../components/navigation/utils';
+
+import { AppRouteResolver } from './AppURLResolver';
 
 const ADD_TABLE_ROUTE = 'application/routing/add-table-route';
 
@@ -27,15 +29,16 @@ type RoutingTable = Map<string, string | boolean>;
 
 let resolvers = OrderedSet<AppRouteResolver>();
 
+let urlMappers: List<URLMapper> = List<URLMapper>();
+
 export interface URLMapper {
     resolve(url, row, column, schema, query): AppURL | string | boolean;
 }
 
 export namespace URLService {
-    export let urlMappers: List<URLMapper> = List<URLMapper>();
 
-    export function getUrlMappers() : List<URLMapper> {
-        return this.urlMappers;
+    export function getUrlMappers(): List<URLMapper> {
+        return urlMappers;
     }
 
     export function registerAppRouteResolvers(...appRouteResolvers: AppRouteResolver[]): void {
@@ -105,8 +108,8 @@ export namespace URLService {
         return state.routing.table;
     }
 
-    export function registerURLMappers(...mappers: URLMapper[]) : void {
-        URLService.urlMappers = URLService.urlMappers.concat(mappers) as List<URLMapper>;
+    export function registerURLMappers(...mappers: URLMapper[]): void {
+        urlMappers = urlMappers.concat(mappers) as List<URLMapper>;
     }
 }
 
@@ -127,8 +130,7 @@ export function parsePathName(path: string) {
     if (dash > 0) {
         controller = action.substring(0, dash);
         action = action.substring(dash + 1);
-    }
-    else {
+    } else {
         const slash = path.indexOf('/', 1);
         if (slash < 0)
             // 21945: e.g. '/admin'
@@ -159,7 +161,7 @@ export class ActionMapper implements URLMapper {
         controller: string,
         action: string,
         resolver: (row?, column?, schema?, query?) => AppURL | string | boolean,
-        productId?: string,
+        productId?: string
     ) {
         this.controller = controller.toLowerCase();
         this.action = action.toLowerCase();

--- a/packages/components/src/util/messaging.tsx
+++ b/packages/components/src/util/messaging.tsx
@@ -38,7 +38,8 @@ export function resolveErrorMessage(error: any, noun: string = undefined, nounPl
         const lcMessage = errorMsg.toLowerCase();
         if (
             lcMessage.indexOf('violates unique constraint') >= 0 ||
-            lcMessage.indexOf('violation of unique key constraint') >= 0
+            lcMessage.indexOf('violation of unique key constraint') >= 0 ||
+            lcMessage.indexOf('cannot insert duplicate key row') >= 0
         ) {
             return `There was a problem ${verb || 'creating'} your ${noun}.  Check the existing ${nounPlural || noun} for possible duplicates and make sure any referenced ${nounPlural || noun} are still valid.`;
         } else if (lcMessage.indexOf('bad sql grammar') >= 0) {


### PR DESCRIPTION
#### Rationale
Different applications route URLs differently, so we have refactored the URLMapper class to require that applications register their own mappers. This allows us to move application-specific mappers into their respective applications.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/60
* https://github.com/LabKey/sampleManagement/pull/331
* https://github.com/LabKey/biologics/pull/641

#### Changes
* Add method for applications to register their URL Mappers so different applications can choose to route Server URLs differently.
* Add a productId property to ActionMapper so it can be used to construct a URL to a separate application.
* Eliminate deprecated `showMaterialSource` link mapping