### PR TITLE
Use QueryModel in query pages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.91.6-fb-biologics-query-pages.1",
+  "version": "0.91.6-fb-biologics-query-pages.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.91.6-fb-biologics-query-pages.0",
+  "version": "0.91.6-fb-biologics-query-pages.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.91.5",
+  "version": "0.91.6-fb-biologics-query-pages.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.91.6-fb-biologics-query-pages.2",
+  "version": "0.91.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.91.6
+*Released*: 9 September 2020
+* Use QueryModel in query pages
+
 ### version 0.91.5
 *Released*: 4 September 2020
 * Updates to EditableGrid data processing functions to fix issues with boolean values

--- a/packages/components/src/components/base/LoadingSpinner.tsx
+++ b/packages/components/src/components/base/LoadingSpinner.tsx
@@ -13,22 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, ReactNode, memo } from 'react';
+import React from 'react';
 
-interface Props {
-    msg?: ReactNode;
+interface SpinnerProps {
+    msg?: React.ReactNode;
     wrapperClassName?: string;
 }
 
-export const LoadingSpinner: FC<Props> = memo(({ msg, wrapperClassName }) => {
-    return (
-        <span className={wrapperClassName}>
-            <i aria-hidden="true" className="fa fa-spinner fa-pulse" /> {msg}
-        </span>
-    );
-});
+export class LoadingSpinner extends React.PureComponent<SpinnerProps, any> {
+    static defaultProps = {
+        msg: 'Loading...',
+        wrapperClassName: '',
+    };
 
-LoadingSpinner.defaultProps = {
-    msg: 'Loading...',
-    wrapperClassName: '',
-};
+    render() {
+        const { msg, wrapperClassName } = this.props;
+
+        return (
+            <span className={wrapperClassName}>
+                <i aria-hidden="true" className="fa fa-spinner fa-pulse" /> {msg}
+            </span>
+        );
+    }
+}

--- a/packages/components/src/components/base/LoadingSpinner.tsx
+++ b/packages/components/src/components/base/LoadingSpinner.tsx
@@ -13,26 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { FC, ReactNode, memo } from 'react';
 
-interface SpinnerProps {
-    msg?: React.ReactNode;
+interface Props {
+    msg?: ReactNode;
     wrapperClassName?: string;
 }
 
-export class LoadingSpinner extends React.PureComponent<SpinnerProps, any> {
-    static defaultProps = {
-        msg: 'Loading...',
-        wrapperClassName: '',
-    };
+export const LoadingSpinner: FC<Props> = memo(({ msg, wrapperClassName }) => {
+    return (
+        <span className={wrapperClassName}>
+            <i aria-hidden="true" className="fa fa-spinner fa-pulse" /> {msg}
+        </span>
+    );
+});
 
-    render() {
-        const { msg, wrapperClassName } = this.props;
-
-        return (
-            <span className={wrapperClassName}>
-                <i aria-hidden="true" className="fa fa-spinner fa-pulse" /> {msg}
-            </span>
-        );
-    }
-}
+LoadingSpinner.defaultProps = {
+    msg: 'Loading...',
+    wrapperClassName: '',
+};

--- a/packages/components/src/components/listing/pages/QueryDetailPage.tsx
+++ b/packages/components/src/components/listing/pages/QueryDetailPage.tsx
@@ -1,112 +1,105 @@
 /*
- * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * Copyright (c) 2016-2020 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { Component, ReactNode } from 'react';
+import React, { PureComponent, ReactNode } from 'react';
+import { fromJS } from 'immutable';
 import { Link, WithRouterProps } from 'react-router';
-
 import {
-    getStateQueryGridModel,
-    QueryGridModel,
+    AppURL,
+    BreadcrumbCreate,
+    DetailPanel,
+    InjectedQueryModels,
+    LoadingPage,
+    Page,
+    PageHeader,
     SchemaQuery,
     SCHEMAS,
-    getQueryGridModel,
-    gridInit,
-    Page,
-    BreadcrumbCreate,
-    AppURL,
-    PageHeader,
-    Detail,
-    resolveDetailRenderer,
-    LoadingSpinner,
 } from '../../..';
 
-export class QueryDetailPage extends Component<WithRouterProps> {
-    componentDidMount = (): void => {
-        this.initModel();
-    };
+// Importing "withQueryModels" from "../.." causes a circular dependency break...
+import { withQueryModels } from '../../../QueryModel/withQueryModels';
 
-    componentDidUpdate = (prevProps: Readonly<WithRouterProps>): void => {
-        if (prevProps.location?.pathname !== this.props.location?.pathname) {
-            this.initModel();
-        }
-    };
+interface BodyProps {
+    id: string;
+}
 
-    initModel = (): void => {
-        gridInit(this.getQueryGridModel(), true, this);
-    };
-
-    getQueryGridModel = (): QueryGridModel => {
-        const { params } = this.props;
-        const { schema, query, id } = params;
-        const model = getStateQueryGridModel(
-            'querydetail',
-            SchemaQuery.create(schema, query),
-            {
-                allowSelection: false,
-                requiredColumns: SCHEMAS.CBMB,
-            },
-            id
-        );
-
-        return getQueryGridModel(model.getId()) || model;
-    };
-
-    title = (row: any): string => {
-        const model = this.getQueryGridModel();
-        const queryInfo = model.queryInfo;
+class DetailBodyImpl extends PureComponent<BodyProps & InjectedQueryModels> {
+    get title(): string {
+        const { id, queryModels } = this.props;
+        const model = queryModels[id];
+        const { gridData, hasRows, queryInfo } = model;
         let title: string;
 
-        if (queryInfo) {
-            // default to titleColumn
-            if (queryInfo.titleColumn && row) {
-                title =
-                    row.getIn([queryInfo.titleColumn, 'formattedValue']) ||
-                    row.getIn([queryInfo.titleColumn, 'displayValue']) ||
-                    row.getIn([queryInfo.titleColumn, 'value']);
+        if (queryInfo && hasRows) {
+            const row = gridData[0];
+            const { queryLabel, titleColumn } = queryInfo;
+            let potentialValues = [];
+
+            if (titleColumn && row[titleColumn]) {
+                const { displayValue, formattedValue, value } = row[titleColumn];
+                potentialValues = potentialValues.concat([formattedValue, displayValue, value]);
             }
 
-            // secondary to queryLabel
-            if (!title && queryInfo.queryLabel && row) {
-                title =
-                    row.getIn([queryInfo.queryLabel, 'formattedValue']) ||
-                    row.getIn([queryInfo.queryLabel, 'displayValue']) ||
-                    row.getIn([queryInfo.queryLabel, 'value']);
+            if (queryLabel && row[queryLabel]) {
+                const { displayValue, formattedValue, value } = row[queryLabel];
+                potentialValues = potentialValues.concat([formattedValue, displayValue, value]);
             }
+
+            title = potentialValues.find(v => v !== undefined && v !== null);
         }
 
-        // lastly, just show the id
-        if (!title) {
-            title = `<${model.keyValue}>`;
+        if (title === undefined) {
+            title = `<${id}>`;
         }
 
         return title;
-    };
+    }
 
-    render = (): ReactNode => {
-        const model = this.getQueryGridModel();
+    render(): ReactNode {
+        const { actions, id, queryModels } = this.props;
+        const model = queryModels[id];
 
-        if (model && model.isLoaded) {
-            const queryInfo = model.queryInfo;
-            const row = model.getRow();
-            const title = this.title(row);
-            const pageTitle = queryInfo.schemaLabel + ' - ' + queryInfo.plural + ' ' + title;
-
-            return (
-                <Page title={pageTitle} hasHeader={true}>
-                    <BreadcrumbCreate row={row}>
-                        <Link to={AppURL.create('q').toString()}>Schemas</Link>
-                        <Link to={AppURL.create('q', queryInfo.schemaName).toString()}>{queryInfo.schemaLabel}</Link>
-                        <Link to={AppURL.create('q', queryInfo.schemaName, queryInfo.name).toString()}>
-                            {queryInfo.plural}
-                        </Link>
-                    </BreadcrumbCreate>
-                    <PageHeader title={title} />
-                    <Detail queryModel={model} detailRenderer={resolveDetailRenderer} asPanel={true} />
-                </Page>
-            );
+        if (model.isLoading) {
+            return <LoadingPage title="Query Details" />;
         }
 
-        return <LoadingSpinner />;
-    };
+        const { queryInfo } = model;
+        const { name, plural, schemaLabel, schemaName } = queryInfo;
+        const title = this.title;
+        const pageTitle = schemaLabel + ' - ' + plural + ' ' + title;
+        const row = fromJS(model.gridData[0]);
+
+        return (
+            <Page hasHeader={true} title={pageTitle}>
+                <BreadcrumbCreate row={row}>
+                    <Link to={AppURL.create('q').toString()}>Schemas</Link>
+                    <Link to={AppURL.create('q', schemaName).toString()}>{schemaLabel}</Link>
+                    <Link to={AppURL.create('q', schemaName, name).toString()}>{plural}</Link>
+                </BreadcrumbCreate>
+                <PageHeader title={title} />
+                <DetailPanel actions={actions} asPanel model={model} />
+            </Page>
+        );
+    }
+}
+
+const DetailBody = withQueryModels<BodyProps>(DetailBodyImpl);
+
+export class QueryDetailPage extends PureComponent<WithRouterProps> {
+    render(): ReactNode {
+        const { schema, query, id } = this.props.params;
+        const modelId = `q.details.${schema}.${query}.${id}`;
+        const queryConfigs = {
+            [modelId]: {
+                bindURL: true,
+                keyValue: id,
+                requiredColumns: SCHEMAS.CBMB.toArray(),
+                schemaQuery: SchemaQuery.create(schema, query),
+            },
+        };
+
+        // Key is needed so if the user navigates directly from one detail page to another we trigger a remount/reload
+        return <DetailBody autoLoad id={modelId} key={modelId} queryConfigs={queryConfigs} />;
+    }
 }

--- a/packages/components/src/components/listing/pages/QueryListingPage.tsx
+++ b/packages/components/src/components/listing/pages/QueryListingPage.tsx
@@ -1,68 +1,49 @@
 /*
- * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * Copyright (c) 2016-2020 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { Component, ReactNode } from 'react';
+import React, { FC, memo } from 'react';
 import { Link, WithRouterProps } from 'react-router';
-import { Query } from '@labkey/api';
 
-import {
-    getStateQueryGridModel,
-    gridInit,
-    QueryGridModel,
-    SchemaQuery,
-    getQueryGridModel,
-    Page,
-    Breadcrumb,
-    PageHeader,
-    AppURL,
-    QueryGridPanel,
-} from '../../..';
+import { AppURL, SchemaQuery, Breadcrumb, InjectedQueryModels, GridPanel, Page, PageHeader } from '../../..';
 
-export class QueryListingPage extends Component<WithRouterProps> {
-    componentDidMount = (): void => {
-        this.initModel();
-    };
+// Importing "withQueryModels" from "../.." causes a circular dependency break...
+import { withQueryModels } from '../../../QueryModel/withQueryModels';
 
-    componentDidUpdate = (prevProps: Readonly<WithRouterProps>): void => {
-        if (prevProps.location?.pathname !== this.props.location?.pathname) {
-            this.initModel();
-        }
-    };
-
-    initModel = (): void => {
-        gridInit(this.getQueryGridModel(), true, this);
-    };
-
-    getQueryGridModel = (): QueryGridModel => {
-        const { location, params } = this.props;
-        const { schema, query } = params;
-
-        const model = getStateQueryGridModel('querylisting', SchemaQuery.create(schema, query), () => ({
-            containerFilter: Query.ContainerFilter[location.query.containerFilter as string],
-            isPaged: true,
-        }));
-        return getQueryGridModel(model.getId()) || model;
-    };
-
-    render = (): ReactNode => {
-        const model = this.getQueryGridModel();
-        const queryInfo = model.queryInfo;
-
-        const schemaTitle = queryInfo ? queryInfo.schemaLabel : model.schema;
-        const title = queryInfo ? queryInfo.queryLabel : model.query;
-
-        return (
-            <Page title={'Query - ' + schemaTitle + '.' + title} hasHeader={true}>
-                {queryInfo !== undefined && (
-                    <Breadcrumb>
-                        <Link to={AppURL.create('q').toString()}>Schemas</Link>
-                        <Link to={AppURL.create('q', queryInfo.schemaName).toString()}>{schemaTitle}</Link>
-                    </Breadcrumb>
-                )}
-                <PageHeader title={title} />
-                <QueryGridPanel model={model} />
-            </Page>
-        );
-    };
+interface BodyProps {
+    id: string;
 }
+
+const QueryListingBodyImpl: FC<BodyProps & InjectedQueryModels> = memo(({ actions, id, queryModels }) => {
+    const model = queryModels[id];
+    const { queryInfo } = model;
+    const schemaTitle = queryInfo?.schemaLabel ?? '';
+    const title = queryInfo?.queryLabel ?? '';
+
+    return (
+        <Page hasHeader={true} title={`Query - ${schemaTitle}.${title}`}>
+            {queryInfo !== undefined && (
+                <Breadcrumb>
+                    <Link to={AppURL.create('q').toString()}>Schemas</Link>
+                    <Link to={AppURL.create('q', queryInfo.schemaName).toString()}>{schemaTitle}</Link>
+                </Breadcrumb>
+            )}
+
+            <PageHeader title={title} />
+
+            <GridPanel actions={actions} model={model} />
+        </Page>
+    );
+});
+
+const QueryListingBody = withQueryModels<BodyProps>(QueryListingBodyImpl);
+
+export const QueryListingPage: FC<WithRouterProps> = ({ params }) => {
+    const { schema, query } = params;
+    const modelId = `q.${schema}.${query}`;
+    const queryConfigs = { [modelId]: { bindURL: true, schemaQuery: SchemaQuery.create(schema, query) } };
+
+    // Key is used here so that if the schema or query change via the URL we remount the component which will
+    // instantiate a new model and reload all page data.
+    return <QueryListingBody id={modelId} key={modelId} queryConfigs={queryConfigs} />;
+};

--- a/packages/components/src/components/listing/pages/QueryListingPage.tsx
+++ b/packages/components/src/components/listing/pages/QueryListingPage.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-2020 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, memo } from 'react';
+import React, { FC, memo, useMemo } from 'react';
 import { Link, WithRouterProps } from 'react-router';
 
 import { AppURL, SchemaQuery, Breadcrumb, InjectedQueryModels, GridPanel, Page, PageHeader } from '../../..';
@@ -41,7 +41,12 @@ const QueryListingBody = withQueryModels<BodyProps>(QueryListingBodyImpl);
 export const QueryListingPage: FC<WithRouterProps> = ({ params }) => {
     const { schema, query } = params;
     const modelId = `q.${schema}.${query}`;
-    const queryConfigs = { [modelId]: { bindURL: true, schemaQuery: SchemaQuery.create(schema, query) } };
+    const queryConfigs = useMemo(
+        () => ({
+            [modelId]: { bindURL: true, schemaQuery: SchemaQuery.create(schema, query) },
+        }),
+        [modelId]
+    );
 
     // Key is used here so that if the schema or query change via the URL we remount the component which will
     // instantiate a new model and reload all page data.


### PR DESCRIPTION
#### Rationale
The implementation for the `/q` route pages in Biologics were recently updated by @labkey-alan to use `QueryModel`. This PR migrates these implementations into their corollary in `@labkey/components`.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/671
* https://github.com/LabKey/sampleManagement/pull/359
* https://github.com/LabKey/inventory/pull/85

#### Changes
* `QueryListingPage` and `QueryDetailPage` refactored to use `QueryModel` approach.
