### PR TITLE
Issue 41737: Storage actions do not respect filters on the grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.6.0-fb-issue-41737.1",
+  "version": "1.6.0-fb-issue-41737.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.1",
+  "version": "1.6.0-fb-issue-41737.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Issue 41737: Storage actions do not respect filters on the grid
+    - Add setSnapshotSelections utility function
+
 ### version 1.5.1
 *Released*: 30 November 2020
 * Disable "Submit" button on DetailEditing when in the process of submitting

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -133,6 +133,7 @@ import {
     replaceSelected,
     schemaGridInvalidate,
     setSelected,
+    setSnapshotSelections,
     unselectAll,
 } from './internal/actions';
 import { cancelEvent } from './internal/events';
@@ -453,6 +454,7 @@ export {
     gridShowError,
     replaceSelected,
     setSelected,
+    setSnapshotSelections,
     unselectAll,
     // query related items
     ISelectRowsResult,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1141,7 +1141,7 @@ export function replaceSelected(key: string, ids: string[] | string, containerPa
 export function setSnapshotSelections(key: string, ids: string[] | string, containerPath?: string): Promise<ISelectResponse> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
-            url: buildURL('query', 'setSnapshotSelectionAction.api', undefined, {
+            url: buildURL('query', 'setSnapshotSelection.api', undefined, {
                 container: containerPath,
             }),
             method: 'POST',

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1132,6 +1132,38 @@ export function replaceSelected(key: string, ids: string[] | string, containerPa
     });
 }
 
+/**
+ * Set the snapshot selections for a grid
+ * @param key the selection key for the grid
+ * @param ids ids to change selection for
+ * @param containerPath optional path to the container for this grid.  Default is the current container path
+ */
+export function setSnapshotSelections(key: string, ids: string[] | string, containerPath?: string): Promise<ISelectResponse> {
+    return new Promise((resolve, reject) => {
+        return Ajax.request({
+            url: buildURL('query', 'setSnapshotSelectionAction.api', undefined, {
+                container: containerPath,
+            }),
+            method: 'POST',
+            jsonData: {
+                key,
+                id: ids,
+            },
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response);
+            }),
+            failure: Utils.getCallbackWrapper(
+                response => {
+                    reject(response);
+                },
+                this,
+                true
+            ),
+        });
+    });
+}
+
+
 function removeAll(selected: List<string>, toDelete: List<string>): List<string> {
     toDelete.forEach(id => {
         const idx = selected.indexOf(id);


### PR DESCRIPTION
#### Rationale
dataRegionSelectionKey holds a data region's checked row keys in session, which has been used by LKSM and LKFM to retrieve the set of samples or workflows to operate on. When there are user filters applied on the data region the client side (QueryGridModel or QueryModel), the set of selections may contain those that would have been filtered out on the active view. The desired behavior is for LKSM and LKFM actions to operate on filtered selections only.

Without affecting the existing selection handling, this PR adds a new setSnapshotSelections action to allow storing filtered selection using a new session key

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1747
* https://github.com/LabKey/labkey-ui-components/pull/401
* https://github.com/LabKey/inventory/pull/145
* https://github.com/LabKey/sampleManagement/pull/421

#### Changes
* Add setSnapshotSelections utility function
