### PR TITLE
BaseBarChart and processChartData() updates to support per-bar fill color designations

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0-fb-smBarChartSampleTypeColors.0",
+  "version": "0.83.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.83.0",
+  "version": "0.83.0-fb-smBarChartSampleTypeColors.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.83.1
+*Released*: 6 August 2020
 * BaseBarChart and processChartData updates to support per-bar fill color designations
 
 ### version 0.83.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* BaseBarChart and processChartData updates to support per-bar fill color designations
+
 ### version 0.83.0
 *Released*: 5 August 2020
 * Fix bug in QueryModel.getColumnString when omittedColumns is present.

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import $ from 'jquery';
 
 import { debounce, generateId } from '../..';
-import { getBarChartPlotConfig } from "./utils";
+
+import { getBarChartPlotConfig } from './utils';
 
 interface Props {
     title: string;

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import $ from 'jquery';
 
 import { debounce, generateId } from '../..';
+import { getBarChartPlotConfig } from "./utils";
 
 interface Props {
     title: string;
@@ -58,56 +59,17 @@ export class BaseBarChart extends React.Component<Props, State> {
 
     getPlotConfig(props: Props): Object {
         const { title, data, onClick, chartHeight, defaultFillColor, defaultBorderColor, barFillColors } = props;
-        const aes = {
-            x: 'label',
-            y: 'count',
-        };
-        const scales = {
-            y: {
-                tickFormat: function (v) {
-                    if (v.toString().indexOf('.') > -1) {
-                        return;
-                    }
-
-                    return v;
-                },
-            },
-        };
-
-        if (barFillColors) {
-            aes['color'] = 'label';
-
-            scales['color'] = {
-                scaleType: 'discrete',
-                scale: function (key) {
-                    return barFillColors[key] || defaultFillColor;
-                },
-            };
-        }
-
-        return {
+        return getBarChartPlotConfig({
             renderTo: this.state.plotId,
-            rendererType: 'd3',
-            width: this.getPlotElement().width() + 50,
+            title,
             height: chartHeight,
-            labels: {
-                main: { value: title, visibility: 'hidden' },
-                yLeft: { value: 'Count' },
-            },
-            options: {
-                color: defaultBorderColor,
-                fill: defaultFillColor,
-                showValues: true,
-                clickFn: onClick,
-                hoverFn: function (row) {
-                    return row.label + '\nClick to view details';
-                },
-            },
-            legendPos: 'none',
-            aes,
-            scales,
+            width: this.getPlotElement().width() + 50,
+            defaultFillColor,
+            defaultBorderColor,
+            onClick,
             data,
-        };
+            barFillColors,
+        });
     }
 
     renderPlot(props: Props) {

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -10,7 +10,7 @@ interface Props {
     chartHeight: number;
     defaultFillColor?: string;
     defaultBorderColor?: string;
-    barFillColors?: { [key: string]: string }
+    barFillColors?: { [key: string]: string };
 }
 
 interface State {
@@ -79,7 +79,7 @@ export class BaseBarChart extends React.Component<Props, State> {
 
             scales['color'] = {
                 scaleType: 'discrete',
-                scale: function(key) {
+                scale: function (key) {
                     return barFillColors[key] || defaultFillColor;
                 },
             };

--- a/packages/components/src/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/components/chart/BaseBarChart.tsx
@@ -7,7 +7,10 @@ interface Props {
     title: string;
     data: any[];
     onClick: (evt: any, row: any) => any;
-    chartHeight: number
+    chartHeight: number;
+    defaultFillColor?: string;
+    defaultBorderColor?: string;
+    barFillColors?: { [key: string]: string }
 }
 
 interface State {
@@ -15,9 +18,11 @@ interface State {
 }
 
 export class BaseBarChart extends React.Component<Props, State> {
-    static defaultProps  = {
-        chartHeight: 350
-    }
+    static defaultProps = {
+        chartHeight: 350,
+        defaultFillColor: '#236fa0',
+        defaultBorderColor: '#236fa0',
+    };
 
     constructor(props: Props) {
         super(props);
@@ -52,7 +57,33 @@ export class BaseBarChart extends React.Component<Props, State> {
     }
 
     getPlotConfig(props: Props): Object {
-        const { title, data, onClick, chartHeight } = props;
+        const { title, data, onClick, chartHeight, defaultFillColor, defaultBorderColor, barFillColors } = props;
+        const aes = {
+            x: 'label',
+            y: 'count',
+        };
+        const scales = {
+            y: {
+                tickFormat: function (v) {
+                    if (v.toString().indexOf('.') > -1) {
+                        return;
+                    }
+
+                    return v;
+                },
+            },
+        };
+
+        if (barFillColors) {
+            aes['color'] = 'label';
+
+            scales['color'] = {
+                scaleType: 'discrete',
+                scale: function(key) {
+                    return barFillColors[key] || defaultFillColor;
+                },
+            };
+        }
 
         return {
             renderTo: this.state.plotId,
@@ -63,30 +94,18 @@ export class BaseBarChart extends React.Component<Props, State> {
                 main: { value: title, visibility: 'hidden' },
                 yLeft: { value: 'Count' },
             },
-            aes: {
-                x: 'label',
-                y: 'count',
-            },
             options: {
-                color: '#236fa0',
-                fill: '#236fa0',
+                color: defaultBorderColor,
+                fill: defaultFillColor,
                 showValues: true,
                 clickFn: onClick,
                 hoverFn: function (row) {
                     return row.label + '\nClick to view details';
                 },
             },
-            scales: {
-                y: {
-                    tickFormat: function (v) {
-                        if (v.toString().indexOf('.') > -1) {
-                            return;
-                        }
-
-                        return v;
-                    },
-                },
-            },
+            legendPos: 'none',
+            aes,
+            scales,
             data,
         };
     }

--- a/packages/components/src/components/chart/utils.spec.ts
+++ b/packages/components/src/components/chart/utils.spec.ts
@@ -26,4 +26,14 @@ describe('processChartData', () => {
         expect(data.length).toBe(4);
         expect(data[0].label).toBe(5051);
     });
+
+    test('barFillColors', () => {
+        let barFillColors = processChartData(response, ['TotalCount', 'value']).barFillColors;
+        expect(barFillColors).toBe(undefined);
+
+        barFillColors = processChartData(response, ['TotalCount', 'value'], ['Name', 'value'], ['Color', 'value']).barFillColors;
+        expect(Object.keys(barFillColors).length).toBe(4);
+        expect(barFillColors['GPAT 1']).toBe('#ffffff');
+        expect(barFillColors['GPAT 10']).toBe('#dddddd');
+    });
 });

--- a/packages/components/src/components/chart/utils.spec.ts
+++ b/packages/components/src/components/chart/utils.spec.ts
@@ -8,7 +8,7 @@ describe('processChartData', () => {
     } as ISelectRowsResult;
 
     test('with data', () => {
-        const data = processChartData(response, ['TotalCount', 'value']);
+        const data = processChartData(response, ['TotalCount', 'value']).data;
         expect(data.length).toBe(4);
         expect(data[0].label).toBe('GPAT 1');
         expect(data[0].count).toBe(6);
@@ -17,12 +17,12 @@ describe('processChartData', () => {
     });
 
     test('without data', () => {
-        const data = processChartData(response, ['TodayCount', 'value']);
+        const data = processChartData(response, ['TodayCount', 'value']).data;
         expect(data.length).toBe(0);
     });
 
     test('with alternate label field', () => {
-        const data = processChartData(response, ['TotalCount', 'value'], ['RowId', 'value']);
+        const data = processChartData(response, ['TotalCount', 'value'], ['RowId', 'value']).data;
         expect(data.length).toBe(4);
         expect(data[0].label).toBe(5051);
     });

--- a/packages/components/src/components/chart/utils.spec.ts
+++ b/packages/components/src/components/chart/utils.spec.ts
@@ -1,6 +1,7 @@
 import { ISelectRowsResult, processChartData } from '../..';
 import AssayRunCountsRowsJson from '../../test/data/AssayRunCounts-getQueryRows.json';
-import { getBarChartPlotConfig } from "./utils";
+
+import { getBarChartPlotConfig } from './utils';
 
 describe('processChartData', () => {
     const response = {
@@ -34,7 +35,8 @@ describe('processChartData', () => {
     });
 
     test('barFillColors with colorPath', () => {
-        const barFillColors = processChartData(response, ['TotalCount', 'value'], ['Name', 'value'], ['Color', 'value']).barFillColors;
+        const barFillColors = processChartData(response, ['TotalCount', 'value'], ['Name', 'value'], ['Color', 'value'])
+            .barFillColors;
         expect(Object.keys(barFillColors).length).toBe(4);
         expect(barFillColors['GPAT 1']).toBe('#ffffff');
         expect(barFillColors['GPAT 10']).toBe('#dddddd');
@@ -66,7 +68,7 @@ describe('processChartData', () => {
             height: 100,
             defaultFillColor: 'red',
             defaultBorderColor: 'blue',
-            barFillColors: {test1: 'green'},
+            barFillColors: { test1: 'green' },
             onClick: jest.fn,
         });
 

--- a/packages/components/src/components/chart/utils.spec.ts
+++ b/packages/components/src/components/chart/utils.spec.ts
@@ -1,5 +1,6 @@
 import { ISelectRowsResult, processChartData } from '../..';
 import AssayRunCountsRowsJson from '../../test/data/AssayRunCounts-getQueryRows.json';
+import { getBarChartPlotConfig } from "./utils";
 
 describe('processChartData', () => {
     const response = {
@@ -27,13 +28,56 @@ describe('processChartData', () => {
         expect(data[0].label).toBe(5051);
     });
 
-    test('barFillColors', () => {
-        let barFillColors = processChartData(response, ['TotalCount', 'value']).barFillColors;
+    test('barFillColors without colorPath', () => {
+        const barFillColors = processChartData(response, ['TotalCount', 'value']).barFillColors;
         expect(barFillColors).toBe(undefined);
+    });
 
-        barFillColors = processChartData(response, ['TotalCount', 'value'], ['Name', 'value'], ['Color', 'value']).barFillColors;
+    test('barFillColors with colorPath', () => {
+        const barFillColors = processChartData(response, ['TotalCount', 'value'], ['Name', 'value'], ['Color', 'value']).barFillColors;
         expect(Object.keys(barFillColors).length).toBe(4);
         expect(barFillColors['GPAT 1']).toBe('#ffffff');
         expect(barFillColors['GPAT 10']).toBe('#dddddd');
+    });
+
+    test('getBarChartPlotConfig default props', () => {
+        const config = getBarChartPlotConfig({
+            renderTo: 'renderToTest',
+            title: 'titleTest',
+            width: 100,
+            data: [],
+        });
+
+        expect(JSON.stringify(Object.keys(config.aes))).toBe('["x","y"]');
+        expect(JSON.stringify(Object.keys(config.scales))).toBe('["y"]');
+        expect(config.height).toBe(undefined);
+        expect(config.width).toBe(100);
+        expect(config.options.clickFn).toBe(undefined);
+        expect(config.options.color).toBe(undefined);
+        expect(config.options.fill).toBe(undefined);
+    });
+
+    test('getBarChartPlotConfig custom props', () => {
+        const config = getBarChartPlotConfig({
+            renderTo: 'renderToTest',
+            title: 'titleTest',
+            width: 100,
+            data: [],
+            height: 100,
+            defaultFillColor: 'red',
+            defaultBorderColor: 'blue',
+            barFillColors: {test1: 'green'},
+            onClick: jest.fn,
+        });
+
+        expect(JSON.stringify(Object.keys(config.aes))).toBe('["x","y","color"]');
+        expect(JSON.stringify(Object.keys(config.scales))).toBe('["y","color"]');
+        expect(config.height).toBe(100);
+        expect(config.width).toBe(100);
+        expect(config.options.clickFn).toBe(jest.fn);
+        expect(config.options.color).toBe('blue');
+        expect(config.options.fill).toBe('red');
+        expect(config.scales.color.scale('test1')).toBe('green');
+        expect(config.scales.color.scale('test2')).toBe('red');
     });
 });

--- a/packages/components/src/components/chart/utils.ts
+++ b/packages/components/src/components/chart/utils.ts
@@ -36,19 +36,29 @@ export function processChartData(
 }
 
 interface BarChartPlotConfigProps {
-    renderTo: string,
-    title: string,
-    height?: number,
-    width: number,
-    defaultFillColor?: string,
-    defaultBorderColor?: string,
-    data: any[],
-    barFillColors?: { [key: string]: any },
-    onClick?: (evt: any, row: any) => void,
+    renderTo: string;
+    title: string;
+    height?: number;
+    width: number;
+    defaultFillColor?: string;
+    defaultBorderColor?: string;
+    data: any[];
+    barFillColors?: { [key: string]: any };
+    onClick?: (evt: any, row: any) => void;
 }
 
 export function getBarChartPlotConfig(props: BarChartPlotConfigProps): { [key: string]: any } {
-    const { renderTo, title, data, onClick, height, width, defaultFillColor, defaultBorderColor, barFillColors } = props;
+    const {
+        renderTo,
+        title,
+        data,
+        onClick,
+        height,
+        width,
+        defaultFillColor,
+        defaultBorderColor,
+        barFillColors,
+    } = props;
     const aes = {
         x: 'label',
         y: 'count',

--- a/packages/components/src/components/chart/utils.ts
+++ b/packages/components/src/components/chart/utils.ts
@@ -3,8 +3,8 @@ import { fromJS } from 'immutable';
 import { ISelectRowsResult, naturalSort } from '../..';
 
 interface ChartDataProps {
-    data: any[],
-    barFillColors: { [key: string]: string },
+    data: any[];
+    barFillColors: { [key: string]: string };
 }
 
 export function processChartData(
@@ -16,8 +16,8 @@ export function processChartData(
     const rows = fromJS(response.models[response.key]);
 
     const data = rows
-        .filter((row) => row.getIn(countPath) > 0)
-        .map((row) => ({
+        .filter(row => row.getIn(countPath) > 0)
+        .map(row => ({
             label: row.getIn(namePath),
             count: row.getIn(countPath),
         }))
@@ -27,7 +27,7 @@ export function processChartData(
     let barFillColors;
     if (colorPath) {
         barFillColors = {};
-        rows.map((row) => {
+        rows.map(row => {
             barFillColors[row.getIn(namePath)] = row.getIn(colorPath);
         });
     }

--- a/packages/components/src/components/chart/utils.ts
+++ b/packages/components/src/components/chart/utils.ts
@@ -2,19 +2,35 @@ import { fromJS } from 'immutable';
 
 import { ISelectRowsResult, naturalSort } from '../..';
 
+interface ChartDataProps {
+    data: any[],
+    barFillColors: { [key: string]: string },
+}
+
 export function processChartData(
     response: ISelectRowsResult,
     countPath: string[] = ['count', 'value'],
-    namePath: string[] = ['Name', 'value']
-): any[] {
+    namePath: string[] = ['Name', 'value'],
+    colorPath?: string[]
+): ChartDataProps {
     const rows = fromJS(response.models[response.key]);
 
-    return rows
-        .filter((row, key) => row.getIn(countPath) > 0)
-        .map((row, key) => ({
+    const data = rows
+        .filter((row) => row.getIn(countPath) > 0)
+        .map((row) => ({
             label: row.getIn(namePath),
             count: row.getIn(countPath),
         }))
         .sortBy(row => row.label, naturalSort)
         .toArray();
+
+    let barFillColors;
+    if (colorPath) {
+        barFillColors = {};
+        rows.map((row) => {
+            barFillColors[row.getIn(namePath)] = row.getIn(colorPath);
+        });
+    }
+
+    return { data, barFillColors } as ChartDataProps;
 }

--- a/packages/components/src/components/chart/utils.ts
+++ b/packages/components/src/components/chart/utils.ts
@@ -34,3 +34,69 @@ export function processChartData(
 
     return { data, barFillColors } as ChartDataProps;
 }
+
+interface BarChartPlotConfigProps {
+    renderTo: string,
+    title: string,
+    height?: number,
+    width: number,
+    defaultFillColor?: string,
+    defaultBorderColor?: string,
+    data: any[],
+    barFillColors?: { [key: string]: any },
+    onClick?: (evt: any, row: any) => void,
+}
+
+export function getBarChartPlotConfig(props: BarChartPlotConfigProps): { [key: string]: any } {
+    const { renderTo, title, data, onClick, height, width, defaultFillColor, defaultBorderColor, barFillColors } = props;
+    const aes = {
+        x: 'label',
+        y: 'count',
+    };
+    const scales = {
+        y: {
+            tickFormat: function (v) {
+                if (v.toString().indexOf('.') > -1) {
+                    return;
+                }
+
+                return v;
+            },
+        },
+    };
+
+    if (barFillColors) {
+        aes['color'] = 'label';
+
+        scales['color'] = {
+            scaleType: 'discrete',
+            scale: function (key) {
+                return barFillColors[key] || defaultFillColor;
+            },
+        };
+    }
+
+    return {
+        renderTo,
+        rendererType: 'd3',
+        width,
+        height,
+        labels: {
+            main: { value: title, visibility: 'hidden' },
+            yLeft: { value: 'Count' },
+        },
+        options: {
+            color: defaultBorderColor,
+            fill: defaultFillColor,
+            showValues: true,
+            clickFn: onClick,
+            hoverFn: function (row) {
+                return row.label + '\nClick to view details';
+            },
+        },
+        legendPos: 'none',
+        aes,
+        scales,
+        data,
+    };
+}

--- a/packages/components/src/test/data/AssayRunCounts-getQueryRows.json
+++ b/packages/components/src/test/data/AssayRunCounts-getQueryRows.json
@@ -19,6 +19,9 @@
       },
       "Name" : {
         "value" : "GPAT 1"
+      },
+      "Color" : {
+        "value" : "#ffffff"
       }
   }, {
       "Last7DaysCount" : {
@@ -41,6 +44,9 @@
       },
       "Name" : {
         "value" : "GPAT 2"
+      },
+      "Color" : {
+        "value" : "#eeeeee"
       }
   }, {
       "Last7DaysCount" : {
@@ -63,6 +69,9 @@
       },
       "Name" : {
         "value" : "GPAT 10"
+      },
+      "Color" : {
+        "value" : "#dddddd"
       }
   }, {
       "Last7DaysCount" : {
@@ -85,5 +94,8 @@
       },
       "Name" : {
         "value" : "GPAT 25 with a longer name then the rest"
+      },
+      "Color" : {
+        "value" : "#cccccc"
       }
   } ]


### PR DESCRIPTION
#### Rationale
With sample types in LKS having a LabelColor property, we want to start using that in more places in the SM and FM apps. Each of those apps have a dashboard bar chart section. In order to make use of those sample type labelcolors in the bar chart we need some property updates to the BaseBarChart and processChartData() to allow usages to identify properties of the chart data which can be used for the per-bar fill color designation.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/339
* https://github.com/LabKey/inventory/pull/64

#### Changes
* BaseBarChart updates to support per-bar fill color designation and usage of that in the bar chart config scale object
* processChartData() updates to include a map of barFillColors based on a colorPath variable from the response data
