### PR TITLE
Item 7882: Add support for discovery of data involved in transactions through detailed audit logging

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.98.0-transactiionAuditRecords.1",
+  "version": "0.98.0-transactiionAuditRecords.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.98.0-transactiionAuditRecords.2",
+  "version": "0.98.0-transactiionAuditRecords.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.98.0-transactiionAuditRecords.5",
+  "version": "0.98.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.98.0-transactiionAuditRecords.4",
+  "version": "0.98.0-transactiionAuditRecords.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.97.1-transactiionAuditRecords.0",
+  "version": "0.98.0-transactiionAuditRecords.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.98.0-transactiionAuditRecords.3",
+  "version": "0.98.0-transactiionAuditRecords.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.97.0",
+  "version": "0.97.1-transactiionAuditRecords.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 
-### version TBD
-*Released*: TBD
+### version 0.98.0
+*Released*: 13 October 2020
 * add optional transactionAuditId in InsertRowsResponse and as argument after file import
 * add new replaceSelected method (for new action in QueryController)
 * Fix styling of links in notifications

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -3,6 +3,7 @@
 ### version TBD
 *Released*: TBD
 * add optional transactionAuditId in InsertRowsResponse and as argument after file import
+* add new replaceSelected method (for new action in QueryController)
 
 ### version 0.97.0
 *Released*: 29 September 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -4,6 +4,7 @@
 *Released*: TBD
 * add optional transactionAuditId in InsertRowsResponse and as argument after file import
 * add new replaceSelected method (for new action in QueryController)
+* Fix styling of links in notifications
 
 ### version 0.97.0
 *Released*: 29 September 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,5 +1,9 @@
 # @labkey/components
 
+### version TBD
+*Released*: TBD
+* add optional transactionAuditId in InsertRowsResponse and as argument after file import
+
 ### version 0.97.0
 *Released*: 29 September 2020
 * FieldEditorOverlay updates

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -94,7 +94,7 @@ import { FileAttachmentEntry } from './internal/components/files/FileAttachmentE
 import { getWebDavFiles, uploadWebDavFile, WebDavFile } from './internal/components/files/WebDav';
 import { FileTree } from './internal/components/files/FileTree';
 import { Notification } from './internal/components/notifications/Notification';
-import { createNotification } from './internal/components/notifications/actions';
+import { createNotification, NotificationCreatable } from './internal/components/notifications/actions';
 import {
     addNotification,
     dismissNotifications,
@@ -664,6 +664,7 @@ export {
     NotificationItemProps,
     NotificationItemModel,
     Notification,
+    NotificationCreatable,
     Persistence,
     MessageFunction,
     createNotification,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -132,6 +132,7 @@ import {
     gridInvalidate,
     gridShowError,
     queryGridInvalidate,
+    replaceSelected,
     schemaGridInvalidate,
     setSelected,
     unselectAll,
@@ -437,6 +438,7 @@ export {
     gridExport,
     gridInit,
     gridShowError,
+    replaceSelected,
     setSelected,
     unselectAll,
     // query related items

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1059,6 +1059,7 @@ export function clearSelected(
  * @param key the selection key for the grid
  * @param checked whether to set selected or unselected
  * @param ids ids to change selection for
+ * @param containerPath optional path to the conatiner for this grid.  Default is the current container path
  */
 export function setSelected(
     key: string,
@@ -1096,6 +1097,48 @@ export function setSelected(
         });
     });
 }
+
+/**
+ * Selects individual ids for a particular view
+ * @param key the selection key for the grid
+ * @param ids ids to change selection for
+ * @param containerPath optional path to the container for this grid.  Default is the current container path
+ */
+export function replaceSelected(
+    key: string,
+    ids: string[] | string,
+    containerPath?: string
+): Promise<ISelectResponse> {
+    return new Promise((resolve, reject) => {
+        return Ajax.request({
+            url: buildURL(
+                'query',
+                'replaceSelected.api',
+                {
+                    key
+                },
+                {
+                    container: containerPath,
+                }
+            ),
+            method: 'POST',
+            params: {
+                id: ids,
+            },
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response);
+            }),
+            failure: Utils.getCallbackWrapper(
+                response => {
+                    reject(response);
+                },
+                this,
+                true
+            ),
+        });
+    });
+}
+
 
 function removeAll(selected: List<string>, toDelete: List<string>): List<string> {
     toDelete.forEach(id => {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1059,7 +1059,7 @@ export function clearSelected(
  * @param key the selection key for the grid
  * @param checked whether to set selected or unselected
  * @param ids ids to change selection for
- * @param containerPath optional path to the conatiner for this grid.  Default is the current container path
+ * @param containerPath optional path to the container for this grid.  Default is the current container path
  */
 export function setSelected(
     key: string,
@@ -1072,17 +1072,16 @@ export function setSelected(
             url: buildURL(
                 'query',
                 'setSelected.api',
-                {
-                    key,
-                    checked,
-                },
+                undefined,
                 {
                     container: containerPath,
                 }
             ),
             method: 'POST',
-            params: {
+            jsonData: {
                 id: ids,
+                key,
+                checked,
             },
             success: Utils.getCallbackWrapper(response => {
                 resolve(response);
@@ -1114,15 +1113,14 @@ export function replaceSelected(
             url: buildURL(
                 'query',
                 'replaceSelected.api',
-                {
-                    key
-                },
+                undefined,
                 {
                     container: containerPath,
                 }
             ),
             method: 'POST',
-            params: {
+            jsonData: {
+                key,
                 id: ids,
             },
             success: Utils.getCallbackWrapper(response => {

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -95,7 +95,7 @@ class EntityGridLoader implements IGridLoader {
 
 interface OwnProps {
     disableMerge?: boolean;
-    afterEntityCreation?: (entityTypetName, filter, entityCount, actionStr, transactionAuditId?) => void;
+    afterEntityCreation?: (entityTypeName, filter, entityCount, actionStr, transactionAuditId?) => void;
     getFileTemplateUrl?: (queryInfo: QueryInfo) => string;
     location?: Location;
     onCancel?: () => void;

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -95,7 +95,7 @@ class EntityGridLoader implements IGridLoader {
 
 interface OwnProps {
     disableMerge?: boolean;
-    afterEntityCreation?: (entityTypetName, filter, entityCount, actionStr) => void;
+    afterEntityCreation?: (entityTypetName, filter, entityCount, actionStr, transactionAuditId?) => void;
     getFileTemplateUrl?: (queryInfo: QueryInfo) => string;
     location?: Location;
     onCancel?: () => void;
@@ -689,7 +689,8 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
                             insertModel.getTargetEntityTypeName(),
                             response.getFilter(),
                             response.rows.length,
-                            'created'
+                            'created',
+                            response.transactionAuditId
                         );
                     }
                 } else {
@@ -963,7 +964,8 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
                         insertModel.getTargetEntityTypeName(),
                         null,
                         response.rowCount,
-                        'imported'
+                        'imported',
+                        response.transactionAuditId,
                     );
                 }
             })

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -625,10 +625,12 @@ export class InsertRowsResponse extends Record({
     rows: Array<any>(),
     schemaQuery: undefined,
     error: undefined,
+    transactionAuditId: undefined
 }) {
     rows: any[];
     schemaQuery: SchemaQuery;
     error: InsertRowsErrorResponse;
+    transactionAuditId?: number;
 
     getFilter(): Filter.IFilter {
         const rowIds = [];
@@ -663,6 +665,7 @@ export function insertRows(options: InsertRowsOptions): Promise<InsertRowsRespon
                     new InsertRowsResponse({
                         schemaQuery,
                         rows: response.rows,
+                        transactionAuditId: response.transactionAuditId
                     })
                 );
             },

--- a/packages/components/src/public/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/public/QueryModel/QueryModelLoader.ts
@@ -8,6 +8,7 @@ import {
     loadReports,
     naturalSortByProperty,
     QueryInfo,
+    replaceSelected,
     selectRows,
     setSelected,
 } from '../..';
@@ -51,6 +52,14 @@ export interface QueryModelLoader {
      * @param model: QueryModel
      */
     loadSelections: (model: QueryModel) => Promise<Set<string>>;
+
+    /**
+     * Replaces the currently selected items with the given set of selections.
+     * @param model: QueryModel
+     * @param checked: boolean, the checked status of the ids
+     * @param selections: A list of stringified RowIds.
+     */
+    replaceSelections: (model: QueryModel, selections: string[]) => Promise<ISelectResponse>;
 
     /**
      * Sets the selected status for the list of selections.
@@ -121,6 +130,10 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
     setSelections(model, checked: boolean, selections: string[]) {
         const { id, containerPath } = model;
         return setSelected(id, checked, selections, containerPath);
+    },
+    replaceSelections(model, selections: string[]) {
+        const { id, containerPath } = model;
+        return replaceSelected(id, selections, containerPath);
     },
     async selectAllRows(model) {
         const { id, schemaName, queryName, filters, containerPath, queryParameters } = model;

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -389,8 +389,7 @@ export function withQueryModels<Props>(
             );
 
             try {
-                await modelLoader.clearSelections(this.state.queryModels[id]);
-                await modelLoader.setSelections(this.state.queryModels[id], true, selections);
+                await modelLoader.replaceSelections(this.state.queryModels[id], selections);
                 this.setState(
                     produce((draft: Draft<State>) => {
                         const model = draft.queryModels[id];

--- a/packages/components/src/test/MockQueryModelLoader.ts
+++ b/packages/components/src/test/MockQueryModelLoader.ts
@@ -56,6 +56,11 @@ export class MockQueryModelLoader implements QueryModelLoader {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    replaceSelections = (model: QueryModel, selections): Promise<never> => {
+        return Promise.reject('Not implemented!');
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     selectAllRows = (model: QueryModel): Promise<never> => {
         return Promise.reject('Not implemented!');
     };

--- a/packages/components/src/theme/notification.scss
+++ b/packages/components/src/theme/notification.scss
@@ -1,3 +1,6 @@
 .notification-container {
   margin-top: 10px;
+    a:hover {
+        cursor: pointer;
+    }
 }


### PR DESCRIPTION
#### Rationale
Within LKSM, we want to enable users to work with the samples and sources that have just been imported, either via a file import or import within a grid.  Currently, this is possible when importing from a grid because the records created from using the `insertRows` operation are returned in the api response.  When importing from a file, only a count of the rows is returned (which is reasonable).  Here we add in an ability to find the data items that were inserted or updated during an upload operation by way of a new audit event type, which is created when the transaction begins and contains a unique transactionId that can then be stored in other audit logs as a reference.  

* [Issue 39594](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39594)

This also adds a method `replaceSelected` for replacing a set of selected rows in a QueryGridModel.  This was needed for the first implementation of this feature, but then the feature request changed and it is no longer needed.  The method was left as it is potentially useful but could also be removed if deemed frivolous.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1621

#### Changes
* add optional transactionAuditId in InsertRowsResponse and as argument after file import
* add new replaceSelected method (for new action in QueryController) 
