### PR TITLE
@labkey/build update to use a LABKEY_UI_COMPONENTS_HOME environment variable for webpack aliasing of @labkey packages

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "0.1.0",
+  "version": "0.1.0-fb-webpackEnvVarForLink.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "0.1.0-fb-webpackEnvVarForLink.0",
+  "version": "0.2.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/webpack/README.md
+++ b/packages/build/webpack/README.md
@@ -125,11 +125,14 @@ npm run start
 ```
 
 For those modules that use other @labkey packages (e.g., `@labkey/components`), you can run the start command
-with linking enabled so that the HMR environment will alias to the source repository `/dist` directory so that
-you don't have to do a copy of the re-built `/dist` directory for that package in order for the changes to be
-picked up.
+with linking enabled so that the HMR environment will alias to the source repository `/dist` directory.
+This means that you won't have to do a copy of the re-built `/dist` directory for that package in order for the
+changes to be picked up in your module.
 
-To enable HMR with @labkey/components linking:
+In order to use this linking option, you must set a `LABKEY_UI_COMPONENTS_HOME` environment variable on your
+machine with the absolute path to your `labkey-ui-components` enlistment.
+
+To enable HMR with @labkey package linking:
 ```
 npm run start-link
 ```

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -9,16 +9,26 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-// This path assumes the enlistment in labkey-ui-components is a sibling of the root of the LabKey enlistment.
-// TODO figure out how we can make this more flexible and get an absolute path from the dev based on their setup
-const labkeyUIComponentsRelPath = (lkModuleContainer ? "../../../../../" : "../../../../") + "labkey-ui-components/packages/components";
-const labkeyUIComponentsPath = process.env.LINK ? path.resolve(labkeyUIComponentsRelPath) : path.resolve("./node_modules/@labkey/components");
-console.log("Using @labkey/components path: " + labkeyUIComponentsPath);
+// Conditionalize the path to use for the @labkey packages based on if the user wants to LINK their labkey-ui-components repo.
+// NOTE: the LABKEY_UI_COMPONENTS_HOME environment variable must be set for this to work.
+let labkeyUIComponentsPath = path.resolve("./node_modules/@labkey/components");
+let freezerManagerPath = path.resolve("./node_modules/@labkey/freezermanager");
+if (process.env.LINK) {
+    if (process.env.LABKEY_UI_COMPONENTS_HOME === undefined) {
+        console.log("ERROR: You must set your LABKEY_UI_COMPONENTS_HOME environment variable in order to link your @labkey packages.")
+    }
 
-// TODO not all modules will have this package as a dependency, how can we hide this behind an env var or set it locally for a module?
-const freezerManagerRelPath = (lkModuleContainer ? "../../../../../../" : "../../../../../") + "inventory/packages/freezermanager";
-const freezerManagerPath = process.env.LINK ? path.resolve(__dirname, freezerManagerRelPath) : path.resolve("./node_modules/@labkey/freezermanager");
-console.log("Using @labkey/freezermanager path: " + freezerManagerPath);
+    labkeyUIComponentsPath = process.env.LABKEY_UI_COMPONENTS_HOME + "/packages/components";
+
+    const freezerManagerRelPath = (lkModuleContainer ? "../../../../../../" : "../../../../../") + "inventory/packages/freezermanager";
+    freezerManagerPath = path.resolve(__dirname, freezerManagerRelPath);
+}
+if (process.env.npm_package_dependencies__labkey_components) {
+    console.log("Using @labkey/components path: " + labkeyUIComponentsPath);
+}
+if (process.env.npm_package_dependencies__labkey_freezermanager) {
+    console.log("Using @labkey/freezermanager path: " + freezerManagerPath);
+}
 
 const watchPort = process.env.WATCH_PORT || 3001;
 

--- a/packages/components/releaseNotes/labkey/build.md
+++ b/packages/components/releaseNotes/labkey/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
-### TBD
-*Released*: TBD
+### 0.2.0
+*Released*: 27 October 2020
 * Use a LABKEY_UI_COMPONENTS_HOME environment variable from the user's setup to define the
     path for the webpack aliasing of @labkey packages when using "npm run start-link"
 

--- a/packages/components/releaseNotes/labkey/build.md
+++ b/packages/components/releaseNotes/labkey/build.md
@@ -1,5 +1,10 @@
 # @labkey/build
 
+### TBD
+*Released*: TBD
+* Use a LABKEY_UI_COMPONENTS_HOME environment variable from the user's setup to define the
+    path for the webpack aliasing of @labkey packages when using "npm run start-link"
+
 ### version 0.1.0
 *Released*: 26 October 2020
 * Initial package contents with webpack config assets ported over from platform/webpack (with additions to fit scenarios from other modules)


### PR DESCRIPTION
#### Rationale
The initial v0.1.0 of @labkey/build was fixed on using a relative path to get to the labkey-ui-components repository when using "npm run start-link". This version update changes that to using a LABKEY_UI_COMPONENTS_HOME environment variable so that each dev can set it based on their local setup.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/379
* https://github.com/LabKey/platform/pull/1664
* https://github.com/LabKey/inventory/pull/117
* https://github.com/LabKey/provenance/pull/42
* https://github.com/LabKey/moduleEditor/pull/17
* https://github.com/LabKey/commonAssays/pull/252
* https://github.com/LabKey/tutorialModules/pull/30

#### Changes
* Use a LABKEY_UI_COMPONENTS_HOME environment variable from the user's setup to define the path for the webpack aliasing of @labkey packages when using "npm run start-link"
* Only output the @labkey/components and @labkey/freezermangaer package paths for the npm start commands if those packages are part of the package.json for the given module
