### PR TITLE
Issue 42216: Fix for logout event notification issue with different user sessions (i.e. different browsers)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.16.1-fb-issue42216-logoutEvent.2",
+  "version": "1.16.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.16.1-fb-issue42216-logoutEvent.1",
+  "version": "1.16.1-fb-issue42216-logoutEvent.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.16.1",
+  "version": "1.16.1-fb-issue42216-logoutEvent.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.16.1-fb-issue42216-logoutEvent.0",
+  "version": "1.16.1-fb-issue42216-logoutEvent.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 42216: Fix for logout event notification issue with different user sessions (i.e. different browsers)
+    * add check for evt.wasClean in event listener callbacks before dispatching (to match platform dom/WebSocket.js)
 
 ### version 1.16.1
 *Released*: 22 January 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 1.16.2
+*Released*: 26 January 2021
 * Issue 42216: Fix for logout event notification issue with different user sessions (i.e. different browsers)
     * add check for evt.wasClean in server event listener callbacks before dispatching (to match platform dom/WebSocket.js)
     * move CloseEventCode enum type from Biologics to use in App.initWebSocketListeners

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42216: Fix for logout event notification issue with different user sessions (i.e. different browsers)
+
 ### version 1.16.1
 *Released*: 22 January 2021
 * fix server notification content html encoding

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 42216: Fix for logout event notification issue with different user sessions (i.e. different browsers)
-    * add check for evt.wasClean in event listener callbacks before dispatching (to match platform dom/WebSocket.js)
+    * add check for evt.wasClean in server event listener callbacks before dispatching (to match platform dom/WebSocket.js)
 
 ### version 1.16.1
 *Released*: 22 January 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Issue 42216: Fix for logout event notification issue with different user sessions (i.e. different browsers)
     * add check for evt.wasClean in server event listener callbacks before dispatching (to match platform dom/WebSocket.js)
+    * move CloseEventCode enum type from Biologics to use in App.initWebSocketListeners
 
 ### version 1.16.1
 *Released*: 22 January 2021

--- a/packages/components/src/internal/app/index.ts
+++ b/packages/components/src/internal/app/index.ts
@@ -56,6 +56,7 @@ import {
     isFreezerManagementEnabled,
     getDateFormat,
     getMenuSectionConfigs,
+    CloseEventCode,
 } from './utils';
 
 import {
@@ -80,6 +81,7 @@ export {
     RoutingTableReducers,
     ServerNotificationState,
     ServerNotificationReducers,
+    CloseEventCode,
     initWebSocketListeners,
     isFreezerManagementEnabled,
     isSampleManagerEnabled,

--- a/packages/components/src/internal/app/index.ts
+++ b/packages/components/src/internal/app/index.ts
@@ -12,7 +12,16 @@ import {
     TEST_USER_READER,
 } from '../../test/data/users';
 
-import { getUserPermissions, setReloadRequired, updateUserDisplayName, menuInit, menuInvalidate, menuReload, serverNotificationInit, serverNotificationInvalidate } from './actions';
+import {
+    getUserPermissions,
+    setReloadRequired,
+    updateUserDisplayName,
+    menuInit,
+    menuInvalidate,
+    menuReload,
+    serverNotificationInit,
+    serverNotificationInvalidate,
+} from './actions';
 import {
     SECURITY_LOGOUT,
     SECURITY_SERVER_UNAVAILABLE,
@@ -43,7 +52,7 @@ import {
     SAMPLE_MANAGER_PRODUCT_ID,
     STICKY_HEADER_HEIGHT,
     NOTIFICATION_TIMEOUT,
-    SERVER_NOTIFICATION_MAX_ROWS
+    SERVER_NOTIFICATION_MAX_ROWS,
 } from './constants';
 import { AppModel, LogoutReason } from './models';
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -52,7 +52,7 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
     // register websocket listener for the case where a user logs out in another tab
     function _logOutCallback(evt) {
         if (evt.wasClean && evt.reason === 'org.labkey.api.security.AuthNotify#SessionLogOut') {
-            window.setTimeout(() => store.dispatch({type: SECURITY_LOGOUT}), 1000);
+            window.setTimeout(() => store.dispatch({ type: SECURITY_LOGOUT }), 1000);
         }
     }
     LABKEY.WebSocket.addServerEventListener(CloseEventCode.NORMAL_CLOSURE, _logOutCallback);

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -53,9 +53,8 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
     if (notificationListeners) {
         notificationListeners.forEach(listener => {
             LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
-                if (evt.wasClean) {
-                    window.setTimeout(() => store.dispatch({ type: SERVER_NOTIFICATIONS_INVALIDATE }), 1000);
-                }
+                // not checking evt.wasClean since we want this event for all user sessions
+                window.setTimeout(() => store.dispatch({ type: SERVER_NOTIFICATIONS_INVALIDATE }), 1000);
             });
         });
     }
@@ -63,9 +62,8 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
     if (menuReloadListeners) {
         menuReloadListeners.forEach(listener => {
             LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
-                if (evt.wasClean) {
-                    window.setTimeout(() => store.dispatch({ type: MENU_RELOAD }), 1000);
-                }
+                // not checking evt.wasClean since we want this event for all user sessions
+                window.setTimeout(() => store.dispatch({ type: MENU_RELOAD }), 1000);
             });
         });
     }

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -30,18 +30,22 @@ import {
 export function initWebSocketListeners(store, notificationListeners?: string[], menuReloadListeners?: string[]): void {
     // register websocket listener for the case where a user logs out in another tab
     LABKEY.WebSocket.addServerEventListener('org.labkey.api.security.AuthNotify#LoggedOut', function (evt) {
-        window.setTimeout(() => store.dispatch({ type: SECURITY_LOGOUT }), 1000);
+        if (evt.wasClean) {
+            window.setTimeout(() => store.dispatch({type: SECURITY_LOGOUT}), 1000);
+        }
     });
 
     // register websocket listener for session timeout code
     LABKEY.WebSocket.addServerEventListener(1008, function (evt) {
-        window.setTimeout(() => store.dispatch({ type: SECURITY_SESSION_TIMEOUT }), 1000);
+        if (evt.wasClean) {
+            window.setTimeout(() => store.dispatch({ type: SECURITY_SESSION_TIMEOUT }), 1000);
+        }
     });
 
     // register websocket listener for server being shutdown
     LABKEY.WebSocket.addServerEventListener(1001, function (evt) {
         // Issue 39473: 1001 sent when server is shutdown normally (AND on page reload in FireFox, but that one doesn't have a reason)
-        if (evt.code === 1001 && evt.reason && evt.reason !== '') {
+        if (evt.wasClean && evt.code === 1001 && evt.reason && evt.reason !== '') {
             window.setTimeout(() => store.dispatch({ type: SECURITY_SERVER_UNAVAILABLE }), 1000);
         }
     });
@@ -51,7 +55,7 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
             LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
                 window.setTimeout(() => store.dispatch({ type: SERVER_NOTIFICATIONS_INVALIDATE }), 1000);
             });
-        })
+        });
     }
 
     if (menuReloadListeners) {
@@ -59,7 +63,7 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
             LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
                 window.setTimeout(() => store.dispatch({ type: MENU_RELOAD }), 1000);
             });
-        })
+        });
     }
 }
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -53,7 +53,9 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
     if (notificationListeners) {
         notificationListeners.forEach(listener => {
             LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
-                window.setTimeout(() => store.dispatch({ type: SERVER_NOTIFICATIONS_INVALIDATE }), 1000);
+                if (evt.wasClean) {
+                    window.setTimeout(() => store.dispatch({ type: SERVER_NOTIFICATIONS_INVALIDATE }), 1000);
+                }
             });
         });
     }
@@ -61,7 +63,9 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
     if (menuReloadListeners) {
         menuReloadListeners.forEach(listener => {
             LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
-                window.setTimeout(() => store.dispatch({ type: MENU_RELOAD }), 1000);
+                if (evt.wasClean) {
+                    window.setTimeout(() => store.dispatch({ type: MENU_RELOAD }), 1000);
+                }
             });
         });
     }


### PR DESCRIPTION
#### Rationale
Issue [42216](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42216): SM: With two different browsers (one FireFox one Chrome) logging out in one browser will show a "You have been logged out" dialog in the other browser

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/434
* https://github.com/LabKey/inventory/pull/176
* https://github.com/LabKey/sampleManagement/pull/464
* https://github.com/LabKey/biologics/pull/775
* https://github.com/LabKey/platform/pull/1927

#### Changes
* add check for evt.wasClean in server event listener callbacks before dispatching (to match platform dom/WebSocket.js)
