### PR TITLE
Define and export more scss variables

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.1.1",
+  "version": "1.1.2-fmPolishStorageView.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.1.2-fmPolishStorageView.0",
+  "version": "1.1.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Sccs variable maintenance
+
 ### version 1.1.1
-*Release*: 11 November 2020
+*Released*: 11 November 2020
 * More error message resolution improvements, particularly for importing with EntityInsertPanel
 
 ### version 1.1.0

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 1.1.2
+*Released*: 19 November 2020
 * Sccs variable maintenance
 
 ### version 1.1.1

--- a/packages/components/src/internal/app/scss/variables.scss
+++ b/packages/components/src/internal/app/scss/variables.scss
@@ -8,6 +8,7 @@
 
 //== Colors
 $brand-primary:         #2980b9;
+$cyan: #33e0ff;
 
 //== Scaffolding
 $body-bg:               #f3f3f4 !default;
@@ -41,8 +42,12 @@ $breadcrumb-padding-horizontal: 0;
 //** Breadcrumb background color
 $breadcrumb-bg:                 transparent;
 //** Breadcrumb text color
-$breadcrumb-color:              $gray !default;
+$breadcrumb-color:              #999 !default;
 //** Textual separator for between breadcrumb elements
 $breadcrumb-separator:          ">" !default;
+
+// Domain properties variables
+$gray-border:           #CCC;
+$gray-shadow:           #F3F3F4;
 
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/_variables";


### PR DESCRIPTION
#### Rationale
Some variables used in the exported scss variables were not being defined, causing applications that want to use these variables to have to define them separately.  We also need some more gray variables.  Can never have too many gray variables.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/133

#### Changes
* Define missing variables
* Export a couple of other variables.
