### PR TITLE
@labkey/build - remove postcss-loader

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "1.0.0-fb-postcssLoaderFix.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "1.0.0",
+  "version": "1.0.0-fb-postcssLoaderFix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1436,14 +1436,6 @@
         }
       }
     },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "arity-n": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
@@ -2004,27 +1996,6 @@
         "get-intrinsic": "^1.0.0"
       }
     },
-    "caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "requires": {
-        "callsites": "^2.0.0"
-      }
-    },
-    "caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "requires": {
-        "caller-callsite": "^2.0.0"
-      }
-    },
-    "callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
-    },
     "camel-case": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
@@ -2440,28 +2411,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        }
-      }
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -3115,11 +3064,6 @@
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -4470,31 +4414,6 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
-    "import-cwd": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
-      "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
-      "requires": {
-        "import-from": "^2.1.0"
-      }
-    },
-    "import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-      "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      }
-    },
-    "import-from": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
-      "requires": {
-        "resolve-from": "^3.0.0"
-      }
-    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -4691,11 +4610,6 @@
         }
       }
     },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4841,15 +4755,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -6074,38 +5979,6 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "postcss-load-config": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
-      "integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
-      "requires": {
-        "cosmiconfig": "^5.0.0",
-        "import-cwd": "^2.0.0"
-      }
-    },
-    "postcss-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
-      "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "postcss": "^7.0.0",
-        "postcss-load-config": "^2.0.0",
-        "schema-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -7364,11 +7237,6 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "1.0.0",
+  "version": "1.0.0-fb-postcssLoaderFix.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"
@@ -26,7 +26,6 @@
     "html-webpack-plugin": "4.5.0",
     "mini-css-extract-plugin": "0.11.3",
     "node-sass": "4.14.1",
-    "postcss-loader": "3.0.0",
     "react-hot-loader": "4.13.0",
     "resolve-url-loader": "3.1.2",
     "rimraf": "3.0.2",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,8 +1,8 @@
 # @labkey/build
 
-### version TBD
-*Released*: TBD
-* Remove postcss-loader
+### version 1.1.1
+*Released*: 12 January 2021
+* Remove, no longer used, postcss-loader
 
 ### version 1.1.0
 *Released*: 11 January 2021

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,9 @@
 # @labkey/build
 
+### version TBD
+*Released*: TBD
+* Remove postcss-loader
+
 ### version 1.0.0
 *Released*: 7 January 2021
 * postcss-loader: inline the postcss.config.js properties

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -69,17 +69,6 @@ module.exports = {
                             importLoaders: 1
                         }
                     },{
-                        loader: 'postcss-loader',
-                        options: {
-                            sourceMap: true,
-                            postcssOptions: (ctx) => {
-                                return {
-                                    parser: ctx.parser ? 'sugarss' : false,
-                                    map: ctx.env === 'development' ? ctx.map : false
-                                }
-                            }
-                        }
-                    },{
                         loader: 'resolve-url-loader'
                     },{
                         loader: 'sass-loader',
@@ -112,11 +101,6 @@ module.exports = {
                         loader: 'css-loader',
                         options: {
                             importLoaders: 1
-                        }
-                    },{
-                        loader: 'postcss-loader',
-                        options: {
-                            sourceMap: true
                         }
                     },{
                         loader: 'resolve-url-loader'


### PR DESCRIPTION
#### Rationale
Nick discovered that the hot module reload for various LK modules was broken because of the change in the related PR for the @labkey/build package to replace the postcss.config.js file with inline properties in the webpack config. I had missed adding the necessary props to the `STYLE_LOADERS_DEV`. After further review, we were getting the same "postcss-loader is not being used" message in the prod build, so I removed that dev dependency with this PR. I believe it isn't being use anymore every since we converted the @labkey/components package to expose the SCSS files instead of having it build a css file.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/428

#### Changes
* Remove postcss-loader from devDependencies and webpack/constants.js
