### PR TITLE
Item 6775: Asynchronous import for samples and sources

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-smAsyncImport.5",
+  "version": "1.7.1-fb-smAsyncImport.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.2-fb-smAsyncImport.1",
+  "version": "1.7.2-fb-smAsyncImport.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-smAsyncImport.4",
+  "version": "1.7.1-fb-smAsyncImport.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.0",
+  "version": "1.7.1-fb-smAsyncImport.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-smAsyncImport.3",
+  "version": "1.7.1-fb-smAsyncImport.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1",
+  "version": "1.7.2-fb-smAsyncImport.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.2-fb-smAsyncImport.3",
+  "version": "1.7.2-fb-smAsyncImport.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.2",
+  "version": "1.7.3-fb-smAsyncImport.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-smAsyncImport.6",
+  "version": "1.7.1-fb-smAsyncImport.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@labkey/api": "1.1.2-fb-smAsyncImport.1",
+    "@labkey/api": "1.1.4-fb-smAsyncImport.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@labkey/api": "1.1.3",
+    "@labkey/api": "1.1.4-fb-smAsyncImport.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.2-fb-smAsyncImport.2",
+  "version": "1.7.2-fb-smAsyncImport.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-smAsyncImport.2",
+  "version": "1.7.1-fb-smAsyncImport.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-smAsyncImport.1",
+  "version": "1.7.1-fb-smAsyncImport.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.3-fb-smAsyncImport.1",
+  "version": "1.7.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@labkey/api": "1.1.1",
+    "@labkey/api": "1.1.2-fb-smAsyncImport.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 1.7.3
+*Released*: 15 December 2020
 * add allowAsync for EntityInsertPanel
 
 ### version 1.7.2

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* add allowAsync for EntityInsertPanel
+
 ### version 1.7.0
 *Released*: 7 December 2020
 * Item 8203: Domain designer row styling updates

--- a/packages/components/src/internal/app/index.ts
+++ b/packages/components/src/internal/app/index.ts
@@ -52,6 +52,7 @@ import {
     userCanDesignSourceTypes,
     isSampleManagerEnabled,
     isFreezerManagementEnabled,
+    isAsynchronousImportEnabled,
     getDateFormat,
     getMenuSectionConfigs,
 } from './utils';
@@ -77,6 +78,7 @@ export {
     initWebSocketListeners,
     isFreezerManagementEnabled,
     isSampleManagerEnabled,
+    isAsynchronousImportEnabled,
     getDateFormat,
     getMenuSectionConfigs,
     getUserPermissions,

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -107,7 +107,7 @@ interface OwnProps {
     onCancel?: () => void;
     maxEntities?: number;
     fileSizeLimits?: Map<string, FileSizeLimitProps>;
-    handleFileImport?: (queryInfo: QueryInfo, file: File, isMerge: boolean) => Promise<any>;
+    handleFileImport?: (queryInfo: QueryInfo, file: File, isMerge: boolean, isAsync?: boolean) => Promise<any>;
     canEditEntityTypeDetails?: boolean;
     onDataChange?: (dirty: boolean, changeType?: IMPORT_DATA_FORM_TYPES) => void;
     nounSingular: string;
@@ -118,6 +118,8 @@ interface OwnProps {
     auditBehavior?: AuditBehaviorTypes;
     importOnly?: boolean;
     combineParentTypes?: boolean; // Puts all parent types in one parent button. Name on the button will be the first parent type listed
+    allowAsyncImport?: boolean;
+    asyncSize?: number;
 }
 
 type Props = OwnProps & WithFormStepsProps;
@@ -129,6 +131,7 @@ interface StateProps {
     error: ReactNode;
     isMerge: boolean;
     file: File;
+    useAsync: boolean;
 }
 
 export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
@@ -157,6 +160,7 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
             error: undefined,
             isMerge: false,
             file: undefined,
+            useAsync: false,
         };
     }
 
@@ -932,12 +936,17 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
     };
 
     handleFileChange = (files: Map<string, File>): void => {
+        const { allowAsyncImport, asyncSize } = this.props;
+
         if (this.props.onDataChange) {
             this.props.onDataChange(files.size > 0, IMPORT_DATA_FORM_TYPES.FILE);
         }
+
+        const fileSize = files.valueSeq().first().size;
         this.setState(() => ({
             error: undefined,
             file: files.first(),
+            useAsync: allowAsyncImport && fileSize > asyncSize,
         }));
     };
 
@@ -948,18 +957,19 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
         this.setState(() => ({
             error: undefined,
             file: undefined,
+            useAsync: false,
         }));
     };
 
     submitFileHandler = (): void => {
         const { handleFileImport } = this.props;
-        const { insertModel, file, isMerge, originalQueryInfo } = this.state;
+        const { insertModel, file, isMerge, originalQueryInfo, useAsync } = this.state;
 
         if (!handleFileImport) return;
 
         this.setSubmitting(true);
 
-        handleFileImport(originalQueryInfo, file, isMerge)
+        handleFileImport(originalQueryInfo, file, isMerge, useAsync)
             .then(response => {
                 this.setSubmitting(false);
                 if (this.props.onDataChange) {
@@ -1013,7 +1023,7 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
     };
 
     renderImportEntitiesFromFile = (): ReactNode => {
-        const { fileSizeLimits, disableMerge } = this.props;
+        const { fileSizeLimits, disableMerge, allowAsyncImport } = this.props;
 
         return (
             <>
@@ -1035,6 +1045,7 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
                             {helpLinkNode(DATA_IMPORT_TOPIC, 'help article')} for best practices on data import.
                         </>
                     }
+                    allowOversize={allowAsyncImport}
                 />
             </>
         );

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -986,7 +986,7 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
                     );
                 }
                 if (useAsync && this.props.onBackgroundJobStart) {
-                    this.props.onBackgroundJobStart(insertModel.getTargetEntityTypeName(), file.name)
+                    this.props.onBackgroundJobStart(insertModel.getTargetEntityTypeName(), file.name);
                 }
             })
             .catch(error => {
@@ -1049,7 +1049,7 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
                             {helpLinkNode(DATA_IMPORT_TOPIC, 'help article')} for best practices on data import.
                         </>
                     }
-                    allowOversize={allowAsyncImport}
+                    allowOversize={allowAsyncImport} // use allowOversize to bypass maxSize check, but sizeLimits maxPreviewSize remains effective
                 />
             </>
         );

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -102,6 +102,7 @@ class EntityGridLoader implements IGridLoader {
 interface OwnProps {
     disableMerge?: boolean;
     afterEntityCreation?: (entityTypeName, filter, entityCount, actionStr, transactionAuditId?) => void;
+    onBackgroundJobStart?: (entityTypeName, filename) => void;
     getFileTemplateUrl?: (queryInfo: QueryInfo) => string;
     location?: Location;
     onCancel?: () => void;
@@ -975,7 +976,7 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
                 if (this.props.onDataChange) {
                     this.props.onDataChange(false);
                 }
-                if (this.props.afterEntityCreation) {
+                if (!useAsync && this.props.afterEntityCreation) {
                     this.props.afterEntityCreation(
                         insertModel.getTargetEntityTypeName(),
                         null,
@@ -983,6 +984,9 @@ export class EntityInsertPanelImpl extends ReactN.Component<Props, StateProps> {
                         'imported',
                         response.transactionAuditId
                     );
+                }
+                if (useAsync && this.props.onBackgroundJobStart) {
+                    this.props.onBackgroundJobStart(insertModel.getTargetEntityTypeName(), file.name)
                 }
             })
             .catch(error => {

--- a/packages/components/src/internal/components/files/FileAttachmentContainer.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentContainer.tsx
@@ -39,7 +39,6 @@ interface FileAttachmentContainerProps {
     initialFileNames?: string[];
     initialFiles?: { [key: string]: File };
     compact?: boolean;
-    allowOversize?: boolean;
 }
 
 interface FileAttachmentContainerState {
@@ -89,7 +88,7 @@ export class FileAttachmentContainer extends React.Component<
     }
 
     validateFiles = (fileList: FileList, transferItems?: DataTransferItemList): Set<string> => {
-        const { acceptedFormats, allowDirectories, sizeLimits, allowOversize } = this.props;
+        const { acceptedFormats, allowDirectories, sizeLimits } = this.props;
 
         this.setState({
             errorMsg: undefined,
@@ -118,7 +117,7 @@ export class FileAttachmentContainer extends React.Component<
                     invalidNames = invalidNames.add(file.name);
                 }
             }
-            if (sizeLimits && !allowOversize) {
+            if (sizeLimits) {
                 if (!invalidFileTypes.has(file.name) && invalidDirectories.indexOf(file.name) < 0) {
                     const sizeCheck = fileSizeLimitCompare(file, sizeLimits);
                     if (sizeCheck.isOversized) {

--- a/packages/components/src/internal/components/files/FileAttachmentContainer.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentContainer.tsx
@@ -39,6 +39,7 @@ interface FileAttachmentContainerProps {
     initialFileNames?: string[];
     initialFiles?: { [key: string]: File };
     compact?: boolean;
+    allowOversize?: boolean;
 }
 
 interface FileAttachmentContainerState {
@@ -88,7 +89,7 @@ export class FileAttachmentContainer extends React.Component<
     }
 
     validateFiles = (fileList: FileList, transferItems?: DataTransferItemList): Set<string> => {
-        const { acceptedFormats, allowDirectories, sizeLimits } = this.props;
+        const { acceptedFormats, allowDirectories, sizeLimits, allowOversize } = this.props;
 
         this.setState({
             errorMsg: undefined,
@@ -117,7 +118,7 @@ export class FileAttachmentContainer extends React.Component<
                     invalidNames = invalidNames.add(file.name);
                 }
             }
-            if (sizeLimits) {
+            if (sizeLimits && !allowOversize) {
                 if (!invalidFileTypes.has(file.name) && invalidDirectories.indexOf(file.name) < 0) {
                     const sizeCheck = fileSizeLimitCompare(file, sizeLimits);
                     if (sizeCheck.isOversized) {

--- a/packages/components/src/internal/components/files/FileAttachmentForm.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentForm.tsx
@@ -390,6 +390,7 @@ export class FileAttachmentForm extends React.Component<FileAttachmentFormProps,
             sizeLimitsHelpText,
             isSubmitting,
             compact,
+            allowOversize,
         } = this.props;
 
         return (
@@ -411,6 +412,7 @@ export class FileAttachmentForm extends React.Component<FileAttachmentFormProps,
                                 sizeLimitsHelpText={sizeLimitsHelpText}
                                 labelLong={labelLong}
                                 compact={compact}
+                                allowOversize={allowOversize}
                             />
                             {compact && showButtons && this.renderButtons()}
                         </div>

--- a/packages/components/src/internal/components/files/FileAttachmentForm.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentForm.tsx
@@ -408,11 +408,10 @@ export class FileAttachmentForm extends React.Component<FileAttachmentFormProps,
                                 initialFileNames={initialFileNames}
                                 initialFiles={initialFiles}
                                 allowMultiple={allowMultiple}
-                                sizeLimits={sizeLimits}
+                                sizeLimits={allowOversize ? null : sizeLimits}
                                 sizeLimitsHelpText={sizeLimitsHelpText}
                                 labelLong={labelLong}
                                 compact={compact}
-                                allowOversize={allowOversize}
                             />
                             {compact && showButtons && this.renderButtons()}
                         </div>

--- a/packages/components/src/internal/components/files/FileAttachmentForm.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentForm.tsx
@@ -61,6 +61,7 @@ interface FileAttachmentFormProps {
     templateUrl?: string;
     compact?: boolean;
     ref?: any;
+    allowOversize?: boolean;
 }
 
 interface State {
@@ -143,7 +144,7 @@ export class FileAttachmentForm extends React.Component<FileAttachmentFormProps,
     };
 
     handleFileChange = (fileList: { [key: string]: File }): void => {
-        const { onFileChange, sizeLimits, fileSpecificCallback, allowMultiple } = this.props;
+        const { onFileChange, sizeLimits, fileSpecificCallback, allowMultiple, allowOversize } = this.props;
         const attachedFiles = this.state.attachedFiles.merge(fileList);
 
         this.setState(
@@ -156,7 +157,7 @@ export class FileAttachmentForm extends React.Component<FileAttachmentFormProps,
 
                     const fileTypeFn = fileSpecificCallback?.get(getFileExtension(firstFile.name));
                     if (fileTypeFn) {
-                        if (!sizeCheck.isOversized) {
+                        if (!sizeCheck.isOversized || allowOversize) {
                             fileTypeFn(firstFile)
                                 .then(res => {
                                     this.updateErrors(res.success ? null : res.msg);

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -840,7 +840,7 @@ export interface IImportData {
     importLookupByAlternateKey?: boolean;
     saveToPipeline?: boolean;
     importUrl?: string;
-    useAsync?: boolean
+    useAsync?: boolean;
 }
 
 export function importData(config: IImportData): Promise<any> {

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -840,6 +840,7 @@ export interface IImportData {
     importLookupByAlternateKey?: boolean;
     saveToPipeline?: boolean;
     importUrl?: string;
+    useAsync?: boolean
 }
 
 export function importData(config: IImportData): Promise<any> {

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1359,10 +1359,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.1.2-fb-smAsyncImport.1":
-  version "1.1.2-fb-smAsyncImport.1"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.2-fb-smAsyncImport.1.tgz#f149f3213ee6fb03814df2799089b3b9591cc2e2"
-  integrity sha1-8UnzIT7m+wOBTfJ5kImzuVkcwuI=
+"@labkey/api@1.1.4-fb-smAsyncImport.1":
+  version "1.1.4-fb-smAsyncImport.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.4-fb-smAsyncImport.1.tgz#a22467476f3eda841d8500a0e66b455eec879a57"
+  integrity sha1-oiRnR28+2oQdhQCg5mtFXuyHmlc=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1359,10 +1359,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.1.1":
-  version "1.1.1"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.1.tgz#ab87622a530b2dd13a4238c202108a7f3f6a84d6"
-  integrity sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY=
+"@labkey/api@1.1.2-fb-smAsyncImport.1":
+  version "1.1.2-fb-smAsyncImport.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.2-fb-smAsyncImport.1.tgz#f149f3213ee6fb03814df2799089b3b9591cc2e2"
+  integrity sha1-8UnzIT7m+wOBTfJ5kImzuVkcwuI=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1359,10 +1359,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.1.3":
-  version "1.1.3"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.3.tgz#24849ae8ed30389a8b8e0e282057be403e4378ae"
-  integrity sha1-JISa6O0wOJqLjg4oIFe+QD5DeK4=
+"@labkey/api@1.1.4-fb-smAsyncImport.1":
+  version "1.1.4-fb-smAsyncImport.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.4-fb-smAsyncImport.1.tgz#a22467476f3eda841d8500a0e66b455eec879a57"
+  integrity sha1-oiRnR28+2oQdhQCg5mtFXuyHmlc=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"


### PR DESCRIPTION
#### Rationale
EntityInsertPanel is used to handle import of samples and sources. Currently, it rejects any file that's larger than the configured 5mb. With async import support added, EntityInsertPanel should be able to accept larger files and determine actions to take based on file size. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1770
* https://github.com/LabKey/labkey-api-js/pull/81
* https://github.com/LabKey/labkey-ui-components/pull/410
* https://github.com/LabKey/sampleManagement/pull/427

#### Changes
* add allowAsync for EntityInsertPanel
