### PR TITLE
Item 8117: Hide overly long display values and disable Submit button for DetailEditing when submitting

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.1-fmMiscDisplayPolish.1",
+  "version": "1.5.1-fmMiscDisplayPolish.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.1-fmMiscDisplayPolish.0",
+  "version": "1.5.1-fmMiscDisplayPolish.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.0",
+  "version": "1.5.1-fmMiscDisplayPolish.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.1-fmMiscDisplayPolish.2",
+  "version": "1.5.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Disable "Submit" button on DetailEditing when in the process of submitting
 * Add some styling to hide text that overflows a field
+* Fix bug in QueryInfo that did not add columns designated as addToDisplayView in all cases
 
 ### version 1.5.0
 *Released*: 27 November 2020

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 1.5.1
+*Released*: 30 November 2020
 * Disable "Submit" button on DetailEditing when in the process of submitting
 * Add some styling to hide text that overflows a field
 * Fix bug in QueryInfo that did not add columns designated as addToDisplayView in all cases

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Disable "Submit" button on DetailEditing when in the process of submitting
+* Add some styling to hide text that overflows a field
+
 ### version 1.5.0
-*Release*: 27 November 2020
+*Released*: 27 November 2020
 * Item 8116: Make insertRows, updateRows, and deleteRows API success response consistent
     - make sure to include "rows" and "transactionAuditId" for each
     - minor display / layout fix for PageDetailHeader body content to flow better below image
@@ -12,7 +17,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * yarn run lint-fix on src/internal/components/domainproperties
 
 ### version 1.4.0
-*Release*: 24 November 2020
+*Released*: 24 November 2020
 * Item 8137: Misc package changes to support LKFM freezer hierarchy polish
     - export existing DomainFieldLabel for use in app
     - add new LockIcon components to package

--- a/packages/components/src/internal/components/auditlog/TimelineView.tsx
+++ b/packages/components/src/internal/components/auditlog/TimelineView.tsx
@@ -170,7 +170,7 @@ export class TimelineView extends React.Component<Props, any> {
                     {entity != null && getEventDataValueDisplay(entity)}
                 </div>
                 <div>
-                    {getEventDataValueDisplay(user, showUserLinks)} {this.renderComment(comment)}
+                    <div className="field-hide-overflow">{getEventDataValueDisplay(user, showUserLinks)}</div> {this.renderComment(comment)}
                 </div>
             </td>
         );

--- a/packages/components/src/internal/components/auditlog/TimelineView.tsx
+++ b/packages/components/src/internal/components/auditlog/TimelineView.tsx
@@ -170,7 +170,7 @@ export class TimelineView extends React.Component<Props, any> {
                     {entity != null && getEventDataValueDisplay(entity)}
                 </div>
                 <div>
-                    <div className="field-hide-overflow">{getEventDataValueDisplay(user, showUserLinks)}</div> {this.renderComment(comment)}
+                    <div className="field-text-nowrap">{getEventDataValueDisplay(user, showUserLinks)}</div> {this.renderComment(comment)}
                 </div>
             </td>
         );

--- a/packages/components/src/internal/components/auditlog/__snapshots__/TimelineView.spec.tsx.snap
+++ b/packages/components/src/internal/components/auditlog/__snapshots__/TimelineView.spec.tsx.snap
@@ -53,11 +53,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           Sample Registered
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -118,11 +122,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -183,11 +191,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            xyang
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              xyang
+            </a>
+          </div>
            
         </div>
       </td>
@@ -248,11 +260,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -313,11 +329,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1038"
+          <div
+            className="field-text-nowrap"
           >
-            Test Lab User
-          </a>
+            <a
+              href="#/q/core/siteusers/1038"
+            >
+              Test Lab User
+            </a>
+          </div>
            
         </div>
       </td>
@@ -378,11 +398,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1038"
+          <div
+            className="field-text-nowrap"
           >
-            Test Lab User
-          </a>
+            <a
+              href="#/q/core/siteusers/1038"
+            >
+              Test Lab User
+            </a>
+          </div>
            
         </div>
       </td>
@@ -443,11 +467,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -508,11 +536,15 @@ exports[`<TimelineView /> Disable selection 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            xyang
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              xyang
+            </a>
+          </div>
            
           <LabelHelpTip
             body={[Function]}
@@ -583,7 +615,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           Sample Registered
         </div>
         <div>
-          Vader
+          <div
+            className="field-text-nowrap"
+          >
+            Vader
+          </div>
            
         </div>
       </td>
@@ -644,7 +680,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           </a>
         </div>
         <div>
-          Vader
+          <div
+            className="field-text-nowrap"
+          >
+            Vader
+          </div>
            
         </div>
       </td>
@@ -705,7 +745,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           </a>
         </div>
         <div>
-          xyang
+          <div
+            className="field-text-nowrap"
+          >
+            xyang
+          </div>
            
         </div>
       </td>
@@ -766,7 +810,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           </a>
         </div>
         <div>
-          Vader
+          <div
+            className="field-text-nowrap"
+          >
+            Vader
+          </div>
            
         </div>
       </td>
@@ -827,7 +875,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           </a>
         </div>
         <div>
-          Test Lab User
+          <div
+            className="field-text-nowrap"
+          >
+            Test Lab User
+          </div>
            
         </div>
       </td>
@@ -888,7 +940,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           </a>
         </div>
         <div>
-          Test Lab User
+          <div
+            className="field-text-nowrap"
+          >
+            Test Lab User
+          </div>
            
         </div>
       </td>
@@ -949,7 +1005,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           </a>
         </div>
         <div>
-          Vader
+          <div
+            className="field-text-nowrap"
+          >
+            Vader
+          </div>
            
         </div>
       </td>
@@ -1010,7 +1070,11 @@ exports[`<TimelineView /> Hide user link 1`] = `
           </a>
         </div>
         <div>
-          xyang
+          <div
+            className="field-text-nowrap"
+          >
+            xyang
+          </div>
            
           <LabelHelpTip
             body={[Function]}
@@ -1081,11 +1145,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           Sample Registered
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1152,11 +1220,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1217,11 +1289,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            xyang
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              xyang
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1282,11 +1358,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1347,11 +1427,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1038"
+          <div
+            className="field-text-nowrap"
           >
-            Test Lab User
-          </a>
+            <a
+              href="#/q/core/siteusers/1038"
+            >
+              Test Lab User
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1418,11 +1502,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1038"
+          <div
+            className="field-text-nowrap"
           >
-            Test Lab User
-          </a>
+            <a
+              href="#/q/core/siteusers/1038"
+            >
+              Test Lab User
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1483,11 +1571,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1548,11 +1640,15 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            xyang
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              xyang
+            </a>
+          </div>
            
           <LabelHelpTip
             body={[Function]}
@@ -1623,11 +1719,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           Sample Registered
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1688,11 +1788,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1759,11 +1863,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            xyang
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              xyang
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1824,11 +1932,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1889,11 +2001,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1038"
+          <div
+            className="field-text-nowrap"
           >
-            Test Lab User
-          </a>
+            <a
+              href="#/q/core/siteusers/1038"
+            >
+              Test Lab User
+            </a>
+          </div>
            
         </div>
       </td>
@@ -1954,11 +2070,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1038"
+          <div
+            className="field-text-nowrap"
           >
-            Test Lab User
-          </a>
+            <a
+              href="#/q/core/siteusers/1038"
+            >
+              Test Lab User
+            </a>
+          </div>
            
         </div>
       </td>
@@ -2019,11 +2139,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            Vader
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              Vader
+            </a>
+          </div>
            
         </div>
       </td>
@@ -2090,11 +2214,15 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
           </a>
         </div>
         <div>
-          <a
-            href="#/q/core/siteusers/1005"
+          <div
+            className="field-text-nowrap"
           >
-            xyang
-          </a>
+            <a
+              href="#/q/core/siteusers/1005"
+            >
+              xyang
+            </a>
+          </div>
            
           <LabelHelpTip
             body={[Function]}

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Button, Panel } from 'react-bootstrap';
 import { List } from 'immutable';
 import Formsy from 'formsy-react';
@@ -46,6 +46,7 @@ interface DetailEditingState {
     editing?: boolean;
     warning?: string;
     error?: React.ReactNode;
+    isSubmitting?: boolean;
 }
 
 export class DetailEditing extends React.Component<DetailEditingProps, DetailEditingState> {
@@ -63,6 +64,7 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
             editing: false,
             warning: undefined,
             error: undefined,
+            isSubmitting: false,
         };
     }
 
@@ -94,6 +96,8 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
     };
 
     handleSubmit = values => {
+        this.setState(() => ({isSubmitting: true}));
+
         const { auditBehavior, queryModel, onUpdate } = this.props;
         const queryData = queryModel.getRow();
         const queryInfo = queryModel.queryInfo;
@@ -120,7 +124,7 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
             })
                 .then(() => {
                     this.setState(
-                        () => ({ editing: false }),
+                        () => ({ isSubmitting: false, editing: false }),
                         () => {
                             if (onUpdate) {
                                 onUpdate();
@@ -133,6 +137,7 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
                     console.error(error);
                     this.setState(() => ({
                         warning: undefined,
+                        isSubmitting: false,
                         error: resolveErrorMessage(error, 'data', undefined, 'update'),
                     }));
                 });
@@ -141,26 +146,27 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
                 canSubmit: false,
                 warning: 'No changes detected. Please update the form and click save.',
                 error: undefined,
+                isSubmitting: false,
             }));
         }
     };
 
-    renderEditControls() {
+    renderEditControls(): ReactNode {
         const { cancelText, submitText } = this.props;
-        const { canSubmit } = this.state;
+        const { canSubmit, isSubmitting } = this.state;
         return (
             <div className="full-width bottom-spacing">
                 <Button className="pull-left" onClick={this.handleClick}>
                     {cancelText}
                 </Button>
-                <Button className="pull-right" bsStyle="success" type="submit" disabled={!canSubmit}>
+                <Button className="pull-right" bsStyle="success" type="submit" disabled={!canSubmit || isSubmitting}>
                     {submitText}
                 </Button>
             </div>
         );
     }
 
-    render() {
+    render(): ReactNode {
         const { queryModel, queryColumns, canUpdate, useEditIcon, appEditable, asSubPanel, title } = this.props;
         const { editing, warning, error } = this.state;
 

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -199,7 +199,7 @@ export class QueryInfo extends Record({
             }, List<string>());
             this.columns.forEach(col => {
                 if (col.fieldKey && col.addToDisplayView && !columnFieldKeys.includes(col.fieldKey.toLowerCase())) {
-                    if (!lowerOmit || (lowerOmit.size > 0 && !lowerOmit.includes(col.fieldKey.toLowerCase())))
+                    if (!lowerOmit || !lowerOmit.includes(col.fieldKey.toLowerCase()))
                         displayColumns = displayColumns.push(col);
                 }
             });

--- a/packages/components/src/theme/fields.scss
+++ b/packages/components/src/theme/fields.scss
@@ -90,10 +90,23 @@
   padding-left: 10px;
 };
 
+.field-text-nowrap {
+    white-space: nowrap;
+}
+
 .field-hide-overflow {
+    @media (max-width: 612px) {
+        max-width: 150px;
+    }
+    @media (min-width: 613px) and (max-width: $screen-md) {
+        max-width: none;
+    }
+    @media (min-width: $screen-md) {
+        max-width: 150px;
+    }
+
     text-overflow: ellipsis;
     overflow: hidden;
-    max-width: 150px;
     display: inline-block;
     white-space: nowrap;
 }

--- a/packages/components/src/theme/fields.scss
+++ b/packages/components/src/theme/fields.scss
@@ -89,3 +89,11 @@
   display: flex;
   padding-left: 10px;
 };
+
+.field-hide-overflow {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 150px;
+    display: inline-block;
+    white-space: nowrap;
+}

--- a/packages/components/src/theme/fields.scss
+++ b/packages/components/src/theme/fields.scss
@@ -92,6 +92,7 @@
 
 .field-text-nowrap {
     white-space: nowrap;
+    display: inline-block;
 }
 
 .field-hide-overflow {

--- a/packages/components/src/theme/timeline.scss
+++ b/packages/components/src/theme/timeline.scss
@@ -1,4 +1,5 @@
 .timeline-grid {
+    margin-top: 10px;
     border-collapse: collapse;
     width: 100%;
 


### PR DESCRIPTION
#### Rationale
During testing for LKFM, we discovered a few areas where long display names for users can cause the page flow to behave in unfortunate ways.  We correct this by hiding the text using CSS styling.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Disable "Submit" button on DetailEditing when in the process of submitting
* Add some styling to hide text that overflows a field