### PR TITLE
Add minify options to HtmlWebpackPlugin in @labkey/build

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "1.1.1-fb-minify-xml-view.1",
+  "version": "1.1.2",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "1.1.1",
+  "version": "1.1.1-fb-minify-xml-view.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,9 @@
 # @labkey/build
 
+### version 1.1.2
+*Released*: 12 January 2021
+* Add minify options to HtmlWebpackPlugin configurations
+
 ### version 1.1.1
 *Released*: 12 January 2021
 * Remove, no longer used, postcss-loader

--- a/packages/build/webpack/README.md
+++ b/packages/build/webpack/README.md
@@ -89,7 +89,8 @@ To add a new `entryPoint` for a LabKey React page:
     For the new entry point, set the following properties:
     1. `name=<action name for the entryPoint page>`
     1. `title=<page title>`
-    1. `permission=<view.xml perm class>`
+    1. `permission=<view.xml permissionType>` (optional)
+    1. `permissionClasses=[<view.xml permissionClassType>]` (optional)
     1. `path=<entryPoint code path from step #1>`
 1. In your `src/client/<ENTRYPOINT_NAME>` dir, create an `app.tsx` file and a `dev.tsx` file based on
     an example from one of the existing app pages. Add your main app React component file,

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -39,6 +39,10 @@ if (process.env.npm_package_dependencies__labkey_workflow) {
 
 const watchPort = process.env.WATCH_PORT || 3001;
 
+// These minification options are a re-declaration of the default minification options
+// for the HtmlWebpackPlugin with the addition of `caseSensitive` because LabKey's
+// view templates can contain case-sensitive elements (e.g. `<permissionClasses>`).
+// For more information see https://github.com/jantimon/html-webpack-plugin#minification.
 const minifyTemplateOptions = {
     caseSensitive: true,
     collapseWhitespace: process.env.NODE_ENV === "production",

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -39,6 +39,17 @@ if (process.env.npm_package_dependencies__labkey_workflow) {
 
 const watchPort = process.env.WATCH_PORT || 3001;
 
+const minifyTemplateOptions = {
+    caseSensitive: true,
+    collapseWhitespace: process.env.NODE_ENV === "production",
+    keepClosingSlash: true,
+    removeComments: true,
+    removeRedundantAttributes: true,
+    removeScriptTypeAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+    useShortDoctype: true
+}
+
 module.exports = {
     labkeyUIComponentsPath: labkeyUIComponentsPath,
     freezerManagerPath: freezerManagerPath,
@@ -217,7 +228,8 @@ module.exports = {
                         permission: app.permission,
                         viewTemplate: app.template,
                         filename: '../../../web/' + lkModule + '/gen/' + app.name + '.lib.xml',
-                        template: 'node_modules/@labkey/build/webpack/lib.template.xml'
+                        template: 'node_modules/@labkey/build/webpack/lib.template.xml',
+                        minify: minifyTemplateOptions
                     }),
                 ]);
             } else {
@@ -231,12 +243,14 @@ module.exports = {
                         permissionClasses: app.permissionClasses,
                         viewTemplate: app.template,
                         filename: '../../../views/gen/' + app.name + '.view.xml',
-                        template: 'node_modules/@labkey/build/webpack/app.view.template.xml'
+                        template: 'node_modules/@labkey/build/webpack/app.view.template.xml',
+                        minify: minifyTemplateOptions
                     }),
                     new HtmlWebpackPlugin({
                         inject: false,
                         filename: '../../../views/gen/' + app.name + '.html',
-                        template: 'node_modules/@labkey/build/webpack/app.template.html'
+                        template: 'node_modules/@labkey/build/webpack/app.template.html',
+                        minify: minifyTemplateOptions
                     }),
                     new HtmlWebpackPlugin({
                         inject: false,
@@ -248,7 +262,8 @@ module.exports = {
                         permissionClasses: app.permissionClasses,
                         viewTemplate: app.template,
                         filename: '../../../views/gen/' + app.name + 'Dev.view.xml',
-                        template: 'node_modules/@labkey/build/webpack/app.view.template.xml'
+                        template: 'node_modules/@labkey/build/webpack/app.view.template.xml',
+                        minify: minifyTemplateOptions
                     }),
                     new HtmlWebpackPlugin({
                         inject: false,
@@ -256,7 +271,8 @@ module.exports = {
                         port: watchPort,
                         name: app.name,
                         filename: '../../../views/gen/' + app.name + 'Dev.html',
-                        template: 'node_modules/@labkey/build/webpack/app.template.html'
+                        template: 'node_modules/@labkey/build/webpack/app.template.html',
+                        minify: minifyTemplateOptions
                     })
                 ]);
             }


### PR DESCRIPTION
#### Rationale
Recent update to HtmlWebpackPlugin template in @labkey/build exposed an issue where the generated files are not case sensitive on all OSes.  Linux based OSes generate all lower case tags (e.g. `<permissionclasses>`).  This adds minify options to ensure case sensitivity.  A few other properties added to minify options as well.

#### Changes
* Add minify options to all HtmlWebpackPlugin configs
