### PR TITLE
Component updates for use with QueryModel

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "0.104.0",
+  "version": "0.105.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 0.10#.#
-*Released*: ## November 2020
+### version 0.105.0
+*Released*: 2 November 2020
 * ImmutableJS-free `CreatedModified`.
 * `resolveDetailFieldValue` updated to handle `Record` type. Typings improved.
 * `FilesListingForm` and `WebDavFile` updates.

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 0.10#.#
+*Released*: ## November 2020
+* ImmutableJS-free `CreatedModified`.
+* `resolveDetailFieldValue` updated to handle `Record` type. Typings improved.
+* `FilesListingForm` and `WebDavFile` updates.
+
 ### version 0.104.0
 *Released*: 1 Nov 2020
 * Item 7984: DomainForm component support for export/import field definitions from .json file

--- a/packages/components/src/internal/components/base/CreatedModified.spec.tsx
+++ b/packages/components/src/internal/components/base/CreatedModified.spec.tsx
@@ -14,52 +14,25 @@
  * limitations under the License.
  */
 import React from 'react';
-import { fromJS, Map } from 'immutable';
 import { mount } from 'enzyme';
 
 import { JEST_SITE_ADMIN_USER_ID } from '../../../test/data/constants';
 
 import { CreatedModified } from './CreatedModified';
 
-const createdRow = Map<string, any>(
-    fromJS({
-        Created: {
-            formattedValue: '2019-05-15 19:45',
-            value: '2019-05-15 19:45:40.593',
-        },
-        CreatedBy: {
-            displayValue: 'username',
-            url: '#/q/core/siteusers/' + JEST_SITE_ADMIN_USER_ID,
-            value: 1001,
-        },
-    })
-);
-
-const createdModifiedRow = Map<string, any>(
-    fromJS({
-        Created: {
-            formattedValue: '2019-05-15 19:45',
-            value: '2019-05-15 19:45:40.593',
-        },
-        CreatedBy: {
-            displayValue: 'username',
-            url: '#/q/core/siteusers/1001',
-            value: 1001,
-        },
-        Modified: {
-            formattedValue: '2019-05-16 19:45',
-            value: '2019-05-16 19:45:40.593',
-        },
-        ModifiedBy: {
-            displayValue: 'username2',
-            url: '#/q/core/siteusers/1002',
-            value: 1002,
-        },
-    })
-);
-
 describe('<CreatedModified/>', () => {
     test('with created row', () => {
+        const createdRow = {
+            Created: {
+                formattedValue: '2019-05-15 19:45',
+                value: '2019-05-15 19:45:40.593',
+            },
+            CreatedBy: {
+                displayValue: 'username',
+                url: '#/q/core/siteusers/' + JEST_SITE_ADMIN_USER_ID,
+                value: 1001,
+            },
+        };
         const component = <CreatedModified row={createdRow} useServerDate={false} />;
 
         const wrapper = mount(component);
@@ -73,6 +46,26 @@ describe('<CreatedModified/>', () => {
     });
 
     test('with modified row', () => {
+        const createdModifiedRow = {
+            Created: {
+                formattedValue: '2019-05-15 19:45',
+                value: '2019-05-15 19:45:40.593',
+            },
+            CreatedBy: {
+                displayValue: 'username',
+                url: '#/q/core/siteusers/1001',
+                value: 1001,
+            },
+            Modified: {
+                formattedValue: '2019-05-16 19:45',
+                value: '2019-05-16 19:45:40.593',
+            },
+            ModifiedBy: {
+                displayValue: 'username2',
+                url: '#/q/core/siteusers/1002',
+                value: 1002,
+            },
+        };
         const component = <CreatedModified row={createdModifiedRow} useServerDate={false} />;
 
         const wrapper = mount(component);

--- a/packages/components/src/internal/components/base/CreatedModified.tsx
+++ b/packages/components/src/internal/components/base/CreatedModified.tsx
@@ -13,23 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { Component } from 'react';
+import React, { Component, ReactNode } from 'react';
 import classNames from 'classnames';
-import { Map } from 'immutable';
 import moment from 'moment';
 import { Query } from '@labkey/api';
 
 import { caseInsensitive, LoadingSpinner } from '../../..';
 
-interface ICreatedModified {
+interface IRowConfig {
     createdBy: string;
     createdTS: any;
+    display: boolean;
     modifiedBy: string;
     modifiedTS: any;
-}
-
-interface IRowConfig extends ICreatedModified {
-    display: boolean;
     hasCreated: boolean;
     hasModified: boolean;
     useCreated: boolean;
@@ -37,7 +33,7 @@ interface IRowConfig extends ICreatedModified {
 
 interface CreatedModifiedProps {
     className?: string;
-    row: Map<string, any> | Record<string, any>;
+    row: Record<string, any>;
     useServerDate?: boolean;
 }
 
@@ -47,17 +43,12 @@ interface State {
 }
 
 export class CreatedModified extends Component<CreatedModifiedProps, State> {
-    static defaultProps = {
-        useServerDate: true,
-    };
+    static defaultProps = { className: 'cbmb-inline', useServerDate: true };
 
     constructor(props) {
         super(props);
 
-        this.state = {
-            serverDate: undefined,
-            loading: props.useServerDate,
-        };
+        this.state = { loading: props.useServerDate, serverDate: undefined };
     }
 
     componentDidMount(): void {
@@ -69,7 +60,7 @@ export class CreatedModified extends Component<CreatedModifiedProps, State> {
         }
     }
 
-    formatTitle(config: IRowConfig): string {
+    formatTitle = (config: IRowConfig): string => {
         const title = [];
 
         if (config.display) {
@@ -95,35 +86,16 @@ export class CreatedModified extends Component<CreatedModifiedProps, State> {
         }
 
         return '';
-    }
-
-    processCreatedModified = (): ICreatedModified => {
-        const { row } = this.props;
-
-        // Map<string, any>
-        if (Map.isMap(row)) {
-            return {
-                createdBy: row.getIn(['CreatedBy', 'displayValue']) || row.getIn(['createdby', 'displayValue']),
-                createdTS: row.getIn(['Created', 'value']) || row.getIn(['created', 'value']),
-                modifiedBy: row.getIn(['ModifiedBy', 'displayValue']) || row.getIn(['modifiedby', 'displayValue']),
-                modifiedTS: row.getIn(['Modified', 'value']) || row.getIn(['modified', 'value']),
-            };
-        }
-
-        // Record<string, any>
-        return {
-            createdBy: caseInsensitive(row, 'createdBy')?.displayValue,
-            createdTS: caseInsensitive(row, 'created')?.value,
-            modifiedBy: caseInsensitive(row, 'modifiedBy')?.displayValue,
-            modifiedTS: caseInsensitive(row, 'modified')?.value,
-        };
     };
 
     processRow = (): IRowConfig => {
         const { row } = this.props;
 
         if (row) {
-            const { createdBy, createdTS, modifiedBy, modifiedTS } = this.processCreatedModified();
+            const createdBy = caseInsensitive(row, 'createdBy')?.displayValue;
+            const createdTS = caseInsensitive(row, 'created')?.value;
+            const modifiedBy = caseInsensitive(row, 'modifiedBy')?.displayValue;
+            const modifiedTS = caseInsensitive(row, 'modified')?.value;
 
             const hasCreated = createdTS !== undefined;
             const hasModified = modifiedTS !== undefined;
@@ -152,7 +124,7 @@ export class CreatedModified extends Component<CreatedModifiedProps, State> {
         };
     };
 
-    render() {
+    render(): ReactNode {
         const { className } = this.props;
         const { serverDate, loading } = this.state;
 

--- a/packages/components/src/internal/components/files/FilesListing.tsx
+++ b/packages/components/src/internal/components/files/FilesListing.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent, ReactNode } from 'react';
 
 import { Button } from 'react-bootstrap';
 import { List, Set } from 'immutable';
@@ -6,30 +6,28 @@ import { List, Set } from 'immutable';
 import { IFile } from './models';
 
 interface Props {
+    canDelete?: boolean;
     files: List<IFile>;
+    getFilePropertiesEditTrigger?: (file: IFile) => ReactNode;
     headerText?: string;
     noFilesMessage: string;
-    onFileSelection: (event) => any;
-    onDelete?: (fileName: string) => any;
-    canDelete?: boolean;
+    onDelete?: (fileName: string) => void;
+    onFileSelection: (event) => void;
     selectedFiles: Set<string>;
     useFilePropertiesEditTrigger?: boolean;
-    getFilePropertiesEditTrigger?: (file: IFile) => React.ReactNode;
 }
 
 interface State {
     confirmDeletionSet: Set<string>;
 }
 
-export class FilesListing extends React.PureComponent<Props, State> {
+export class FilesListing extends PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
-        this.state = {
-            confirmDeletionSet: Set<string>(),
-        };
+        this.state = { confirmDeletionSet: Set<string>() };
     }
 
-    toggleDeleteConfirmation = (fileName: string) => {
+    toggleDeleteConfirmation = (fileName: string): void => {
         const { confirmDeletionSet } = this.state;
 
         this.setState({
@@ -39,12 +37,9 @@ export class FilesListing extends React.PureComponent<Props, State> {
         });
     };
 
-    deleteFile = (fileName: string) => {
-        const { onDelete } = this.props;
-        this.setState({
-            confirmDeletionSet: this.state.confirmDeletionSet.delete(fileName),
-        });
-        onDelete(fileName);
+    deleteFile = (fileName: string): void => {
+        this.setState(state => ({ confirmDeletionSet: state.confirmDeletionSet.delete(fileName) }));
+        this.props.onDelete?.(fileName);
     };
 
     render() {
@@ -55,7 +50,10 @@ export class FilesListing extends React.PureComponent<Props, State> {
             useFilePropertiesEditTrigger,
             getFilePropertiesEditTrigger,
             canDelete,
+            onFileSelection,
+            selectedFiles,
         } = this.props;
+        const { confirmDeletionSet } = this.state;
 
         if (!files || files.size === 0) return <div>{noFilesMessage}</div>;
 
@@ -64,7 +62,7 @@ export class FilesListing extends React.PureComponent<Props, State> {
                 {headerText && <div className="file-listing--header bottom-spacing">{headerText}</div>}
                 {files.map((file: IFile, key) => {
                     const { description, downloadUrl, name } = file;
-                    const confirmDelete = this.state.confirmDeletionSet.has(name);
+                    const confirmDelete = confirmDeletionSet.has(name);
 
                     return (
                         <div className="component file-listing-row--container" key={key}>
@@ -72,9 +70,9 @@ export class FilesListing extends React.PureComponent<Props, State> {
                                 <div className="row" key={key}>
                                     <div className="col-xs-4 file-listing-icon--container">
                                         <input
-                                            checked={this.props.selectedFiles.contains(name)}
+                                            checked={selectedFiles.contains(name)}
                                             name={name}
-                                            onClick={this.props.onFileSelection}
+                                            onClick={onFileSelection}
                                             type="checkbox"
                                         />
                                         <i className={file.iconFontCls + ' file-listing-icon'} />

--- a/packages/components/src/internal/components/files/FilesListingForm.tsx
+++ b/packages/components/src/internal/components/files/FilesListingForm.tsx
@@ -54,7 +54,8 @@ export class FilesListingForm extends Component<Props, State> {
     };
 
     toggleFileSelection = (event): void => {
-        const { name, target } = event;
+        const { target } = event;
+        const { name } = target;
         this.setState(state => ({
             selectedFiles: target.checked ? state.selectedFiles.add(name) : state.selectedFiles.delete(name),
         }));

--- a/packages/components/src/internal/components/files/models.ts
+++ b/packages/components/src/internal/components/files/models.ts
@@ -24,6 +24,11 @@ export interface FileAttachmentFormModel {
 }
 
 export interface IFile {
+    canDelete: boolean;
+    canEdit: boolean;
+    canRead: boolean;
+    canRename: boolean;
+    canUpload: boolean;
     contentLength: number;
     contentType: string;
     created: string;
@@ -41,14 +46,14 @@ export interface IFile {
     name: string;
     options: string;
     propertiesRowId?: number;
-    canDelete: boolean;
-    canEdit: boolean;
-    canRead: boolean;
-    canRename: boolean;
-    canUpload: boolean;
 }
 
 export const DEFAULT_FILE: IFile = {
+    canDelete: false,
+    canEdit: false,
+    canRead: false,
+    canRename: false,
+    canUpload: false,
     contentLength: 0,
     contentType: undefined,
     created: undefined,
@@ -66,11 +71,6 @@ export const DEFAULT_FILE: IFile = {
     name: undefined,
     options: undefined,
     propertiesRowId: undefined,
-    canDelete: false,
-    canEdit: false,
-    canRead: false,
-    canRename: false,
-    canUpload: false,
 };
 
 export interface FileSizeLimitProps {

--- a/packages/components/src/internal/components/forms/input/AliasInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 import { generateId, QueryColumn, SelectInput } from '../../../..';
 
 interface AliasInputProps {
     col: QueryColumn;
     editing?: boolean;
-    value?: string | Array<Record<string, any>>;
+    value?: string | Record<string, any>[];
     allowDisable?: boolean;
     initiallyDisabled: boolean;
-    onToggleDisable?: (boolean) => void;
+    onToggleDisable?: (disabled: boolean) => void;
 }
 
-export class AliasInput extends React.Component<AliasInputProps> {
+export class AliasInput extends Component<AliasInputProps> {
     _id: string;
     _labelKey: string;
 

--- a/packages/components/src/internal/components/forms/input/AliasInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.tsx
@@ -5,7 +5,7 @@ import { generateId, QueryColumn, SelectInput } from '../../../..';
 interface AliasInputProps {
     col: QueryColumn;
     editing?: boolean;
-    value?: string | Record<string, any>[];
+    value?: string | Array<Record<string, any>>;
     allowDisable?: boolean;
     initiallyDisabled: boolean;
     onToggleDisable?: (disabled: boolean) => void;

--- a/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
+++ b/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
@@ -67,7 +67,7 @@ class DetailBodyImpl extends PureComponent<BodyProps & InjectedQueryModels> {
         const { name, plural, schemaLabel, schemaName } = queryInfo;
         const title = this.title;
         const pageTitle = schemaLabel + ' - ' + plural + ' ' + title;
-        const row = fromJS(model.gridData[0]);
+        const row = model.gridData[0];
 
         return (
             <Page hasHeader={true} title={pageTitle}>

--- a/packages/components/src/internal/components/navigation/BreadcrumbCreate.spec.tsx
+++ b/packages/components/src/internal/components/navigation/BreadcrumbCreate.spec.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import React from 'react';
-import { fromJS, Map } from 'immutable';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
@@ -22,28 +21,26 @@ import { AppURL } from '../../..';
 
 import { BreadcrumbCreate } from './BreadcrumbCreate';
 
-const createdModifiedRow = Map<string, any>(
-    fromJS({
-        Created: {
-            formattedValue: '2019-05-15 19:45',
-            value: '2019-05-15 19:45:40.593',
-        },
-        CreatedBy: {
-            displayValue: 'username',
-            url: '#/q/core/siteusers/1001',
-            value: 1001,
-        },
-        Modified: {
-            formattedValue: '2019-05-16 19:45',
-            value: '2019-05-16 19:45:40.593',
-        },
-        ModifiedBy: {
-            displayValue: 'username2',
-            url: '#/q/core/siteusers/1002',
-            value: 1002,
-        },
-    })
-);
+const createdModifiedRow = {
+    Created: {
+        formattedValue: '2019-05-15 19:45',
+        value: '2019-05-15 19:45:40.593',
+    },
+    CreatedBy: {
+        displayValue: 'username',
+        url: '#/q/core/siteusers/1001',
+        value: 1001,
+    },
+    Modified: {
+        formattedValue: '2019-05-16 19:45',
+        value: '2019-05-16 19:45:40.593',
+    },
+    ModifiedBy: {
+        displayValue: 'username2',
+        url: '#/q/core/siteusers/1002',
+        value: 1002,
+    },
+};
 
 describe('<BreadcrumbCreate/>', () => {
     test('with created row', () => {

--- a/packages/components/src/internal/components/navigation/BreadcrumbCreate.tsx
+++ b/packages/components/src/internal/components/navigation/BreadcrumbCreate.tsx
@@ -13,31 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { Map } from 'immutable';
+import React, { FC, memo } from 'react';
 
 import { CreatedModified } from '../../..';
 
 import { Breadcrumb } from './Breadcrumb';
 
 interface Props {
-    row?: Map<string, any>;
+    row?: Record<string, any>;
     useServerDate?: boolean;
 }
 
-export class BreadcrumbCreate extends React.Component<Props, any> {
-    static defaultProps = {
-        useServerDate: true,
-    };
-
-    render() {
-        const { children, row, useServerDate } = this.props;
-
-        return (
-            <div className="row component-crumbcreate--container">
-                <Breadcrumb className="col-xs-8 col-sm-8 col-md-8">{children}</Breadcrumb>
-                <CreatedModified row={row} useServerDate={useServerDate} className="col-xs-4 col-sm-4 col-md-4" />
-            </div>
-        );
-    }
-}
+export const BreadcrumbCreate: FC<Props> = memo(props => (
+    <div className="row component-crumbcreate--container">
+        <Breadcrumb className="col-xs-8 col-sm-8 col-md-8">{props.children}</Breadcrumb>
+        <CreatedModified row={props.row} useServerDate={props.useServerDate} className="col-xs-4 col-sm-4 col-md-4" />
+    </div>
+));

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -345,7 +345,6 @@ export class QueryModel {
         this.orderedRows = undefined;
         this.rows = undefined;
         this.rowCount = undefined;
-        this.rowsError = undefined;
         this.rowsLoadingState = LoadingState.INITIALIZED;
         this.selectedReportId = undefined;
         this.selections = undefined;

--- a/packages/components/src/stories/FilesListingForm.tsx
+++ b/packages/components/src/stories/FilesListingForm.tsx
@@ -13,7 +13,7 @@ storiesOf('FilesListingForm', module)
         return (
             <FilesListingForm
                 files={List<IFile>()}
-                handleUpload={() => {}}
+                handleUpload={async () => {}}
                 handleDelete={() => {}}
                 handleDownload={() => {}}
                 addFileText={text('addFileText', undefined)}
@@ -33,7 +33,7 @@ storiesOf('FilesListingForm', module)
         return (
             <FilesListingForm
                 files={FILES_DATA}
-                handleUpload={() => {}}
+                handleUpload={async () => {}}
                 handleDelete={() => {}}
                 handleDownload={() => {}}
                 addFileText={text('addFileText', undefined)}
@@ -56,7 +56,7 @@ storiesOf('FilesListingForm', module)
                 readOnlyFiles={FILES_DATA_2}
                 headerText={text('headerText', 'Editable files')}
                 readOnlyHeaderText={text('readOnlyHeaderText', 'Read-only files')}
-                handleUpload={() => {}}
+                handleUpload={async () => {}}
                 handleDelete={() => {}}
                 handleDownload={() => {}}
                 addFileText={text('addFileText', undefined)}

--- a/packages/components/src/stories/PageDetailHeader.tsx
+++ b/packages/components/src/stories/PageDetailHeader.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import React from 'react';
-import { fromJS, Map } from 'immutable';
 import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs';
 
@@ -26,28 +25,26 @@ import './stories.scss';
 storiesOf('PageDetailHeader', module)
     .addDecorator(withKnobs)
     .add('with knobs', () => {
-        const createdRow = Map<string, any>(
-            fromJS({
-                Created: {
-                    formattedValue: '2019-05-15 19:45',
-                    value: '2019-05-15 19:45:40.593',
-                },
-                CreatedBy: {
-                    displayValue: 'username',
-                    url: '#/q/core/siteusers/1001',
-                    value: 1001,
-                },
-                Modified: {
-                    formattedValue: '2019-05-16 19:45',
-                    value: '2019-05-16 19:45:40.593',
-                },
-                ModifiedBy: {
-                    displayValue: 'username2',
-                    url: '#/q/core/siteusers/1002',
-                    value: 1002,
-                },
-            })
-        );
+        const createdRow = {
+            Created: {
+                formattedValue: '2019-05-15 19:45',
+                value: '2019-05-15 19:45:40.593',
+            },
+            CreatedBy: {
+                displayValue: 'username',
+                url: '#/q/core/siteusers/1001',
+                value: 1001,
+            },
+            Modified: {
+                formattedValue: '2019-05-16 19:45',
+                value: '2019-05-16 19:45:40.593',
+            },
+            ModifiedBy: {
+                displayValue: 'username2',
+                url: '#/q/core/siteusers/1002',
+                value: 1002,
+            },
+        };
 
         return (
             <PageDetailHeader


### PR DESCRIPTION
#### Rationale
As we migrate our usages of `QueryGridModel` to `QueryModel` we'll also be updating our shared components to be more easily used with either implementation. This PR updates the following:

* `<CreatedModified/>` is switched from using taking a `Map<string, any>` to a `Record<string, any>`. This reduces our dependence on `ImmutableJS`. `QueryGridModel` usages can use `Map.toJS()` and pass to the associated `<CreatedModified/>`.
* `resolveDetailFieldValue` is used to resolve data from a variety of object types. This PR updates the types and streamlines the logic so it works with `Immutable` types as well as `Record`.

Additionally, this work has been done in tandem with the Experiment updates in Biologics. As a part of this work Biologics now utilizes the shared `FilesListingForm` as well as the `WebDavFile` model.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/728
* https://github.com/LabKey/sampleManagement/pull/395

#### Changes
* ImmutableJS-free `CreatedModified`.
* `resolveDetailFieldValue` updated to handle `Record` type. Typings improved.
* `FilesListingForm` and `WebDavFile` updates.