### PR TITLE
@labkey/themes - 41972: Fix expand indicators

### DIFF
--- a/packages/components/releaseNotes/labkey/themes.md
+++ b/packages/components/releaseNotes/labkey/themes.md
@@ -1,6 +1,10 @@
 # @labkey/themes
 UI themes for LabKey Server.
 
+### version 1.0.1
+*Released*: 7 December 2020
+* [41972](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41972): Fix expand indicators
+
 ### version 1.0.0
 *Released*: 21 September 2020
 * Initial package copied from LKS core module.

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.0.1-fb-themes-font-awesome.0",
+  "version": "1.0.1",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.0.0",
+  "version": "1.0.1-fb-themes-font-awesome.0",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/styles/scss/labkey/_labkey.scss
+++ b/packages/themes/styles/scss/labkey/_labkey.scss
@@ -221,8 +221,8 @@ pre.labkey-log-text.multiline.expanded {
 
 // add [-] icon before multiline block
 pre.labkey-log-text.multiline.expanded::before {
-  //font-family: FontAwesome;
-  //content: '\f147'; /* fa-minus-square-o */
+  font-family: FontAwesome;
+  content: '\f147'; /* fa-minus-square-o */
   float: left;
   margin-left: -1.4em;
   cursor: pointer;
@@ -230,8 +230,8 @@ pre.labkey-log-text.multiline.expanded::before {
 
 // add [+] icon before multiline block
 pre.labkey-log-text.multiline.collapsed::before {
-  //font-family: FontAwesome;
-  //content: '\f196'; /* fa-plus-square-o */
+  font-family: FontAwesome;
+  content: '\f196'; /* fa-plus-square-o */
   float: left;
   margin-left: -1.4em;
   cursor: pointer;


### PR DESCRIPTION
#### Rationale
[Issue 41972](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41972) describes how some UI indicators in the pipeline job details page are no longer appearing properly. This was a regression that occurred when porting the themes into their own package (see #347). This PR uncomments the `font-family` and `content` declarations related to `pre.labkey-log-text` so that these indicators appear as expected.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1750

#### Changes
* Uncomment `font-family` and `content` declarations as it was an unintended change.
