### PR TITLE
Issues 41327 and 37931: Add optional verb property to delete confirmation and update formatting for DetailDisplay

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.1-fmDeleteSample-41327.0",
+  "version": "0.92.1-fmDeleteSample-41327.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.2-fmDeleteSample-41327.2",
+  "version": "0.92.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.0",
+  "version": "0.92.1-fmDeleteSample-41327.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.2-fmDeleteSample-41327.1",
+  "version": "0.92.2-fmDeleteSample-41327.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add optional verb property to EntityDeleteConfirmModal
+
 ### version 0.92.0
 *Released*: 10 September 2020
 * Update FieldEditTrigger

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.92.2
+*Released*: 14 September 2020
 * Add optional verb property to EntityDeleteConfirmModal
 * Add styling to DetailDisplay to preserve line breaks
 

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Add optional verb property to EntityDeleteConfirmModal
+* Add styling to DetailDisplay to preserve line breaks
 
 ### version 0.92.0
 *Released*: 10 September 2020

--- a/packages/components/src/components/__snapshots__/QueryGridPanel.spec.tsx.snap
+++ b/packages/components/src/components/__snapshots__/QueryGridPanel.spec.tsx.snap
@@ -3115,7 +3115,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3124,7 +3126,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3146,7 +3150,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span>
+                  <span
+                    className="detail-display"
+                  >
                     2019-08-07 13:18
                   </span>
                 </td>
@@ -3170,7 +3176,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3179,7 +3187,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span>
+                  <span
+                    className="detail-display"
+                  >
                     reimport run 2
                   </span>
                 </td>
@@ -3190,7 +3200,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3199,7 +3211,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3208,7 +3222,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3217,7 +3233,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3226,7 +3244,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
                 <td
                   style={
@@ -3235,7 +3255,9 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                     }
                   }
                 >
-                  <span />
+                  <span
+                    className="detail-display"
+                  />
                 </td>
               </tr>
             </tbody>

--- a/packages/components/src/components/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/components/entities/EntityDeleteConfirmModal.tsx
@@ -29,6 +29,7 @@ interface Props {
     entityDataType: EntityDataType;
     rowIds?: string[];
     selectionKey?: string;
+    verb?: string
 }
 
 interface State {
@@ -116,6 +117,7 @@ export class EntityDeleteConfirmModal extends React.Component<Props, State> {
                 confirmationData={this.state.confirmationData}
                 onConfirm={onConfirm}
                 onCancel={onCancel}
+                verb={this.props.verb}
                 entityDataType={entityDataType}
             />
         );

--- a/packages/components/src/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -26,6 +26,7 @@ interface Props {
     onCancel: () => any;
     confirmationData: DeleteConfirmationData;
     entityDataType: EntityDataType;
+    verb?: string
 }
 
 /**
@@ -35,8 +36,12 @@ interface Props {
  * different confirmation data scenarios.
  */
 export class EntityDeleteConfirmModalDisplay extends React.Component<Props, any> {
+    static defaultProps = {
+        verb: 'deleted'
+    }
+
     getConfirmationProperties(): { message: any; title: string; canDelete: boolean } {
-        const { confirmationData, entityDataType } = this.props;
+        const { confirmationData, entityDataType, verb } = this.props;
         const { deleteHelpLinkTopic, nounSingular, nounPlural, dependencyText } = entityDataType;
 
         if (!confirmationData) return undefined;
@@ -57,7 +62,7 @@ export class EntityDeleteConfirmModalDisplay extends React.Component<Props, any>
                 ' are no longer valid.';
         } else if (numCannotDelete === 0) {
             text = totalNum === 1 ? 'The selected ' : totalNum === 2 ? 'Both ' : 'All ' + totalNum + ' ';
-            text += totalNoun + ' will be permanently deleted.';
+            text += totalNoun + ' will be permanently ' + verb + '.';
         } else if (numCanDelete === 0) {
             if (totalNum === 1) {
                 text =
@@ -68,7 +73,7 @@ export class EntityDeleteConfirmModalDisplay extends React.Component<Props, any>
                 text += ' because they have ' + dependencyText + '.';
             }
         } else {
-            text = "You've selected " + totalNum + ' ' + totalNoun + ' but only ' + numCanDelete + ' can be deleted.  ';
+            text = "You've selected " + totalNum + ' ' + totalNoun + ' but only ' + numCanDelete + ' can be ' + verb + '.  ';
             text += numCannotDelete + ' ' + cannotDeleteNoun + ' cannot be deleted because ';
             text += (numCannotDelete === 1 ? ' it has ' : ' they have ') + dependencyText + '.';
         }

--- a/packages/components/src/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -73,7 +73,7 @@ export class EntityDeleteConfirmModalDisplay extends React.Component<Props, any>
                 text += ' because they have ' + dependencyText + '.';
             }
         } else {
-            text = "You've selected " + totalNum + ' ' + totalNoun + ' but only ' + numCanDelete + ' can be ' + verb + '.  ';
+            text = "You've selected " + totalNum + ' ' + totalNoun + ' but only ' + numCanDelete + ' can be ' + verb + '. ';
             text += numCannotDelete + ' ' + cannotDeleteNoun + ' cannot be deleted because ';
             text += (numCannotDelete === 1 ? ' it has ' : ' they have ') + dependencyText + '.';
         }

--- a/packages/components/src/components/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/components/entities/EntityDeleteModal.tsx
@@ -23,6 +23,7 @@ interface Props {
     onCancel: () => any;
     entityDataType: EntityDataType;
     auditBehavior?: AuditBehaviorTypes;
+    verb?: string
 }
 
 export const EntityDeleteModal: React.FC<Props> = (props) => {
@@ -103,6 +104,7 @@ export const EntityDeleteModal: React.FC<Props> = (props) => {
                     onConfirm={onConfirm}
                     onCancel={onCancel}
                     entityDataType={entityDataType}
+                    verb={props.verb}
                 />
             )}
             <Progress

--- a/packages/components/src/components/forms/FieldEditorOverlay.tsx
+++ b/packages/components/src/components/forms/FieldEditorOverlay.tsx
@@ -229,7 +229,7 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
                         <span className={haveValues ? 'field__set' : 'field__unset'}>
                             <span title={'Edit ' + caption} className="field-edit__icon fa fa-pencil-square-o" />
                             {showIconText && (
-                                <span title={fieldValue}>
+                                <span className="detail-display" title={fieldValue}>
                                     {haveValues
                                         ? fieldValue
                                             ? fieldValue
@@ -240,7 +240,7 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
                         </span>
                     </OverlayTrigger>
                 )}
-                {!canUpdate && showValueOnNotAllowed && <span title={fieldValue}>{fieldValue}</span>}
+                {!canUpdate && showValueOnNotAllowed && <span className="detail-display" title={fieldValue}>{fieldValue}</span>}
             </>
         );
     }

--- a/packages/components/src/components/forms/detail/__snapshots__/Detail.spec.tsx.snap
+++ b/packages/components/src/components/forms/detail/__snapshots__/Detail.spec.tsx.snap
@@ -29,7 +29,9 @@ exports[`<Detail/> asPanel 1`] = `
               data-caption="Flag"
               data-fieldkey="flag"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 
               </span>
             </td>
@@ -46,7 +48,9 @@ exports[`<Detail/> asPanel 1`] = `
               data-caption="For set 3"
               data-fieldkey="for set 3"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 abc
               </span>
             </td>
@@ -63,7 +67,9 @@ exports[`<Detail/> asPanel 1`] = `
               data-caption="Again for set 3"
               data-fieldkey="again for set 3"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 false
               </span>
             </td>
@@ -80,7 +86,9 @@ exports[`<Detail/> asPanel 1`] = `
               data-caption="Another"
               data-fieldkey="another"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 test test
               </span>
             </td>
@@ -142,7 +150,9 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-caption="Flag"
           data-fieldkey="flag"
         >
-          <span>
+          <span
+            className="detail-display"
+          >
             
           </span>
         </td>
@@ -159,7 +169,9 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-caption="For set 3"
           data-fieldkey="for set 3"
         >
-          <span>
+          <span
+            className="detail-display"
+          >
             abc
           </span>
         </td>
@@ -176,7 +188,9 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-caption="Again for set 3"
           data-fieldkey="again for set 3"
         >
-          <span>
+          <span
+            className="detail-display"
+          >
             false
           </span>
         </td>
@@ -193,7 +207,9 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-caption="Another"
           data-fieldkey="another"
         >
-          <span>
+          <span
+            className="detail-display"
+          >
             test test
           </span>
         </td>

--- a/packages/components/src/components/forms/detail/__snapshots__/DetailEditing.spec.tsx.snap
+++ b/packages/components/src/components/forms/detail/__snapshots__/DetailEditing.spec.tsx.snap
@@ -33,7 +33,9 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-caption="Flag"
               data-fieldkey="flag"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 
               </span>
             </td>
@@ -50,7 +52,9 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-caption="For set 3"
               data-fieldkey="for set 3"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 abc
               </span>
             </td>
@@ -67,7 +71,9 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-caption="Again for set 3"
               data-fieldkey="again for set 3"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 false
               </span>
             </td>
@@ -84,7 +90,9 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-caption="Another"
               data-fieldkey="another"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 test test
               </span>
             </td>
@@ -159,7 +167,9 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-caption="Flag"
               data-fieldkey="flag"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 
               </span>
             </td>
@@ -176,7 +186,9 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-caption="For set 3"
               data-fieldkey="for set 3"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 abc
               </span>
             </td>
@@ -193,7 +205,9 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-caption="Again for set 3"
               data-fieldkey="again for set 3"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 false
               </span>
             </td>
@@ -210,7 +224,9 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-caption="Another"
               data-fieldkey="another"
             >
-              <span>
+              <span
+                className="detail-display"
+              >
                 test test
               </span>
             </td>

--- a/packages/components/src/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/renderers/DefaultRenderer.tsx
@@ -48,6 +48,6 @@ export class DefaultRenderer extends React.Component<any, any> {
             }
         }
 
-        return <span>{display}</span>;
+        return <span className="detail-display">{display}</span>;
     }
 }

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -164,6 +164,7 @@
 .detail__header--desc {
   color: grey;
   font-style: $font-size-small;
+  white-space: pre-wrap;
 }
 
 .detail__header--name {

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -56,6 +56,10 @@
   padding-left: 5px;
 }
 
+.detail-display {
+    white-space: pre-wrap;
+}
+
 .component-detail--child {
   position: absolute;
   width: 5%;


### PR DESCRIPTION
#### Rationale
When deleting samples in sample manager with freezer manager enabled, the deletion causes a cascade of deletions of items from the inventory tables.  We want to be able to customize the message to users so that it says "permanently deleted and removed from storage" vs. just "permanently deleted", so we allow the verb to be customized.

I've also included here a seemingly small styling change for detail display that will preserve line breaks in multi-line detail fields.  I may regret trying to do these two unrelated changes together.  We'll see how unhappy the tests are.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1558
* https://github.com/LabKey/inventory/pull/88
* https://github.com/LabKey/sampleManagement/pull/363

#### Changes
* Add optional verb property to EntityDeleteConfirmModal
* Add styling to DetailDisplay to preserve line breaks