### PR TITLE
RequiresPermission, ServerContext

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.102.1",
+  "version": "0.102.2-fb-requires-permission.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.102.2-fb-requires-permission.0",
+  "version": "0.103.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 0.103.0
-*Released*: ## Oct 2020
+*Released*: 23 Oct 2020
 * Add `RequiresPermission` (formerly known in apps as `RequiresPermissionHOC`).
 * Add `ServerContext` to allow retrieving up-to-date server context via React.Context.
 * Remove `<PermissionAllowed/>` and `<PermissionNotAllowed/>` as they are no longer utilized.

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.10#.0
+*Released*: ## Oct 2020
+* Add `RequiresPermission` (formerly known in apps as `RequiresPermissionHOC`).
+* Add `ServerContext` to allow retrieving up-to-date server context via React.Context.
+* Remove `<PermissionAllowed/>` and `<PermissionNotAllowed/>` as they are no longer utilized.
+* Unit tests for `RequiresPermission`.
+* Add `mountWithServerContext` and `waitForLifecycle` test utility methods.
+
 ### version 0.102.1
 *Released*: 23 Oct 2020
 * Switch `IUserProps` to fully extend `UserWithPermissions`

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.10#.0
+### version 0.103.0
 *Released*: ## Oct 2020
 * Add `RequiresPermission` (formerly known in apps as `RequiresPermissionHOC`).
 * Add `ServerContext` to allow retrieving up-to-date server context via React.Context.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -423,6 +423,7 @@ import { DataClassDesigner } from './internal/components/domainproperties/datacl
 import { DataClassModel } from './internal/components/domainproperties/dataclasses/models';
 import { deleteDataClass, fetchDataClass } from './internal/components/domainproperties/dataclasses/actions';
 import { AssayImportPanels } from './internal/components/assay/AssayImportPanels';
+import { mountWithServerContext, sleep, waitForLifecycle } from './internal/testHelpers';
 
 // See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 enableMapSet();
@@ -886,4 +887,8 @@ export {
     TimelineEventModel,
     TimelineGroupedEventInfo,
     TimelineView,
+    // Test Helpers
+    mountWithServerContext,
+    sleep,
+    waitForLifecycle,
 };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -25,6 +25,14 @@ import { QuerySort } from './public/QuerySort';
 import { isLoading, LoadingState } from './public/LoadingState';
 import { Container } from './internal/components/base/models/Container';
 import { hasAllPermissions, User } from './internal/components/base/models/User';
+import {
+    ServerContext,
+    ServerContextProvider,
+    ServerContextConsumer,
+    useServerContext,
+    useServerContextDispatch,
+    withAppUser,
+} from './internal/components/base/ServerContext';
 import { naturalSort, naturalSortByProperty } from './public/sort';
 import {
     AssayDefinitionModel,
@@ -108,7 +116,7 @@ import {
     NotificationItemProps,
     Persistence,
 } from './internal/components/notifications/model';
-import { PermissionAllowed, PermissionNotAllowed } from './internal/components/base/Permissions';
+import { RequiresPermission } from './internal/components/base/Permissions';
 import { PaginationButtons, PaginationButtonsProps } from './internal/components/buttons/PaginationButtons';
 import { ManageDropdownButton } from './internal/components/buttons/ManageDropdownButton';
 import { WizardNavButtons } from './internal/components/buttons/WizardNavButtons';
@@ -554,8 +562,7 @@ export {
     SiteUsersGridPanel,
     InsufficientPermissionsPage,
     BasePermissionsCheckPage,
-    PermissionAllowed,
-    PermissionNotAllowed,
+    RequiresPermission,
     hasAllPermissions,
     fetchContainerSecurityPolicy,
     PermissionAssignments,
@@ -819,6 +826,12 @@ export {
     // base models, enums, constants
     Container,
     User,
+    ServerContext,
+    ServerContextProvider,
+    ServerContextConsumer,
+    useServerContext,
+    useServerContextDispatch,
+    withAppUser,
     QueryColumn,
     QueryInfo,
     QueryLookup,

--- a/packages/components/src/internal/components/base/Permissions.spec.tsx
+++ b/packages/components/src/internal/components/base/Permissions.spec.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { PermissionTypes } from '@labkey/api';
+
+import {
+    TEST_USER_APP_ADMIN,
+    TEST_USER_ASSAY_DESIGNER,
+    TEST_USER_EDITOR,
+    TEST_USER_READER,
+} from '../../../test/data/users';
+import { mountWithServerContext } from '../../testHelpers';
+
+import { RequiresPermission } from './Permissions';
+
+const CONTENT = <div className="requires-permission-content" />;
+const CONTENT_SELECTOR = 'div.requires-permission-content';
+
+describe('<RequiresPermission/>', () => {
+    test('does not have permission', () => {
+        // Act
+        const wrapper = mountWithServerContext(
+            <RequiresPermission perms={PermissionTypes.Admin}>{CONTENT}</RequiresPermission>,
+            { user: TEST_USER_READER }
+        );
+
+        // Assert
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(false);
+    });
+    test('has permission', () => {
+        // Act
+        const wrapper = mountWithServerContext(
+            <RequiresPermission perms={PermissionTypes.Admin}>{CONTENT}</RequiresPermission>,
+            { user: TEST_USER_APP_ADMIN }
+        );
+
+        // Assert
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(true);
+    });
+    test('does not have all permissions', () => {
+        // Act
+        // TEST_USER_ASSAY_DESIGNER does not have PermissionTypes.Delete
+        const wrapper = mountWithServerContext(
+            <RequiresPermission perms={[PermissionTypes.Delete, PermissionTypes.DesignAssay]}>
+                {CONTENT}
+            </RequiresPermission>,
+            { user: TEST_USER_ASSAY_DESIGNER }
+        );
+
+        // Assert
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(false);
+    });
+    test('has all permissions', () => {
+        // Act
+        const wrapper = mountWithServerContext(
+            <RequiresPermission perms={[PermissionTypes.Read, PermissionTypes.Update, PermissionTypes.Delete]}>
+                {CONTENT}
+            </RequiresPermission>,
+            { user: TEST_USER_EDITOR }
+        );
+
+        // Assert
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(true);
+    });
+});

--- a/packages/components/src/internal/components/base/Permissions.tsx
+++ b/packages/components/src/internal/components/base/Permissions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 LabKey Corporation
+ * Copyright (c) 2019-2020 LabKey Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ interface Props {
 /**
  * This component is intended to be used to wrap other components which should only be displayed when the
  * user has specific permissions. Permissions are defined on the application user and can be specified by
- * importing PermissionTypes. The component uses "useServerContext to access the current user so it
+ * importing PermissionTypes. The component uses "useServerContext" to access the current user so it
  * requires access to the "ServerContext".
  */
 export const RequiresPermission: FC<Props> = ({ children, perms }) => {
@@ -35,15 +35,5 @@ export const RequiresPermission: FC<Props> = ({ children, perms }) => {
         user,
     ]);
 
-    return (
-        <>
-            {React.Children.map(children, (child: any) => {
-                const isNotAllowed = child && child.props.isAllowed === false;
-                if (allow) {
-                    return !isNotAllowed ? child : null;
-                }
-                return isNotAllowed ? child : null;
-            })}
-        </>
-    );
+    return <>{React.Children.map(children, child => (allow ? child : null))}</>;
 };

--- a/packages/components/src/internal/components/base/ServerContext.tsx
+++ b/packages/components/src/internal/components/base/ServerContext.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { createContext, FC, useContext, useReducer } from 'react';
+import { LabKey } from '@labkey/api';
+
+import { User } from '../../..';
+
+export interface ServerContext extends LabKey {
+    user: User;
+}
+
+type AppLabKeyDispatch = (context: Partial<ServerContext>) => void;
+
+const Context = createContext<ServerContext>(undefined);
+const ContextDispatch = createContext<AppLabKeyDispatch>(undefined);
+
+const serverContextReducer = (state, payload): ServerContext => {
+    return Object.assign({}, state, payload);
+};
+
+export interface ServerContextProviderProps {
+    initialContext?: ServerContext;
+}
+
+export const ServerContextProvider: FC<ServerContextProviderProps> = ({ children, initialContext }) => {
+    const [state, dispatch] = useReducer(serverContextReducer, initialContext);
+
+    return (
+        <Context.Provider value={state}>
+            <ContextDispatch.Provider value={dispatch}>{children}</ContextDispatch.Provider>
+        </Context.Provider>
+    );
+};
+
+export const useServerContext = (): ServerContext => {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useServerContext must be used within a ServerContext.Provider');
+    }
+    return context;
+};
+
+export const useServerContextDispatch = (): AppLabKeyDispatch => {
+    const context = useContext(ContextDispatch);
+    if (context === undefined) {
+        throw new Error('useServerContextDispatch must be used within a ServerContextDispatch.Provider');
+    }
+    return context;
+};
+
+export const ServerContextConsumer = Context.Consumer;
+
+export const withAppUser = (ctx: LabKey): ServerContext => {
+    return Object.assign({}, ctx, {
+        user: new User(ctx.user),
+    });
+};

--- a/packages/components/src/internal/testHelpers.ts
+++ b/packages/components/src/internal/testHelpers.ts
@@ -1,9 +1,12 @@
+import { ReactElement } from 'react';
+import { act } from 'react-dom/test-utils';
 import { Map } from 'immutable';
+import { mount, MountRendererProps, ReactWrapper } from 'enzyme';
 import { LabKey, Query } from '@labkey/api';
 import mock, { proxy } from 'xhr-mock';
 
 import { initLineageMocks, initQueryGridMocks, initUserPropsMocks } from '../stories/mock';
-import { initQueryGridState, QueryInfo } from '..';
+import { initQueryGridState, QueryInfo, ServerContextProvider } from '..';
 
 import { RowsResponse } from '../public/QueryModel/QueryModelLoader';
 
@@ -21,7 +24,7 @@ export function initMockServerContext(context: Partial<LabKey>): void {
 /**
  * Initializes the server context and QueryGrid state which is needed in order to run most tests.
  */
-export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Map<string, any>) => {
+export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Map<string, any>): void => {
     initMockServerContext({
         container: {
             formats: {
@@ -40,7 +43,7 @@ export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Map
  * Use this method in beforeAll() for your jest tests and you'll have full access
  * to all of the same mock API responses we use in storybook.
  */
-export function initUnitTestMocks(metadata?: Map<string, any>, columnRenderers?: Map<string, any>) {
+export function initUnitTestMocks(metadata?: Map<string, any>, columnRenderers?: Map<string, any>): void {
     initUnitTests(metadata, columnRenderers);
     mock.setup();
     initQueryGridMocks();
@@ -49,7 +52,7 @@ export function initUnitTestMocks(metadata?: Map<string, any>, columnRenderers?:
     mock.use(proxy);
 }
 
-export function registerDefaultURLMappers() {
+export function registerDefaultURLMappers(): void {
     URLService.registerURLMappers(
         ...URL_MAPPERS.ASSAY_MAPPERS,
         ...URL_MAPPERS.DATA_CLASS_MAPPERS,
@@ -76,19 +79,39 @@ export const makeQueryInfo = (getQueryDetailsResponse): QueryInfo => {
  * looks like: { messages: any, rows: any, orderedRows: string[], rowCount: number }
  * @param getQueryResponse: getQuery Response object (e.g. imported from test/data/mixtures-getQuery.json)
  */
-export const makeTestData = (getQueryResponse): Promise<RowsResponse> => {
+export const makeTestData = async (getQueryResponse): Promise<RowsResponse> => {
     // Hack: need to stringify and parse the query response object because Query.Response modifies the object in place,
     // which causes errors if you try to use the same response object twice.
     const response = new Query.Response(JSON.parse(JSON.stringify(getQueryResponse)));
-    return handle132Response(response).then(resp => {
-        const { messages, models, orderedModels, rowCount } = resp;
-        const key = Object.keys(models)[0];
-        return {
-            messages: messages.toJS(),
-            rows: models[key],
-            orderedRows: orderedModels[key].toArray(),
-            rowCount,
-        };
+
+    const { key, messages, models, orderedModels, rowCount } = await handle132Response(response);
+
+    return {
+        messages: messages.toJS(),
+        orderedRows: orderedModels[key].toArray(),
+        rowCount,
+        rows: models[key],
+    };
+};
+
+/**
+ * Use this if you're testing a component that requires a wrapping <ServerContextProvider/> to provide context.
+ * This test method wraps enzyme's mount() method and provides the wrapping component with "initialContext".
+ * With this the returned mounted component will still be the component under test
+ * (as opposed to <ServerContextProvider />).
+ * @param node The React node to mount
+ * @param initialContext The server context to be provided by the wrapping <ServerContextProvider/>
+ * @param options Pass through for mount's rendering options
+ */
+export const mountWithServerContext = (
+    node: ReactElement,
+    initialContext: any,
+    options?: MountRendererProps
+): ReactWrapper => {
+    return mount(node, {
+        wrappingComponent: ServerContextProvider,
+        wrappingComponentProps: { initialContext },
+        ...options,
     });
 };
 
@@ -102,5 +125,24 @@ export const sleep = (ms = 0): Promise<void> => {
         setTimeout(() => {
             resolve();
         }, ms);
+    });
+};
+
+/**
+ * If you're testing a react component that uses hooks to load data use this method to flush promises and transition
+ * your component to the next part of the lifecycle. Example:
+ *      const wrapper = mount(<MyComponentThatLoadsStuff />);
+ *      // Loading state is expected
+ *      expect(wrapper.find(LOADING_SPINNER).exists()).toEqual(true);
+ *      await waitForLifecycle(wrapper);
+ *      // Items have been loaded and rendered
+ *      expect(wrapper.find('.item').length).toEqual(4);
+ * @param wrapper: enzyme ReactWrapper
+ */
+export const waitForLifecycle = (wrapper: ReactWrapper): Promise<undefined> => {
+    // Wrap in react-dom/utils act so we don't get errors in our test logs
+    return act(async () => {
+        await sleep();
+        wrapper.update();
     });
 };

--- a/packages/components/src/internal/util/helpLinks.tsx
+++ b/packages/components/src/internal/util/helpLinks.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
+import { getServerContext } from '@labkey/api';
 
 export const CHART_MEASURES_AND_DIMENSIONS_TOPIC = 'chartTrouble';
 export const MISSING_VALUES_TOPIC = 'manageMissing';
@@ -28,19 +29,18 @@ export const DATASET_PROPERTIES_TOPIC = 'datasetProperties#advanced';
 export const DELETE_SAMPLES_TOPIC = 'viewSampleSets#delete';
 export const DERIVE_SAMPLES_TOPIC = 'deriveSamples';
 export const DERIVE_SAMPLES_ALIAS_TOPIC = DERIVE_SAMPLES_TOPIC + '#alias';
-// export const DERIVE_SAMPLES_GRAPH_TOPIC = DERIVE_SAMPLES_TOPIC + '#graph';
-// export const DERIVE_SAMPLES_GRID_TOPIC = DERIVE_SAMPLES_TOPIC + '#grid';
 
 export const URL_ENCODING_TOPIC = 'urlEncoding';
 
 export const SEARCH_SYNTAX_TOPIC = 'luceneSearch';
 export const DATA_IMPORT_TOPIC = 'dataImport';
 
-export function getHelpLink(topic: string) {
-    return LABKEY.helpLinkPrefix + topic;
+export function getHelpLink(topic: string): string {
+    return getServerContext().helpLinkPrefix + topic;
 }
 
-export function helpLinkNode(topic: string, text: React.ReactNode, className?: string): React.ReactNode {
+// TODO: This should be converted into a React.FC with arguments switched to props
+export function helpLinkNode(topic: string, text: ReactNode, className?: string): ReactNode {
     return (
         <a target="_blank" href={getHelpLink(topic)} className={className}>
             {text}


### PR DESCRIPTION
#### Rationale
This PR does three things:
1. Hoists the implementation for `<RequiresPermissionHOC/>` into a shared component now called `<RequiresPermission/>`
1. Hoists `ServerContext` and it's associated providers/hooks from Biologics so it can be shared across apps. This is now leveraged by `<RequiresPermission/>` to source the `User`.
1. Removes `<PermissionAllowed/>` and `<PermissionNotAllowed/>` as they are no longer utilized.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/719
* https://github.com/LabKey/sampleManagement/pull/386
* https://github.com/LabKey/inventory/pull/113

#### Changes
* Add `RequiresPermission` (formerly known in apps as `RequiresPermissionHOC`).
* Add `ServerContext` to allow retrieving up-to-date server context via React.Context.
* Remove `<PermissionAllowed/>` and `<PermissionNotAllowed/>` as they are no longer utilized.
* Unit tests for `RequiresPermission`.
* Add `mountWithServerContext` and `waitForLifecycle` test utility methods.