### PR TITLE
Remove explicit usages of enzyme-to-json

### DIFF
--- a/packages/components/src/components/domainproperties/BooleanFieldOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/BooleanFieldOptions.spec.tsx
@@ -1,8 +1,6 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import toJson from 'enzyme-to-json';
-
 import { BooleanFieldOptions } from './BooleanFieldOptions';
 import { createFormInputId } from './actions';
 import { DOMAIN_FIELD_FORMAT, DOMAIN_FIELD_NOT_LOCKED } from './constants';
@@ -39,7 +37,7 @@ describe('BooleanFieldOptions', () => {
         formatField = boolean.find({ id: createFormInputId(DOMAIN_FIELD_FORMAT, 1, 1), className: 'form-control' });
         expect(formatField.props().value).toEqual(_format2);
 
-        expect(toJson(boolean)).toMatchSnapshot();
+        expect(boolean).toMatchSnapshot();
         boolean.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/ConditionalFormattingAndValidation.spec.tsx
+++ b/packages/components/src/components/domainproperties/ConditionalFormattingAndValidation.spec.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import propertyValidatorRange from '../../test/data/propertyValidator-range.json';
 import propertyValidatorRegex from '../../test/data/propertyValidator-regex.json';
@@ -78,7 +77,7 @@ describe('ConditionalFormattingAndValidation', () => {
         expect(validatorStrings.at(0).text()).toEqual(expectedValidators);
         expect(validatorStrings.at(1).text()).toEqual(expectedValidators);
 
-        expect(toJson(cfv)).toMatchSnapshot();
+        expect(cfv).toMatchSnapshot();
         cfv.unmount();
     });
 
@@ -123,7 +122,7 @@ describe('ConditionalFormattingAndValidation', () => {
         expect(validatorStrings.length).toEqual(1);
         expect(validatorStrings.at(0).text()).toEqual(formatsString);
 
-        expect(toJson(cfv)).toMatchSnapshot();
+        expect(cfv).toMatchSnapshot();
         cfv.unmount();
     });
 
@@ -145,7 +144,7 @@ describe('ConditionalFormattingAndValidation', () => {
         const validatorStrings = cfv.find({ className: 'domain-validator-link' });
         expect(validatorStrings.length).toEqual(0);
 
-        expect(toJson(cfv)).toMatchSnapshot();
+        expect(cfv).toMatchSnapshot();
         cfv.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/DateTimeFieldOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/DateTimeFieldOptions.spec.tsx
@@ -1,8 +1,5 @@
 import { mount } from 'enzyme';
-
 import React from 'react';
-
-import toJson from 'enzyme-to-json';
 
 import { createFormInputId } from './actions';
 import { DOMAIN_FIELD_FORMAT, DOMAIN_FIELD_NOT_LOCKED } from './constants';
@@ -44,7 +41,7 @@ describe('DateTimeFieldOptions', () => {
         formatField = dateTime.find({ id: createFormInputId(DOMAIN_FIELD_FORMAT, 1, 1), className: 'form-control' });
         expect(formatField.props().value).toEqual(_format2);
 
-        expect(toJson(dateTime)).toMatchSnapshot();
+        expect(dateTime).toMatchSnapshot();
         dateTime.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/LookupFieldOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/LookupFieldOptions.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import toJson from 'enzyme-to-json';
 import { mount, ReactWrapper } from 'enzyme';
 
 import { MockLookupProvider } from '../../test/components/Lookup';
@@ -147,7 +146,7 @@ describe('LookupFieldOptions', () => {
                     expect(queryField.state().queries.size).toEqual(3);
                     expect(queryField.state().queries.get(1).name).toEqual(_queries1);
 
-                    expect(toJson(lookupField)).toMatchSnapshot();
+                    expect(lookupField).toMatchSnapshot();
                     lookupField.unmount();
                 });
             });
@@ -223,7 +222,7 @@ describe('LookupFieldOptions', () => {
                     expect(schema.state().schemas.size).toEqual(1);
                     expect(schema.state().schemas.get(0).schemaName).toEqual(_newSchema);
 
-                    expect(toJson(lookupField)).toMatchSnapshot();
+                    expect(lookupField).toMatchSnapshot();
                     lookupField.unmount();
                 });
             });
@@ -301,7 +300,7 @@ describe('LookupFieldOptions', () => {
                     expect(queryField.state().queries.size).toEqual(1);
                     expect(queryField.state().queries.get(0).name).toEqual(_query2);
 
-                    expect(toJson(lookupField)).toMatchSnapshot();
+                    expect(lookupField).toMatchSnapshot();
                     lookupField.unmount();
                 });
             });
@@ -372,7 +371,7 @@ describe('LookupFieldOptions', () => {
                 expect(queryField.state().queries.size).toEqual(0);
                 expect(queryField.props().value).toEqual('');
 
-                expect(toJson(lookupField)).toMatchSnapshot();
+                expect(lookupField).toMatchSnapshot();
                 lookupField.unmount();
             });
         });

--- a/packages/components/src/components/domainproperties/NameAndLinkingOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/NameAndLinkingOptions.spec.tsx
@@ -1,8 +1,5 @@
 import { mount } from 'enzyme';
-
 import React from 'react';
-
-import toJson from 'enzyme-to-json';
 
 import { createFormInputId } from './actions';
 import {
@@ -68,7 +65,7 @@ describe('NameAndLinkingOptions', () => {
         expect(formField.length).toEqual(1);
         expect(formField.props().value).toEqual(_URL);
 
-        expect(toJson(numeric)).toMatchSnapshot();
+        expect(numeric).toMatchSnapshot();
         numeric.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/NumericFieldOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/NumericFieldOptions.spec.tsx
@@ -1,8 +1,5 @@
 import { mount } from 'enzyme';
-
 import React from 'react';
-
-import toJson from 'enzyme-to-json';
 
 import { createFormInputId } from './actions';
 import { DOMAIN_FIELD_DEFAULT_SCALE, DOMAIN_FIELD_FORMAT, DOMAIN_FIELD_NOT_LOCKED } from './constants';
@@ -57,7 +54,7 @@ describe('NumericFieldOptions', () => {
         });
         expect(defaultScale.props().value).toEqual('LOG');
 
-        expect(toJson(numeric)).toMatchSnapshot();
+        expect(numeric).toMatchSnapshot();
         numeric.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/TextFieldOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/TextFieldOptions.spec.tsx
@@ -1,8 +1,5 @@
 import { mount } from 'enzyme';
-
 import React from 'react';
-
-import toJson from 'enzyme-to-json';
 
 import { createFormInputId } from './actions';
 import {
@@ -96,7 +93,7 @@ describe('TextFieldOptions', () => {
         expect(lengthField2.length).toEqual(1);
         expect(lengthField2.props().value).toEqual(_scale2);
 
-        expect(toJson(textField)).toMatchSnapshot();
+        expect(textField).toMatchSnapshot();
         textField.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/validation/ConditionalFormatOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/validation/ConditionalFormatOptions.spec.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import { INTEGER_TYPE, TEXT_TYPE } from '../models';
 import { createFormInputId } from '../actions';
@@ -77,7 +76,7 @@ describe('ConditionalFormatOptions', () => {
             width: '100px',
         });
 
-        expect(toJson(format)).toMatchSnapshot();
+        expect(format).toMatchSnapshot();
         format.unmount();
     });
 
@@ -103,7 +102,7 @@ describe('ConditionalFormatOptions', () => {
         const collapsed = format.find({ id: 'domain-condition-format-' + validatorIndex });
         expect(collapsed.children().children().text()).toEqual('Is Not Blank and Is Greater Than 5');
 
-        expect(toJson(format)).toMatchSnapshot();
+        expect(format).toMatchSnapshot();
         format.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/validation/Filters.spec.tsx
+++ b/packages/components/src/components/domainproperties/validation/Filters.spec.tsx
@@ -1,8 +1,6 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import toJson from 'enzyme-to-json';
-
 import { JsonType } from '../models';
 import { createFormInputId } from '../actions';
 import {
@@ -62,7 +60,7 @@ describe('Filters', () => {
         select = filters.find({ id: createFormInputId(DOMAIN_SECOND_FILTER_TYPE, domainIndex, validatorIndex) });
         expect(select.at(0).props().value).toEqual('None');
 
-        expect(toJson(filters)).toMatchSnapshot();
+        expect(filters).toMatchSnapshot();
         filters.unmount();
     });
 
@@ -161,7 +159,7 @@ describe('Filters', () => {
                 expect(Filters.isValid(invalidExpression1, prefix)).toEqual(false);
                 expect(Filters.isValid(invalidExpression2, prefix)).toEqual(false);
 
-                expect(toJson(filters)).toMatchSnapshot();
+                expect(filters).toMatchSnapshot();
                 filters.unmount();
             });
         });
@@ -188,7 +186,7 @@ describe('Filters', () => {
         const dateValues = filters.find('input[type="date"]');
         expect(dateValues.length).toEqual(2);
 
-        expect(toJson(filters)).toMatchSnapshot();
+        expect(filters).toMatchSnapshot();
         filters.unmount();
     });
 

--- a/packages/components/src/components/domainproperties/validation/RangeValidationOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/validation/RangeValidationOptions.spec.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import { INTEGER_TYPE, PropertyValidator } from '../models';
 import { createFormInputId } from '../actions';
@@ -57,7 +56,7 @@ describe('RangeValidationOptions', () => {
 
         expect(RangeValidationOptions.isValid(validatorModel)).toEqual(true);
 
-        expect(toJson(validator)).toMatchSnapshot();
+        expect(validator).toMatchSnapshot();
         validator.unmount();
     });
 
@@ -86,7 +85,7 @@ describe('RangeValidationOptions', () => {
             'Test range validator: Is Greater Than 0 and Is Less Than 10'
         );
 
-        expect(toJson(validator)).toMatchSnapshot();
+        expect(validator).toMatchSnapshot();
         validator.unmount();
     });
 });

--- a/packages/components/src/components/domainproperties/validation/RegexValidationOptions.spec.tsx
+++ b/packages/components/src/components/domainproperties/validation/RegexValidationOptions.spec.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import { INTEGER_TYPE, PropertyValidator } from '../models';
 import { createFormInputId } from '../actions';
@@ -61,7 +60,7 @@ describe('RegexValidationOptions', () => {
 
         expect(RegexValidationOptions.isValid(validatorModel)).toEqual(true);
 
-        expect(toJson(validator)).toMatchSnapshot();
+        expect(validator).toMatchSnapshot();
         validator.unmount();
     });
 
@@ -88,7 +87,7 @@ describe('RegexValidationOptions', () => {
         const collapsed = validator.find({ id: 'domain-regex-validator-' + validatorIndex });
         expect(collapsed.children().children().text()).toEqual('Test Validator: $[abc]');
 
-        expect(toJson(validator)).toMatchSnapshot();
+        expect(validator).toMatchSnapshot();
         validator.unmount();
     });
 });

--- a/packages/components/src/components/navigation/ProductMenuSection.spec.tsx
+++ b/packages/components/src/components/navigation/ProductMenuSection.spec.tsx
@@ -15,7 +15,6 @@
  */
 import React from 'react';
 import { mount } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { List } from 'immutable';
 
 import { AppURL } from '../../url/AppURL';
@@ -66,19 +65,6 @@ describe('ProductMenuSection render', () => {
         },
     ]);
 
-    const yourItems = List<MenuSectionModel>([
-        {
-            id: 21,
-            label: 'Documentation',
-        },
-    ]);
-
-    const yourItemsSection = MenuSectionModel.create({
-        label: 'Your Items',
-        items: yourItems,
-        key: 'user',
-    });
-
     test('empty section no text', () => {
         const section = MenuSectionModel.create({
             label: 'Sample Sets',
@@ -100,7 +86,7 @@ describe('ProductMenuSection render', () => {
         );
 
         expect(menuSection.find('li').length).toBe(0);
-        expect(toJson(menuSection)).toMatchSnapshot();
+        expect(menuSection).toMatchSnapshot();
     });
 
     test('empty section with empty text and create link', () => {
@@ -126,7 +112,7 @@ describe('ProductMenuSection render', () => {
 
         expect(menuSection.find('li.empty-section').length).toBe(1);
         expect(menuSection.contains('Test empty text')).toBe(true);
-        expect(toJson(menuSection)).toMatchSnapshot();
+        expect(menuSection).toMatchSnapshot();
     });
 
     test('section with custom headerURL and headerText', () => {
@@ -151,7 +137,7 @@ describe('ProductMenuSection render', () => {
             />
         );
 
-        expect(toJson(menuSection)).toMatchSnapshot();
+        expect(menuSection).toMatchSnapshot();
     });
 
     test('one-column section', () => {
@@ -177,7 +163,7 @@ describe('ProductMenuSection render', () => {
             />
         );
         expect(menuSection.find('ul').length).toBe(1);
-        expect(toJson(menuSection)).toMatchSnapshot();
+        expect(menuSection).toMatchSnapshot();
         menuSection.unmount();
     });
 
@@ -201,13 +187,12 @@ describe('ProductMenuSection render', () => {
         );
 
         expect(menuSection.find('ul').length).toBe(2);
-        expect(toJson(menuSection)).toMatchSnapshot();
+        expect(menuSection).toMatchSnapshot();
         menuSection.unmount();
     });
 
     test('two columns with overflow link', () => {
         const productId = 'testProductOverflowLink';
-        const sections = List<MenuSectionModel>().asMutable();
 
         const section = new MenuSectionModel({
             label: 'Assays',
@@ -227,7 +212,7 @@ describe('ProductMenuSection render', () => {
         );
         expect(menuSection.find('ul').length).toBe(2);
         expect(menuSection.find('span.overflow-link').length).toBe(1);
-        expect(toJson(menuSection)).toMatchSnapshot();
+        expect(menuSection).toMatchSnapshot();
         menuSection.unmount();
     });
 });


### PR DESCRIPTION
#### Rationale
Removes redundant usages of the `enzyme-to-json` package as it is already configured via `package.json` when setting the `snapshotSerializers`.

```json
"snapshotSerializers": [
  "enzyme-to-json/serializer"
],
```

**Note!** Since this PR only touches test files I do not plan on bumping the package version.

#### Changes
* Remove explicit calls to `enzyme-to-json` in favor of implicit configuration declaration.
