### PR TITLE
@labkey/test: Expose additional test user context

### DIFF
--- a/packages/components/releaseNotes/labkey/test.md
+++ b/packages/components/releaseNotes/labkey/test.md
@@ -1,6 +1,10 @@
 # @labkey/test
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
+### version 0.0.3
+*Released*: 17 September 2020
+* Expose additional test user metadata
+
 ### version 0.0.2
 *Released*: 14 September 2020
 * Support multiple containers and users

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.3-fb-notebook-review.0",
+  "version": "0.0.3",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.2",
+  "version": "0.0.3-fb-notebook-review.0",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -18,7 +18,8 @@ import {
     IntegrationTestServer,
     RequestOptions,
     SecurityRole,
-    successfulResponse
+    successfulResponse,
+    TestUser,
 } from './integrationUtils';
 import { sleep } from './utils';
 
@@ -29,4 +30,5 @@ export {
     SecurityRole,
     sleep,
     successfulResponse,
+    TestUser,
 };

--- a/packages/test/src/integrationUtils.ts
+++ b/packages/test/src/integrationUtils.ts
@@ -26,11 +26,17 @@ interface CreateNewUser {
     email: string;
     isNew: boolean;
     message: string;
+    userId: number;
 }
 
 interface UserCredentials {
     password: string;
     username: string;
+}
+
+export interface TestUser extends UserCredentials {
+    email: string;
+    userId: number;
 }
 
 class RequestContext implements UserCredentials {
@@ -91,7 +97,7 @@ export interface IntegrationTestServer {
      * Create a new user account on the server with the specified credentials. If the account already exists, then
      * the account will be deleted and re-created to ensure credentials and permissions are configured as expected.
      */
-    createUser: (email: string, password: string) => Promise<UserCredentials>;
+    createUser: (email: string, password: string) => Promise<TestUser>;
     /** Make a GET request against the server. */
     get: (controller: string, action: string, params?: any, options?: RequestOptions) => Test;
     /** Initializes the server for the test run. This is required to be called prior to any tests running. */
@@ -146,7 +152,7 @@ const createTestContainer = async (ctx: ServerContext, containerOptions?: any /*
     return await _createContainer(ctx, ctx.projectPath, Utils.generateUUID(), containerOptions);
 };
 
-const createUser = async (ctx: ServerContext, email: string, password: string): Promise<UserCredentials> => {
+const createUser = async (ctx: ServerContext, email: string, password: string): Promise<TestUser> => {
     // Delete user (if the account already exists)
     // This ensures the given user's password and subsequent permissions are as expected
     await deleteUser(ctx, email);
@@ -171,7 +177,12 @@ const createUser = async (ctx: ServerContext, email: string, password: string): 
 
     ctx.createdUsers.push(email);
 
-    return { username: email, password };
+    return {
+        email,
+        password,
+        userId: user.userId,
+        username: email,
+    };
 };
 
 const deleteUser = async (ctx: ServerContext, email: string): Promise<void> => {


### PR DESCRIPTION
#### Rationale
Expose additional test user context so that tests don't have to re-query for user information.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/685

#### Changes
* Define and export a `TestUser` interface with richer user context. This is now what is returned by `IntegrationTestServer.createUser()`.
