### PR TITLE
Item 7611 - freezer box display 

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -251,7 +251,7 @@ yarn run lint-fix "./src/components/**/*"
 ## Publishing
 
 ### Credentials
-In order to publish, you will need to set up your npm credentials.  Follow [these instructions](https://internal.labkey.com/wiki/Handbook/Dev/page.view?name=npmrc) to create your .npmrc file.
+In order to publish, you will need to set up your npm credentials.  Follow [these instructions](https://www.labkey.org/Documentation/_PremiumResources/wiki-page.view?name=npmrc) to create your .npmrc file.
 If you do not have permissions to publish to this repository, contact a LabKey Artifactory administrator who can grant you those permissions.
 
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.1",
+  "version": "0.82.2-fb-fmBoxDisplay",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.81.1-fb-fmBoxDisplay.1",
+  "version": "0.81.1-fb-fmBoxDisplay.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.78.3",
+  "version": "0.78.4-fb-fmBoxDisplay.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.1-fb-fmBoxDisplay.1",
+  "version": "0.80.1-fb-fmBoxDisplay.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.2-fb-fmBoxDisplay",
+  "version": "0.82.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.1-fb-fmBoxDisplay.2",
+  "version": "0.82.1-fb-fmBoxDisplay.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.81.0",
+  "version": "0.81.1-fb-fmBoxDisplay.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.80.0",
+  "version": "0.80.1-fb-fmBoxDisplay.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.82.2
+*Released*: 4 August 2020
+* Add headerCls prop to GridColumn
+* Add useSmall prop to ColorIcon to show small sized icon
+* Add setSelections and replaceSelections to QueryModel Actions
+* Export cancelEvent method
+
 ### version 0.82.1
 *Released*: 29 July 2020
 * Fix sorts issue with QueryModel.urlQueryParams

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Add headerCls prop to GridColumn
 * Add useSmall prop to ColorIcon to show small sized icon
 * Add setSelections and replaceSelections to QueryModel Actions
+* Export cancelEvent method
 
 
 ### version 0.81.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -10,6 +10,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 * EntityInsertPanel: Ability to filter Sample Type Options without filtering Parent Options
 * EntityInsertPanel: Option to combine all parent entity types into one button and one select input
 
+### version XXX
+*Released*: XXX
+* Add headerCls prop to GridColumn
+* Add useSmall prop to ColorIcon to show small sized icon
+
 ### version 0.78.1
 *Released*: 20 July 2020
 * Support custom gridColumnRenderer for AuditDetails

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Add headerCls prop to GridColumn
+* Add useSmall prop to ColorIcon to show small sized icon
+* Add setSelections and replaceSelections to QueryModel Actions
+
+
 ### version 0.80.0
 *Released*: 24 July 2020
 * Add support for parameterized queries when getting and setting selections on a grid
@@ -33,11 +40,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 20 July 2020
 * EntityInsertPanel: Ability to filter Sample Type Options without filtering Parent Options
 * EntityInsertPanel: Option to combine all parent entity types into one button and one select input
-
-### version XXX
-*Released*: XXX
-* Add headerCls prop to GridColumn
-* Add useSmall prop to ColorIcon to show small sized icon
 
 ### version 0.78.1
 *Released*: 20 July 2020

--- a/packages/components/src/QueryModel/testUtils.ts
+++ b/packages/components/src/QueryModel/testUtils.ts
@@ -68,5 +68,7 @@ export const makeTestActions = (): Actions => {
         setSchemaQuery: jest.fn(),
         setSorts: jest.fn(),
         setView: jest.fn(),
+        setSelections: jest.fn(),
+        replaceSelections: jest.fn(),
     };
 };

--- a/packages/components/src/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/QueryModel/withQueryModels.tsx
@@ -34,6 +34,8 @@ export interface Actions {
     setSchemaQuery: (id: string, schemaQuery: SchemaQuery, loadSelections?: boolean) => void;
     setSorts: (id: string, sorts: QuerySort[]) => void;
     setView: (id: string, viewName: string, loadSelections?: boolean) => void;
+    setSelections: (id: string, checked: boolean, selections: string[]) => void;
+    replaceSelections: (id: string, selections: string[]) => void;
 }
 
 export interface RequiresModelAndActions {
@@ -162,6 +164,7 @@ export function withQueryModels<Props>(
                 loadFirstPage: this.loadFirstPage,
                 loadLastPage: this.loadLastPage,
                 loadCharts: this.loadCharts,
+                replaceSelections: this.replaceSelections,
                 selectAllRows: this.selectAllRows,
                 selectRow: this.selectRow,
                 selectPage: this.selectPage,
@@ -172,6 +175,7 @@ export function withQueryModels<Props>(
                 setSchemaQuery: this.setSchemaQuery,
                 setSorts: this.setSorts,
                 setView: this.setView,
+                setSelections: this.setSelections,
             };
         }
 
@@ -348,6 +352,24 @@ export function withQueryModels<Props>(
                 );
             } catch (error) {
                 this.setSelectionsError(id, error, 'setting');
+            }
+        };
+
+        replaceSelections = async (id: string, selections: string[]): Promise<void> => {
+            const { modelLoader } = this.props;
+
+            try {
+                await modelLoader.clearSelections(this.state.queryModels[id]);
+                await modelLoader.setSelections(this.state.queryModels[id], true, selections);
+                this.setState(
+                    produce((draft: Draft<State>) => {
+                        const model = draft.queryModels[id];
+                        model.selections = new Set(selections);
+                        model.selectionsError = undefined;
+                    })
+                );
+            } catch (error) {
+                this.setSelectionsError(id, error, 'replace');
             }
         };
 

--- a/packages/components/src/components/base/ColorIcon.tsx
+++ b/packages/components/src/components/base/ColorIcon.tsx
@@ -5,7 +5,7 @@ interface Props {
     value: string;
     asSquare?: boolean;
     label?: string;
-    useSmall?: boolean
+    useSmall?: boolean;
 }
 
 export class ColorIcon extends PureComponent<Props> {
@@ -15,8 +15,7 @@ export class ColorIcon extends PureComponent<Props> {
         let iconCls = cls;
         if (!iconCls) {
             iconCls = asSquare ? 'color-picker__chip' : 'color-icon__circle';
-            if (useSmall)
-                iconCls += '-small';
+            if (useSmall) iconCls += '-small';
         }
 
         let icon;

--- a/packages/components/src/components/base/ColorIcon.tsx
+++ b/packages/components/src/components/base/ColorIcon.tsx
@@ -5,23 +5,23 @@ interface Props {
     value: string;
     asSquare?: boolean;
     label?: string;
+    useSmall?: boolean
 }
 
 export class ColorIcon extends PureComponent<Props> {
-    static defaultProps = {
-        cls: 'color-picker__chip',
-    };
-
     render(): ReactNode {
-        const { cls, value, asSquare, label } = this.props;
+        const { cls, value, asSquare, label, useSmall } = this.props;
+
+        let iconCls = cls;
+        if (!iconCls) {
+            iconCls = asSquare ? 'color-picker__chip' : 'color-icon__circle';
+            if (useSmall)
+                iconCls += '-small';
+        }
 
         let icon;
         if (value) {
-            if (asSquare) {
-                icon = <i className={cls} style={{ backgroundColor: value }} />;
-            } else {
-                icon = <i className="color-icon__circle" style={{ backgroundColor: value }} />;
-            }
+            icon = <i className={iconCls} style={{ backgroundColor: value }} />;
         }
 
         return (

--- a/packages/components/src/components/base/Grid.tsx
+++ b/packages/components/src/components/base/Grid.tsx
@@ -27,6 +27,7 @@ interface ColumnProps {
     tableCell?: boolean;
     title: string;
     width?: any;
+    headerCls?: string;
 }
 
 export class GridColumn implements ColumnProps {
@@ -39,6 +40,7 @@ export class GridColumn implements ColumnProps {
     tableCell: boolean;
     title: string;
     width: any;
+    headerCls: string;
 
     constructor(config: ColumnProps) {
         this.align = config.align;
@@ -46,6 +48,7 @@ export class GridColumn implements ColumnProps {
         this.format = config.format;
         this.raw = config.raw;
         this.width = config.width;
+        this.headerCls = config.headerCls;
 
         // react render displays '&nbsp', see: https://facebook.github.io/react/docs/jsx-gotchas.html
         if (config.title && config.title == '&nbsp;') {
@@ -177,9 +180,10 @@ class GridHeader extends React.PureComponent<GridHeaderProps, any> {
                         }
 
                         if (column.showHeader) {
+                            const headerCls = column.headerCls ? column.headerCls : "grid-header-cell";
                             return (
                                 <th
-                                    className="grid-header-cell"
+                                    className={headerCls}
                                     key={i}
                                     onClick={this._handleClick.bind(this, column)}
                                     style={{ minWidth }}

--- a/packages/components/src/components/base/Grid.tsx
+++ b/packages/components/src/components/base/Grid.tsx
@@ -180,7 +180,7 @@ class GridHeader extends React.PureComponent<GridHeaderProps, any> {
                         }
 
                         if (column.showHeader) {
-                            const headerCls = column.headerCls ? column.headerCls : "grid-header-cell";
+                            const headerCls = column.headerCls ? column.headerCls : 'grid-header-cell';
                             return (
                                 <th
                                     className={headerCls}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -423,6 +423,7 @@ export {
     EditableGridModal,
     EditableColumnMetadata,
     EditorModel,
+    cancelEvent,
     // url and location related items
     AppURL,
     Location,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -130,9 +130,7 @@ import {
     setSelected,
     unselectAll,
 } from './actions';
-import {
-    cancelEvent,
-} from './events';
+import { cancelEvent } from './events';
 import {
     getEditorModel,
     getQueryGridModel,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -131,6 +131,9 @@ import {
     unselectAll,
 } from './actions';
 import {
+    cancelEvent,
+} from './events';
+import {
     getEditorModel,
     getQueryGridModel,
     getQueryGridModelsForGridId,

--- a/packages/components/src/stories/ColorIcon.tsx
+++ b/packages/components/src/stories/ColorIcon.tsx
@@ -18,6 +18,7 @@ storiesOf('ColorIcon', module)
                 label={text('label', 'Color Label')}
                 value={text('value', '#009ce0')}
                 asSquare={boolean('asSquare', false)}
+                useSmall={boolean('useSmall', false)}
             />
         );
     });

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -248,10 +248,19 @@ div.react-datepicker__current-month {
     display: inline-block;
     padding-left: 4px;
 }
-.color-icon__circle {
+
+.color-icon__circle-small {
     display: inline-block;
     border-radius: 50%;
     border: solid 1px $gray;
     height: 12px;
     width: 12px;
+}
+
+.color-icon__circle {
+    display: inline-block;
+    border-radius: 50%;
+    border: solid 1px $gray;
+    height: 16px;
+    width: 16px;
 }


### PR DESCRIPTION
#### Rationale
Freezer box viewer uses Grid for rendering and needs to be in sync with QueryModel's selection state. A few changes are made to allow more flexible styling of grid, and also to allow easy selection updates for QueryModel.  

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/309
* https://github.com/LabKey/sampleManagement/pull/333
* https://github.com/LabKey/inventory/pull/61

#### Changes
* Add headerCls prop to GridColumn
* Add useSmall prop to ColorIcon to show small sized icon
* Add setSelections and replaceSelections to QueryModel Actions
* Export cancelEvent method
