### PR TITLE
Generate files into views/gen instead of views for better cleaning and caching possibilities

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "0.3.0-generatedViews.0",
+  "version": "0.3.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "0.2.0",
+  "version": "0.3.0-generatedViews.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -219,12 +219,12 @@ module.exports = {
                         title: app.title,
                         permission: app.permission,
                         viewTemplate: app.template,
-                        filename: '../../../views/' + app.name + '.view.xml',
+                        filename: '../../../views/gen/' + app.name + '.view.xml',
                         template: 'node_modules/@labkey/build/webpack/app.view.template.xml'
                     }),
                     new HtmlWebpackPlugin({
                         inject: false,
-                        filename: '../../../views/' + app.name + '.html',
+                        filename: '../../../views/gen/' + app.name + '.html',
                         template: 'node_modules/@labkey/build/webpack/app.template.html'
                     }),
                     new HtmlWebpackPlugin({
@@ -235,7 +235,7 @@ module.exports = {
                         title: app.title,
                         permission: app.permission,
                         viewTemplate: app.template,
-                        filename: '../../../views/' + app.name + 'Dev.view.xml',
+                        filename: '../../../views/gen/' + app.name + 'Dev.view.xml',
                         template: 'node_modules/@labkey/build/webpack/app.view.template.xml'
                     }),
                     new HtmlWebpackPlugin({
@@ -243,7 +243,7 @@ module.exports = {
                         mode: 'dev',
                         port: watchPort,
                         name: app.name,
-                        filename: '../../../views/' + app.name + 'Dev.html',
+                        filename: '../../../views/gen/' + app.name + 'Dev.html',
                         template: 'node_modules/@labkey/build/webpack/app.template.html'
                     })
                 ]);

--- a/packages/components/releaseNotes/labkey/build.md
+++ b/packages/components/releaseNotes/labkey/build.md
@@ -1,4 +1,7 @@
 # @labkey/build
+### version TBD
+*Released*: TBD
+* Generate files into views/gen instead of views for better cleaning and caching possibilities
 
 ### version 0.1.0
 *Released*: 26 October 2020

--- a/packages/components/releaseNotes/labkey/build.md
+++ b/packages/components/releaseNotes/labkey/build.md
@@ -1,6 +1,6 @@
 # @labkey/build
-### version TBD
-*Released*: TBD
+### version 0.3.0
+*Released*: 28 October 2020
 * Generate files into views/gen instead of views for better cleaning and caching possibilities
 
 ### 0.2.0


### PR DESCRIPTION
#### Rationale
Gradle build caching requires that the directories designated as output directories be fully under the control of the build, so any task that outputs files to a directory that may already be occupied by checked-in files makes a task not able to be cached.  With the next version of gradlePlugin, we'll have tasks enabled for using the build cache.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/98
* https://github.com/LabKey/platform/pull/1662

#### Changes
* Generate files into``views/gen` instead of `views` for better cleaning and caching possibilities
