### PR TITLE
Move bootstrap import to bottom per BS instructions

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.96.4",
+  "version": "0.96.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.96.5
+*Released*: 28 September 2020
+* Fix for Bootstrap SCSS variable overrides.
+
 ### version 0.96.4
 *Released*: 28 September 2020
 * Update timeline icons for inventory events

--- a/packages/components/src/internal/app/scss/variables.scss
+++ b/packages/components/src/internal/app/scss/variables.scss
@@ -1,4 +1,4 @@
-@import "~bootstrap-sass/assets/stylesheets/bootstrap/_variables";
+
 
 //
 // Bootstrap Variable Overrides
@@ -20,7 +20,8 @@ $font-family-sans-serif:  "Roboto", "Helvetica Neue", Helvetica, Arial, sans-ser
 $border-radius-small:       2px !default;
 
 //== Container sizes
-$container-desktop:            (970px + $grid-gutter-width) !default;
+$grid-gutter-width:             30px !default;
+$container-desktop:             (970px + $grid-gutter-width) !default;
 
 //== Navbar links
 $navbar-default-link-active-color:         $cyan !default;
@@ -43,3 +44,5 @@ $breadcrumb-bg:                 transparent;
 $breadcrumb-color:              $gray !default;
 //** Textual separator for between breadcrumb elements
 $breadcrumb-separator:          ">" !default;
+
+@import "~bootstrap-sass/assets/stylesheets/bootstrap/_variables";


### PR DESCRIPTION
#### Rationale
Caught and troubleshot by Cory, some of the Bootstrap variable overrides are not coming through.  Need to import bootstrap variables after BS overrides [per sass instructions](https://github.com/twbs/bootstrap-sass#sass-1)

#### Changes
- Move bootstrap variables import to bottom of variables.scss.  Define $grid-gutter-width same as default BS value as it is used in an override before import.
