### PR TITLE
Issue 41068

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.101.2-fb-issue-41068.0",
+  "version": "0.101.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.101.1",
+  "version": "0.101.2-fb-issue-41068.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.101.2
+*Released*: 21 Oct 2020
+* Issue 41068: GridPanel does not respect the hideEmptyChartSelector and hideEmptyViewSelector properties set in a
+global query metadata override
+* Renamed global settings 'hideEmptyViewSelector', 'hideEmptyChartSelector' to 'hideEmptyViewMenu', 'hideEmptyChartMenu'
+
 ### version 0.101.1
 *Released*: 21 Oct 2020
 * Make visual updates to FileTree.
@@ -11,12 +17,6 @@ Components, models, actions, and utility functions for LabKey applications and p
     * add "Metric Unit" property to Sample Manager
     * add validateProperties prop to allow caller to validate sample domain properties before save
 * Allow custom caption and placeholder text for fields in FieldEditorOverlay
-
-### version 0.100.1
-*Released*: 21 Oct 2020
-* Issue 41068: GridPanel does not respect the hideEmptyChartSelector and hideEmptyViewSelector properties set in a
-global query metadata override
-* Renamed global settings 'hideEmptyViewSelector', 'hideEmptyChartSelector' to 'hideEmptyViewMenu', 'hideEmptyChartMenu'
 
 ### version 0.100.1
 *Released*: 21 Oct 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -14,6 +14,12 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 0.100.1
 *Released*: 21 Oct 2020
+* Issue 41068: GridPanel does not respect the hideEmptyChartSelector and hideEmptyViewSelector properties set in a
+global query metadata override
+* Renamed global settings 'hideEmptyViewSelector', 'hideEmptyChartSelector' to 'hideEmptyViewMenu', 'hideEmptyChartMenu'
+
+### version 0.100.1
+*Released*: 21 Oct 2020
 * Issue 41574: Dataset designer file import column mapping fix for demographics dataset creation case
 
 ### version 0.100.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 0.101.2
-*Released*: 21 Oct 2020
+*Released*: 22 Oct 2020
 * Issue 41068: GridPanel does not respect the hideEmptyChartSelector and hideEmptyViewSelector properties set in a
 global query metadata override
 * Renamed global settings 'hideEmptyViewSelector', 'hideEmptyChartSelector' to 'hideEmptyViewMenu', 'hideEmptyChartMenu'

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -79,8 +79,8 @@ export function getStateQueryGridModel(
         schema: schemaQuery.schemaName,
         query: schemaQuery.queryName,
         view: schemaQuery.viewName,
-        hideEmptyChartSelector: metadata.get('hideEmptyChartSelector'),
-        hideEmptyViewSelector: metadata.get('hideEmptyViewSelector'),
+        hideEmptyChartSelector: metadata.get('hideEmptyChartMenu'),
+        hideEmptyViewSelector: metadata.get('hideEmptyViewMenu'),
     };
 
     if (keyValue !== undefined && schemaQuery.viewName === undefined) {

--- a/packages/components/src/public/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/public/QueryModel/ChartMenu.tsx
@@ -9,6 +9,7 @@ import { ChartModal } from '../../internal/components/chart/ChartModal';
 import { blurActiveElement } from '../../internal/util/utils';
 
 import { RequiresModelAndActions } from './withQueryModels';
+import { getQueryMetadata } from '../../internal/global';
 
 interface Props extends RequiresModelAndActions {
     hideEmptyChartMenu: boolean;
@@ -75,12 +76,13 @@ export class ChartMenu extends PureComponent<Props> {
         const disabled = isLoading || isLoadingCharts || noCharts || hasError;
         const selectedChart = charts?.find(chart => chart.reportId === selectedReportId);
         const showChartModal = queryInfo !== undefined && selectedChart !== undefined;
+        const _hideEmptyChartMenu = getQueryMetadata().get('hideEmptyChartMenu', hideEmptyChartMenu);
 
         if (
             privateCharts.length === 0 &&
             publicCharts.length === 0 &&
             !showSampleComparisonReports &&
-            hideEmptyChartMenu
+            _hideEmptyChartMenu
         ) {
             return null;
         }

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -3,6 +3,7 @@ import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { QueryModel, ViewInfo } from '../..';
 import { blurActiveElement } from '../../internal/util/utils';
+import { getQueryMetadata } from '../../internal/global';
 
 interface ViewMenuProps {
     hideEmptyViewMenu: boolean;
@@ -20,7 +21,8 @@ export class ViewMenu extends PureComponent<ViewMenuProps> {
         const publicViews = validViews.filter(view => !view.isDefault && view.shared);
         const privateViews = validViews.filter(view => !view.isDefault && !view.shared);
         const noViews = publicViews.length === 0 && privateViews.length === 0;
-        const hidden = hideEmptyViewMenu && noViews;
+        const _hideEmptyViewMenu = getQueryMetadata().get('hideEmptyViewMenu', hideEmptyViewMenu);
+        const hidden = _hideEmptyViewMenu && noViews;
         const disabled = isLoading || noViews;
 
         const viewMapper = (viewInfo): ReactNode => {


### PR DESCRIPTION
#### Rationale
GridPanel does not honor the hideEmptyChartSelector or hideEmptyViewSelector settings.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/385
* https://github.com/LabKey/inventory/pull/112

#### Changes
* Issue 41068: GridPanel does not respect the hideEmptyChartSelector and hideEmptyViewSelector properties set in a
global query metadata override
* Renamed global settings 'hideEmptyViewSelector', 'hideEmptyChartSelector' to 'hideEmptyViewMenu', 'hideEmptyChartMenu'
