### PR TITLE
Item 7586: Updates to support common dashboard panels for applications

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fmDashboardUpperPanels.6",
+  "version": "0.83.0-fmDashboardUpperPanels.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fmDashboardUpperPanels.3",
+  "version": "0.83.0-fmDashboardUpperPanels.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fmDashboardUpperPanels.1",
+  "version": "0.83.0-fmDashboardUpperPanels.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.1",
+  "version": "0.82.2-fmDashboardUpperPanels.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fmDashboardUpperPanels.4",
+  "version": "0.83.0-fmDashboardUpperPanels.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fmDashboardUpperPanels.7",
+  "version": "0.83.0-fmDashboardUpperPanels.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fmDashboardUpperPanels.8",
+  "version": "0.83.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fmDashboardUpperPanels.2",
+  "version": "0.83.0-fmDashboardUpperPanels.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.2-fmDashboardUpperPanels.0",
+  "version": "0.83.0-fmDashboardUpperPanels.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.83.0
+*Released*: 5 August 2020
 * Fix bug in QueryModel.getColumnString when omittedColumns is present.
 * Section component is now a PureComponent with css classes and more customizable styles
 * Add UserProvider for getting a user and user properties onto a page

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -3,6 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
+* Fix bug in QueryModel.getColumnString when omittedColumns is present.
 * Section component is now a PureComponent with css classes and more customizable styles
 * Add UserProvider for getting a user and user properties onto a page
 * Surface emptyText and showHeader properties of Grid through GridPanel

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Section component is now a PureComponent with css classes and more customizable styles
+* Add UserProvider for getting a user and user properties onto a page
+
 ### version 0.82.1
 *Released*: 29 July 2020
 * Fix sorts issue with QueryModel.urlQueryParams

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -5,6 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Section component is now a PureComponent with css classes and more customizable styles
 * Add UserProvider for getting a user and user properties onto a page
+* Surface emptyText and showHeader properties of Grid through GridPanel
+* Update to StorageStatusRenderer for different text representing "not in storage"
 
 ### version 0.82.1
 *Released*: 29 July 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Add UserProvider for getting a user and user properties onto a page
 * Surface emptyText and showHeader properties of Grid through GridPanel
 * Update to StorageStatusRenderer for different text representing "not in storage"
+* Move BaseBarChart and utility method from sampleManagement
 
 ### version 0.82.1
 *Released*: 29 July 2020

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -156,7 +156,7 @@ export class GridPanel extends PureComponent<Props, State> {
         showOmniBox: true,
         showSampleComparisonReports: false,
         showViewMenu: true,
-        showHeader: true
+        showHeader: true,
     };
 
     constructor(props) {
@@ -502,7 +502,17 @@ export class GridPanel extends PureComponent<Props, State> {
     };
 
     render(): ReactNode {
-        const { actions, allowSelections, asPanel, emptyText, model, showButtonBar, showOmniBox, showHeader, title } = this.props;
+        const {
+            actions,
+            allowSelections,
+            asPanel,
+            emptyText,
+            model,
+            showButtonBar,
+            showOmniBox,
+            showHeader,
+            title,
+        } = this.props;
         const {
             hasData,
             id,
@@ -552,8 +562,8 @@ export class GridPanel extends PureComponent<Props, State> {
 
                     {(loadingMessage || allowSelections) && (
                         <div className="grid-panel__info">
-                            {loadingMessage && <LoadingSpinner msg={loadingMessage}/>}
-                            {allowSelections && <SelectionStatus model={model} actions={actions}/>}
+                            {loadingMessage && <LoadingSpinner msg={loadingMessage} />}
+                            {allowSelections && <SelectionStatus model={model} actions={actions} />}
                         </div>
                     )}
 

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -28,6 +28,7 @@ interface GridPanelProps {
     asPanel?: boolean;
     advancedExportOptions?: { [key: string]: string };
     ButtonsComponent?: ComponentType<RequiresModelAndActions>;
+    emptyText?: string;
     hideEmptyViewMenu?: boolean;
     pageSizes?: number[];
     title?: string;
@@ -38,6 +39,7 @@ interface GridPanelProps {
     showPagination?: boolean;
     showSampleComparisonReports?: boolean;
     showViewMenu?: boolean;
+    showHeader?: boolean;
 }
 
 type Props = GridPanelProps & RequiresModelAndActions;
@@ -154,6 +156,7 @@ export class GridPanel extends PureComponent<Props, State> {
         showOmniBox: true,
         showSampleComparisonReports: false,
         showViewMenu: true,
+        showHeader: true
     };
 
     constructor(props) {
@@ -499,7 +502,7 @@ export class GridPanel extends PureComponent<Props, State> {
     };
 
     render(): ReactNode {
-        const { actions, allowSelections, asPanel, model, showButtonBar, showOmniBox, title } = this.props;
+        const { actions, allowSelections, asPanel, emptyText, model, showButtonBar, showOmniBox, showHeader, title } = this.props;
         const {
             hasData,
             id,
@@ -547,10 +550,12 @@ export class GridPanel extends PureComponent<Props, State> {
                         </div>
                     )}
 
-                    <div className="grid-panel__info">
-                        {loadingMessage && <LoadingSpinner msg={loadingMessage} />}
-                        {allowSelections && <SelectionStatus model={model} actions={actions} />}
-                    </div>
+                    {(loadingMessage || allowSelections) && (
+                        <div className="grid-panel__info">
+                            {loadingMessage && <LoadingSpinner msg={loadingMessage}/>}
+                            {allowSelections && <SelectionStatus model={model} actions={actions}/>}
+                        </div>
+                    )}
 
                     <div className="grid-panel__grid">
                         {hasError && <Alert>{queryInfoError || rowsError || selectionsError}</Alert>}
@@ -558,8 +563,10 @@ export class GridPanel extends PureComponent<Props, State> {
                         {!hasGridError && hasData && (
                             <Grid
                                 headerCell={this.headerCell}
+                                showHeader={showHeader}
                                 calcWidths
                                 condensed
+                                emptyText={emptyText}
                                 gridId={id}
                                 messages={fromJS(messages)}
                                 columns={this.getGridColumns()}

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -352,7 +352,7 @@ export class QueryModel {
         const allColumns = this.allColumns;
 
         // First attempt to find by name/lookup
-        const column = allColumns.find((queryColumn) => {
+        const column = allColumns.find(queryColumn => {
             if (isLookup && queryColumn.isLookup()) {
                 return lowered.split('/')[0] === queryColumn.name.toLowerCase();
             } else if (isLookup && !queryColumn.isLookup()) {
@@ -367,7 +367,7 @@ export class QueryModel {
         }
 
         // Fallback to finding by shortCaption
-        return allColumns.find((column) => {
+        return allColumns.find(column => {
             return column.shortCaption.toLowerCase() === lowered;
         });
     }

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -251,7 +251,7 @@ export class QueryModel {
 
         if (omittedColumns.length) {
             const lowerOmit = new Set(omittedColumns.map(c => c.toLowerCase()));
-            fieldKeys = fieldKeys.filter(fieldKey => lowerOmit.has(fieldKey.toLowerCase()));
+            fieldKeys = fieldKeys.filter(fieldKey => !lowerOmit.has(fieldKey.toLowerCase()));
         }
 
         return fieldKeys.join(',');

--- a/packages/components/src/components/base/Section.tsx
+++ b/packages/components/src/components/base/Section.tsx
@@ -22,35 +22,41 @@ interface SectionProps {
     titleClassName?: string;
     titleContainerClassName?: string;
     title?: string;
-    titleSize?: string
+    titleSize?: string;
 }
 
 export class Section extends React.PureComponent<SectionProps> {
     static defaultProps = {
-        titleSize: 'large'
-    }
+        titleSize: 'large',
+    };
 
     render() {
-        const { panelClassName, titleClassName, titleContainerClassName, title, titleSize, context, caption, children }  = this.props;
-        let titleContainerCls = titleContainerClassName || 'section-panel--title-container-' + titleSize ;
+        const {
+            panelClassName,
+            titleClassName,
+            titleContainerClassName,
+            title,
+            titleSize,
+            context,
+            caption,
+            children,
+        } = this.props;
+        const titleContainerCls = titleContainerClassName || 'section-panel--title-container-' + titleSize;
         return (
             <div className="g-section">
                 <div className={`panel panel-default ${panelClassName ? panelClassName : ''}`}>
                     <div className="panel-body">
                         <div className={title ? titleContainerCls : ''}>
                             {title && (
-                                <div className={titleClassName || "section-panel--title-" + titleSize}>
-                                    {title}
-                                </div>
+                                <div className={titleClassName || 'section-panel--title-' + titleSize}>{title}</div>
                             )}
                             {context && <div className="pull-right">{context}</div>}
-                            {caption &&
-                            <div className={"section-panel--title-caption-" + titleSize}>{caption}</div>}
+                            {caption && <div className={'section-panel--title-caption-' + titleSize}>{caption}</div>}
                         </div>
                         {children}
                     </div>
                 </div>
             </div>
-        )
+        );
     }
 }

--- a/packages/components/src/components/base/Section.tsx
+++ b/packages/components/src/components/base/Section.tsx
@@ -19,28 +19,38 @@ interface SectionProps {
     caption?: React.ReactNode;
     context?: React.ReactNode;
     panelClassName?: string;
+    titleClassName?: string;
+    titleContainerClassName?: string;
     title?: string;
+    titleSize?: string
 }
 
-// FIXME: remove all of these inline styles, make actual CSS classes.
-// FIXME: stop using React.SFC as it is deprecated (likely just convert to a PureComponent for now)
-export const Section: React.SFC<SectionProps> = props => (
-    <>
-        <div className="g-section">
-            <div className={`panel panel-default ${props.panelClassName ? props.panelClassName : ''}`}>
-                <div className="panel-body">
-                    <div style={props.title ? { borderBottom: '2px solid #cccccc', marginBottom: '30px' } : {}}>
-                        {props.title && (
-                            <div style={{ display: 'inline-block', fontSize: '200%', marginBottom: '8px' }}>
-                                {props.title}
-                            </div>
-                        )}
-                        {props.context && <div className="pull-right">{props.context}</div>}
-                        {props.caption && <div style={{ fontWeight: 300, marginBottom: '8px' }}>{props.caption}</div>}
+export class Section extends React.PureComponent<SectionProps> {
+    static defaultProps = {
+        titleSize: 'large'
+    }
+
+    render() {
+        const { panelClassName, titleClassName, titleContainerClassName, title, titleSize, context, caption, children }  = this.props;
+        let titleContainerCls = titleContainerClassName || 'section-panel--title-container-' + titleSize ;
+        return (
+            <div className="g-section">
+                <div className={`panel panel-default ${panelClassName ? panelClassName : ''}`}>
+                    <div className="panel-body">
+                        <div className={title ? titleContainerCls : ''}>
+                            {title && (
+                                <div className={titleClassName || "section-panel--title-" + titleSize}>
+                                    {title}
+                                </div>
+                            )}
+                            {context && <div className="pull-right">{context}</div>}
+                            {caption &&
+                            <div className={"section-panel--title-caption-" + titleSize}>{caption}</div>}
+                        </div>
+                        {children}
                     </div>
-                    {props.children}
                 </div>
             </div>
-        </div>
-    </>
-);
+        )
+    }
+}

--- a/packages/components/src/components/base/__snapshots__/Section.spec.tsx.snap
+++ b/packages/components/src/components/base/__snapshots__/Section.spec.tsx.snap
@@ -11,21 +11,10 @@ exports[`<Section /> custom properties 1`] = `
       className="panel-body"
     >
       <div
-        style={
-          Object {
-            "borderBottom": "2px solid #cccccc",
-            "marginBottom": "30px",
-          }
-        }
+        className="section-panel--title-container-large"
       >
         <div
-          style={
-            Object {
-              "display": "inline-block",
-              "fontSize": "200%",
-              "marginBottom": "8px",
-            }
-          }
+          className="section-panel--title-large"
         >
           Testing Title
         </div>
@@ -37,12 +26,7 @@ exports[`<Section /> custom properties 1`] = `
           </div>
         </div>
         <div
-          style={
-            Object {
-              "fontWeight": 300,
-              "marginBottom": "8px",
-            }
-          }
+          className="section-panel--title-caption-large"
         >
           <p>
             Testing Caption
@@ -65,7 +49,7 @@ exports[`<Section /> default properties 1`] = `
       className="panel-body"
     >
       <div
-        style={Object {}}
+        className=""
       />
     </div>
   </div>

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import $ from 'jquery'
+import { OrderedMap } from 'immutable'
+import { debounce, generateId } from '../..';
+
+interface Props {
+    title: string
+    data: OrderedMap<string, any>
+    onClick: (evt: any, row: Object) => any
+}
+
+interface State {
+    plotId: string
+}
+
+export class BaseBarChart extends React.Component<Props, State> {
+
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            plotId: generateId('base-barchart-')
+        };
+
+        this.handleResize = debounce(this.handleResize.bind(this), 75);
+    }
+
+    componentDidMount(): void {
+        $(window).on('resize', this.handleResize);
+
+        this.renderPlot(this.props);
+    }
+
+    componentWillReceiveProps(nextProps: Readonly<Props>) {
+        this.renderPlot(nextProps);
+    }
+
+    componentWillUnmount() {
+        $(window).off('resize', this.handleResize);
+    }
+
+    getPlotElement() {
+        return $('#' + this.state.plotId);
+    }
+
+    handleResize(e) {
+        this.renderPlot(this.props);
+    }
+
+    getPlotConfig(props: Props): Object {
+        const { title, data, onClick } = props;
+
+        return {
+            renderTo: this.state.plotId,
+            rendererType: 'd3',
+            width: this.getPlotElement().width() + 50,
+            height: 350,
+            labels: {
+                main: {value: title, visibility: 'hidden'},
+                yLeft: {value: 'Count'}
+            },
+            aes: {
+                x: 'label',
+                y: 'count'
+            },
+            options: {
+                color: '#236fa0',
+                fill: '#236fa0',
+                showValues: true,
+                clickFn: onClick,
+                hoverFn: function(row) {
+                    return row.label + '\nClick to view details';
+                }
+            },
+            scales: {
+                y: {
+                    tickFormat: function(v){
+                        if (v.toString().indexOf('.') > -1) {
+                            return;
+                        }
+
+                        return v;
+                    }
+                }
+            },
+            data: data.toArray()
+        };
+    }
+
+    renderPlot(props: Props) {
+        this.getPlotElement().html('');
+        const plot = new LABKEY.vis.BarPlot(this.getPlotConfig(props));
+        plot.render();
+    }
+
+    render () {
+        return (
+            <div id={this.state.plotId} className={'dashboard-bar-chart'}></div>
+        )
+    }
+}

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -1,24 +1,24 @@
-import * as React from 'react'
-import $ from 'jquery'
+import * as React from 'react';
+import $ from 'jquery';
+
 import { debounce, generateId } from '../..';
 
 interface Props {
-    title: string
-    data: any[]
-    onClick: (evt: any, row: Object) => any
+    title: string;
+    data: any[];
+    onClick: (evt: any, row: any) => any;
 }
 
 interface State {
-    plotId: string
+    plotId: string;
 }
 
 export class BaseBarChart extends React.Component<Props, State> {
-
     constructor(props: Props) {
         super(props);
 
         this.state = {
-            plotId: generateId('base-barchart-')
+            plotId: generateId('base-barchart-'),
         };
 
         this.handleResize = debounce(this.handleResize.bind(this), 75);
@@ -55,34 +55,34 @@ export class BaseBarChart extends React.Component<Props, State> {
             width: this.getPlotElement().width() + 50,
             height: 350,
             labels: {
-                main: {value: title, visibility: 'hidden'},
-                yLeft: {value: 'Count'}
+                main: { value: title, visibility: 'hidden' },
+                yLeft: { value: 'Count' },
             },
             aes: {
                 x: 'label',
-                y: 'count'
+                y: 'count',
             },
             options: {
                 color: '#236fa0',
                 fill: '#236fa0',
                 showValues: true,
                 clickFn: onClick,
-                hoverFn: function(row) {
+                hoverFn: function (row) {
                     return row.label + '\nClick to view details';
-                }
+                },
             },
             scales: {
                 y: {
-                    tickFormat: function(v){
+                    tickFormat: function (v) {
                         if (v.toString().indexOf('.') > -1) {
                             return;
                         }
 
                         return v;
-                    }
-                }
+                    },
+                },
             },
-            data
+            data,
         };
     }
 
@@ -92,9 +92,7 @@ export class BaseBarChart extends React.Component<Props, State> {
         plot.render();
     }
 
-    render () {
-        return (
-            <div id={this.state.plotId} className={'dashboard-bar-chart'}></div>
-        )
+    render() {
+        return <div id={this.state.plotId} className="dashboard-bar-chart"></div>;
     }
 }

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react'
 import $ from 'jquery'
-import { OrderedMap } from 'immutable'
 import { debounce, generateId } from '../..';
 
 interface Props {
     title: string
-    data: OrderedMap<string, any>
+    data: any[]
     onClick: (evt: any, row: Object) => any
 }
 
@@ -83,7 +82,7 @@ export class BaseBarChart extends React.Component<Props, State> {
                     }
                 }
             },
-            data: data.toArray()
+            data
         };
     }
 

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -7,6 +7,7 @@ interface Props {
     title: string;
     data: any[];
     onClick: (evt: any, row: any) => any;
+    chartHeight: number
 }
 
 interface State {
@@ -14,6 +15,10 @@ interface State {
 }
 
 export class BaseBarChart extends React.Component<Props, State> {
+    static defaultProps  = {
+        chartHeight: 350
+    }
+
     constructor(props: Props) {
         super(props);
 
@@ -47,13 +52,13 @@ export class BaseBarChart extends React.Component<Props, State> {
     }
 
     getPlotConfig(props: Props): Object {
-        const { title, data, onClick } = props;
+        const { title, data, onClick, chartHeight } = props;
 
         return {
             renderTo: this.state.plotId,
             rendererType: 'd3',
             width: this.getPlotElement().width() + 50,
-            height: 350,
+            height: chartHeight,
             labels: {
                 main: { value: title, visibility: 'hidden' },
                 yLeft: { value: 'Count' },

--- a/packages/components/src/components/chart/utils.spec.ts
+++ b/packages/components/src/components/chart/utils.spec.ts
@@ -1,0 +1,23 @@
+import { ISelectRowsResult, processChartData } from '../..';
+import AssayRunCountsRowsJson from "../../test/data/AssayRunCounts-getQueryRows.json";
+
+describe("processChartData", () => {
+    const response = {
+        key: '0',
+        models: {0: AssayRunCountsRowsJson}
+    } as ISelectRowsResult;
+
+    test('with data', () => {
+        const data = processChartData(response, ['TotalCount', 'value']);
+        expect(data.length).toBe(4);
+        expect(data[0].label).toBe('GPAT 1');
+        expect(data[0].count).toBe(6);
+        expect(data[3].label).toBe('GPAT 25 with a longer name then the rest');
+        expect(data[3].count).toBe(1);
+    });
+
+    test('without data', () => {
+        const data = processChartData(response, ['TodayCount', 'value']);
+        expect(data.length).toBe(0);
+    });
+})

--- a/packages/components/src/components/chart/utils.spec.ts
+++ b/packages/components/src/components/chart/utils.spec.ts
@@ -20,4 +20,10 @@ describe("processChartData", () => {
         const data = processChartData(response, ['TodayCount', 'value']);
         expect(data.length).toBe(0);
     });
+
+    test ('with alternate label field', () => {
+        const data = processChartData(response, ['TotalCount', 'value'], ['RowId', 'value']);
+        expect(data.length).toBe(4);
+        expect(data[0].label).toBe(5051);
+    })
 })

--- a/packages/components/src/components/chart/utils.spec.ts
+++ b/packages/components/src/components/chart/utils.spec.ts
@@ -1,10 +1,10 @@
 import { ISelectRowsResult, processChartData } from '../..';
-import AssayRunCountsRowsJson from "../../test/data/AssayRunCounts-getQueryRows.json";
+import AssayRunCountsRowsJson from '../../test/data/AssayRunCounts-getQueryRows.json';
 
-describe("processChartData", () => {
+describe('processChartData', () => {
     const response = {
         key: '0',
-        models: {0: AssayRunCountsRowsJson}
+        models: { 0: AssayRunCountsRowsJson },
     } as ISelectRowsResult;
 
     test('with data', () => {
@@ -21,9 +21,9 @@ describe("processChartData", () => {
         expect(data.length).toBe(0);
     });
 
-    test ('with alternate label field', () => {
+    test('with alternate label field', () => {
         const data = processChartData(response, ['TotalCount', 'value'], ['RowId', 'value']);
         expect(data.length).toBe(4);
         expect(data[0].label).toBe(5051);
-    })
-})
+    });
+});

--- a/packages/components/src/components/chart/utils.ts
+++ b/packages/components/src/components/chart/utils.ts
@@ -1,14 +1,19 @@
-import { ISelectRowsResult, naturalSort } from '../..';
 import { fromJS } from 'immutable';
 
-export function processChartData(response: ISelectRowsResult, countPath: string[] = ['count', 'value'], namePath: string[] = ['Name', 'value']): any[] {
+import { ISelectRowsResult, naturalSort } from '../..';
+
+export function processChartData(
+    response: ISelectRowsResult,
+    countPath: string[] = ['count', 'value'],
+    namePath: string[] = ['Name', 'value']
+): any[] {
     const rows = fromJS(response.models[response.key]);
 
     return rows
         .filter((row, key) => row.getIn(countPath) > 0)
         .map((row, key) => ({
             label: row.getIn(namePath),
-            count: row.getIn(countPath)
+            count: row.getIn(countPath),
         }))
         .sortBy(row => row.label, naturalSort)
         .toArray();

--- a/packages/components/src/components/chart/utils.ts
+++ b/packages/components/src/components/chart/utils.ts
@@ -1,7 +1,7 @@
 import { ISelectRowsResult, naturalSort } from '../..';
-import { fromJS, OrderedMap } from 'immutable';
+import { fromJS } from 'immutable';
 
-export function processChartData(response: ISelectRowsResult, countPath: string[] = ['count', 'value'], namePath: string[] = ['Name', 'value']): OrderedMap<string, any> {
+export function processChartData(response: ISelectRowsResult, countPath: string[] = ['count', 'value'], namePath: string[] = ['Name', 'value']): any[] {
     const rows = fromJS(response.models[response.key]);
 
     return rows
@@ -10,5 +10,6 @@ export function processChartData(response: ISelectRowsResult, countPath: string[
             label: row.getIn(namePath),
             count: row.getIn(countPath)
         }))
-        .sortBy(row => row.label, naturalSort);
+        .sortBy(row => row.label, naturalSort)
+        .toArray();
 }

--- a/packages/components/src/components/chart/utils.ts
+++ b/packages/components/src/components/chart/utils.ts
@@ -1,0 +1,14 @@
+import { ISelectRowsResult, naturalSort } from '../..';
+import { fromJS, OrderedMap } from 'immutable';
+
+export function processChartData(response: ISelectRowsResult, countPath: string[] = ['count', 'value'], namePath: string[] = ['Name', 'value']): OrderedMap<string, any> {
+    const rows = fromJS(response.models[response.key]);
+
+    return rows
+        .filter((row, key) => row.getIn(countPath) > 0)
+        .map((row, key) => ({
+            label: row.getIn(namePath),
+            count: row.getIn(countPath)
+        }))
+        .sortBy(row => row.label, naturalSort);
+}

--- a/packages/components/src/components/user/UserProvider.tsx
+++ b/packages/components/src/components/user/UserProvider.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import * as React from 'react'
+import { Map, fromJS } from 'immutable'
+import { getUserProperties, LoadingPage, User } from '../..';
+
+interface Props {
+    user: User
+}
+
+interface State {
+    userProperties: Map<string, any>
+}
+
+export type UserProviderProps = Props & State;
+
+const Context = React.createContext<State>(undefined);
+const UserContextProvider = Context.Provider;
+export const UserContextConsumer = Context.Consumer;
+
+export const UserProvider = (Component: React.ComponentType) => {
+
+    return class UserProviderImpl extends React.Component<Props, State> {
+
+        constructor(props: Props) {
+            super(props);
+
+            this.state = {
+                userProperties: undefined
+            };
+        }
+
+        componentDidMount(): void {
+            const { user } = this.props;
+
+            if (!user.isGuest) {
+                getUserProperties(user.id)
+                    .then((response) => {
+                        if (response && response.props) {
+                            this.setState(() => ({userProperties: fromJS(response.props)}));
+                        }
+                        else {
+                            this.setEmptyUserProperties();
+                        }
+                    })
+                    .catch((reason) => {
+                        console.error(reason);
+                        this.setEmptyUserProperties();
+                    });
+            }
+            else {
+                this.setEmptyUserProperties();
+            }
+        }
+
+        setEmptyUserProperties() {
+            this.setState(() => ({userProperties: Map<string, any>()}));
+        }
+
+        render() {
+            if (this.state.userProperties) {
+                return (
+                    <UserContextProvider value={this.state}>
+                        <Component {...this.props} {...this.state}/>
+                    </UserContextProvider>
+                );
+            }
+            else {
+                return <LoadingPage/>;
+            }
+        }
+    }
+};

--- a/packages/components/src/components/user/UserProvider.tsx
+++ b/packages/components/src/components/user/UserProvider.tsx
@@ -2,16 +2,17 @@
  * Copyright (c) 2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import * as React from 'react'
-import { Map, fromJS } from 'immutable'
+import * as React from 'react';
+import { Map, fromJS } from 'immutable';
+
 import { getUserProperties, LoadingPage, User } from '../..';
 
 interface Props {
-    user: User
+    user: User;
 }
 
 interface State {
-    userProperties: Map<string, any>
+    userProperties: Map<string, any>;
 }
 
 export type UserProviderProps = Props & State;
@@ -21,14 +22,12 @@ const UserContextProvider = Context.Provider;
 export const UserContextConsumer = Context.Consumer;
 
 export const UserProvider = (Component: React.ComponentType) => {
-
     return class UserProviderImpl extends React.Component<Props, State> {
-
         constructor(props: Props) {
             super(props);
 
             this.state = {
-                userProperties: undefined
+                userProperties: undefined,
             };
         }
 
@@ -37,39 +36,36 @@ export const UserProvider = (Component: React.ComponentType) => {
 
             if (!user.isGuest) {
                 getUserProperties(user.id)
-                    .then((response) => {
+                    .then(response => {
                         if (response && response.props) {
-                            this.setState(() => ({userProperties: fromJS(response.props)}));
-                        }
-                        else {
+                            this.setState(() => ({ userProperties: fromJS(response.props) }));
+                        } else {
                             this.setEmptyUserProperties();
                         }
                     })
-                    .catch((reason) => {
+                    .catch(reason => {
                         console.error(reason);
                         this.setEmptyUserProperties();
                     });
-            }
-            else {
+            } else {
                 this.setEmptyUserProperties();
             }
         }
 
         setEmptyUserProperties() {
-            this.setState(() => ({userProperties: Map<string, any>()}));
+            this.setState(() => ({ userProperties: Map<string, any>() }));
         }
 
         render() {
             if (this.state.userProperties) {
                 return (
                     <UserContextProvider value={this.state}>
-                        <Component {...this.props} {...this.state}/>
+                        <Component {...this.props} {...this.state} />
                     </UserContextProvider>
                 );
-            }
-            else {
-                return <LoadingPage/>;
+            } else {
+                return <LoadingPage />;
             }
         }
-    }
+    };
 };

--- a/packages/components/src/components/user/actions.spec.ts
+++ b/packages/components/src/components/user/actions.spec.ts
@@ -5,10 +5,10 @@
 import { fromJS } from 'immutable';
 
 import {
-    TEST_USER_FOLDER_ADMIN,
     TEST_USER_ASSAY_DESIGNER,
     TEST_USER_AUTHOR,
     TEST_USER_EDITOR,
+    TEST_USER_FOLDER_ADMIN,
     TEST_USER_GUEST,
     TEST_USER_READER,
 } from '../../test/data/users';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -272,6 +272,8 @@ import {
     importAssayRun,
 } from './components/assay/actions';
 import { RUN_PROPERTIES_GRID_ID, RUN_PROPERTIES_REQUIRED_COLUMNS } from './components/assay/constants';
+import { BaseBarChart } from './components/chart/BaseBarChart';
+import { processChartData } from './components/chart/utils';
 import { ReportItemModal, ReportList, ReportListItem } from './components/report-list/ReportList';
 import { invalidateLineageResults } from './components/lineage/actions';
 import {
@@ -582,6 +584,8 @@ export {
     last12Months,
     monthSort,
     // report / chart related items
+    BaseBarChart,
+    processChartData,
     DataViewInfoTypes,
     IDataViewInfo,
     loadReports,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -299,6 +299,7 @@ import { UserDetailHeader } from './components/user/UserDetailHeader';
 import { UserProfile } from './components/user/UserProfile';
 import { ChangePasswordModal } from './components/user/ChangePasswordModal';
 import { SiteUsersGridPanel } from './components/user/SiteUsersGridPanel';
+import { UserProvider, UserProviderProps } from './components/user/UserProvider';
 
 import { createFormInputId, fetchDomain, saveDomain, setDomainFields } from './components/domainproperties/actions';
 import {
@@ -509,6 +510,8 @@ export {
     SecurityPolicy,
     SecurityRole,
     Principal,
+    UserProvider,
+    UserProviderProps,
     // data class and sample type related items
     DataClassModel,
     deleteDataClass,

--- a/packages/components/src/renderers/StorageStatusRenderer.tsx
+++ b/packages/components/src/renderers/StorageStatusRenderer.tsx
@@ -11,7 +11,8 @@ export class StorageStatusRenderer extends React.PureComponent<StorageStatusProp
 
         const value = data?.get('value');
 
-        if (value?.toLowerCase() === 'not in storage') {
+        if (value?.toLowerCase() === 'not in storage' ||
+            value?.toLowerCase() === 'discarded') {
             return value;
         } else {
             return <a href={data.get('url')}>{value}</a>;

--- a/packages/components/src/renderers/StorageStatusRenderer.tsx
+++ b/packages/components/src/renderers/StorageStatusRenderer.tsx
@@ -11,8 +11,7 @@ export class StorageStatusRenderer extends React.PureComponent<StorageStatusProp
 
         const value = data?.get('value');
 
-        if (value?.toLowerCase() === 'not in storage' ||
-            value?.toLowerCase() === 'discarded') {
+        if (value?.toLowerCase() === 'not in storage' || value?.toLowerCase() === 'discarded') {
             return value;
         } else {
             return <a href={data.get('url')}>{value}</a>;

--- a/packages/components/src/stories/Section.tsx
+++ b/packages/components/src/stories/Section.tsx
@@ -1,18 +1,19 @@
 import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs';
-import { Section } from '..';
+
 import React from 'react';
+
+import { Section } from '..';
 
 storiesOf('Section', module)
     .addDecorator(withKnobs)
     .add('default', () => {
         return (
             <Section
-                caption={text("Caption", undefined)}
-                context={text("Context", "Your context here")}
-                title={text("Title", "Title")}
-                titleSize={text("Title size", undefined)}
+                caption={text('Caption', undefined)}
+                context={text('Context', 'Your context here')}
+                title={text('Title', 'Title')}
+                titleSize={text('Title size', undefined)}
             />
-        )
-    })
-;
+        );
+    });

--- a/packages/components/src/stories/Section.tsx
+++ b/packages/components/src/stories/Section.tsx
@@ -1,0 +1,18 @@
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs } from '@storybook/addon-knobs';
+import { Section } from '..';
+import React from 'react';
+
+storiesOf('Section', module)
+    .addDecorator(withKnobs)
+    .add('default', () => {
+        return (
+            <Section
+                caption={text("Caption", undefined)}
+                context={text("Context", "Your context here")}
+                title={text("Title", "Title")}
+                titleSize={text("Title size", undefined)}
+            />
+        )
+    })
+;

--- a/packages/components/src/test/data/AssayRunCounts-getQueryRows.json
+++ b/packages/components/src/test/data/AssayRunCounts-getQueryRows.json
@@ -1,0 +1,89 @@
+[ {
+      "Last7DaysCount" : {
+        "value" : 1
+      },
+      "RowId" : {
+        "value" : 5051
+      },
+      "TotalCount" : {
+        "value" : 6
+      },
+      "Last365DaysCount" : {
+        "value" : 6
+      },
+      "Last30DaysCount" : {
+        "value" : 5
+      },
+      "TodayCount" : {
+        "value" : 0
+      },
+      "Name" : {
+        "value" : "GPAT 1"
+      }
+  }, {
+      "Last7DaysCount" : {
+        "value" : 0
+      },
+      "RowId" : {
+        "value" : 5054
+      },
+      "TotalCount" : {
+        "value" : 1
+      },
+      "Last365DaysCount" : {
+        "value" : 1
+      },
+      "Last30DaysCount" : {
+        "value" : 1
+      },
+      "TodayCount" : {
+        "value" : 0
+      },
+      "Name" : {
+        "value" : "GPAT 2"
+      }
+  }, {
+      "Last7DaysCount" : {
+        "value" : 0
+      },
+      "RowId" : {
+        "value" : 5078
+      },
+      "TotalCount" : {
+        "value" : 9
+      },
+      "Last365DaysCount" : {
+        "value" : 9
+      },
+      "Last30DaysCount" : {
+        "value" : 9
+      },
+      "TodayCount" : {
+        "value" : 0
+      },
+      "Name" : {
+        "value" : "GPAT 10"
+      }
+  }, {
+      "Last7DaysCount" : {
+        "value" : 0
+      },
+      "RowId" : {
+        "value" : 5123
+      },
+      "TotalCount" : {
+        "value" : 1
+      },
+      "Last365DaysCount" : {
+        "value" : 1
+      },
+      "Last30DaysCount" : {
+        "value" : 0
+      },
+      "TodayCount" : {
+        "value" : 0
+      },
+      "Name" : {
+        "value" : "GPAT 25 with a longer name then the rest"
+      }
+  } ]

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -1,0 +1,3 @@
+.dashboard-bar-chart a.bar-individual {
+    cursor: pointer;
+}

--- a/packages/components/src/theme/section.scss
+++ b/packages/components/src/theme/section.scss
@@ -50,3 +50,31 @@
 .display-light {
     color: darkgray
 }
+
+.section-panel--title-container-large {
+    border-bottom: 2px solid #cccccc;
+    margin-bottom: 30px;
+}
+
+.section-panel--title-large {
+    display: inline-block;
+    font-size: 200%;
+    margin-bottom: 8px;
+}
+
+.section-panel--title-caption-large, .section-panel--title-caption-medium {
+    font-weight: 300;
+    margin-bottom: 8px;
+}
+
+.section-panel--title-container-medium {
+    border-bottom: 2px solid #cccccc;
+    margin-bottom: 15px;
+}
+
+.section-panel--title-medium {
+    display: inline-block;
+    font-size: 125%;
+    color: $gray-light;
+    margin-bottom: 8px;
+}


### PR DESCRIPTION
#### Rationale
We are adding bar graphs to the Freezer Management dashboard and adjusting some styling for both FM and SM dashboards to be more consistent.  We are making more use of the `Section` component and need it to be more configurable.  And we've move a general `UserProvider` and `BarChartBase` from sampleManagement to here.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1455
* https://github.com/LabKey/sampleManagement/pull/338
* https://github.com/LabKey/inventory/pull/63

#### Changes
* Section component is now a PureComponent with css classes and more customizable styles
* Add UserProvider for getting a user and user properties onto a page
* Surface emptyText and showHeader properties of Grid through GridPanel
* Update to StorageStatusRenderer for different text representing "not in storage"
* Move BaseBarChart and utility method from sampleManagement
