### PR TITLE
Fix issue 40917

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.100.1",
+  "version": "0.100.2-fb-issue-40917.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,5 +1,9 @@
 # @labkey/components
 
+### version 0.100.??
+*Released*: ?? Oct 2020
+* Issue 40917: Unable to select plate template for import in Biologics general plate assay
+
 ### version 0.100.1
 *Released*: 21 Oct 2020
 * Issue 41574: Dataset designer file import column mapping fix for demographics dataset creation case

--- a/packages/components/src/internal/components/base/models/model.ts
+++ b/packages/components/src/internal/components/base/models/model.ts
@@ -966,6 +966,12 @@ export class AssayDefinitionModel extends Record({
 
             if (domainColumns && domainColumns.size) {
                 domainColumns.forEach(dc => {
+                    if (dc.getIn(['lookup', 'table']) === 'Plate') {
+                        // Issue 40917
+                        // We need to override the queryName to be PlateTemplate instead of Plate because Plate is the
+                        // physical table, PlateTemplate is the exposed virtual table.
+                        dc = dc.setIn(['lookup', 'queryName'], 'PlateTemplate') as QueryColumn;
+                    }
                     columns = columns.set(dc.fieldKey.toLowerCase(), dc);
                 });
             }


### PR DESCRIPTION
#### Rationale
GPAT Plate Templates use the query "PlateTemplate" but the metadata returned from the server has the query as "Plate", which is the physical DB table, PlateTemplate is the exposed virtual table.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/717

#### Changes
* Override any columns that have table name set to "Plate" to use "PlateTemplate" query.
