### PR TITLE
7857: Apply moduleEditor feedback

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.2-fb-fixDropdown.2",
+  "version": "0.92.2-fb-fixDropdown.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.2-fb-fixDropdown.1",
+  "version": "0.92.2-fb-fixDropdown.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.92.2-fb-fixDropdown.3",
+  "version": "0.95.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 0.95.0
+*Released*: 22 September 2020
 * Allow for custom root label for FileTree
 
 ### version 0.94.0

--- a/packages/components/src/components/files/FileTree.tsx
+++ b/packages/components/src/components/files/FileTree.tsx
@@ -189,6 +189,7 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
         allowMultiSelect: true,
         useFileIconCls: false,
         emptyDirectoryText: 'No Files Found',
+        defaultRootName: 'root'
     };
 
     constructor(props: FileTreeProps) {
@@ -221,9 +222,8 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
                         }];
                     }
 
-                    const rootName = defaultRootName ? defaultRootName : 'root';
                     loadedData = {
-                        name: rootName,
+                        name: defaultRootName,
                         id: DEFAULT_ROOT_PREFIX, // Special id
                         children: data,
                         toggled: true,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -88,7 +88,7 @@ import { Grid, GridColumn, GridProps } from './components/base/Grid';
 import { FormSection } from './components/base/FormSection';
 import { Section } from './components/base/Section';
 import { FileAttachmentForm } from './components/files/FileAttachmentForm';
-import { DEFAULT_FILE, FileAttachmentFormModel, IFile } from './components/files/models';
+import { DEFAULT_FILE, FileAttachmentFormModel, IFile, FileSizeLimitProps } from './components/files/models';
 import { FilesListing } from './components/files/FilesListing';
 import { FilesListingForm } from './components/files/FilesListingForm';
 import { FileAttachmentEntry } from './components/files/FileAttachmentEntry';
@@ -687,6 +687,7 @@ export {
     FileAttachmentFormModel,
     DEFAULT_FILE,
     IFile,
+    FileSizeLimitProps,
     FilesListing,
     FilesListingForm,
     FileAttachmentEntry,


### PR DESCRIPTION
#### Rationale
Module root name rather than 'root' is desired as the label of a root node within FileTree

#### Related Pull Requests
* https://github.com/LabKey/moduleEditor/pull/12
* https://github.com/LabKey/platform/pull/1576

#### Changes
* Add optional prop for root node
