### PR TITLE
Issue 41574: Dataset designer file import column mapping fix for demographics dataset creation case

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.100.0",
+  "version": "0.100.0-fb-datasetColumnMapping-41574.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.100.0-fb-datasetColumnMapping-41574.0",
+  "version": "0.100.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 
-### version TBD
-*Released*: TBD
+### version 0.100.1
+*Released*: 21 Oct 2020
 * Issue 41574: Dataset designer file import column mapping fix for demographics dataset creation case
 
 ### version 0.100.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,5 +1,9 @@
 # @labkey/components
 
+### version TBD
+*Released*: TBD
+* Issue 41574: Dataset designer file import column mapping fix for demographics dataset creation case
+
 ### version 0.100.0
 *Released*: 20 Oct 2020
 * DetailPanel/DetailPanelWithModel now take QueryConfig as a prop instead of QueryConfig & DetailDisplaySharedProps

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
@@ -169,15 +169,15 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
     onFinish = () => {
         const { setSubmitting } = this.props;
         const { model, shouldImportData } = this.state;
+        const missingRequiredTimepointMapping = !model.demographicData && !this._sequenceNum;
 
-        if (shouldImportData && !(this._participantId && this._sequenceNum)) {
+        if (shouldImportData && (!this._participantId || missingRequiredTimepointMapping)) {
             this.setState(
                 produce((draft: Draft<State>) => {
                     draft.model.exception =
                         'You must select a column mapping field for ' +
                         getStudySubjectProp('nounPlural') +
-                        ' and ' +
-                        getStudyTimepointLabel() +
+                        (missingRequiredTimepointMapping ? ' and ' + getStudyTimepointLabel() : '') +
                         ' in the fields panel.';
                 }),
                 () => {


### PR DESCRIPTION
#### Rationale
Issue [41574](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41574): Mapping visit field to a demographics dataset is required when inferring a field from a file

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1640

#### Changes
* DatasetDesignerPanels update to check for demographic dataset configuration when validating column mapping
