### PR TITLE
Issue 41278: repeated sample ids in parent dropdown

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.94.0-fb-smXBugFix.2",
+  "version": "0.94.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.2",
+  "version": "0.93.0-fb-smXBugFix.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.94.0-fb-smXBugFix.1",
+  "version": "0.94.0-fb-smXBugFix.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Add getDisambiguatedSelectInputOptions util
+
 ### version 0.92.2
 *Released*: 14 September 2020
 * Add optional verb property to EntityDeleteConfirmModal

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 0.94.0
+*Released*: 16 September 2020
 * Add getDisambiguatedSelectInputOptions util
 
 ### version 0.93.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -47,6 +47,7 @@ import {
     debounce,
     devToolsActive,
     generateId,
+    getDisambiguatedSelectInputOptions,
     getSchemaQuery,
     hasAllPermissions,
     naturalSort,
@@ -696,6 +697,7 @@ export {
     // util functions (TODO: need to see if all of these are still being used outside of this package)
     datePlaceholder,
     getDateFormat,
+    getDisambiguatedSelectInputOptions,
     getUnFormattedNumber,
     formatDate,
     formatDateTime,

--- a/packages/components/src/util/utils.spec.ts
+++ b/packages/components/src/util/utils.spec.ts
@@ -794,7 +794,7 @@ describe('getUpdatedDataFromGrid', () => {
             Name: 'S-20190516-9042',
             Other: 'other1',
             Bool: true,
-            Int: 0
+            Int: 0,
         },
         447: {
             RowId: 447,
@@ -804,7 +804,7 @@ describe('getUpdatedDataFromGrid', () => {
             Name: 'S-20190516-4622',
             Other: 'other2',
             Bool: false,
-            Int: 7
+            Int: 7,
         },
         446: {
             RowId: 446,
@@ -814,7 +814,7 @@ describe('getUpdatedDataFromGrid', () => {
             Name: 'S-20190516-2368',
             Other: 'other3',
             Bool: true,
-            Int: 6
+            Int: 6,
         },
         445: {
             RowId: 445,
@@ -824,7 +824,7 @@ describe('getUpdatedDataFromGrid', () => {
             Name: 'S-20190516-9512',
             Other: null,
             Bool: false,
-            Int: 5
+            Int: 5,
         },
     });
     test('no edited rows', () => {
@@ -844,7 +844,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-9042',
                     Other: 'other1',
                     Bool: true,
-                    Int: 0
+                    Int: 0,
                 }),
                 Map<string, any>({
                     RowId: '447',
@@ -854,7 +854,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-4622',
                     Other: 'other2',
                     Bool: false,
-                    Int: '7'
+                    Int: '7',
                 }),
                 Map<string, any>({
                     RowId: '446',
@@ -864,7 +864,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-2368',
                     Other: 'other3',
                     Bool: true,
-                    Int: '6'
+                    Int: '6',
                 }),
                 Map<string, any>({
                     RowId: '445',
@@ -874,7 +874,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-9512',
                     Other: null,
                     Bool: false,
-                    Int: 5
+                    Int: 5,
                 }),
             ],
             'RowId'
@@ -894,7 +894,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-9042',
                     Other: 'other1',
                     Bool: undefined,
-                    Int: undefined
+                    Int: undefined,
                 }),
                 Map<string, any>({
                     RowId: '447',
@@ -904,7 +904,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-4622',
                     Other: 'other2',
                     Bool: undefined,
-                    Int: undefined
+                    Int: undefined,
                 }),
                 Map<string, any>({
                     RowId: '446',
@@ -914,7 +914,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-2368',
                     Other: 'other3',
                     Bool: true,
-                    Int: 6
+                    Int: 6,
                 }),
                 Map<string, any>({
                     RowId: '445',
@@ -924,7 +924,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-9512',
                     Other: null,
                     Bool: false,
-                    Int: 5
+                    Int: 5,
                 }),
             ],
             'RowId'
@@ -956,7 +956,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-9042',
                     Other: 'other1',
                     Bool: '',
-                    Int: ''
+                    Int: '',
                 }),
                 Map<string, any>({
                     RowId: '447',
@@ -966,7 +966,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-4622',
                     Other: 'other2',
                     Bool: '',
-                    Int: '0'
+                    Int: '0',
                 }),
                 Map<string, any>({
                     RowId: '446',
@@ -976,7 +976,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-2368',
                     Other: 'other3',
                     Bool: false,
-                    Int: 66
+                    Int: 66,
                 }),
                 Map<string, any>({
                     RowId: '445',
@@ -986,7 +986,7 @@ describe('getUpdatedDataFromGrid', () => {
                     Name: 'S-20190516-9512',
                     Other: null,
                     Bool: true,
-                    Int: 5
+                    Int: 5,
                 }),
             ],
             'RowId'
@@ -1137,77 +1137,89 @@ describe('similaritySortFactory', () => {
     });
 });
 
-const sourceOptions = [{
-    "value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6",
-    "label": "Source-1 (sourceType1)"
-}, {
-    "value": "urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14",
-    "label": "Source-1 (sourceType2)"
-}, {
-    "value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6",
-    "label": "Source-2"
-}];
+const sourceOptions = [
+    {
+        value: 'urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6',
+        label: 'Source-1 (sourceType1)',
+    },
+    {
+        value: 'urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14',
+        label: 'Source-1 (sourceType2)',
+    },
+    {
+        value: 'urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6',
+        label: 'Source-2',
+    },
+];
 
 describe('getDisambiguatedSelectInputOptions', () => {
     test('from QueryGridModel data', () => {
-        const rows = [{
-            "links": null,
-            "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6"},
-            "SourceType": {"url": "#/rd/dataclass/sourceType1", "value": "sourceType1"},
-            "rowId": {"value": 57},
-            "Name": {"value": "Source-1"}
-        }, {
-            "links": null,
-            "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6"},
-            "SourceType": {"url": "#/rd/dataclass/sourceType1", "value": "sourceType1"},
-            "rowId": {"value": 58},
-            "Name": {"value": "Source-2"}
-        }, {
-            "links": null,
-            "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14"},
-            "SourceType": {"url": "#/rd/dataclass/sourceType2", "value": "sourceType2"},
-            "rowId": {"value": 65},
-            "Name": {"value": "Source-1"}
-        }];
+        const rows = [
+            {
+                links: null,
+                lsid: { value: 'urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6' },
+                SourceType: { url: '#/rd/dataclass/sourceType1', value: 'sourceType1' },
+                rowId: { value: 57 },
+                Name: { value: 'Source-1' },
+            },
+            {
+                links: null,
+                lsid: { value: 'urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6' },
+                SourceType: { url: '#/rd/dataclass/sourceType1', value: 'sourceType1' },
+                rowId: { value: 58 },
+                Name: { value: 'Source-2' },
+            },
+            {
+                links: null,
+                lsid: { value: 'urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14' },
+                SourceType: { url: '#/rd/dataclass/sourceType2', value: 'sourceType2' },
+                rowId: { value: 65 },
+                Name: { value: 'Source-1' },
+            },
+        ];
 
-        expect(getDisambiguatedSelectInputOptions(fromJS(rows), 'lsid', 'Name', 'SourceType')).toEqual(expect.arrayContaining([
-            expect.objectContaining(sourceOptions[0]),
-            expect.objectContaining(sourceOptions[1]),
-            expect.objectContaining(sourceOptions[2])
-        ]));
+        expect(getDisambiguatedSelectInputOptions(fromJS(rows), 'lsid', 'Name', 'SourceType')).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining(sourceOptions[0]),
+                expect.objectContaining(sourceOptions[1]),
+                expect.objectContaining(sourceOptions[2]),
+            ])
+        );
     });
 
     test('from selectRows result', () => {
         const rows = {
-            "0": {
-                "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6"},
-                "SourceType": {
-                    "value": "sourceType1"
+            '0': {
+                lsid: { value: 'urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6' },
+                SourceType: {
+                    value: 'sourceType1',
                 },
-                "rowId": {"value": 57},
-                "Name": {"value": "Source-1"}
+                rowId: { value: 57 },
+                Name: { value: 'Source-1' },
             },
-            "1": {
-                "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6"},
-                "SourceType": {
-                    "value": "sourceType1"
+            '1': {
+                lsid: { value: 'urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6' },
+                SourceType: {
+                    value: 'sourceType1',
                 },
-                "rowId": {"value": 58},
-                "Name": {"value": "Source-2"}
+                rowId: { value: 58 },
+                Name: { value: 'Source-2' },
             },
-            "2": {
-                "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14"},
-                "SourceType": {
-                    "value": "sourceType2"
+            '2': {
+                lsid: { value: 'urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14' },
+                SourceType: {
+                    value: 'sourceType2',
                 },
-                "rowId": {"value": 65},
-                "Name": {"value": "Source-1"}
-            }
-        }
-        expect(getDisambiguatedSelectInputOptions(rows, 'lsid', 'Name', 'SourceType')).toEqual(expect.arrayContaining([
-            expect.objectContaining(sourceOptions[0]),
-            expect.objectContaining(sourceOptions[1]),
-            expect.objectContaining(sourceOptions[2])
-        ]));
+                rowId: { value: 65 },
+                Name: { value: 'Source-1' },
+            },
+        };
+        expect(getDisambiguatedSelectInputOptions(rows, 'lsid', 'Name', 'SourceType')).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining(sourceOptions[0]),
+                expect.objectContaining(sourceOptions[1]),
+                expect.objectContaining(sourceOptions[2]),
+            ])
+        );
     });
 });

--- a/packages/components/src/util/utils.spec.ts
+++ b/packages/components/src/util/utils.spec.ts
@@ -31,6 +31,7 @@ import {
     caseInsensitive,
     contains,
     getCommonDataValues,
+    getDisambiguatedSelectInputOptions,
     getSchemaQuery,
     getUpdatedData,
     getUpdatedDataFromGrid,
@@ -1133,5 +1134,80 @@ describe('similaritySortFactory', () => {
         // case-sensitive
         result = getValues().sort(similaritySortFactory('s-1', true));
         expect(result[0]).toEqual('6S-1'); // degrade to natural sort
+    });
+});
+
+const sourceOptions = [{
+    "value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6",
+    "label": "Source-1 (sourceType1)"
+}, {
+    "value": "urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14",
+    "label": "Source-1 (sourceType2)"
+}, {
+    "value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6",
+    "label": "Source-2"
+}];
+
+describe('getDisambiguatedSelectInputOptions', () => {
+    test('from QueryGridModel data', () => {
+        const rows = [{
+            "links": null,
+            "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6"},
+            "SourceType": {"url": "#/rd/dataclass/sourceType1", "value": "sourceType1"},
+            "rowId": {"value": 57},
+            "Name": {"value": "Source-1"}
+        }, {
+            "links": null,
+            "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6"},
+            "SourceType": {"url": "#/rd/dataclass/sourceType1", "value": "sourceType1"},
+            "rowId": {"value": 58},
+            "Name": {"value": "Source-2"}
+        }, {
+            "links": null,
+            "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14"},
+            "SourceType": {"url": "#/rd/dataclass/sourceType2", "value": "sourceType2"},
+            "rowId": {"value": 65},
+            "Name": {"value": "Source-1"}
+        }];
+
+        expect(getDisambiguatedSelectInputOptions(fromJS(rows), 'lsid', 'Name', 'SourceType')).toEqual(expect.arrayContaining([
+            expect.objectContaining(sourceOptions[0]),
+            expect.objectContaining(sourceOptions[1]),
+            expect.objectContaining(sourceOptions[2])
+        ]));
+    });
+
+    test('from selectRows result', () => {
+        const rows = {
+            "0": {
+                "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0b7-c884-1038-ba3d-f653126805a6"},
+                "SourceType": {
+                    "value": "sourceType1"
+                },
+                "rowId": {"value": 57},
+                "Name": {"value": "Source-1"}
+            },
+            "1": {
+                "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:81c1e0c4-c884-1038-ba3d-f653126805a6"},
+                "SourceType": {
+                    "value": "sourceType1"
+                },
+                "rowId": {"value": 58},
+                "Name": {"value": "Source-2"}
+            },
+            "2": {
+                "lsid": {"value": "urn:lsid:labkey.com:Data.Folder-8:3d55fee0-d81c-1038-b2c8-93ec7daaff14"},
+                "SourceType": {
+                    "value": "sourceType2"
+                },
+                "rowId": {"value": 65},
+                "Name": {"value": "Source-1"}
+            }
+        }
+        expect(getDisambiguatedSelectInputOptions(rows, 'lsid', 'Name', 'SourceType')).toEqual(expect.arrayContaining([
+            expect.objectContaining(sourceOptions[0]),
+            expect.objectContaining(sourceOptions[1]),
+            expect.objectContaining(sourceOptions[2])
+        ]));
     });
 });

--- a/packages/components/src/util/utils.ts
+++ b/packages/components/src/util/utils.ts
@@ -515,16 +515,14 @@ export function getUpdatedDataFromGrid(
                 const originalValue = originalRow.has(key) ? originalRow.get(key) : undefined;
 
                 // Convert empty cell to null
-                if (value === '')
-                    value = null;
+                if (value === '') value = null;
 
                 // EditableGrid passes in strings for single values. Attempt this conversion here to help check for
                 // updated values. This is not the final type check.
-                if (typeof originalValue === "number" || typeof originalValue === "boolean") {
+                if (typeof originalValue === 'number' || typeof originalValue === 'boolean') {
                     try {
                         value = JSON.parse(value);
-                    }
-                    catch (e) {
+                    } catch (e) {
                         // Incorrect types are handled by API and user feedback created from that response. Don't need
                         // to handle that here.
                     }
@@ -582,38 +580,50 @@ export const blurActiveElement = (): void => {
  * @param valueField
  * @param typeField
  */
-export function getDisambiguatedSelectInputOptions(rows: List<Map<string, any>> | { [key: string] : any }, keyField: string, valueField: string, typeField: string) {
-    let options = [], rawOptions = [];
+export function getDisambiguatedSelectInputOptions(
+    rows: List<Map<string, any>> | { [key: string]: any },
+    keyField: string,
+    valueField: string,
+    typeField: string
+) {
+    const options = [],
+        rawOptions = [];
 
     if (Iterable.isIterable(rows)) {
         rows.forEach(row => {
-            rawOptions.push({value: row.getIn([keyField, 'value']), label: row.getIn([valueField, 'value']), type: row.getIn([typeField, 'value'])});
+            rawOptions.push({
+                value: row.getIn([keyField, 'value']),
+                label: row.getIn([valueField, 'value']),
+                type: row.getIn([typeField, 'value']),
+            });
         });
-    }
-    else {
-        Object.keys(rows).forEach((row) => {
+    } else {
+        Object.keys(rows).forEach(row => {
             const data = rows[row];
-            rawOptions.push({value: data[keyField].value, label: data[valueField].value, type: data[typeField].value});
-        })
+            rawOptions.push({
+                value: data[keyField].value,
+                label: data[valueField].value,
+                type: data[typeField].value,
+            });
+        });
     }
 
     rawOptions.sort((a, b) => {
         return a.label.localeCompare(b.label);
-    })
+    });
 
-    let duplicateValues = [];
+    const duplicateValues = [];
     for (let i = 0; i < rawOptions.length - 1; i++) {
         if (rawOptions[i + 1].label == rawOptions[i].label) {
-            if (duplicateValues.indexOf(rawOptions[i].label) === -1)
-                duplicateValues.push(rawOptions[i].label);
+            if (duplicateValues.indexOf(rawOptions[i].label) === -1) duplicateValues.push(rawOptions[i].label);
         }
     }
 
     rawOptions.forEach(option => {
-        const label = duplicateValues.indexOf(option.label) > -1 ? option.label + " (" + option.type + ")" : option.label;
-        options.push({value: option.value, label});
-    })
+        const label =
+            duplicateValues.indexOf(option.label) > -1 ? option.label + ' (' + option.type + ')' : option.label;
+        options.push({ value: option.value, label });
+    });
 
     return options;
 }
-

--- a/packages/components/src/util/utils.ts
+++ b/packages/components/src/util/utils.ts
@@ -582,7 +582,7 @@ export const blurActiveElement = (): void => {
  * @param valueField
  * @param typeField
  */
-export function getDisambiguatedSelectInputOptions(rows: List<any> | { [key: string] : any }, keyField: string, valueField: string, typeField: string) {
+export function getDisambiguatedSelectInputOptions(rows: List<Map<string, any>> | { [key: string] : any }, keyField: string, valueField: string, typeField: string) {
     let options = [], rawOptions = [];
 
     if (Iterable.isIterable(rows)) {


### PR DESCRIPTION
#### Rationale
Unique names are not enforced for samples when they belong to different sample types, or data from different data classes. When generating SelectInput options, we want to append sample type or source type to entries with duplicate names so user know which item they are selecting.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/92
* https://github.com/LabKey/sampleManagement/pull/365

#### Changes
* Add getDisambiguatedSelectInputOptions util
