### PR TITLE
7984: Field Editor Import & Export Unit Tests

### DIFF
--- a/packages/components/src/internal/components/buttons/ActionButton.spec.tsx
+++ b/packages/components/src/internal/components/buttons/ActionButton.spec.tsx
@@ -1,14 +1,14 @@
 /*
  * Copyright (c) 2019 LabKey Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the 'License');
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an 'AS IS' BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/packages/components/src/internal/components/buttons/ActionButton.spec.tsx
+++ b/packages/components/src/internal/components/buttons/ActionButton.spec.tsx
@@ -1,14 +1,14 @@
 /*
  * Copyright (c) 2019 LabKey Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an 'AS IS' BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -24,20 +24,24 @@ describe('<ActionButton />', () => {
     test('Default properties', () => {
         const onClick = jest.fn();
         const wrapper = shallow(<ActionButton onClick={onClick} />);
-        console.log(wrapper.debug());
         wrapper.find('span').simulate('click');
         expect(onClick).toHaveBeenCalledTimes(1);
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('Specify entity and classes', () => {
+    test('With custom props', () => {
         const onClick = jest.fn();
+        const helperBody = <p> Test Body Contents </p>;
         const tree = renderer
             .create(
                 <ActionButton
+                    buttonClass='test-button-class'
+                    containerClass='test-container-class'
+                    disabled={false}
+                    title='test-title'
                     onClick={onClick}
-                    containerClass="test-container-class"
-                    buttonClass="test-button-class"
+                    helperTitle='test-helperTitle'
+                    helperBody={() => {return helperBody}}
                 />
             )
             .toJSON();
@@ -50,11 +54,5 @@ describe('<ActionButton />', () => {
         wrapper.find('span').simulate('click');
         expect(onClick).toHaveBeenCalledTimes(0);
         expect(wrapper).toMatchSnapshot();
-    });
-
-    test('With title', () => {
-        const onClick = jest.fn();
-        const tree = renderer.create(<ActionButton onClick={onClick} title="Test title" />).toJSON();
-        expect(tree).toMatchSnapshot();
     });
 });

--- a/packages/components/src/internal/components/buttons/ActionButton.tsx
+++ b/packages/components/src/internal/components/buttons/ActionButton.tsx
@@ -25,7 +25,7 @@ export interface ActionButtonProps {
     title?: string;
     onClick: () => void;
     helperTitle?: string;
-    helperBody?: any;
+    helperBody?: () => any;
 }
 
 export class ActionButton extends React.PureComponent<ActionButtonProps> {

--- a/packages/components/src/internal/components/buttons/AddEntityButton.spec.tsx
+++ b/packages/components/src/internal/components/buttons/AddEntityButton.spec.tsx
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import { shallow } from 'enzyme';
 
 import { AddEntityButton } from './AddEntityButton';
 
 describe('<AddEntityButton />', () => {
-    test('Minimal properties', () => {
+    test('Minimal props', () => {
         const onClick = jest.fn();
         const wrapper = shallow(
             <AddEntityButton
@@ -31,14 +30,19 @@ describe('<AddEntityButton />', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('Typical properties', () => {
+    test('Fully populated props', () => {
         const onClick = jest.fn();
+        const helperBody = <p> Test Body Contents </p>;
         const wrapper = shallow(
             <AddEntityButton
                 entity="EntityName"
-                buttonClass="button-class-name"
-                containerClass="container-class-name"
                 onClick={onClick}
+                buttonClass='test-button-class'
+                containerClass='test-container-class'
+                disabled={false}
+                title='test-title'
+                helperTitle='test-helperTitle'
+                helperBody={() => {return helperBody}}
             />);
         expect(wrapper).toMatchSnapshot();
     });

--- a/packages/components/src/internal/components/buttons/__snapshots__/ActionButton.spec.tsx.snap
+++ b/packages/components/src/internal/components/buttons/__snapshots__/ActionButton.spec.tsx.snap
@@ -53,6 +53,45 @@ exports[`<ActionButton /> Specify entity and classes 1`] = `
 </div>
 `;
 
+exports[`<ActionButton /> With custom props 1`] = `
+<div
+  className="test-container-class"
+  title="test-title"
+>
+  <div
+    className="test-button-class"
+  >
+    <span
+      className="container--action-button btn btn-default"
+      onClick={[MockFunction]}
+    />
+    <span
+      className="label-help-target"
+      onMouseOut={[Function]}
+      onMouseOver={[Function]}
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+        data-icon="question-circle"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`<ActionButton /> With title 1`] = `
 <div
   className="form-group"

--- a/packages/components/src/internal/components/buttons/__snapshots__/ActionButton.spec.tsx.snap
+++ b/packages/components/src/internal/components/buttons/__snapshots__/ActionButton.spec.tsx.snap
@@ -37,22 +37,6 @@ exports[`<ActionButton /> Disabled 1`] = `
 </div>
 `;
 
-exports[`<ActionButton /> Specify entity and classes 1`] = `
-<div
-  className="test-container-class"
->
-  <div
-    className="test-button-class"
-  >
-    <span
-      className="container--action-button btn btn-default"
-      onClick={[MockFunction]}
-    />
-    
-  </div>
-</div>
-`;
-
 exports[`<ActionButton /> With custom props 1`] = `
 <div
   className="test-container-class"
@@ -88,21 +72,6 @@ exports[`<ActionButton /> With custom props 1`] = `
         />
       </svg>
     </span>
-  </div>
-</div>
-`;
-
-exports[`<ActionButton /> With title 1`] = `
-<div
-  className="form-group"
-  title="Test title"
->
-  <div>
-    <span
-      className="container--action-button btn btn-default"
-      onClick={[MockFunction]}
-    />
-    
   </div>
 </div>
 `;

--- a/packages/components/src/internal/components/buttons/__snapshots__/AddEntityButton.spec.tsx.snap
+++ b/packages/components/src/internal/components/buttons/__snapshots__/AddEntityButton.spec.tsx.snap
@@ -19,40 +19,9 @@ exports[`<AddEntityButton /> Fully populated props 1`] = `
 </ActionButton>
 `;
 
-exports[`<AddEntityButton /> Minimal properties 1`] = `
-<ActionButton
-  containerClass="form-group"
-  entity="EntityName"
-  helperTitle="More Info"
-  onClick={[MockFunction]}
->
-  <i
-    className="fa fa-plus-circle container--addition-icon"
-  />
-   Add 
-  EntityName
-</ActionButton>
-`;
-
 exports[`<AddEntityButton /> Minimal props 1`] = `
 <ActionButton
   containerClass="form-group"
-  entity="EntityName"
-  helperTitle="More Info"
-  onClick={[MockFunction]}
->
-  <i
-    className="fa fa-plus-circle container--addition-icon"
-  />
-   Add 
-  EntityName
-</ActionButton>
-`;
-
-exports[`<AddEntityButton /> Typical properties 1`] = `
-<ActionButton
-  buttonClass="button-class-name"
-  containerClass="container-class-name"
   entity="EntityName"
   helperTitle="More Info"
   onClick={[MockFunction]}

--- a/packages/components/src/internal/components/buttons/__snapshots__/AddEntityButton.spec.tsx.snap
+++ b/packages/components/src/internal/components/buttons/__snapshots__/AddEntityButton.spec.tsx.snap
@@ -1,6 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<AddEntityButton /> Fully populated props 1`] = `
+<ActionButton
+  buttonClass="test-button-class"
+  containerClass="test-container-class"
+  disabled={false}
+  entity="EntityName"
+  helperBody={[Function]}
+  helperTitle="test-helperTitle"
+  onClick={[MockFunction]}
+  title="test-title"
+>
+  <i
+    className="fa fa-plus-circle container--addition-icon"
+  />
+   Add 
+  EntityName
+</ActionButton>
+`;
+
 exports[`<AddEntityButton /> Minimal properties 1`] = `
+<ActionButton
+  containerClass="form-group"
+  entity="EntityName"
+  helperTitle="More Info"
+  onClick={[MockFunction]}
+>
+  <i
+    className="fa fa-plus-circle container--addition-icon"
+  />
+   Add 
+  EntityName
+</ActionButton>
+`;
+
+exports[`<AddEntityButton /> Minimal props 1`] = `
 <ActionButton
   containerClass="form-group"
   entity="EntityName"

--- a/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
@@ -684,4 +684,59 @@ describe('DomainForm', () => {
         expect(form).toMatchSnapshot();
         form.unmount();
     });
+
+    test('using allowImportExport', () => {
+        const domain = DomainDesign.create({});
+
+        const form = mount(
+            <DomainForm
+                domain={domain}
+                onChange={jest.fn()}
+                allowImportExport={true}
+            />
+        );
+
+        expect(form.find('.domain-form-manual-section').length).toEqual(1);
+        expect(form.find('.domain-form-manual-section').length).toEqual(1);
+        expect(form.find('.file-form-formats').text()).toContain('.json');
+
+        expect(form).toMatchSnapshot();
+        form.unmount();
+    });
+
+    test('using allowImportExport, field view', () => {
+        const fields = [];
+        fields.push({
+            name: 'key',
+            rangeURI: INT_RANGE_URI,
+            propertyId: 1,
+            propertyURI: 'test',
+        });
+
+        const domain = DomainDesign.create({
+            name: 'allowImportExport field view',
+            description: 'basic list domain form',
+            domainURI: 'test',
+            domainId: 1,
+            fields,
+            indices: [],
+        });
+
+        const form = mount(
+            <DomainForm
+                domain={domain}
+                onChange={jest.fn()}
+                domainFormDisplayOptions={{
+                    hideRequired: true,
+                }}
+                allowImportExport={true}
+            />
+        );
+
+        expect(form.find('.domain-toolbar-export-btn').length).toEqual(1);
+        expect(form.find('.domain-field-top-noBuffer').length).toEqual(2);
+
+        expect(form).toMatchSnapshot();
+        form.unmount();
+    });
 });

--- a/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
@@ -699,6 +699,8 @@ describe('DomainForm', () => {
 
         expect(form.find('.domain-form-manual-section').length).toEqual(1);
         expect(form.find('.file-form-formats').text()).toContain('.json');
+        expect(form.find('.domain-toolbar-export-btn').length).toEqual(0);
+        expect(form.find('.domain-field-top-noBuffer').length).toEqual(0);
 
         form.unmount();
     });
@@ -754,6 +756,7 @@ describe('DomainForm', () => {
         expect(form.find('.domain-toolbar-export-btn').length).toEqual(1);
         expect(form.find('.domain-field-top-noBuffer').length).toEqual(2);
 
+        // Note that the button at index i is the export button
         const actionButtons = form.find(ActionButton);
         expect(actionButtons.length).toBe(3);
         expect(actionButtons.at(1).prop('disabled')).toBe(false);

--- a/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
@@ -40,6 +40,7 @@ import {
 import { clearFieldDetails, createFormInputId, updateDomainField } from './actions';
 
 import { DomainRow } from './DomainRow';
+import { ActionButton } from "../buttons/ActionButton";
 
 interface Props {
     showInferFromFile?: boolean;
@@ -697,10 +698,27 @@ describe('DomainForm', () => {
         );
 
         expect(form.find('.domain-form-manual-section').length).toEqual(1);
-        expect(form.find('.domain-form-manual-section').length).toEqual(1);
         expect(form.find('.file-form-formats').text()).toContain('.json');
 
-        expect(form).toMatchSnapshot();
+        form.unmount();
+    });
+
+    test('not using allowImportExport', () => {
+        const domain = DomainDesign.create({});
+
+        const form = mount(
+            <DomainForm
+                domain={domain}
+                onChange={jest.fn()}
+                allowImportExport={false}
+            />
+        );
+
+        expect(form.find('.domain-form-manual-section').length).toEqual(0);
+        expect(form.find('.file-form-formats').length).toEqual(0);
+        expect(form.find('.domain-toolbar-export-btn').length).toEqual(0);
+        expect(form.find('.domain-field-top-noBuffer').length).toEqual(2);
+
         form.unmount();
     });
 
@@ -736,7 +754,48 @@ describe('DomainForm', () => {
         expect(form.find('.domain-toolbar-export-btn').length).toEqual(1);
         expect(form.find('.domain-field-top-noBuffer').length).toEqual(2);
 
-        expect(form).toMatchSnapshot();
+        const actionButtons = form.find(ActionButton);
+        expect(actionButtons.length).toBe(3);
+        expect(actionButtons.at(1).prop('disabled')).toBe(false);
+
+        form.unmount();
+    });
+
+    test('not using allowImportExport, field view', () => {
+        const fields = [];
+        fields.push({
+            name: 'key',
+            rangeURI: INT_RANGE_URI,
+            propertyId: 1,
+            propertyURI: 'test',
+        });
+
+        const domain = DomainDesign.create({
+            name: 'allowImportExport field view',
+            description: 'basic list domain form',
+            domainURI: 'test',
+            domainId: 1,
+            fields,
+            indices: [],
+        });
+
+        const form = mount(
+            <DomainForm
+                domain={domain}
+                onChange={jest.fn()}
+                domainFormDisplayOptions={{
+                    hideRequired: true,
+                }}
+                allowImportExport={false}
+            />
+        );
+
+        expect(form.find('.domain-toolbar-export-btn').length).toEqual(0);
+        expect(form.find('.domain-field-top-noBuffer').length).toEqual(2);
+
+        const actionButtons = form.find(ActionButton);
+        expect(actionButtons.length).toBe(2);
+
         form.unmount();
     });
 });

--- a/packages/components/src/internal/components/domainproperties/actions.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.spec.ts
@@ -28,6 +28,8 @@ import {
     getDomainPanelStatus,
     setDomainFields,
     updateDomainException,
+    processJsonImport,
+    downloadJsonFile
 } from './actions';
 import { DomainDesign, DomainException, DomainField } from './models';
 import { DATETIME_TYPE, DOUBLE_TYPE, INTEGER_TYPE, TEXT_TYPE } from './PropDescType';
@@ -294,4 +296,42 @@ describe('domain properties actions', () => {
         expect(getDomainHeaderName('Test Name', 'Test Header Title', 'test')).toBe('Test Header Title');
         expect(getDomainHeaderName('Data Fields')).toBe('Results Fields');
     });
-});
+
+    test('downloadJsonFile ', () => {
+        const link = {
+            click: jest.fn()
+        };
+        jest.spyOn(document, "createElement").mockImplementation(() => link as any);
+        downloadJsonFile("test-file", "fileName");
+
+        expect(link.className).toEqual("download-helper");
+        expect(link.download).toEqual("test-file.txt");
+        expect(link.href).toEqual("data:application/txt,hello%20world");
+        expect(link.click).toHaveBeenCalledTimes(1);
+
+    });
+
+    test('downloadJsonFile ', () => {
+
+        expect(FileSaver.saveAs).toHaveBeenCalledWith(
+            {content:'content', options: { type: 'application/octet-stream' }},
+            'filename.extension'
+        )
+    });
+
+    test('processJsonImport ', () => {
+        const domain = DomainDesign.create({});
+
+        const emptinessError = {success: false, msg: 'No field definitions were found in the imported json file. Please check the file contents and try again.'};
+        expect(processJsonImport("[]", domain)).toStrictEqual(emptinessError);
+        expect(processJsonImport("{}", domain)).toStrictEqual(emptinessError);
+        expect(processJsonImport("", domain)).toStrictEqual(emptinessError);
+
+        expect(() => {processJsonImport("<<< Invalid JSON", domain)}).toThrow();
+
+        const notListButContainsPKDomain = DomainDesign.create({});
+
+
+    });
+
+    });

--- a/packages/components/src/stories/DomainForm.tsx
+++ b/packages/components/src/stories/DomainForm.tsx
@@ -71,6 +71,7 @@ storiesOf('DomainForm', module)
                 data={undefined}
                 helpNoun={text('helpNoun', undefined)}
                 helpTopic={text('helpTopic', undefined)}
+                allowImportExport={boolean('allowImportExport', false)}
             />
         );
     })


### PR DESCRIPTION
#### Rationale
Adds Jest tests for added functionality

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/378
* https://github.com/LabKey/platform/pull/1661
* https://github.com/LabKey/sampleManagement/pull/391

#### Changes
* Added tests for functions processJsonImport, downloadJsonFile
* Exercise allowImportExport Prop in DomainForm
* Update tests for refactored ActionButton and AddEntityButton components
* Fix minor type issue in ActionButton
