### PR TITLE
Item 7514: Allow users to attach comments for the audit log when inserting, updating, or deleting rows

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@labkey/api": "1.0.2",
+    "@labkey/api": "1.0.3-fmCheckInAndOut.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.89.1",
+  "version": "0.90.0-fmCheckInAndOut.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.90.0-fmCheckInAndOut.1",
+  "version": "0.90.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@labkey/api": "1.0.3-fmCheckInAndOut.0",
+    "@labkey/api": "1.1.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.90.0-fmCheckInAndOut.0",
+  "version": "0.90.0-fmCheckInAndOut.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -3,6 +3,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
+* Add ability to show comments from metadata on timeline events.
+
+### version 0.89.1
+*Released*: 21 August 2020
 * Bind URL parameters when adding QueryModels
 
 ### version 0.89.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.90.0
+*Released*: 27 August 2020
 * Add ability to show comments from metadata on timeline events.
 
 ### version 0.89.2

--- a/packages/components/src/components/auditlog/TimelineView.tsx
+++ b/packages/components/src/components/auditlog/TimelineView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { App, getEventDataValueDisplay, SVGIcon } from '../../index';
+import { App, getEventDataValueDisplay, LabelHelpTip, SVGIcon } from '../../index';
 
 import { TimelineEventModel, TimelineGroupedEventInfo } from './models';
 
@@ -70,7 +70,7 @@ export class TimelineView extends React.Component<Props, any> {
             >
                 {this.renderTimestampCol(event.timestamp)}
                 {this.renderIconCol(icon, eventSelected, isFirstEvent, isLastEvent, isEventCompleted, isConnection)}
-                {this.renderDetailCol(event.summary, event.user, event.entity)}
+                {this.renderDetailCol(event.summary, event.user, event.entity, event.getComment())}
             </tr>
         );
     }
@@ -149,7 +149,22 @@ export class TimelineView extends React.Component<Props, any> {
         );
     }
 
-    renderDetailCol(summary: string, user: any, entity: any) {
+    renderComment(comment: string) : React.ReactNode {
+        if (!comment)
+            return null;
+
+        const icon = <i className="timeline-comments fa fa-comments"/>;
+        return (
+            <LabelHelpTip
+                title={"Comment"}
+                body={() => {return comment}}
+                placement="bottom"
+                iconComponent ={() => {return icon}}
+            />
+        )
+    }
+
+    renderDetailCol(summary: string, user: any, entity: any, comment: string) {
         const { showUserLinks } = this.props;
         return (
             <td key="tl-detail-col" className="detail-col">
@@ -158,7 +173,7 @@ export class TimelineView extends React.Component<Props, any> {
                     {entity != null && <span> - </span>}
                     {entity != null && getEventDataValueDisplay(entity)}
                 </div>
-                <div>{getEventDataValueDisplay(user, showUserLinks)}</div>
+                <div>{getEventDataValueDisplay(user, showUserLinks)} {this.renderComment(comment)}</div>
             </td>
         );
     }

--- a/packages/components/src/components/auditlog/__snapshots__/TimelineView.spec.tsx.snap
+++ b/packages/components/src/components/auditlog/__snapshots__/TimelineView.spec.tsx.snap
@@ -58,6 +58,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -122,6 +123,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -186,6 +188,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             xyang
           </a>
+           
         </div>
       </td>
     </tr>
@@ -250,6 +253,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -314,6 +318,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             Test Lab User
           </a>
+           
         </div>
       </td>
     </tr>
@@ -378,6 +383,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             Test Lab User
           </a>
+           
         </div>
       </td>
     </tr>
@@ -442,6 +448,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -506,6 +513,16 @@ exports[`<TimelineView /> Disable selection 1`] = `
           >
             xyang
           </a>
+           
+          <LabelHelpTip
+            body={[Function]}
+            customStyle={Object {}}
+            iconComponent={[Function]}
+            id="tooltip"
+            placement="bottom"
+            size="1x"
+            title="Comment"
+          />
         </div>
       </td>
     </tr>
@@ -567,6 +584,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           Vader
+           
         </div>
       </td>
     </tr>
@@ -627,6 +645,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           Vader
+           
         </div>
       </td>
     </tr>
@@ -687,6 +706,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           xyang
+           
         </div>
       </td>
     </tr>
@@ -747,6 +767,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           Vader
+           
         </div>
       </td>
     </tr>
@@ -807,6 +828,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           Test Lab User
+           
         </div>
       </td>
     </tr>
@@ -867,6 +889,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           Test Lab User
+           
         </div>
       </td>
     </tr>
@@ -927,6 +950,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           Vader
+           
         </div>
       </td>
     </tr>
@@ -987,6 +1011,16 @@ exports[`<TimelineView /> Hide user link 1`] = `
         </div>
         <div>
           xyang
+           
+          <LabelHelpTip
+            body={[Function]}
+            customStyle={Object {}}
+            iconComponent={[Function]}
+            id="tooltip"
+            placement="bottom"
+            size="1x"
+            title="Comment"
+          />
         </div>
       </td>
     </tr>
@@ -1052,6 +1086,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1122,6 +1157,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1186,6 +1222,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             xyang
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1250,6 +1287,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1314,6 +1352,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             Test Lab User
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1384,6 +1423,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             Test Lab User
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1448,6 +1488,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1512,6 +1553,16 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           >
             xyang
           </a>
+           
+          <LabelHelpTip
+            body={[Function]}
+            customStyle={Object {}}
+            iconComponent={[Function]}
+            id="tooltip"
+            placement="bottom"
+            size="1x"
+            title="Comment"
+          />
         </div>
       </td>
     </tr>
@@ -1577,6 +1628,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1641,6 +1693,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1711,6 +1764,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             xyang
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1775,6 +1829,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1839,6 +1894,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             Test Lab User
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1903,6 +1959,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             Test Lab User
           </a>
+           
         </div>
       </td>
     </tr>
@@ -1967,6 +2024,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             Vader
           </a>
+           
         </div>
       </td>
     </tr>
@@ -2037,6 +2095,16 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           >
             xyang
           </a>
+           
+          <LabelHelpTip
+            body={[Function]}
+            customStyle={Object {}}
+            iconComponent={[Function]}
+            id="tooltip"
+            placement="bottom"
+            size="1x"
+            title="Comment"
+          />
         </div>
       </td>
     </tr>

--- a/packages/components/src/components/auditlog/models.ts
+++ b/packages/components/src/components/auditlog/models.ts
@@ -122,6 +122,15 @@ export class TimelineEventModel extends Record({
     isSameEntity(event: TimelineEventModel): boolean {
         return this.entity && event.entity && this.entity.get('value') === event.entity.get('value');
     }
+
+    getComment() : string {
+        if (!this.metadata)
+            return undefined;
+        const commentField = this.metadata.find((metadataRow) => (metadataRow.get('field').toLowerCase() === 'comment'));
+        if (commentField)
+            return commentField.get('value');
+        return undefined;
+    }
 }
 
 export interface TimelineGroupedEventInfo {

--- a/packages/components/src/query/api.ts
+++ b/packages/components/src/query/api.ts
@@ -618,6 +618,7 @@ export interface InsertRowsOptions {
     rows: List<any>;
     schemaQuery: SchemaQuery;
     auditBehavior?: AuditBehaviorTypes;
+    auditUserComment?: string;
 }
 
 export class InsertRowsResponse extends Record({
@@ -647,7 +648,7 @@ export class InsertRowsResponse extends Record({
 
 export function insertRows(options: InsertRowsOptions): Promise<InsertRowsResponse> {
     return new Promise((resolve, reject) => {
-        const { fillEmptyFields, rows, schemaQuery, auditBehavior } = options;
+        const { fillEmptyFields, rows, schemaQuery, auditBehavior, auditUserComment } = options;
         const _rows = fillEmptyFields === true ? ensureAllFieldsInAllRows(rows) : rows;
 
         Query.insertRows({
@@ -655,6 +656,7 @@ export function insertRows(options: InsertRowsOptions): Promise<InsertRowsRespon
             queryName: schemaQuery.queryName,
             rows: _rows.toArray(),
             auditBehavior,
+            auditUserComment,
             apiVersion: 13.2,
             success: response => {
                 resolve(
@@ -721,6 +723,7 @@ interface IUpdateRowsOptions {
     schemaQuery: SchemaQuery;
     rows: any[];
     auditBehavior?: AuditBehaviorTypes;
+    auditUserComment?: string;
 }
 
 export function updateRows(options: IUpdateRowsOptions): Promise<any> {
@@ -731,6 +734,7 @@ export function updateRows(options: IUpdateRowsOptions): Promise<any> {
             queryName: options.schemaQuery.queryName,
             rows: options.rows,
             auditBehavior: options.auditBehavior,
+            auditUserComment: options.auditUserComment,
             success: response => {
                 resolve(
                     Object.assign(
@@ -761,6 +765,7 @@ interface DeleteRowsOptions {
     schemaQuery: SchemaQuery;
     rows: any[];
     auditBehavior?: AuditBehaviorTypes;
+    auditUserComment?: string;
 }
 
 export function deleteRows(options: DeleteRowsOptions): Promise<any> {
@@ -770,6 +775,7 @@ export function deleteRows(options: DeleteRowsOptions): Promise<any> {
             queryName: options.schemaQuery.queryName,
             rows: options.rows,
             auditBehavior: options.auditBehavior,
+            auditUserComment: options.auditUserComment,
             apiVersion: 13.2,
             success: () => {
                 resolve(

--- a/packages/components/src/test/data/constants.ts
+++ b/packages/components/src/test/data/constants.ts
@@ -369,5 +369,12 @@ export const TIMELINE_DATA = [
         entity: { displayValue: 'S-1', value: 6, url: '/labkey/inventory0804/experiment-showMaterial.view?rowId=6' },
         rowId: 49,
         timestamp: { formattedValue: '2020-05-04 23:00', value: '2020-05-04 23:00:23.403' },
+        metadata: {
+            'Checked Out': { formattedValue: "2020-05-4 23:00", value: '2020-5-4 23:00:23.403'},
+            'Checked Out By': { displayValue: 'xyang', urlType: 'user', value: 1005 },
+            'Comment': "This is why I checked it out.",
+            'Storage box': { displayValue: 'Box f', urlType: "box", value: "38"},
+            'Storage space': {displayValue: 'A-1', urlType: 'boxCell', value: "38-1-1"}
+        }
     },
 ];

--- a/packages/components/src/theme/timeline.scss
+++ b/packages/components/src/theme/timeline.scss
@@ -123,3 +123,7 @@
     }
 
 }
+
+.timeline-comments {
+    color: $brand-primary;
+}

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1432,10 +1432,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.0.3-fmCheckInAndOut.0":
-  version "1.0.3-fmCheckInAndOut.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.0.3-fmCheckInAndOut.0.tgz#fba21f979bea9c66f6d32a587ddd3afeba285d1a"
-  integrity sha1-+6Ifl5vqnGb20ypYfd06/rooXRo=
+"@labkey/api@1.1.0":
+  version "1.1.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.0.tgz#b70fbe749d7c3b30ae77f5d8e9e12a2cde5cedbe"
+  integrity sha1-tw++dJ18OzCud/XY6eEqLN5c7b4=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1432,10 +1432,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.0.2":
-  version "1.0.2"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.0.2.tgz#61cf04b5c159f5ccafb4dc172831ceaf956063c8"
-  integrity sha1-Yc8EtcFZ9cyvtNwXKDHOr5VgY8g=
+"@labkey/api@1.0.3-fmCheckInAndOut.0":
+  version "1.0.3-fmCheckInAndOut.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.0.3-fmCheckInAndOut.0.tgz#fba21f979bea9c66f6d32a587ddd3afeba285d1a"
+  integrity sha1-+6Ifl5vqnGb20ypYfd06/rooXRo=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"
@@ -12198,8 +12198,6 @@ supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
 
 supports-color@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
#### Rationale
When checking items in and out of the freezer, we want to allow users to optionally provide comments on the action. These comments are naturally associated with the audit event, not with the sample or the inventory item, so we provide a parameter in the request for attaching the user comments that can then be passed through to the methods for creating the audit events. They are to be surfaced with the sample timeline and inventory location history views within the applications.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/351
* https://github.com/LabKey/platform/pull/1512
* https://github.com/LabKey/labkey-api-js/pull/73
* https://github.com/LabKey/inventory/pull/75

#### Changes
* Add optional display of comments from event metadata with timeline events
* Add optional `auditUserComment` when updating, deleting, or inserting rows
