### PR TITLE
Item 8116: Make insertRows, updateRows, and deleteRows API success response consistent

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.4.1",
+  "version": "1.4.1-fb-fmDiscardPolishing.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.4.1-fb-fmDiscardPolishing.1",
+  "version": "1.5.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.4.0",
+  "version": "1.4.0-fb-fmDiscardPolishing.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.4.1-fb-fmDiscardPolishing.0",
+  "version": "1.4.1-fb-fmDiscardPolishing.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Release*: TBD
 * Item 8116: Make insertRows, updateRows, and deleteRows API success response consistent
     - make sure to include "rows" and "transactionAuditId" for each
+    - minor display / layout fix for PageDetailHeader body content to flow better below image
 
 ### version 1.4.1
 *Released*: 25 November 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Release*: TBD
+* Item 8116: Make insertRows, updateRows, and deleteRows API success response consistent
+    - make sure to include "rows" and "transactionAuditId" for each
+
 ### version 1.4.0
 *Release*: 24 November 2020
 * Item 8137: Misc package changes to support LKFM freezer hierarchy polish

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Release*: TBD
+### version 1.5.0
+*Release*: 27 November 2020
 * Item 8116: Make insertRows, updateRows, and deleteRows API success response consistent
     - make sure to include "rows" and "transactionAuditId" for each
     - minor display / layout fix for PageDetailHeader body content to flow better below image

--- a/packages/components/src/internal/components/forms/PageDetailHeader.tsx
+++ b/packages/components/src/internal/components/forms/PageDetailHeader.tsx
@@ -74,17 +74,19 @@ export class PageDetailHeader extends PureComponent<Props> {
                             )}
                         </div>
                     )}
-                    <h2 className="no-margin-top detail__header--name">{title}</h2>
-                    {subTitle && <h4 className="test-loc-detail-subtitle">{subTitle}</h4>}
-                    {description && <span className="detail__header--desc">{description}</span>}
-                    {fieldTriggerProps && (
-                        <div className="text__truncate">
-                            <FieldEditorOverlay
-                                {...fieldTriggerProps}
-                                canUpdate={hasAllPermissions(user, [PermissionTypes.Update])}
-                            />
-                        </div>
-                    )}
+                    <div className="detail__header-icon--body-container">
+                        <h2 className="no-margin-top detail__header--name">{title}</h2>
+                        {subTitle && <h4 className="test-loc-detail-subtitle">{subTitle}</h4>}
+                        {description && <span className="detail__header--desc">{description}</span>}
+                        {fieldTriggerProps && (
+                            <div className="text__truncate">
+                                <FieldEditorOverlay
+                                    {...fieldTriggerProps}
+                                    canUpdate={hasAllPermissions(user, [PermissionTypes.Update])}
+                                />
+                            </div>
+                        )}
+                    </div>
                 </div>
                 {children && <div className="pull-right">{children}</div>}
                 <div className="clearfix" />

--- a/packages/components/src/internal/components/forms/__snapshots__/PageDetailHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/forms/__snapshots__/PageDetailHeader.spec.tsx.snap
@@ -18,11 +18,15 @@ exports[`<PageDetailHeader/> default props 1`] = `
         width="100%"
       />
     </div>
-    <h2
-      className="no-margin-top detail__header--name"
+    <div
+      className="detail__header-icon--body-container"
     >
-      Title
-    </h2>
+      <h2
+        className="no-margin-top detail__header--name"
+      >
+        Title
+      </h2>
+    </div>
   </div>
   <div
     className="clearfix"
@@ -48,21 +52,25 @@ exports[`<PageDetailHeader/> with additional props 1`] = `
         width="100%"
       />
     </div>
-    <h2
-      className="no-margin-top detail__header--name"
+    <div
+      className="detail__header-icon--body-container"
     >
-      Title
-    </h2>
-    <h4
-      className="test-loc-detail-subtitle"
-    >
-      Subtitle
-    </h4>
-    <span
-      className="detail__header--desc"
-    >
-      Description
-    </span>
+      <h2
+        className="no-margin-top detail__header--name"
+      >
+        Title
+      </h2>
+      <h4
+        className="test-loc-detail-subtitle"
+      >
+        Subtitle
+      </h4>
+      <span
+        className="detail__header--desc"
+      >
+        Description
+      </span>
+    </div>
   </div>
   <div
     className="pull-right"
@@ -84,11 +92,15 @@ exports[`<PageDetailHeader/> without icon 1`] = `
   <div
     className="col-md-6 detail__header--container"
   >
-    <h2
-      className="no-margin-top detail__header--name"
+    <div
+      className="detail__header-icon--body-container"
     >
-      Title
-    </h2>
+      <h2
+        className="no-margin-top detail__header--name"
+      >
+        Title
+      </h2>
+    </div>
   </div>
   <div
     className="clearfix"

--- a/packages/components/src/internal/components/user/__snapshots__/UserDetailHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/user/__snapshots__/UserDetailHeader.spec.tsx.snap
@@ -15,16 +15,20 @@ exports[`<UserDetailHeader/> custom description 1`] = `
         src="/labkey/_images/defaultavatar.png"
       />
     </div>
-    <h2
-      className="no-margin-top detail__header--name"
+    <div
+      className="detail__header-icon--body-container"
     >
-      Title
-    </h2>
-    <span
-      className="detail__header--desc"
-    >
-      My custom description
-    </span>
+      <h2
+        className="no-margin-top detail__header--name"
+      >
+        Title
+      </h2>
+      <span
+        className="detail__header--desc"
+      >
+        My custom description
+      </span>
+    </div>
   </div>
   <div
     className="pull-right"
@@ -50,16 +54,20 @@ exports[`<UserDetailHeader/> custom properties 1`] = `
         src="/labkey/_images/defaultavatar.png"
       />
     </div>
-    <h2
-      className="no-margin-top detail__header--name"
+    <div
+      className="detail__header-icon--body-container"
     >
-      Title (Custom)
-    </h2>
-    <span
-      className="detail__header--desc"
-    >
-      Assay Designer, Reader
-    </span>
+      <h2
+        className="no-margin-top detail__header--name"
+      >
+        Title (Custom)
+      </h2>
+      <span
+        className="detail__header--desc"
+      >
+        Assay Designer, Reader
+      </span>
+    </div>
   </div>
   <div
     className="pull-right"
@@ -103,16 +111,20 @@ exports[`<UserDetailHeader/> default properties 1`] = `
         src="/labkey/_images/defaultavatar.png"
       />
     </div>
-    <h2
-      className="no-margin-top detail__header--name"
+    <div
+      className="detail__header-icon--body-container"
     >
-      Title
-    </h2>
-    <span
-      className="detail__header--desc"
-    >
-      Reader
-    </span>
+      <h2
+        className="no-margin-top detail__header--name"
+      >
+        Title
+      </h2>
+      <span
+        className="detail__header--desc"
+      >
+        Reader
+      </span>
+    </div>
   </div>
   <div
     className="pull-right"

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -757,6 +757,7 @@ export function updateRows(options: IUpdateRowsOptions): Promise<any> {
                         {
                             schemaQuery: options.schemaQuery,
                             rows: response.rows,
+                            transactionAuditId: response.transactionAuditId,
                         }
                     )
                 );
@@ -792,12 +793,14 @@ export function deleteRows(options: DeleteRowsOptions): Promise<any> {
             auditBehavior: options.auditBehavior,
             auditUserComment: options.auditUserComment,
             apiVersion: 13.2,
-            success: () => {
+            success: response => {
                 resolve(
                     Object.assign(
                         {},
                         {
                             schemaQuery: options.schemaQuery,
+                            rows: response.rows,
+                            transactionAuditId: response.transactionAuditId,
                         }
                     )
                 );

--- a/packages/components/src/stories/PageDetailHeader.tsx
+++ b/packages/components/src/stories/PageDetailHeader.tsx
@@ -52,6 +52,7 @@ storiesOf('PageDetailHeader', module)
                 iconUrl={ICON_URL}
                 title={text('title', 'Page Detail Header')}
                 subTitle={text('subtitle', 'With a subtitle')}
+                description={'With a description\nThat has a newline in it\nwhich extends below the image.'}
             >
                 <CreatedModified row={createdRow} />
             </PageDetailHeader>

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -161,6 +161,10 @@
   float: left;
 }
 
+.detail__header-icon--body-container {
+  padding-left: 120px; // this should match the width from detail__header--image-container
+}
+
 .detail__header--desc {
   color: grey;
   font-style: $font-size-small;


### PR DESCRIPTION
#### Rationale
For LKSM and LKFM they use the insertRows, updateRows, and deleteRows helpers from the @labkey/components package when making API calls for storage actions. The updateRows and deleteRows success response objects were not consistent with the insertRows response. This PR makes them consistent (most notably adding the "rows" to the deleteRows response).

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/414
* https://github.com/LabKey/inventory/pull/139
* https://github.com/LabKey/labkey-ui-components/pull/399

#### Changes
* make sure to include "rows" and "transactionAuditId" for updateRows and deleteRows wrapper functions
* minor display / layout fix for PageDetailHeader body content to flow better below image