### PR TITLE
Fix default grid cell rendered so it displays values that are 0.

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.17.2-nextIssueFixes-seh.0",
+  "version": "1.17.2-nextIssueFixes-seh.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.17.0",
+  "version": "1.17.1-nextIssueFixes-seh.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.17.2-nextIssueFixes-seh.1",
+  "version": "1.17.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
-### version TBD
-*Released*: TBD
-* Fix default grid rendered so it displays values that are 0.
+
+### version 1.17.2
+*Released*: 29 January 2021
+* Fix default grid cell rendered so it displays values that are 0.
 
 ### version 1.17.1
 *Released*: 27 January 2021

--- a/packages/components/src/internal/components/base/Grid.spec.tsx
+++ b/packages/components/src/internal/components/base/Grid.spec.tsx
@@ -36,6 +36,11 @@ const gridData = fromJS([
         number: 15,
         position: 5,
     },
+    {
+        name: 'Zero',
+        number: 0,
+        position: 0,
+    }
 ]);
 
 const gridMessages = fromJS([
@@ -60,6 +65,8 @@ const gridColumns = List([
         title: 'Position',
         cell: posNumber => {
             switch (posNumber) {
+                case 0:
+                    return 'Bench';
                 case 2:
                     return 'C';
                 case 4:

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -70,7 +70,7 @@ export class GridColumn implements ColumnProps {
 
 const defaultCell = (d, row, col: GridColumn) => {
     let display = null;
-    if (d) {
+    if (d != undefined) {
         if (typeof d === 'string' || typeof d === 'number') {
             display = d;
         } else if (typeof d === 'boolean') {

--- a/packages/components/src/internal/components/base/__snapshots__/Grid.spec.tsx.snap
+++ b/packages/components/src/internal/components/base/__snapshots__/Grid.spec.tsx.snap
@@ -209,6 +209,37 @@ exports[`Grid component render with messages 1`] = `
           5
         </td>
       </tr>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Zero
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          0
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          0
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -353,6 +384,37 @@ exports[`Grid component render with non-default properties 1`] = `
           }
         >
           3B
+        </td>
+      </tr>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Zero
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          0
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Bench
         </td>
       </tr>
     </tbody>
@@ -501,6 +563,37 @@ exports[`Grid component rendering with data 1`] = `
           5
         </td>
       </tr>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Zero
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          0
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          0
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -645,6 +738,37 @@ exports[`Grid component rendering with data and columns 1`] = `
           }
         >
           3B
+        </td>
+      </tr>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Zero
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          0
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Bench
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
#### Rationale
Zero is a fine value, so we should display it if we get it.

#### Changes
* change from truthy check to comparison to `undefined`.
