### PR TITLE
@labkey/test: Expose default request context

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Once they're ready, we'll officially push the components as version 1.0.0.
 | [@labkey/eslint-config-base](packages/eslint-config-base/README.md) | | Base ESLint configuration with TypeScript and Prettier support.
 | [@labkey/eslint-config-react](packages/eslint-config-react/README.md) | | Extends the base configuration with React support.
 | [@labkey/test](packages/test/README.md) | [![Build Status](https://teamcity.labkey.org/app/rest/builds/buildType:(id:LabkeyTrunk_ModuleSuites_ApiSuites_LabkeyTestIntegration)/statusIcon)](https://teamcity.labkey.org/viewType.html?buildTypeId=LabkeyTrunk_ModuleSuites_ApiSuites_LabkeyTestIntegration) | Utilities and configurations for running JavaScript tests with LabKey Server.
+| [@labkey/themes](packages/themes/README.md) | | UI themes for LabKey Server.
 
 
 ## Using @labkey npm packages

--- a/packages/components/releaseNotes/labkey/test.md
+++ b/packages/components/releaseNotes/labkey/test.md
@@ -1,6 +1,10 @@
 # @labkey/test
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
+### version 0.0.4
+*Released*: ## September 2020
+* Expose default request context
+
 ### version 0.0.3
 *Released*: 17 September 2020
 * Expose additional test user metadata

--- a/packages/components/releaseNotes/labkey/test.md
+++ b/packages/components/releaseNotes/labkey/test.md
@@ -2,7 +2,7 @@
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
 ### version 0.0.4
-*Released*: ## September 2020
+*Released*: 23 September 2020
 * Expose default request context
 
 ### version 0.0.3

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.4-fb-notebook-auth-7870.0",
+  "version": "0.0.4",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "0.0.3",
+  "version": "0.0.4-fb-notebook-auth-7870.0",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/src/integrationUtils.ts
+++ b/packages/test/src/integrationUtils.ts
@@ -115,6 +115,11 @@ export interface IntegrationTestServer {
      */
     request: (controller: string, action: string, agentProvider: AgentProvider, options?: RequestOptions) => Test;
     /**
+     * This is the default request context used for all requests that do not explicitly specify a different
+     * request context.
+     */
+    requestContext: RequestContext;
+    /**
      * Tears down any test artifacts on the server. This is intended to be called after the tests complete.
      * Specifically, it deletes the test Project along with any test containers created during the test run.
      * Additionally, deletes all user accounts created during the test run.
@@ -246,6 +251,7 @@ export const hookServer = (env: NodeJS.ProcessEnv): IntegrationTestServer => {
         init: init.bind(this, server),
         post: postRequest.bind(this, server),
         request: request.bind(this, server),
+        requestContext: server.defaultContext,
         teardown: teardown.bind(this, server),
     };
 };


### PR DESCRIPTION
#### Rationale
Expose the default request context so it is available on `IntegrationTestServer`.

#### Changes
* Add `requestContext` to the `IntegrationTestServer` interface and initialize to `server.defaultContext`.
* (Unrelated) Add link to `@labkey/themes` in top-level Readme.
