### PR TITLE
EditableQueryGridPanel, reduce QueryGridModel usages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.84.0",
+  "version": "0.82.2-fb-selection-menu-item-querymodel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.85.0-fb-reduce-qgm-usages.4",
+  "version": "0.85.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.84.0-fb-reduce-qgm-usages.2",
+  "version": "0.84.0-fb-reduce-qgm-usages.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.84.0-fb-reduce-qgm-usages.1",
+  "version": "0.84.0-fb-reduce-qgm-usages.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.85.0-fb-reduce-qgm-usages.3",
+  "version": "0.85.0-fb-reduce-qgm-usages.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.84.0-fb-reduce-qgm-usages.0",
+  "version": "0.84.0-fb-reduce-qgm-usages.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.85.0-fb-reduce-qgm-usages.2",
+  "version": "0.85.0-fb-reduce-qgm-usages.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.2-fb-reduce-qgm-usages.0",
+  "version": "0.84.0-fb-reduce-qgm-usages.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.85.0-fb-reduce-qgm-usages.1",
+  "version": "0.85.0-fb-reduce-qgm-usages.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.84.0-fb-reduce-qgm-usages.3",
+  "version": "0.85.0-fb-reduce-qgm-usages.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.85.0-fb-reduce-qgm-usages.0",
+  "version": "0.85.0-fb-reduce-qgm-usages.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.82.2-fb-selection-menu-item-querymodel.0",
+  "version": "0.82.2-fb-reduce-qgm-usages.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -3,8 +3,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 0.??.??
 *Released*: ?? August 2020
-* SelectionMenuItem: add support for QueryModel and QueryGridModel
- * We need to support this while we transition away from QueryGridModel to QueryModel
+* Refactor several components/classes to not depend on QueryGridModel
+    * This allows them to more easily be used by QueryModel and QueryGridModel based components while we transition
+    away from QueryGridModel
+    * Affected Components: SelectionMenuItem, BulkUpdateModel
+    * Affected Classes: EditableGridLoaderFromSelection
 
 ### version 0.84.0
 *Released*: 7 August 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -11,8 +11,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Add EditableDetailPanel, the QueryModel version of DetailEditing
 * DetailPanel: change queryColumns prop from List<QueryColumn> to QueryColumn[]
     * We are moving away from Immutable and want to limit how much of it is exposed in our API
-* GridPanel: add new prop buttonsComponentProps
-    * Use this prop to pass any additional props to your ButtonsComponent (Model and Actions are still passed)
+* GridPanel: add new props buttonsComponentProps, and hideEmptyChartMenu
+    * Use buttonsComponentProps to pass any additional props to your ButtonsComponent (model and actions still get
+    passed to the ButtonsComponent)
+    * Use hideEmptyChartMenu to hide the chart menu when no charts are available
 
 ### version 0.84.0
 *Released*: 7 August 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.??.??
+*Released*: ?? August 2020
+* SelectionMenuItem: add support for QueryModel and QueryGridModel
+ * We need to support this while we transition away from QueryGridModel to QueryModel
+
 ### version 0.84.0
 *Released*: 7 August 2020
 * Updates most package dependencies to the latest version.

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -8,6 +8,11 @@ Components, models, actions, and utility functions for LabKey applications and p
     away from QueryGridModel
     * Affected Components: SelectionMenuItem, BulkUpdateModel
     * Affected Classes: EditableGridLoaderFromSelection
+* Add EditableDetailPanel, the QueryModel version of DetailEditing
+* DetailPanel: change queryColumns prop from List<QueryColumn> to QueryColumn[]
+    * We are moving away from Immutable and want to limit how much of it is exposed in our API
+* GridPanel: add new prop buttonsComponentProps
+    * Use this prop to pass any additional props to your ButtonsComponent (Model and Actions are still passed)
 
 ### version 0.84.0
 *Released*: 7 August 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.??.??
-*Released*: ?? August 2020
+### version 0.85.0
+*Released*: 11 August 2020
 * Refactor several components/classes to not depend on QueryGridModel
     * This allows them to more easily be used by QueryModel and QueryGridModel based components while we transition
     away from QueryGridModel
@@ -15,6 +15,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     * Use buttonsComponentProps to pass any additional props to your ButtonsComponent (model and actions still get
     passed to the ButtonsComponent)
     * Use hideEmptyChartMenu to hide the chart menu when no charts are available
+* Move queryMetadata an columnRenderers out of ReactN global storage
 
 ### version 0.84.0
 *Released*: 7 August 2020

--- a/packages/components/src/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/QueryModel/ChartMenu.tsx
@@ -76,7 +76,12 @@ export class ChartMenu extends PureComponent<Props> {
         const selectedChart = charts?.find(chart => chart.reportId === selectedReportId);
         const showChartModal = queryInfo !== undefined && selectedChart !== undefined;
 
-        if (privateCharts.length === 0 && publicCharts.length === 0 && !showSampleComparisonReports && hideEmptyChartMenu) {
+        if (
+            privateCharts.length === 0 &&
+            publicCharts.length === 0 &&
+            !showSampleComparisonReports &&
+            hideEmptyChartMenu
+        ) {
             return null;
         }
 

--- a/packages/components/src/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/QueryModel/ChartMenu.tsx
@@ -11,6 +11,7 @@ import { blurActiveElement } from '../util/utils';
 import { RequiresModelAndActions } from './withQueryModels';
 
 interface Props extends RequiresModelAndActions {
+    hideEmptyChartMenu: boolean;
     onChartClicked?: (chart: DataViewInfo) => boolean;
     onCreateReportClicked?: (type: DataViewInfoTypes) => void;
     showSampleComparisonReports: boolean;
@@ -53,7 +54,7 @@ export class ChartMenu extends PureComponent<Props> {
     );
 
     render(): ReactNode {
-        const { model, showSampleComparisonReports } = this.props;
+        const { hideEmptyChartMenu, model, showSampleComparisonReports } = this.props;
         const {
             charts,
             chartsError,
@@ -74,6 +75,10 @@ export class ChartMenu extends PureComponent<Props> {
         const disabled = isLoading || isLoadingCharts || noCharts || hasError;
         const selectedChart = charts?.find(chart => chart.reportId === selectedReportId);
         const showChartModal = queryInfo !== undefined && selectedChart !== undefined;
+
+        if (privateCharts.length === 0 && publicCharts.length === 0 && !showSampleComparisonReports && hideEmptyChartMenu) {
+            return null;
+        }
 
         return (
             <div className="chart-menu">

--- a/packages/components/src/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/QueryModel/DetailPanel.tsx
@@ -24,7 +24,7 @@ import { DetailDisplay, DetailDisplaySharedProps } from '../components/forms/det
 import { InjectedQueryModels, withQueryModels } from './withQueryModels';
 
 interface DetailPanelProps extends DetailDisplaySharedProps, RequiresModelAndActions {
-    queryColumns?: List<QueryColumn>;
+    queryColumns?: QueryColumn[];
 }
 
 export class DetailPanel extends PureComponent<DetailPanelProps> {
@@ -33,6 +33,7 @@ export class DetailPanel extends PureComponent<DetailPanelProps> {
         const { actions, model, queryColumns, ...detailDisplayProps } = this.props;
         const { editingMode } = detailDisplayProps;
         const error = model.queryInfoError ?? model.rowsError;
+        let displayColumns: List<QueryColumn>;
 
         if (error !== undefined) {
             return <Alert>{error}</Alert>;
@@ -40,18 +41,24 @@ export class DetailPanel extends PureComponent<DetailPanelProps> {
             return <LoadingSpinner />;
         }
 
+        if (queryColumns !== undefined) {
+            displayColumns = List(queryColumns);
+        } else {
+            displayColumns = List(editingMode ? model.updateColumns : model.detailColumns);
+        }
+
         return (
             <DetailDisplay
                 {...detailDisplayProps}
                 data={fromJS(model.gridData)}
-                displayColumns={queryColumns ?? List(editingMode ? model.updateColumns : model.detailColumns)}
+                displayColumns={displayColumns}
             />
         );
     }
 }
 
 interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
-    queryColumns?: List<QueryColumn>;
+    queryColumns?: QueryColumn[];
 }
 
 class DetailPanelWithModelBodyImpl extends PureComponent<DetailPanelWithModelProps & InjectedQueryModels> {

--- a/packages/components/src/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/QueryModel/DetailPanel.tsx
@@ -30,6 +30,7 @@ interface DetailPanelProps extends DetailDisplaySharedProps, RequiresModelAndAct
 export class DetailPanel extends PureComponent<DetailPanelProps> {
     render(): ReactNode {
         // ignoring actions so we don't pass to DetailDisplay
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { actions, model, queryColumns, ...detailDisplayProps } = this.props;
         const { editingMode } = detailDisplayProps;
         const error = model.queryInfoError ?? model.rowsError;
@@ -47,13 +48,7 @@ export class DetailPanel extends PureComponent<DetailPanelProps> {
             displayColumns = List(editingMode ? model.updateColumns : model.detailColumns);
         }
 
-        return (
-            <DetailDisplay
-                {...detailDisplayProps}
-                data={fromJS(model.gridData)}
-                displayColumns={displayColumns}
-            />
-        );
+        return <DetailDisplay {...detailDisplayProps} data={fromJS(model.gridData)} displayColumns={displayColumns} />;
     }
 }
 

--- a/packages/components/src/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/QueryModel/EditableDetailPanel.tsx
@@ -1,0 +1,194 @@
+import React, { PureComponent, ReactNode } from 'react';
+import Formsy from 'formsy-react';
+import { fromJS } from 'immutable';
+import { Button } from 'react-bootstrap';
+import { AuditBehaviorTypes } from '@labkey/api';
+
+import { DetailPanelHeader } from '../components/forms/detail/DetailPanelHeader';
+import { extractChanges } from '../components/forms/detail/utils';
+
+import {
+    Alert,
+    DetailPanel,
+    QueryColumn,
+    RequiresModelAndActions,
+    resolveDetailEditRenderer,
+    resolveDetailRenderer,
+    resolveErrorMessage,
+    titleRenderer,
+    updateRows,
+} from '..';
+
+interface EditableDetailPanelProps extends RequiresModelAndActions {
+    appEditable?: boolean;
+    asSubPanel?: boolean;
+    auditBehavior?: AuditBehaviorTypes;
+    cancelText?: string;
+    canUpdate: boolean;
+    onEditToggle?: (editing: boolean) => void;
+    onUpdate: () => void;
+    queryColumns?: QueryColumn[];
+    submitText?: string;
+    title?: string;
+    useEditIcon: boolean;
+}
+
+interface EditableDetailPanelState {
+    canSubmit?: boolean;
+    editing?: boolean;
+    error?: string;
+    warning?: string;
+}
+
+export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps, EditableDetailPanelState> {
+    static defaultProps = {
+        useEditIcon: true,
+        cancelText: 'Cancel',
+        submitText: 'Save',
+    };
+
+    state: Readonly<EditableDetailPanelState> = {
+        canSubmit: false,
+        editing: false,
+        error: undefined,
+        warning: undefined,
+    };
+
+    toggleEditing = (): void => {
+        this.setState(
+            state => ({ editing: !state.editing, warning: undefined, error: undefined }),
+            () => {
+                this.props.onEditToggle?.(this.state.editing);
+            }
+        );
+    };
+
+    disableSubmitButton = (): void => {
+        this.setState(() => ({ canSubmit: false }));
+    };
+
+    enableSubmitButton = (): void => {
+        this.setState(() => ({ canSubmit: true }));
+    };
+
+    handleFormChange = (): void => {
+        this.setState(() => ({ warning: undefined }));
+    };
+
+    handleSubmit = (values: Record<string, any>): void => {
+        const { auditBehavior, model, onEditToggle, onUpdate } = this.props;
+        const { queryInfo } = model;
+        const row = model.getRow();
+        const updatedValues = extractChanges(queryInfo, fromJS(model.getRow()), values);
+
+        if (Object.keys(updatedValues).length === 0) {
+            this.setState(() => ({
+                canSubmit: false,
+                warning: 'No changes detected. Please update the form and click save.',
+                error: undefined,
+            }));
+
+            return;
+        }
+
+        // iterate the set of pkCols for this QueryInfo -- include value from queryData
+        queryInfo.getPkCols().forEach(pkCol => {
+            const pkVal = row[pkCol.fieldKey]?.value;
+
+            if (pkVal !== undefined && pkVal !== null) {
+                updatedValues[pkCol.fieldKey] = pkVal;
+            } else {
+                console.warn('Unable to find value for pkCol "' + pkCol.fieldKey + '"');
+            }
+        });
+
+        updateRows({ schemaQuery: queryInfo.schemaQuery, rows: [updatedValues], auditBehavior })
+            .then(() => {
+                this.setState({ editing: false }, () => {
+                    onUpdate?.();
+                    onEditToggle?.(false);
+                });
+            })
+            .catch(error => {
+                console.error(error);
+                this.setState(() => ({
+                    warning: undefined,
+                    error: resolveErrorMessage(error, 'data', undefined, 'update'),
+                }));
+            });
+    };
+
+    render(): ReactNode {
+        const {
+            actions,
+            appEditable,
+            asSubPanel,
+            cancelText,
+            canUpdate,
+            model,
+            queryColumns,
+            submitText,
+            title,
+            useEditIcon,
+        } = this.props;
+        const { canSubmit, editing, error, warning } = this.state;
+        const panelClass = editing ? 'panel-info' : 'panel-default';
+        const renderer = editing ? resolveDetailEditRenderer : resolveDetailRenderer;
+        const isEditable = !model.isLoading && model.hasRows && (model.queryInfo?.isAppEditable() || appEditable);
+
+        const panel = (
+            <div className={`panel ${panelClass}`}>
+                <div className="panel-heading">
+                    <DetailPanelHeader
+                        useEditIcon={useEditIcon}
+                        isEditable={isEditable}
+                        canUpdate={canUpdate}
+                        editing={editing}
+                        title={title}
+                        onClickFn={this.toggleEditing}
+                        warning={warning}
+                    />
+                </div>
+
+                <div className="panel-body">
+                    {error && <Alert>{error}</Alert>}
+
+                    <DetailPanel
+                        actions={actions}
+                        detailRenderer={renderer}
+                        editingMode={editing}
+                        model={model}
+                        queryColumns={editing ? undefined : queryColumns}
+                        titleRenderer={editing ? titleRenderer : undefined}
+                    />
+                </div>
+            </div>
+        );
+
+        if (editing) {
+            return (
+                <Formsy
+                    onChange={this.handleFormChange}
+                    onValidSubmit={this.handleSubmit}
+                    onValid={this.enableSubmitButton}
+                    onInvalid={this.disableSubmitButton}
+                >
+                    {panel}
+
+                    <div className="full-width bottom-spacing">
+                        <Button className="pull-left" onClick={this.toggleEditing}>
+                            {cancelText}
+                        </Button>
+                        <Button className="pull-right" bsStyle="success" type="submit" disabled={!canSubmit}>
+                            {submitText}
+                        </Button>
+                    </div>
+
+                    {asSubPanel && <div className="panel-divider-spacing" />}
+                </Formsy>
+            );
+        }
+
+        return panel;
+    }
+}

--- a/packages/components/src/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/QueryModel/EditableDetailPanel.tsx
@@ -75,6 +75,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
         this.setState(() => ({ warning: undefined }));
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleSubmit = (values: Record<string, any>): void => {
         const { auditBehavior, model, onEditToggle, onUpdate } = this.props;
         const { queryInfo } = model;
@@ -105,8 +106,8 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
         updateRows({ schemaQuery: queryInfo.schemaQuery, rows: [updatedValues], auditBehavior })
             .then(() => {
                 this.setState({ editing: false }, () => {
-                    onUpdate?.();
-                    onEditToggle?.(false);
+                    onUpdate?.(); // eslint-disable-line no-unused-expressions
+                    onEditToggle?.(false); // eslint-disable-line no-unused-expressions
                 });
             })
             .catch(error => {

--- a/packages/components/src/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/QueryModel/GridPanel.spec.tsx
@@ -17,7 +17,7 @@ import { RowsResponse } from './QueryModelLoader';
 import { makeTestActions, makeTestModel } from './testUtils';
 
 // The wrapper's return type for mount<GridPanel>(<GridPanel ... />)
-type GridPanelWrapper = ReactWrapper<Readonly<GridPanel<{}>['props']>, Readonly<GridPanel<{}>['state']>, GridPanel<{}>>;
+type GridPanelWrapper = ReactWrapper<Readonly<GridPanel['props']>, Readonly<GridPanel['state']>, GridPanel>;
 
 const SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
 let QUERY_INFO: QueryInfo;
@@ -112,7 +112,7 @@ describe('GridPanel', () => {
 
         // Model is loading QueryInfo and Rows, should render loading, disabled ChartMenu, no pagination/ViewMenu.
         let model = makeTestModel(SCHEMA_QUERY);
-        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
         expectNoQueryInfo(wrapper);
 
         // Model is loading Rows, but not QueryInfo, should not render pagination, should render disabled ViewMenu.
@@ -359,7 +359,7 @@ describe('GridPanel', () => {
     test('OmniBox', () => {
         const { rows, orderedRows, rowCount } = DATA;
         const model = makeTestModel(SCHEMA_QUERY, QUERY_INFO, rows, orderedRows.slice(0, 20), rowCount);
-        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
         const grid = wrapper.instance();
 
         const filter1 = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
@@ -499,7 +499,7 @@ describe('GridPanel', () => {
         // happens when bindURL is true and there is a URL change.
         const { rows, orderedRows, rowCount } = DATA;
         const model = makeTestModel(SCHEMA_QUERY, QUERY_INFO, rows, orderedRows.slice(0, 20), rowCount);
-        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
         const nameSort = new QuerySort({ fieldKey: 'Name' });
         const nameFilter = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
         const expirFilter = Filter.create('expirationTime', '1', Filter.Types.EQUAL);
@@ -626,7 +626,7 @@ describe('GridPanel', () => {
             selections: new Set(),
             selectionsLoadingState: LoadingState.LOADED,
         });
-        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
 
         // Check that with no selections the header checkbox is not selected.
         expectHeaderSelectionStatus(wrapper, false);

--- a/packages/components/src/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/QueryModel/GridPanel.spec.tsx
@@ -17,7 +17,7 @@ import { RowsResponse } from './QueryModelLoader';
 import { makeTestActions, makeTestModel } from './testUtils';
 
 // The wrapper's return type for mount<GridPanel>(<GridPanel ... />)
-type GridPanelWrapper = ReactWrapper<Readonly<GridPanel['props']>, Readonly<GridPanel['state']>, GridPanel>;
+type GridPanelWrapper = ReactWrapper<Readonly<GridPanel<{}>['props']>, Readonly<GridPanel<{}>['state']>, GridPanel<{}>>;
 
 const SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
 let QUERY_INFO: QueryInfo;
@@ -112,7 +112,7 @@ describe('GridPanel', () => {
 
         // Model is loading QueryInfo and Rows, should render loading, disabled ChartMenu, no pagination/ViewMenu.
         let model = makeTestModel(SCHEMA_QUERY);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
         expectNoQueryInfo(wrapper);
 
         // Model is loading Rows, but not QueryInfo, should not render pagination, should render disabled ViewMenu.
@@ -359,7 +359,7 @@ describe('GridPanel', () => {
     test('OmniBox', () => {
         const { rows, orderedRows, rowCount } = DATA;
         const model = makeTestModel(SCHEMA_QUERY, QUERY_INFO, rows, orderedRows.slice(0, 20), rowCount);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
         const grid = wrapper.instance();
 
         const filter1 = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
@@ -499,7 +499,7 @@ describe('GridPanel', () => {
         // happens when bindURL is true and there is a URL change.
         const { rows, orderedRows, rowCount } = DATA;
         const model = makeTestModel(SCHEMA_QUERY, QUERY_INFO, rows, orderedRows.slice(0, 20), rowCount);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
         const nameSort = new QuerySort({ fieldKey: 'Name' });
         const nameFilter = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
         const expirFilter = Filter.create('expirationTime', '1', Filter.Types.EQUAL);
@@ -626,7 +626,7 @@ describe('GridPanel', () => {
             selections: new Set(),
             selectionsLoadingState: LoadingState.LOADED,
         });
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel<{}>>(<GridPanel actions={actions} model={model} />);
 
         // Check that with no selections the header checkbox is not selected.
         expectHeaderSelectionStatus(wrapper, false);

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -30,6 +30,7 @@ interface GridPanelProps<ButtonsComponentProps> {
     ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
     buttonsComponentProps?: ButtonsComponentProps;
     emptyText?: string;
+    hideEmptyChartMenu?: boolean;
     hideEmptyViewMenu?: boolean;
     pageSizes?: number[];
     title?: string;
@@ -82,6 +83,7 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
             advancedExportOptions,
             ButtonsComponent,
             buttonsComponentProps,
+            hideEmptyChartMenu,
             hideEmptyViewMenu,
             onViewSelect,
             pageSizes,
@@ -109,8 +111,9 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
 
                         {showChartMenu && (
                             <ChartMenu
-                                model={model}
+                                hideEmptyChartMenu={hideEmptyChartMenu}
                                 actions={actions}
+                                model={model}
                                 showSampleComparisonReports={showSampleComparisonReports}
                             />
                         )}
@@ -152,6 +155,7 @@ export class GridPanel<T> extends PureComponent<Props<T>, State> {
         allowSelections: true,
         allowSorting: true,
         asPanel: true,
+        hideEmptyChartSelector: false,
         hideEmptyViewMenu: false,
         showPagination: true,
         showButtonBar: true,

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -611,4 +611,5 @@ class GridPanelWithModelImpl<T> extends PureComponent<GridPanelProps<T> & Inject
  *
  * In the future when GridPanel supports multiple models we will render tabs.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const GridPanelWithModel = withQueryModels<GridPanelProps<any>>(GridPanelWithModelImpl);

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -22,12 +22,13 @@ import { ChartMenu } from './ChartMenu';
 
 import { actionValuesToString, filtersEqual, sortsEqual } from './utils';
 
-interface GridPanelProps {
+interface GridPanelProps<ButtonsComponentProps> {
     allowSelections?: boolean;
     allowSorting?: boolean;
     asPanel?: boolean;
     advancedExportOptions?: { [key: string]: string };
-    ButtonsComponent?: ComponentType<RequiresModelAndActions>;
+    ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
+    buttonsComponentProps?: ButtonsComponentProps;
     emptyText?: string;
     hideEmptyViewMenu?: boolean;
     pageSizes?: number[];
@@ -42,13 +43,13 @@ interface GridPanelProps {
     showHeader?: boolean;
 }
 
-type Props = GridPanelProps & RequiresModelAndActions;
+type Props<T> = GridPanelProps<T> & RequiresModelAndActions;
 
-interface GridBarProps extends Props {
+interface GridBarProps<T> extends Props<T> {
     onViewSelect: (viewName) => void;
 }
 
-class ButtonBar extends PureComponent<GridBarProps> {
+class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
     loadFirstPage = (): void => {
         const { model, actions } = this.props;
         actions.loadFirstPage(model.id);
@@ -80,6 +81,7 @@ class ButtonBar extends PureComponent<GridBarProps> {
             actions,
             advancedExportOptions,
             ButtonsComponent,
+            buttonsComponentProps,
             hideEmptyViewMenu,
             onViewSelect,
             pageSizes,
@@ -101,7 +103,9 @@ class ButtonBar extends PureComponent<GridBarProps> {
             <div className="grid-panel__button-bar">
                 <div className="grid-panel__button-bar-left">
                     <div className="button-bar__section">
-                        {ButtonsComponent !== undefined && <ButtonsComponent model={model} actions={actions} />}
+                        {ButtonsComponent !== undefined && (
+                            <ButtonsComponent {...buttonsComponentProps} model={model} actions={actions} />
+                        )}
 
                         {showChartMenu && (
                             <ChartMenu
@@ -143,7 +147,7 @@ interface State {
     actionValues: ActionValue[];
 }
 
-export class GridPanel extends PureComponent<Props, State> {
+export class GridPanel<T> extends PureComponent<Props<T>, State> {
     static defaultProps = {
         allowSelections: true,
         allowSorting: true,
@@ -187,7 +191,7 @@ export class GridPanel extends PureComponent<Props, State> {
         actions.loadModel(model.id, allowSelections);
     }
 
-    componentDidUpdate(prevProps: Readonly<Props>): void {
+    componentDidUpdate(prevProps: Readonly<Props<T>>): void {
         if (this.props.model.queryInfo !== undefined && this.props.model !== prevProps.model) {
             this.populateOmnibox();
         }
@@ -590,7 +594,7 @@ export class GridPanel extends PureComponent<Props, State> {
     }
 }
 
-class GridPanelWithModelImpl extends PureComponent<GridPanelProps & InjectedQueryModels> {
+class GridPanelWithModelImpl<T> extends PureComponent<GridPanelProps<T> & InjectedQueryModels> {
     render(): ReactNode {
         const { queryModels, actions, ...props } = this.props;
         return <GridPanel actions={actions} model={Object.values(queryModels)[0]} {...props} />;
@@ -603,4 +607,4 @@ class GridPanelWithModelImpl extends PureComponent<GridPanelProps & InjectedQuer
  *
  * In the future when GridPanel supports multiple models we will render tabs.
  */
-export const GridPanelWithModel = withQueryModels<GridPanelProps>(GridPanelWithModelImpl);
+export const GridPanelWithModel = withQueryModels<GridPanelProps<any>>(GridPanelWithModelImpl);

--- a/packages/components/src/QueryModel/GridPanel.tsx
+++ b/packages/components/src/QueryModel/GridPanel.tsx
@@ -82,7 +82,6 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
             actions,
             advancedExportOptions,
             ButtonsComponent,
-            buttonsComponentProps,
             hideEmptyChartMenu,
             hideEmptyViewMenu,
             onViewSelect,
@@ -100,6 +99,7 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
         const canExport = showExport && !hasError;
         // Don't disable view selection when there is an error because it's possible the error may be caused by the view
         const canSelectView = showViewMenu && queryInfo !== undefined;
+        const buttonsComponentProps = this.props.buttonsComponentProps ?? ({} as T);
 
         return (
             <div className="grid-panel__button-bar">
@@ -150,7 +150,7 @@ interface State {
     actionValues: ActionValue[];
 }
 
-export class GridPanel<T> extends PureComponent<Props<T>, State> {
+export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     static defaultProps = {
         allowSelections: true,
         allowSorting: true,

--- a/packages/components/src/QueryModel/QueryModel.ts
+++ b/packages/components/src/QueryModel/QueryModel.ts
@@ -379,12 +379,12 @@ export class QueryModel {
      * @param flattenValues True to flatten the row object to just the key: value pairs
      */
     getRow(key?: string, flattenValues = false): any {
-        if (!this.rows) {
+        if (!this.hasRows) {
             return undefined;
         }
 
         if (key === undefined) {
-            key = Object.keys(this.rows)[0];
+            key = this.orderedRows[0];
         }
 
         const row = this.rows[key];

--- a/packages/components/src/actions.ts
+++ b/packages/components/src/actions.ts
@@ -1247,23 +1247,6 @@ export function getSelectedData(
     );
 }
 
-export function getSelectedDataWithQueryGridModel(
-    model: QueryGridModel,
-    columns?: List<QueryColumn>
-): Promise<IGridResponse> {
-    // If columns defined use those for the query columns else use the display columns
-    const columnString = columns ? columns.map(c => c.fieldKey).join(',') : model.getRequestColumnsString();
-
-    return getSelectedData(
-        model.schema,
-        model.query,
-        model.selectedIds.toArray(),
-        columnString,
-        model.getSorts() || '-RowId',
-        model.queryParameters
-    );
-}
-
 function getFilterParameters(filters: List<any>, remove = false): Map<string, string> {
     const params = {};
 

--- a/packages/components/src/actions.ts
+++ b/packages/components/src/actions.ts
@@ -1227,7 +1227,7 @@ export function getSelectedData(
             queryName,
             filterArray,
             parameters: queryParameters,
-            sort: sorts || '-RowId',
+            sort: sorts,
             columns,
             offset: 0,
         })

--- a/packages/components/src/components/base/CreatedModified.tsx
+++ b/packages/components/src/components/base/CreatedModified.tsx
@@ -57,7 +57,7 @@ export class CreatedModified extends React.Component<CreatedModifiedProps, State
         };
     }
 
-    UNSAFE_componentWillMount(): void {
+    componentDidMount(): void {
         if (this.props.useServerDate) {
             Query.getServerDate({
                 success: serverDate => this.setState(() => ({ serverDate, loading: false })),

--- a/packages/components/src/components/editable/EditableGridLoaderFromSelection.tsx
+++ b/packages/components/src/components/editable/EditableGridLoaderFromSelection.tsx
@@ -36,7 +36,7 @@ export class EditableGridLoaderFromSelection implements IGridLoader {
         return new Promise((resolve, reject) => {
             const { schema, query, queryParameters } = gridModel;
             const columnString = gridModel.getRequestColumnsString();
-            const sorts = gridModel.getSorts() || '-RowId';
+            const sorts = gridModel.getSorts();
             const selectedIds = this.dataIdsForSelection.toArray();
             return getSelectedData(schema, query, selectedIds, columnString, sorts, queryParameters)
                 .then(response => {

--- a/packages/components/src/components/editable/EditableGridLoaderFromSelection.tsx
+++ b/packages/components/src/components/editable/EditableGridLoaderFromSelection.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { List, Map } from 'immutable';
 
-import { getSelectedDataWithQueryGridModel } from '../../actions';
+import { getSelectedData } from '../../actions';
 import { EditorModel } from '../../models';
 import { IGridLoader, IGridResponse, QueryGridModel } from '../base/models/model';
 
@@ -26,8 +26,7 @@ export class EditableGridLoaderFromSelection implements IGridLoader {
     dataIdsForSelection: List<any>;
     model: QueryGridModel;
 
-    constructor(updateData, model: QueryGridModel, dataForSelection: Map<string, any>, dataIdsForSelection: List<any>) {
-        this.model = model;
+    constructor(updateData, dataForSelection: Map<string, any>, dataIdsForSelection: List<any>) {
         this.updateData = updateData || {};
         this.dataForSelection = dataForSelection;
         this.dataIdsForSelection = dataIdsForSelection;
@@ -35,10 +34,11 @@ export class EditableGridLoaderFromSelection implements IGridLoader {
 
     selectAndFetch(gridModel: QueryGridModel): Promise<IGridResponse> {
         return new Promise((resolve, reject) => {
-            // N.B.  gridModel is the model backing the editable grid, which has no selection on it,
-            // so we use this.model, the model for the original query grid with selection.
-            this.model = this.model.set('requiredColumns', gridModel.get('requiredColumns')) as QueryGridModel;
-            return getSelectedDataWithQueryGridModel(this.model)
+            const { schema, query, queryParameters } = gridModel;
+            const columnString = gridModel.getRequestColumnsString();
+            const sorts = gridModel.getSorts() || '-RowId';
+            const selectedIds = this.dataIdsForSelection.toArray();
+            return getSelectedData(schema, query, selectedIds, columnString, sorts, queryParameters)
                 .then(response => {
                     const { data, dataIds, totalRows } = response;
                     resolve({

--- a/packages/components/src/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/components/forms/BulkUpdateForm.tsx
@@ -7,7 +7,7 @@ import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
 
 import { capitalizeFirstChar, getCommonDataValues, getUpdatedData } from '../../util/utils';
 import { QueryInfo } from '../base/models/QueryInfo';
-import { QueryColumn, QueryGridModel, SchemaQuery } from '../base/models/model';
+import { QueryColumn, SchemaQuery } from '../base/models/model';
 
 import { QueryInfoForm } from './QueryInfoForm';
 
@@ -24,6 +24,8 @@ interface Props {
     selectedIds: string[];
     shownInUpdateColumns?: boolean;
     singularNoun?: string;
+    // sortString is used so we render editable grids with the proper sorts when using onSubmitForEdit
+    sortString?: string;
     uniqueFieldKey?: string;
     updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise<any>;
 }
@@ -54,15 +56,22 @@ export class BulkUpdateForm extends React.Component<Props, State> {
     }
 
     UNSAFE_componentWillMount(): void {
-        const { onCancel, pluralNoun, queryInfo, selectedIds, shownInUpdateColumns, readOnlyColumns } = this.props;
-
+        const {
+            onCancel,
+            pluralNoun,
+            queryInfo,
+            readOnlyColumns,
+            selectedIds,
+            shownInUpdateColumns,
+            sortString
+        } = this.props;
         // Get all shownInUpdateView columns or undefined
         const columns = shownInUpdateColumns
             ? (queryInfo.getPkCols().concat(queryInfo.getUpdateColumns(readOnlyColumns)) as List<QueryColumn>)
             : undefined;
         const columnString = columns?.map(c => c.fieldKey).join(',');
         const { schemaName, name } = queryInfo;
-        getSelectedData(schemaName, name, selectedIds, columnString)
+        getSelectedData(schemaName, name, selectedIds, columnString, sortString)
             .then(response => {
                 const { data, dataIds } = response;
                 this.setState(() => ({

--- a/packages/components/src/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/components/forms/BulkUpdateForm.tsx
@@ -55,7 +55,7 @@ export class BulkUpdateForm extends React.Component<Props, State> {
         };
     }
 
-    UNSAFE_componentWillMount(): void {
+    componentDidMount(): void {
         const {
             onCancel,
             pluralNoun,
@@ -63,7 +63,7 @@ export class BulkUpdateForm extends React.Component<Props, State> {
             readOnlyColumns,
             selectedIds,
             shownInUpdateColumns,
-            sortString
+            sortString,
         } = this.props;
         // Get all shownInUpdateView columns or undefined
         const columns = shownInUpdateColumns

--- a/packages/components/src/components/forms/detail/utils.ts
+++ b/packages/components/src/components/forms/detail/utils.ts
@@ -1,0 +1,64 @@
+import { QueryInfo } from '../../..';
+import { List, Map } from 'immutable';
+
+function arrayListIsEqual(valueArr: Array<string | number>, nestedModelList: List<Map<string, any>>): boolean {
+    let matched = 0;
+    // Loop through the submitted array and the existing list and compare values.
+    // If values match, add tally. If submitted values length is same as existing list, consider them equal.
+    // Note: caller should have checked against empty array and list before function.
+    nestedModelList.forEach(nestedField => {
+        return valueArr.forEach(nestedVal => {
+            if (nestedField.get('value') === nestedVal || nestedField.get('displayValue') === nestedVal) {
+                matched++;
+            }
+        });
+    });
+
+    return matched === valueArr.length;
+}
+
+export function extractChanges(queryInfo: QueryInfo, currentData: Map<string, any>, formValues: Record<string, any>): Record<string, any> {
+    const changedValues = {};
+    // Loop through submitted formValues and check against existing currentData from server
+    Object.keys(formValues).forEach(field => {
+        // If nested value, will need to do deeper check
+        if (List.isList(currentData.get(field))) {
+            // If the submitted value and existing value are empty, do not update field
+            if (!formValues[field] && currentData.get(field).size === 0) {
+                return false;
+            }
+            // If the submitted value is empty and there is an existing value, should update field
+            else if (!formValues[field] && currentData.get(field).size > 0) {
+                changedValues[field] = formValues[field];
+            } else {
+                // If submitted value array and existing value array are different size, should update field
+                if (formValues[field].length !== currentData.get(field).size) {
+                    changedValues[field] = formValues[field];
+                }
+                // If submitted value array and existing array are the same size, need to compare full contents
+                else if (formValues[field].length === currentData.get(field).size) {
+                    if (!arrayListIsEqual(formValues[field], currentData.get(field))) {
+                        changedValues[field] = formValues[field];
+                    }
+                }
+            }
+        } else if (formValues[field] != currentData.getIn([field, 'value'])) {
+            const column = queryInfo.getColumn(field);
+
+            // A date field needs to be checked specially
+            if (column && column.jsonType === 'date') {
+                // Ensure dates have same formatting
+                // If submitted value is same as existing date down to the minute (issue 40139), do not update
+                const newDateValue = new Date(formValues[field]).setUTCSeconds(0, 0);
+                const origDateValue = new Date(currentData.getIn([field, 'value'])).setUTCSeconds(0, 0);
+                if (newDateValue === origDateValue) {
+                    return false;
+                }
+            }
+
+            changedValues[field] = formValues[field];
+        }
+    });
+
+    return changedValues;
+}

--- a/packages/components/src/global.ts
+++ b/packages/components/src/global.ts
@@ -23,6 +23,14 @@ import { QueryColumn, QueryGridModel, SchemaQuery } from './components/base/mode
 import { naturalSort, resolveSchemaQuery } from './util/utils';
 import { GRID_CHECKBOX_OPTIONS } from './components/base/models/constants';
 
+// Don't touch this directly, if you need access to it use getQueryMetadata, if you need to set the value use
+// setQueryMetadata
+let _queryMetadata = Map<string, any>();
+
+// Don't touch this directly, if you need access to it use getQueryColumnRenderers, if you need to set the value use
+// setQueryColumnRenderers
+let _queryColumnRenderers = Map<string, any>();
+
 /**
  * Initialize the global state object for this package.
  * @param metadata Optional Map to set the query metadata for this application
@@ -38,6 +46,7 @@ export function initQueryGridState(metadata?: Map<string, any>, columnRenderers?
     if (metadata) {
         setQueryMetadata(metadata);
     }
+
     if (columnRenderers) {
         setQueryColumnRenderers(columnRenderers);
     }
@@ -152,37 +161,33 @@ export function removeQueryGridModel(model: QueryGridModel, connectedComponent?:
 }
 
 /**
- * Get the query metadata object from the global QueryGrid state
+ * Get the query metadata object from the global state.
  */
-export function getQueryMetadata(): any {
-    return getGlobalState('metadata');
+export function getQueryMetadata(): Map<string, any> {
+    return _queryMetadata;
 }
 
 /**
- * Sets the query metadata object to be used for this application in the global QueryGrid state
+ * Sets the query metadata object to be used for this application in the global state.
  * @param metadata Map of query metadata to be applied to the query infos and column infos
  */
 export function setQueryMetadata(metadata: Map<string, any>): void {
-    setGlobal({
-        QueryGrid_metadata: metadata,
-    });
+    _queryMetadata = metadata;
 }
 
 /**
- * Get the query grid column renderers map from the global QueryGrid state
+ * Get the query grid column renderers map from the global state.
  */
-export function getQueryColumnRenderers(): any {
-    return getGlobalState('columnrenderers');
+export function getQueryColumnRenderers(): Map<string, any> {
+    return _queryColumnRenderers;
 }
 
 /**
- * Sets the valid column renderers for this application in the global QueryGrid state
- * @param renderers Map of query grid column renderers to be bound to the queryInfo columns
+ * Sets the valid column renderers for this application in the global state.
+ * @param columnRenderers Map of query grid column renderers to be bound to the queryInfo columns
  */
-export function setQueryColumnRenderers(columnrenderers: Map<string, any>): void {
-    setGlobal({
-        QueryGrid_columnrenderers: columnrenderers,
-    });
+export function setQueryColumnRenderers(columnRenderers: Map<string, any>): void {
+    _queryColumnRenderers = columnRenderers;
 }
 
 function getSelectedState(

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -364,6 +364,7 @@ import {
 } from './QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './QueryModel/GridPanel';
 import { DetailPanel, DetailPanelWithModel } from './QueryModel/DetailPanel';
+import { EditableDetailPanel } from './QueryModel/EditableDetailPanel';
 import { Pagination, PaginationData } from './components/pagination/Pagination';
 import { AuditDetailsModel } from './components/auditlog/models';
 import { AuditQueriesListingPage } from './components/auditlog/AuditQueriesListingPage';
@@ -796,6 +797,7 @@ export {
     GridPanelWithModel,
     DetailPanel,
     DetailPanelWithModel,
+    EditableDetailPanel,
     runDetailsColumnsForQueryModel,
     Pagination,
     PaginationData,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -117,6 +117,7 @@ import { Footer } from './components/base/Footer';
 
 import { EditorModel, getStateModelId, getStateQueryGridModel, IDataViewInfo } from './models';
 import {
+    clearSelected,
     createQueryGridModelFilteredBySample,
     getSelected,
     getSelectedData,
@@ -390,6 +391,7 @@ export {
     getEditorModel,
     removeQueryGridModel,
     invalidateUsers,
+    clearSelected,
     gridInvalidate,
     gridIdInvalidate,
     queryGridInvalidate,

--- a/packages/components/src/renderers.tsx
+++ b/packages/components/src/renderers.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { OrderedMap } from 'immutable';
+import { OrderedMap, Map } from 'immutable';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import { DefaultRenderer } from './renderers/DefaultRenderer';

--- a/packages/components/src/stories/QueryModel.tsx
+++ b/packages/components/src/stories/QueryModel.tsx
@@ -1,13 +1,10 @@
-import React, {
-    ChangeEvent,
-    FunctionComponent,
-    PureComponent,
-    ReactElement,
-} from 'react';
+import React, { ChangeEvent, FunctionComponent, PureComponent, ReactElement, ReactNode } from 'react';
 import { storiesOf } from '@storybook/react';
 import { Button, MenuItem } from 'react-bootstrap';
+import { createMemoryHistory, Route, Router, WithRouterProps } from 'react-router';
 
 import {
+    EditableDetailPanel,
     GridPanel,
     GridPanelWithModel,
     InjectedQueryModels,
@@ -15,10 +12,11 @@ import {
     QueryConfigMap,
     RequiresModelAndActions,
     SchemaQuery,
+    SCHEMAS,
     withQueryModels,
 } from '..';
+
 import './QueryModel.scss';
-import { createMemoryHistory, Route, Router, WithRouterProps } from 'react-router';
 
 class GridPanelButtonsExample extends PureComponent<RequiresModelAndActions> {
     render() {
@@ -119,6 +117,25 @@ class ChangeableSchemaQueryImpl extends PureComponent<{} & InjectedQueryModels, 
 
 const ChangeableSchemaQuery = withQueryModels<{}>(ChangeableSchemaQueryImpl);
 
+export class EditableDetailPanelExampleImpl extends PureComponent<{} & InjectedQueryModels> {
+    render(): ReactNode {
+        const { actions, queryModels } = this.props;
+        const model = Object.values(queryModels)[0];
+        const onUpdate = () => console.log('Update complete');
+        return (
+            <EditableDetailPanel
+                actions={actions}
+                appEditable={true}
+                canUpdate={true}
+                model={model}
+                onUpdate={onUpdate}
+            />
+        );
+    }
+}
+
+const EditableDetailsPanelExample = withQueryModels<{}>(EditableDetailPanelExampleImpl);
+
 storiesOf('QueryModel', module)
     .add('GridPanel', () => {
         const history = createMemoryHistory();
@@ -216,4 +233,18 @@ storiesOf('QueryModel', module)
     })
     .add('Changeable SchemaQuery', () => {
         return <ChangeableSchemaQuery />;
+    })
+    .add('EditableDetailPanel', () => {
+        const queryConfigs: QueryConfigMap = {
+            mixtures: {
+                schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Samples'),
+                keyValue: 123,
+            },
+        };
+
+        return (
+            <div className="query-model-example">
+                <EditableDetailsPanelExample autoLoad queryConfigs={queryConfigs} />
+            </div>
+        );
     });


### PR DESCRIPTION
#### Rationale
I'm in the process of refactoring some of SampleManager to use the QueryModel API and I needed to make some components unaware of either model, and I needed an eitable details panel.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/342

#### Changes
* Refactor several components/classes to not depend on QueryGridModel
    * This allows them to more easily be used by QueryModel and QueryGridModel based components while we transition
    away from QueryGridModel
    * Affected Components: SelectionMenuItem, BulkUpdateModel
    * Affected Classes: EditableGridLoaderFromSelection
* Add EditableDetailPanel, the QueryModel version of DetailEditing
* DetailPanel: change queryColumns prop from List<QueryColumn> to QueryColumn[]
    * We are moving away from Immutable and want to limit how much of it is exposed in our API
* GridPanel: add new prop buttonsComponentProps
    * Use this prop to pass any additional props to your ButtonsComponent (Model and Actions are still passed)
* Change a few usages of componentWillMount to componentDidMount
* Move queryMetadata an columnRenderers out of ReactN global storage
