### PR TITLE
Introduce use of staging directory when building for better hot reloading using webpack aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /node_modules
 /packages/*/.rpt2_cache
 /packages/*/dist
+/packages/*/staging
 /packages/*/node_modules
 *.log
 *.cache

--- a/packages/components/package-scripts.js
+++ b/packages/components/package-scripts.js
@@ -4,25 +4,33 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 const npsUtils = require('nps-utils');
-const { rimraf, series } = npsUtils;
+const { rimraf, series, ncp } = npsUtils;
 
 module.exports = {
     scripts: {
         build: {
             default: series(
+                rimraf('staging'),
+                'webpack --config webpack.config.js',
                 rimraf('dist'),
-                'webpack --config webpack.config.js'
+                "ncp staging dist",
             ),
-            description: 'Clean dist directory and run all builds'
+            description: 'Clean dist and staging directories and run all builds'
         },
         clean: {
-            default: rimraf('dist')
+            default: series(
+                rimraf('dist'),
+                rimraf('staging')
+            ),
+            description: 'Remove the dist and staging directories'
         },
         cleanAll: {
             default: series(
                 rimraf('dist'),
+                rimraf('staging'),
                 rimraf('node_modules')
-            )
+            ),
+            description: 'Remove the dist, staging, and node_modules directories'
         }
     }
 };

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "staging",
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "esModuleInterop": true,

--- a/packages/components/webpack.config.js
+++ b/packages/components/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = {
         minimize: false
     },
     output: {
-        path: path.resolve(__dirname, 'dist'),
+        path: path.resolve(__dirname, 'staging'),
         filename: 'components.js',
         library: '@labkey/components',
         libraryTarget: 'umd'


### PR DESCRIPTION
#### Rationale
We are introducing the use of webpack aliases for better hot-reloading of changes from this package and other premium packages within module applications.  When these aliases are in place, the disappearance of the `dist` directory during the build process causes a recompile of the application that fails (because the dist directory is missing) and then another one that succeeds when the directory appears again.  Using a staging directory prevents the first failed build of the application.

See also: [Sharing Premium Components](https://docs.google.com/document/d/1yPNqONxO23BFPNdyZbLXMlYwinDBTgzbimKSyhuvOUI/edit#)

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/104
* https://github.com/LabKey/platform/pull/1615
* https://github.com/LabKey/sampleManagement/pull/378
* https://github.com/LabKey/biologics/pull/704

#### Changes
* Put build artifacts into a staging directory first then copy them to the dist directory where they are referenced.
