### PR TITLE
Add runDetailsColumnsForQueryModel

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.81.0-fb-runDetailsColumnsForQueryModel.0",
+  "version": "0.81.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.1",
+  "version": "0.81.0-fb-runDetailsColumnsForQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 0.81.0
-*Released*: ?? July 2020
+*Released*: 28 July 2020
 * Add runDetailsColumnsForQueryModel - convenience method for calculating the columns needed for an assay run details
 page, adapted from getRunDetailsQueryColumns.
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.81.0
+*Released*: ?? July 2020
+* Add runDetailsColumnsForQueryModel - convenience method for calculating the columns needed for an assay run details
+page, adapted from getRunDetailsQueryColumns.
+
 ### version 0.80.1
 *Released*: 27 July 2020
 * Audit and schema browser component linting and misc cleanup after move from Sample Manager app

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -366,6 +366,7 @@ import { AuditQueriesListingPage } from './components/auditlog/AuditQueriesListi
 import { AuditDetails } from './components/auditlog/AuditDetails';
 import { getEventDataValueDisplay, getTimelineEntityUrl } from './components/auditlog/utils';
 import * as App from './internal/app';
+import { runDetailsColumnsForQueryModel } from './QueryModel/utils';
 
 // See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 enableMapSet();
@@ -783,6 +784,7 @@ export {
     GridPanelWithModel,
     DetailPanel,
     DetailPanelWithModel,
+    runDetailsColumnsForQueryModel,
     Pagination,
     PaginationData,
     // AuditLog


### PR DESCRIPTION
#### Rationale
Need a QueryModel aware method for calculating the columns needed for the assay run details page which I am currently refactoring to use QueryModel.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/642

#### Changes
* Add runDetailsColumnsForQueryModel - convenience method for calculating the columns needed for an assay run details page, adapted from getRunDetailsQueryColumns.
