### PR TITLE
Issue 40965: Navigating to sample edit grid via bulk-edit grid does not show sampleIds in the edit grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.1",
+  "version": "0.82.1-fb-bug-samples.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.1-fb-bug-samples.0",
+  "version": "0.83.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.83.2
+*Released*: 6 August 2020
+* BulkUpdateForm to pass through readonly columns to EditableGrid
+
 ### version 0.83.1
 *Released*: 6 August 2020
 * BaseBarChart and processChartData updates to support per-bar fill color designations

--- a/packages/components/src/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/components/forms/BulkUpdateForm.tsx
@@ -24,6 +24,7 @@ interface Props {
     onSubmitForEdit: (updateData: any, dataForSelection: Map<string, any>, dataIdsForSelection: List<any>) => any;
     updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise<any>;
     shownInUpdateColumns?: boolean;
+    readOnlyColumns?: List<string>;
 }
 
 interface State {
@@ -52,11 +53,11 @@ export class BulkUpdateForm extends React.Component<Props, State> {
     }
 
     componentWillMount() {
-        const { model, onCancel, pluralNoun, shownInUpdateColumns } = this.props;
+        const { model, onCancel, pluralNoun, shownInUpdateColumns, readOnlyColumns } = this.props;
 
         // Get all shownInUpdateView columns or undefined
         const columns = shownInUpdateColumns
-            ? (model.getKeyColumns().concat(model.getUpdateColumns()) as List<QueryColumn>)
+            ? (model.getKeyColumns().concat(model.getUpdateColumns(readOnlyColumns)) as List<QueryColumn>)
             : undefined;
 
         getSelectedDataWithQueryGridModel(model, columns)


### PR DESCRIPTION
#### Rationale
In Biologics samples, if you go from the grid to bulk edit, then select edit in grid, sample ids were not being shown.  This passes through the readonly columns to the editable grid through the bulk edit UI.

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/648

#### Changes
- Add readonly columns to BulkUpdateForm and add them to the list of columns passed to EditableGrid
