### PR TITLE
Remove experimental flag for freezer management within LKSM

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.1",
+  "version": "1.5.2-fmNotExperimental.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.2-fmNotExperimental.0",
+  "version": "1.5.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 1.5.2
+*Released*: 4 December 2020
 * Remove check for experimental flag from isFreezerManagerEnabled
 
 ### version 1.5.1

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Remove check for experimental flag from isFreezerManagerEnabled
+
 ### version 1.5.1
 *Released*: 30 November 2020
 * Disable "Submit" button on DetailEditing when in the process of submitting

--- a/packages/components/src/internal/app/utils.spec.ts
+++ b/packages/components/src/internal/app/utils.spec.ts
@@ -22,7 +22,6 @@ describe('getMenuSectionConfigs', () => {
     test('sampleManager enabled', () => {
         LABKEY.moduleContext = {
             samplemanagement: {
-                hasFreezerManagementEnabled: true,
                 hasPremiumModule: true,
                 hasStudyModule: true,
                 productId: 'SampleManager',
@@ -64,7 +63,6 @@ describe('getMenuSectionConfigs', () => {
     test('SM and FM enabled, SM current app', () => {
         LABKEY.moduleContext = {
             samplemanagement: {
-                hasFreezerManagementEnabled: true,
                 hasPremiumModule: true,
                 hasStudyModule: true,
                 productId: 'SampleManager',
@@ -97,7 +95,6 @@ describe('getMenuSectionConfigs', () => {
     test('SM and FM enabled, FM current app', () => {
         LABKEY.moduleContext = {
             samplemanagement: {
-                hasFreezerManagementEnabled: true,
                 hasPremiumModule: true,
                 hasStudyModule: true,
                 productId: 'SampleManager',
@@ -137,7 +134,6 @@ describe('getMenuSectionConfigs', () => {
 describe('utils', () => {
     LABKEY.moduleContext = {
         samplemanagement: {
-            hasFreezerManagementEnabled: true,
             hasPremiumModule: true,
             hasStudyModule: true,
             productId: 'SampleManager',
@@ -178,29 +174,6 @@ describe('utils', () => {
             samplemanagement: {},
         };
         expect(isSampleManagerEnabled()).toBeTruthy();
-
-        LABKEY.moduleContext = {
-            inventory: {},
-            samplemanagement: {
-                hasFreezerManagementEnabled: false,
-            },
-        };
-        expect(isSampleManagerEnabled()).toBeTruthy();
-
-        LABKEY.moduleContext = {
-            inventory: {},
-            samplemanagement: {
-                hasFreezerManagementEnabled: true,
-            },
-        };
-        expect(isSampleManagerEnabled()).toBeTruthy();
-
-        LABKEY.moduleContext = {
-            samplemanagement: {
-                hasFreezerManagementEnabled: true,
-            },
-        };
-        expect(isSampleManagerEnabled()).toBeTruthy();
     });
 
     test('isFreezerManagementEnabled', () => {
@@ -216,29 +189,6 @@ describe('utils', () => {
             inventory: {},
             samplemanagement: {},
         };
-        expect(isFreezerManagementEnabled()).toBeFalsy();
-
-        LABKEY.moduleContext = {
-            inventory: {},
-            samplemanagement: {
-                hasFreezerManagementEnabled: false,
-            },
-        };
-        expect(isFreezerManagementEnabled()).toBeFalsy();
-
-        LABKEY.moduleContext = {
-            inventory: {},
-            samplemanagement: {
-                hasFreezerManagementEnabled: true,
-            },
-        };
         expect(isFreezerManagementEnabled()).toBeTruthy();
-
-        LABKEY.moduleContext = {
-            samplemanagement: {
-                hasFreezerManagementEnabled: true,
-            },
-        };
-        expect(isFreezerManagementEnabled()).toBeFalsy();
     });
 });

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -54,11 +54,11 @@ export function userCanDesignLocations(user: User): boolean {
 }
 
 export function isFreezerManagementEnabled(): boolean {
-    const smEnabled = isSampleManagerEnabled();
-    return (
-        getServerContext().moduleContext?.inventory &&
-        (!smEnabled || getServerContext().moduleContext?.samplemanagement.hasFreezerManagementEnabled === true)
-    );
+    return getServerContext().moduleContext?.inventory !== undefined;
+}
+
+export function isAsynchronousImportEnabled(): boolean {
+    return getServerContext().moduleContext?.samplemanagement?.hasAsynchronousImportEnabled === true;
 }
 
 export function isSampleManagerEnabled(): boolean {

--- a/packages/components/src/internal/components/auditlog/utils.spec.ts
+++ b/packages/components/src/internal/components/auditlog/utils.spec.ts
@@ -8,9 +8,7 @@ import { getAuditQueries } from './utils';
 describe('utils', () => {
     test('getAuditQueries', () => {
         LABKEY.moduleContext = {
-            samplemanagement: {
-                hasFreezerManagementEnabled: true,
-            },
+            samplemanagement: {},
             inventory: {},
         };
         let auditQueries = getAuditQueries();
@@ -18,10 +16,7 @@ describe('utils', () => {
         expect(auditQueries.findIndex(entry => entry.value === 'inventoryauditevent')).toBe(5);
 
         LABKEY.moduleContext = {
-            samplemanagement: {
-                hasFreezerManagementEnabled: false,
-            },
-            inventory: {},
+            samplemanagement: {},
         };
         auditQueries = getAuditQueries();
         expect(auditQueries.length).toBe(12);


### PR DESCRIPTION
#### Rationale
Freezer management is no longer an experiment; it's a reality.  We're moving on to developing asynchronous import, which will need its own experimental flag and will likely affect some of the components in here.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/147
* https://github.com/LabKey/sampleManagement/pull/425

#### Changes
* Remove reference to the freezer management experimental flag
* Add method for checking for asynchronous import experimental flag
