### PR TITLE
Dirty form transition confirmation doesn't update history correctly

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-confirm-form-41419.2",
+  "version": "1.7.1-fb-confirm-form-41419.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-confirm-form-41419.3",
+  "version": "1.7.1-fb-confirm-form-41419.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.2-fb-confirm-form-41419.0",
+  "version": "1.5.2-fb-confirm-form-41419.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.5.2",
+  "version": "1.5.2-fb-confirm-form-41419.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.7.1-fb-confirm-form-41419.4",
+  "version": "1.7.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Update RouteLeave to better manage transition confirmations
+
 ### version 1.7.1
 *Released*: 10 December 2020
 * Update @labkey/api dependency

--- a/packages/components/releaseNotes/labkey/components.md
+++ b/packages/components/releaseNotes/labkey/components.md
@@ -1,9 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
-* Update RouteLeave to better manage transition confirmations
+### version 1.7.2
+*Released*: 14 December 2020
+* Issue #41419: Update RouteLeave to better manage form transition confirmations
 
 ### version 1.7.1
 *Released*: 10 December 2020

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -61,9 +61,12 @@ export const withRouteLeave = (Component: React.ComponentType) => {
 
         _dirty = false;
 
-        onBeforeUnload = (event): string => {
-            event.returnValue = ON_LEAVE_DIRTY_STATE_MESSAGE;
-            return ON_LEAVE_DIRTY_STATE_MESSAGE;
+        onBeforeUnload = (event): boolean | string => {
+            if (this._dirty) {
+                event.returnValue = ON_LEAVE_DIRTY_STATE_MESSAGE;
+                return ON_LEAVE_DIRTY_STATE_MESSAGE;
+            }
+            return true;
         };
 
         onRouteLeave = (event): boolean => {
@@ -71,7 +74,7 @@ export const withRouteLeave = (Component: React.ComponentType) => {
                 event.returnValue = true; // this is for the page reload case
                 return confirmLeaveWhenDirty(this.props.location, event);
             }
-            return false;
+            return true;
         };
 
         setDirty = (dirty: boolean): void => {

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -21,8 +21,7 @@ export const ON_LEAVE_DIRTY_STATE_MESSAGE =
  *  https://stackoverflow.com/questions/62792342/in-react-router-v6-how-to-check-form-is-dirty-before-leaving-page-route
  *
  * @param currentLocation the location of the current page
- * @param event
- * @param isUnload
+ * @param event object triggering leave transition
  */
 export function confirmLeaveWhenDirty(currentLocation: Location, event?: any,): boolean {
     const result = confirm(ON_LEAVE_DIRTY_STATE_MESSAGE);
@@ -33,7 +32,7 @@ export function confirmLeaveWhenDirty(currentLocation: Location, event?: any,): 
             ...currentLocation.pathname
                 .substring(1)
                 .split('/')
-                .map(part => decodeURIComponent(part))
+                .map(decodeURIComponent)
         );
 
         // Issue 41419: handle different cases for route leave PUSH vs POP events

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Location} from 'history';
+import { Location } from 'history';
 import { WithRouterProps } from 'react-router';
 
 import { AppURL } from '../..';
@@ -23,17 +23,12 @@ export const ON_LEAVE_DIRTY_STATE_MESSAGE =
  * @param currentLocation the location of the current page
  * @param event object triggering leave transition
  */
-export function confirmLeaveWhenDirty(currentLocation: Location, event?: any,): boolean {
+export function confirmLeaveWhenDirty(currentLocation: Location, event?: any): boolean {
     const result = confirm(ON_LEAVE_DIRTY_STATE_MESSAGE);
 
     // navigation canceled, pushing the previous path
     if (!result && currentLocation) {
-        const appURL = AppURL.create(
-            ...currentLocation.pathname
-                .substring(1)
-                .split('/')
-                .map(decodeURIComponent)
-        );
+        const appURL = AppURL.create(...currentLocation.pathname.substring(1).split('/').map(decodeURIComponent));
 
         // Issue 41419: handle different cases for route leave PUSH vs POP events
         if (event?.action !== 'POP') {
@@ -59,23 +54,24 @@ export type RouteLeaveProps = RouteLeaveInjectedProps & WithRouterProps;
  */
 export const withRouteLeave = (Component: React.ComponentType) => {
     return class RouteLeaveHOCImpl extends React.Component<RouteLeaveProps> {
-        _dirty = false;
-
         componentDidMount(): void {
             // attach the hook to the current route, which will be the last index of the routes prop
             this.props.router.setRouteLeaveHook(this.props.routes[this.props.routes.length - 1], this.onRouteLeave);
         }
 
-        onBeforeUnload = event => {
+        _dirty = false;
+
+        onBeforeUnload = (event): string => {
             event.returnValue = ON_LEAVE_DIRTY_STATE_MESSAGE;
             return ON_LEAVE_DIRTY_STATE_MESSAGE;
         };
 
-        onRouteLeave = event => {
+        onRouteLeave = (event): boolean => {
             if (this._dirty) {
                 event.returnValue = true; // this is for the page reload case
                 return confirmLeaveWhenDirty(this.props.location, event);
             }
+            return false;
         };
 
         setDirty = (dirty: boolean): void => {


### PR DESCRIPTION
#### Rationale
[Issue #41419](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41419)
#### Related Pull Requests
* TBD SM
* TBD Inventory

#### Changes
* Update RouteLeave.confirmLeaveWhenDirty

#### TODOs 
Browser's back button still has bad state. Per Issue discussion may need to bump react-router version to fix.
Update release notes
