### PR TITLE
@labkey/test: Support multiple containers and users

### DIFF
--- a/packages/components/releaseNotes/labkey/test.md
+++ b/packages/components/releaseNotes/labkey/test.md
@@ -1,6 +1,11 @@
 # @labkey/test
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
+### version 0.0.2
+*Released*: 14 September 2020
+* Support multiple containers and users
+* See https://github.com/LabKey/labkey-ui-components/pull/341
+
 ### version 0.0.1
 *Released*: 31 August 2020
 * Initial module.

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -35,9 +35,10 @@
   },
   "devDependencies": {
     "@labkey/api": "1.1.0",
-    "@types/enzyme": "3.10.5",
-    "@types/jest": "26.0.10",
+    "@types/enzyme": "3.10.6",
+    "@types/jest": "26.0.13",
     "@types/node": "12.0.4",
+    "@types/supertest": "2.0.10",
     "copy-webpack-plugin": "6.1.0",
     "cross-env": "7.0.2",
     "enzyme": "3.11.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.2-fb-test-with-users.2",
+  "version": "0.0.2-fb-test-with-users.3",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.2-fb-test-with-users.3",
+  "version": "0.0.2",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.1",
+  "version": "0.0.2-fb-test-with-users.0",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.2-fb-test-with-users.0",
+  "version": "0.0.2-fb-test-with-users.1",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.2-fb-test-with-users.1",
+  "version": "0.0.2-fb-test-with-users.2",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -16,7 +16,6 @@
 import {
     hookServer,
     IntegrationTestServer,
-    PostRequestOptions,
     RequestOptions,
     SecurityRole,
     successfulResponse
@@ -26,7 +25,6 @@ import { sleep } from './utils';
 export {
     hookServer,
     IntegrationTestServer,
-    PostRequestOptions,
     RequestOptions,
     SecurityRole,
     sleep,

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -13,12 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { hookServer, IntegrationTestServer, successfulResponse } from './integrationUtils';
+import {
+    hookServer,
+    IntegrationTestServer,
+    PostRequestOptions,
+    RequestOptions,
+    successfulResponse
+} from './integrationUtils';
 import { sleep } from './utils';
 
 export {
     hookServer,
     IntegrationTestServer,
+    PostRequestOptions,
+    RequestOptions,
     sleep,
     successfulResponse,
 };

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -18,6 +18,7 @@ import {
     IntegrationTestServer,
     PostRequestOptions,
     RequestOptions,
+    SecurityRole,
     successfulResponse
 } from './integrationUtils';
 import { sleep } from './utils';
@@ -27,6 +28,7 @@ export {
     IntegrationTestServer,
     PostRequestOptions,
     RequestOptions,
+    SecurityRole,
     sleep,
     successfulResponse,
 };

--- a/packages/test/src/integrationUtils.ts
+++ b/packages/test/src/integrationUtils.ts
@@ -65,7 +65,7 @@ export interface RequestOptions {
     requestContext?: RequestContext;
 }
 
-interface PostRequestOptions extends RequestOptions {
+export interface PostRequestOptions extends RequestOptions {
     postProcessor?: (postRequest: any, payload: any) => any;
 }
 
@@ -217,7 +217,7 @@ const init = async (ctx: ServerContext, projectName: string, containerOptions?: 
     if (getProjectResponse.status !== 200) {
         if (getProjectResponse.status === 404) {
             try {
-                project = await _createContainer(ctx, '/', projectName);
+                project = await _createContainer(ctx, '/', projectName, containerOptions);
             }
             catch (e) {
                 throw new Error('Failed to initialize integration test. Unable to create test project.');
@@ -233,7 +233,7 @@ const init = async (ctx: ServerContext, projectName: string, containerOptions?: 
 
     // Create default test container
     try {
-        const testContainer = await createTestContainer(ctx, containerOptions);
+        const testContainer = await createTestContainer(ctx);
         ctx.containerPath = testContainer.path;
     }
     catch (e) {

--- a/packages/test/src/test/example.ispec.ts
+++ b/packages/test/src/test/example.ispec.ts
@@ -79,12 +79,21 @@ describe('query-executeSql.api', () => {
         // Act
         // Make a POST request against the server. Here we expect a to be rejected because the user does not
         // have appropriate permissions.
-        const response = await server
-            .post('query', 'executeSql.api', {
-                schemaName: 'core',
-                sql: 'SELECT Name FROM core.containers',
-            }, noPermissionsUserOptions)
-            .expect(403);
+        const response = await server.request(
+            'query',
+            'executeSql.api',
+            (agent, url) => {
+                return agent
+                    .post(url)
+                    .send({
+                        schemaName: 'core',
+                        sql: 'SELECT Name FROM core.containers',
+                    })
+                    .set('Content-Type', 'application/json')
+                    .expect(403);
+            },
+            noPermissionsUserOptions
+        );
 
         // Assert
         const { exception } = response.body;

--- a/packages/test/yarn.lock
+++ b/packages/test/yarn.lock
@@ -560,10 +560,15 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/enzyme@3.10.5":
-  version "3.10.5"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
-  integrity sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==
+"@types/cookiejar@*":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
+  integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
+
+"@types/enzyme@3.10.6":
+  version "3.10.6"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.6.tgz#a34a6b09ff732be29c194dc8d786555f4717fd85"
+  integrity sha512-Jxyn2U+UfhmrE7EaeZYfV1sPA5OEDuZmg9Lxj8TxOnfCn71flf0Cn1136LWdCVYj7yapLFmUWqKCcgplWNZCJg==
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"
@@ -602,7 +607,15 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.0.10", "@types/jest@26.x":
+"@types/jest@26.0.13":
+  version "26.0.13"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.13.tgz#5a7b9d5312f5dd521a38329c38ee9d3802a0b85e"
+  integrity sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
+"@types/jest@26.x":
   version "26.0.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.10.tgz#8faf7e9756c033c39014ae76a7329efea00ea607"
   integrity sha512-i2m0oyh8w/Lum7wWK/YOZJakYF8Mx08UaKA1CtbmFeDquVhAEdA7znacsVSf2hJ1OQ/OfVMGN90pw/AtzF8s/Q==
@@ -652,6 +665,21 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/superagent@*":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.10.tgz#5e2cc721edf58f64fe9b819f326ee74803adee86"
+  integrity sha512-xAgkb2CMWUMCyVc/3+7iQfOEBE75NvuZeezvmixbUw3nmENf2tCnQkW5yQLTYqvXUQ+R6EXxdqKKbal2zM5V/g==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
+
+"@types/supertest@2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.10.tgz#630d79b4d82c73e043e43ff777a9ca98d457cab7"
+  integrity sha512-Xt8TbEyZTnD5Xulw95GLMOkmjGICrOQyJ2jqgkSjAUR3mm7pAIzSR0NFBaMcwlzVvlpCjNwbATcWWwjNiZiFrQ==
+  dependencies:
+    "@types/superagent" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"


### PR DESCRIPTION
#### Rationale
This PR adds several features to the `@labkey/test` integration test utilities. These are exposed on the `IntegrationTestServer` interface:

* `addUserToRole` - Add a user (by their email address) to a permission's role in a the test container. This allows for testing of users with different permissions in the test container.
* `createRequestContext `- Creates a RequestContext that can be used for subsequent server requests (e.g. get, post). This will initialize the CSRF token to ensure that the server requests authenticate as expected.
* `createTestContainer` - Creates a new Container on the server within the test Project. This allows for testing across multiple containers or creating a separate container for a test suite.
* `createUser` - Create a new user account on the server with the specified credentials. If the account already exists, then the account will be deleted and re-created to ensure credentials and permissions are configured as expected.

See the `example.ispec.ts` for an example of these new features in use.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/679
* https://github.com/LabKey/inventory/pull/90

#### Changes
* Add support for multiple test containers.
* Add support for creating user accounts.
* Add support for assigning a user account to a permission's role.
* Expose the `superagent` agent via a new `request()` method. This is useful for more advanced use cases.
* Remove `postProcessor` paradigm in favor of using `request()`.
* Package updates.
