### PR TITLE
20.7 - Fix 38711

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.71.4-20.7-fb-fix-38711.1",
+  "version": "0.71.4-20.7-fb-fix-38711.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.71.4-20.7-fb-fix-38711.2",
+  "version": "0.71.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.71.3",
+  "version": "0.71.4-20.7-fb-fix-38711.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.71.4
+*Released*: 26 August 2020
+* Issue 38711: Biologics: when uploading assay data from an assay request, assay request ID isn't maintained
+
 ### version 0.71.3
 *Released*: 8 July 2020
 * Issue 40795: Query metadata editor should allow editing type of field in built in table

--- a/packages/components/src/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/components/assay/AssayImportPanels.tsx
@@ -262,6 +262,17 @@ class AssayImportPanelsImpl extends React.Component<Props, State> {
         }
     }
 
+    populateAssayRequest(runProperties): Map<string, any> {
+        // Need to pre-populate the run properties form with assayRequest if it is present on the URL (see issue 38711)
+        const assayRequest = this.props.location.query.assayRequest;
+
+        if (assayRequest !== undefined) {
+            return runProperties.set('assayRequest', assayRequest);
+        }
+
+        return runProperties;
+    }
+
     onGetQueryDetailsComplete() {
         const { assayDefinition, location } = this.props;
         const sampleColumnData = assayDefinition.getSampleColumn();
@@ -272,7 +283,7 @@ class AssayImportPanelsImpl extends React.Component<Props, State> {
             // samples.
             this.props.loadSelections(location, sampleColumnData.column).then(samples => {
                 // Only one sample can be added at batch or run level, so ignore selected samples if multiple are selected.
-                let runProperties = this.getRunPropertiesRow(this.props);
+                let runProperties = this.populateAssayRequest(this.getRunPropertiesRow(this.props));
                 let batchProperties = this.getBatchPropertiesRow(this.props);
                 if (sampleColumnData && samples && samples.size == 1) {
                     const { column, domain } = sampleColumnData;
@@ -307,7 +318,7 @@ class AssayImportPanelsImpl extends React.Component<Props, State> {
                     model: state.model.merge({
                         isInit: this.isRunPropertiesInit(this.props),
                         batchProperties: this.getBatchPropertiesRow(this.props),
-                        runProperties: this.getRunPropertiesRow(this.props),
+                        runProperties: this.populateAssayRequest(this.getRunPropertiesRow(this.props)),
                     }) as AssayWizardModel,
                 }),
                 this.onInitModelComplete


### PR DESCRIPTION
#### Rationale
With Biologics recently updated to use AssayImportPanels Issue 38711 was re-introduced. I have updated AssayImportPanels to inject the assayRequest id if it is on the URL.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/658

#### Changes
* Inject the assayRequest ID into the runProperties data if it is on the URL
