### PR TITLE
Item 7767: Make global call to getAuditQueries non global

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.94.0",
+  "version": "0.94.1-fb-ErrorPage-7767.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -50,7 +50,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@labkey/api": "1.1.0",
+    "@labkey/api": "1.1.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.94.1
+*Released*: TBD September 2020
+* Item 7767: Make getAuditQueries non global in AuditQueriesListingPage so that id does not check isSMEnabled and isFMEnabled for all apps consuming ui-components
+
 ### version 0.94.0
 *Released*: 16 September 2020
 * Add getDisambiguatedSelectInputOptions util

--- a/packages/components/src/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/components/auditlog/AuditQueriesListingPage.tsx
@@ -28,14 +28,13 @@ import { AuditDetailsModel } from './models';
 import { getAuditDetail } from './actions';
 import { AuditQuery, getAuditQueries } from './utils';
 
-const AUDIT_QUERIES = getAuditQueries();
-
 interface Props {
     params: any;
     user: User;
 }
 
 interface State {
+    auditQueries: AuditQuery[];
     selected: string;
     selectedRowId: number;
     detail?: AuditDetailsModel;
@@ -47,6 +46,7 @@ export class AuditQueriesListingPage extends PureComponent<Props, State> {
         super(props);
 
         this.state = {
+            auditQueries: getAuditQueries(),
             selected: props.params.query,
             selectedRowId: undefined,
         };
@@ -132,7 +132,7 @@ export class AuditQueriesListingPage extends PureComponent<Props, State> {
     };
 
     get selectedQuery(): AuditQuery {
-        return AUDIT_QUERIES.find(q => q.value === this.state.selected);
+        return this.state.auditQueries.find(q => q.value === this.state.selected);
     }
 
     get containerFilter(): Query.ContainerFilter {
@@ -252,7 +252,7 @@ export class AuditQueriesListingPage extends PureComponent<Props, State> {
                     valueKey="value"
                     labelKey="label"
                     onChange={this.onSelectionChange}
-                    options={AUDIT_QUERIES}
+                    options={this.state.auditQueries}
                 />
                 {this.hasDetailView() ? this.renderMasterDetailGrid() : this.renderSingleGrid()}
             </Page>

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1432,10 +1432,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.1.0":
-  version "1.1.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.0.tgz#b70fbe749d7c3b30ae77f5d8e9e12a2cde5cedbe"
-  integrity sha1-tw++dJ18OzCud/XY6eEqLN5c7b4=
+"@labkey/api@1.1.1":
+  version "1.1.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.1.tgz#ab87622a530b2dd13a4238c202108a7f3f6a84d6"
+  integrity sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"


### PR DESCRIPTION
#### Rationale
AuditQueriesListingPage.tsx has a global call to getAuditQueries which has checks to see isSampleManagerEnabled and isFreezerManagerEnabled that fail in apps consuming ui-components.

#### Related Pull Requests
* 

#### Changes
* make getAuditQueries non global
* pull in latest api/js version to get additional properties exposed via getServerContext() to typings
