### PR TITLE
Navigation/Product Menu Updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.19.1-fb-navigation-updates.2",
+  "version": "1.19.1-fb-navigation-updates.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.19.0",
+  "version": "1.19.1-fb-navigation-updates.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.19.1-fb-navigation-updates.0",
+  "version": "1.19.1-fb-navigation-updates.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.19.1-fb-navigation-updates.3",
+  "version": "1.20.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "1.19.1-fb-navigation-updates.1",
+  "version": "1.19.1-fb-navigation-updates.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 1.20.0
+*Released*: 8 February 2021
+* Refactor navigation components to functional components.
+* Add support for `sectionKey` in menu items.
+* Make resolving URLs implementation non-async. Promises were not needed. This affected `makeTestData` in the same way.
+* Rename `handle132Response` to `handleSelectRowsResponse` as a part of moving to non-async.
+
 ### version 1.19.0
 *Released*: 3 February 2021
 * Update storybook to v6

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -182,7 +182,7 @@ import {
     SM_PIPELINE_JOB_NOTIFICATION_EVENT,
     SM_PIPELINE_JOB_NOTIFICATION_EVENT_START,
     SM_PIPELINE_JOB_NOTIFICATION_EVENT_SUCCESS,
-    SM_PIPELINE_JOB_NOTIFICATION_EVENT_ERROR
+    SM_PIPELINE_JOB_NOTIFICATION_EVENT_ERROR,
 } from './internal/constants';
 import { getLocation, Location, replaceParameter, replaceParameters, resetParameters } from './internal/util/URL';
 import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -335,6 +335,7 @@ import { MenuSectionConfig } from './internal/components/navigation/ProductMenuS
 import { ITab, SubNav } from './internal/components/navigation/SubNav';
 import { Breadcrumb } from './internal/components/navigation/Breadcrumb';
 import { BreadcrumbCreate } from './internal/components/navigation/BreadcrumbCreate';
+import { UserMenu } from './internal/components/navigation/UserMenu';
 import { MenuItemModel, MenuSectionModel, ProductMenuModel } from './internal/components/navigation/model';
 
 import { UserSelectInput } from './internal/components/forms/input/UserSelectInput';
@@ -713,6 +714,7 @@ export {
     Breadcrumb,
     BreadcrumbCreate,
     confirmLeaveWhenDirty,
+    UserMenu, // Removed once Biologics home page no longer uses directly
     // notification related items
     NO_UPDATES_MESSAGE,
     SM_PIPELINE_JOB_NOTIFICATION_EVENT,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -43,6 +43,7 @@ import { AssayDefinitionModel, AssayDomainTypes, AssayLink } from './internal/As
 import { IGridLoader, IGridResponse, QueryGridModel } from './internal/QueryGridModel';
 import {
     applyDevTools,
+    blurActiveElement,
     capitalizeFirstChar,
     caseInsensitive,
     debounce,
@@ -795,6 +796,7 @@ export {
     getDisambiguatedSelectInputOptions,
     formatDate,
     formatDateTime,
+    blurActiveElement,
     caseInsensitive,
     capitalizeFirstChar,
     resolveKey,

--- a/packages/components/src/internal/app/actions.ts
+++ b/packages/components/src/internal/app/actions.ts
@@ -5,6 +5,8 @@
 import { List } from 'immutable';
 import { Security } from '@labkey/api';
 
+import { ServerActivity } from '../components/notifications/model';
+
 import {
     MENU_INVALIDATE,
     MENU_LOADING_END,
@@ -21,14 +23,6 @@ import {
     SERVER_NOTIFICATIONS_INVALIDATE,
     RESET_QUERY_GRID_STATE,
 } from './constants';
-import { ServerActivity } from "../components/notifications/model";
-
-function successUserPermissions(response) {
-    return {
-        type: USER_PERMISSIONS_SUCCESS,
-        response,
-    };
-}
 
 function fetchUserPermissions() {
     return new Promise((resolve, reject) => {
@@ -45,13 +39,14 @@ function fetchUserPermissions() {
 
 export function getUserPermissions() {
     return dispatch => {
-        dispatch({
-            type: USER_PERMISSIONS_REQUEST,
-        });
+        dispatch({ type: USER_PERMISSIONS_REQUEST });
 
         return fetchUserPermissions()
             .then(response => {
-                dispatch(successUserPermissions(response));
+                dispatch({
+                    type: USER_PERMISSIONS_SUCCESS,
+                    response,
+                });
             })
             .catch(error => {
                 console.error(error);
@@ -59,24 +54,11 @@ export function getUserPermissions() {
     };
 }
 
-export function updateUserDisplayName(displayName: string) {
-    return {
-        type: UPDATE_USER_DISPLAY_NAME,
-        displayName,
-    };
-}
+export const updateUserDisplayName = (displayName: string) => ({ type: UPDATE_USER_DISPLAY_NAME, displayName });
 
-export function setReloadRequired() {
-    return {
-        type: SET_RELOAD_REQUIRED,
-    };
-}
+export const setReloadRequired = () => ({ type: SET_RELOAD_REQUIRED });
 
-export function doResetQueryGridState() {
-    return {
-        type: RESET_QUERY_GRID_STATE
-    };
-}
+export const doResetQueryGridState = () => ({ type: RESET_QUERY_GRID_STATE });
 
 export function menuInit(currentProductId: string, userMenuProductId: string, productIds?: List<string>) {
     return (dispatch, getState) => {
@@ -109,26 +91,18 @@ export function menuInit(currentProductId: string, userMenuProductId: string, pr
     };
 }
 
-export function menuInvalidate() {
-    return (dispatch, getState) => {
-        dispatch({ type: MENU_INVALIDATE });
-    };
-}
+export const menuInvalidate = () => ({ type: MENU_INVALIDATE });
 
 // an alternative to menuInvalidate, which doesn't erase current menu during reload
-export function menuReload() {
-    return (dispatch, getState) => {
-        dispatch({ type: MENU_RELOAD });
-    };
-}
+export const menuReload = () => ({ type: MENU_RELOAD });
 
 export function serverNotificationInit(serverActivitiesLoaderFn: (maxRows?: number) => Promise<ServerActivity>) {
     return (dispatch, getState) => {
-        let serverNotificationModel = getState().serverNotifications;
+        const serverNotificationModel = getState().serverNotifications;
         if (serverNotificationModel && !serverNotificationModel.isLoaded && !serverNotificationModel.isLoading) {
             dispatch({
                 type: SERVER_NOTIFICATIONS_LOADING_START,
-                serverActivitiesLoaderFn
+                serverActivitiesLoaderFn,
             });
             serverActivitiesLoaderFn()
                 .then(serverActivity => {
@@ -148,8 +122,4 @@ export function serverNotificationInit(serverActivitiesLoaderFn: (maxRows?: numb
     };
 }
 
-export function serverNotificationInvalidate() {
-    return (dispatch, getState) => {
-        dispatch({ type: SERVER_NOTIFICATIONS_INVALIDATE });
-    };
-}
+export const serverNotificationInvalidate = () => ({ type: SERVER_NOTIFICATIONS_INVALIDATE });

--- a/packages/components/src/internal/app/models.ts
+++ b/packages/components/src/internal/app/models.ts
@@ -9,6 +9,12 @@ import { Container, User } from '../..';
 
 const user = new User(getServerContext().user);
 
+export enum LogoutReason {
+    SERVER_LOGOUT,
+    SESSION_EXPIRED,
+    SERVER_UNAVAILABLE,
+}
+
 export class AppModel extends Record({
     container: new Container(getServerContext().container),
     contextPath: ActionURL.getContextPath(),
@@ -71,11 +77,4 @@ export class AppModel extends Record({
     shouldInvalidateQueryGrid(): boolean {
         return this.needsInvalidateQueryGrid;
     }
-
-}
-
-export enum LogoutReason {
-    SERVER_LOGOUT,
-    SESSION_EXPIRED,
-    SERVER_UNAVAILABLE,
 }

--- a/packages/components/src/internal/app/reducers.ts
+++ b/packages/components/src/internal/app/reducers.ts
@@ -7,6 +7,8 @@ import { handleActions } from 'redux-actions';
 
 import { ServerNotificationModel, ProductMenuModel } from '../..';
 
+import { resetQueryGridState } from '../global';
+
 import { AppModel, LogoutReason } from './models';
 import {
     SECURITY_LOGOUT,
@@ -29,7 +31,6 @@ import {
     SET_RESET_QUERY_GRID_STATE,
     RESET_QUERY_GRID_STATE,
 } from './constants';
-import { resetQueryGridState } from "../global";
 
 export type AppReducerState = AppModel;
 
@@ -38,9 +39,8 @@ export const AppReducers = handleActions<AppReducerState, any>(
         [SET_RELOAD_REQUIRED]: (state: AppReducerState) => state.set('reloadRequired', true),
 
         [UPDATE_USER_DISPLAY_NAME]: (state: AppReducerState, action: any) => {
-            const { displayName } = action;
             return state.merge({
-                user: state.user.set('displayName', displayName),
+                user: state.user.set('displayName', action.displayName),
             });
         },
 
@@ -55,40 +55,39 @@ export const AppReducers = handleActions<AppReducerState, any>(
             });
         },
 
-        [SECURITY_LOGOUT]: (state: AppReducerState, action: any) => {
+        [SECURITY_LOGOUT]: (state: AppReducerState) => {
             return state.merge({
                 reloadRequired: true,
                 logoutReason: LogoutReason.SERVER_LOGOUT,
             });
         },
 
-        [SECURITY_SESSION_TIMEOUT]: (state: AppReducerState, action: any) => {
+        [SECURITY_SESSION_TIMEOUT]: (state: AppReducerState) => {
             return state.merge({
                 reloadRequired: true,
                 logoutReason: LogoutReason.SESSION_EXPIRED,
             });
         },
 
-        [SECURITY_SERVER_UNAVAILABLE]: (state: AppReducerState, action: any) => {
+        [SECURITY_SERVER_UNAVAILABLE]: (state: AppReducerState) => {
             return state.merge({
                 reloadRequired: true,
                 logoutReason: LogoutReason.SERVER_UNAVAILABLE,
             });
         },
 
-        [SET_RESET_QUERY_GRID_STATE]: (state: AppReducerState, action: any) => {
+        [SET_RESET_QUERY_GRID_STATE]: (state: AppReducerState) => {
             return state.merge({
-                needsInvalidateQueryGrid: true
+                needsInvalidateQueryGrid: true,
             });
         },
 
-        [RESET_QUERY_GRID_STATE]: (state: AppReducerState, action: any) => {
+        [RESET_QUERY_GRID_STATE]: (state: AppReducerState) => {
             resetQueryGridState();
             return state.merge({
-                needsInvalidateQueryGrid: false
+                needsInvalidateQueryGrid: false,
             });
         },
-
     },
     new AppModel()
 );
@@ -110,13 +109,9 @@ export type ProductMenuState = ProductMenuModel;
 
 export const ProductMenuReducers = handleActions<ProductMenuState, any>(
     {
-        [MENU_INVALIDATE]: (state: ProductMenuState, action: any) => {
-            return new ProductMenuModel();
-        },
+        [MENU_INVALIDATE]: () => new ProductMenuModel(),
 
-        [MENU_RELOAD]: (state: ProductMenuState, action: any) => {
-            return state.setNeedsReload();
-        },
+        [MENU_RELOAD]: (state: ProductMenuState) => state.setNeedsReload(),
 
         [MENU_LOADING_START]: (state: ProductMenuState, action: any) => {
             const { currentProductId, userMenuProductId, productIds } = action;
@@ -130,13 +125,11 @@ export const ProductMenuReducers = handleActions<ProductMenuState, any>(
         },
 
         [MENU_LOADING_ERROR]: (state: ProductMenuState, action: any) => {
-            const { message } = action;
-            return state.setError(message);
+            return state.setError(action.message);
         },
 
         [MENU_LOADING_END]: (state: ProductMenuState, action: any) => {
-            const { sections } = action;
-            return state.setLoadedSections(sections);
+            return state.setLoadedSections(action.sections);
         },
     },
     new ProductMenuModel()
@@ -146,22 +139,18 @@ export type ServerNotificationState = ServerNotificationModel;
 
 export const ServerNotificationReducers = handleActions<ServerNotificationState, any>(
     {
-        [SERVER_NOTIFICATIONS_INVALIDATE]: (state: ServerNotificationState, action: any) => {
-            return new ServerNotificationModel();
-        },
+        [SERVER_NOTIFICATIONS_INVALIDATE]: () => new ServerNotificationModel(),
 
-        [SERVER_NOTIFICATIONS_LOADING_START]: (state: ServerNotificationState, action: any) => {
+        [SERVER_NOTIFICATIONS_LOADING_START]: (state: ServerNotificationState) => {
             return state.setLoadingStart();
         },
 
         [SERVER_NOTIFICATIONS_LOADING_END]: (state: ServerNotificationState, action: any) => {
-            const { serverActivity } = action;
-            return state.setLoadingComplete(serverActivity);
+            return state.setLoadingComplete(action.serverActivity);
         },
 
         [SERVER_NOTIFICATIONS_LOADING_ERROR]: (state: ServerNotificationState, action: any) => {
-            const { message } = action;
-            return state.setError(message);
+            return state.setError(action.message);
         },
     },
     new ServerNotificationModel()

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -56,6 +56,8 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
             window.setTimeout(() => store.dispatch({ type: SECURITY_LOGOUT }), 1000);
         }
     }
+
+    // TODO: Make "WebSocket" available from @labkey/api
     LABKEY.WebSocket.addServerEventListener(CloseEventCode.NORMAL_CLOSURE, _logOutCallback);
     LABKEY.WebSocket.addServerEventListener(CloseEventCode.UNSUPPORTED_DATA, _logOutCallback);
 
@@ -97,7 +99,7 @@ export function initWebSocketListeners(store, notificationListeners?: string[], 
             LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
                 window.setTimeout(() => store.dispatch({ type: SET_RESET_QUERY_GRID_STATE }), 1000);
             });
-        })
+        });
     }
 }
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -49,7 +49,12 @@ export enum CloseEventCode {
     TLS_HANDSHAKE = 1015,
 }
 
-export function initWebSocketListeners(store, notificationListeners?: string[], menuReloadListeners?: string[], resetQueryGridListeners?: string[]): void {
+export function initWebSocketListeners(
+    store,
+    notificationListeners?: string[],
+    menuReloadListeners?: string[],
+    resetQueryGridListeners?: string[]
+): void {
     // register websocket listener for the case where a user logs out in another tab
     function _logOutCallback(evt) {
         if (evt.wasClean && evt.reason === 'org.labkey.api.security.AuthNotify#SessionLogOut') {

--- a/packages/components/src/internal/components/gridbar/PageSizeSelector.tsx
+++ b/packages/components/src/internal/components/gridbar/PageSizeSelector.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { List } from 'immutable';
 
 import { QueryGridModel, Tip } from '../../..';
 import { setMaxRows } from '../../actions';
+import { blurActiveElement } from '../../util/utils';
 
 const DEFAULT_SIZE_OPTIONS = List.of(20, 40, 100, 250, 400);
 
@@ -34,15 +35,15 @@ interface Props {
 /**
  * Displays a dropdown button with the different supported page size options. The default, from getStateQueryGridModel, is 20.
  */
-export class PageSizeSelector extends React.PureComponent<Props, any> {
+export class PageSizeSelector extends PureComponent<Props> {
     static defaultProps = {
         options: DEFAULT_SIZE_OPTIONS,
     };
 
-    onClick(selectedVal: number) {
+    onClick = (selectedVal: number): void => {
         setMaxRows(this.props.model, selectedVal);
-        (document.activeElement as HTMLElement).blur(); // Issue 39418
-    }
+        blurActiveElement(); // Issue 39418
+    };
 
     render() {
         const { model, options } = this.props;

--- a/packages/components/src/internal/components/navigation/HeaderWrapper.tsx
+++ b/packages/components/src/internal/components/navigation/HeaderWrapper.tsx
@@ -13,28 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { Component } from 'react';
 import $ from 'jquery';
 
 interface Props {
     headerHeight: number;
 }
 
-export class HeaderWrapper extends React.Component<Props, any> {
+export class HeaderWrapper extends Component<Props> {
     private headerWrapper: React.RefObject<HTMLDivElement>;
     private lastScrollY: number;
 
     constructor(props: Props) {
         super(props);
 
-        this.onDocScroll = this.onDocScroll.bind(this);
-
         this.lastScrollY = 0;
         this.headerWrapper = React.createRef();
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         window.addEventListener('scroll', this.onDocScroll);
+    }
+
+    componentWillUnmount(): void {
+        window.removeEventListener('scroll', this.onDocScroll);
     }
 
     componentDidUpdate() {
@@ -43,7 +45,7 @@ export class HeaderWrapper extends React.Component<Props, any> {
         });
     }
 
-    onDocScroll() {
+    onDocScroll = (): void => {
         const { headerHeight } = this.props;
         const scrollY = window.scrollY;
 
@@ -66,7 +68,7 @@ export class HeaderWrapper extends React.Component<Props, any> {
 
             this.lastScrollY = scrollY;
         });
-    }
+    };
 
     render() {
         return (

--- a/packages/components/src/internal/components/navigation/NavigationBar.spec.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.spec.tsx
@@ -15,16 +15,18 @@
  */
 import React from 'react';
 import renderer from 'react-test-renderer';
-
-import { NavigationBar } from './NavigationBar';
 import { mount } from 'enzyme';
+import { List } from 'immutable';
+
 import { TEST_USER_GUEST, TEST_USER_READER } from '../../../test/data/users';
 import { ServerNotifications } from '../notifications/ServerNotifications';
-import { MenuSectionModel, ProductMenuModel } from './model';
-import { List } from 'immutable';
+
 import { markAllNotificationsRead } from '../../../test/data/notificationData';
-import {ServerNotificationModel} from "../notifications/model";
-import {ServerActivityList} from "../notifications/ServerActivityList";
+import { ServerNotificationModel } from '../notifications/model';
+
+import { MenuSectionModel, ProductMenuModel } from './model';
+
+import { NavigationBar } from './NavigationBar';
 
 describe('<NavigationBar/>', () => {
     const productMenuModel = new ProductMenuModel({
@@ -36,22 +38,22 @@ describe('<NavigationBar/>', () => {
 
     const notificationsConfig = {
         maxRows: 1,
-        markAllNotificationsRead: markAllNotificationsRead,
+        markAllNotificationsRead,
         serverActivity: new ServerNotificationModel(),
-        onViewAll:jest.fn(),
+        onViewAll: jest.fn(),
     };
 
     test('default props', () => {
         const component = <NavigationBar model={null} />;
 
-        const tree = renderer.create(component).toJSON();
+        const tree = renderer.create(component);
         expect(tree).toMatchSnapshot();
     });
 
     test('with search box', () => {
         const component = <NavigationBar model={null} showSearchBox={true} />;
 
-        const tree = renderer.create(component).toJSON();
+        const tree = renderer.create(component);
         expect(tree).toMatchSnapshot();
     });
 

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -13,90 +13,102 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { FC, memo, ReactNode, useCallback } from 'react';
 import { List, Map } from 'immutable';
 
 import { User } from '../../..';
+
+import { ServerNotifications } from '../notifications/ServerNotifications';
+
+import { ServerNotificationsConfig } from '../notifications/model';
 
 import { ProductMenu } from './ProductMenu';
 import { SearchBox } from './SearchBox';
 import { UserMenu } from './UserMenu';
 import { MenuSectionConfig } from './ProductMenuSection';
 import { ProductMenuModel } from './model';
-import { ServerNotifications } from "../notifications/ServerNotifications";
-import { ServerNotificationsConfig } from '../notifications/model';
 
 interface NavigationBarProps {
     brand?: ReactNode;
-    projectName?: string;
     menuSectionConfigs?: List<Map<string, MenuSectionConfig>>;
     model: ProductMenuModel;
-    showSearchBox: boolean;
-    onSearch?: (form: any) => any;
-    searchPlaceholder?: string;
-    user?: User;
-    showSwitchToLabKey: boolean;
-    signOutUrl?: string;
     notificationsConfig?: ServerNotificationsConfig;
+    onSearch?: (form: any) => void;
+    projectName?: string;
+    searchPlaceholder?: string;
+    showSearchBox?: boolean;
+    showSwitchToLabKey?: boolean;
+    signOutUrl?: string;
+    user?: User;
 }
 
-export class NavigationBar extends React.Component<NavigationBarProps, any> {
-    static defaultProps: {
-        showSearchBox: false;
-        showSwitchToLabKey: true;
-        notificationsConfig: undefined;
-    };
+export const NavigationBar: FC<NavigationBarProps> = memo(props => {
+    const {
+        brand,
+        menuSectionConfigs,
+        model,
+        notificationsConfig,
+        onSearch,
+        projectName,
+        searchPlaceholder,
+        showSearchBox,
+        showSwitchToLabKey,
+        signOutUrl,
+        user,
+    } = props;
 
-    render(): ReactNode {
-        const {
-            brand,
-            menuSectionConfigs,
-            model,
-            projectName,
-            showSearchBox,
-            onSearch,
-            searchPlaceholder,
-            user,
-            notificationsConfig,
-            showSwitchToLabKey,
-            signOutUrl,
-        } = this.props;
-        const productMenu = model ? <ProductMenu model={model} sectionConfigs={menuSectionConfigs} /> : null;
-        const searchBox = showSearchBox ? <SearchBox onSearch={onSearch} placeholder={searchPlaceholder} /> : null;
-        const userMenu = user ? (
-            <UserMenu model={model} user={user} showSwitchToLabKey={showSwitchToLabKey} signOutUrl={signOutUrl} />
-        ) : null;
+    const onSearchIconClick = useCallback(() => {
+        onSearch('');
+    }, [onSearch]);
 
-        const notifications = notificationsConfig && user && !user.isGuest ? <ServerNotifications {...notificationsConfig} /> : null;
+    const notifications =
+        !!notificationsConfig && user && !user.isGuest ? <ServerNotifications {...notificationsConfig} /> : null;
 
-        return (
-            <nav className="navbar navbar-container test-loc-nav-header">
-                <div className="container">
-                    <div className="row">
-                        <div className="navbar-left col-sm-5 col-xs-7">
-                            <span className="navbar-item pull-left">{brand}</span>
-                            <span className="navbar-item-padded">{productMenu}</span>
-                            {projectName && (
-                                <span className="navbar-item hidden-sm hidden-xs">
-                                    <span className="project-name">
-                                        <i className="fa fa-folder-open-o" /> {projectName}{' '}
-                                    </span>
+    return (
+        <nav className="navbar navbar-container test-loc-nav-header">
+            <div className="container">
+                <div className="row">
+                    <div className="navbar-left col-sm-5 col-xs-7">
+                        <span className="navbar-item pull-left">{brand}</span>
+                        <span className="navbar-item-padded">
+                            {!!model && <ProductMenu model={model} sectionConfigs={menuSectionConfigs} />}
+                        </span>
+                        {projectName && (
+                            <span className="navbar-item hidden-sm hidden-xs">
+                                <span className="project-name">
+                                    <i className="fa fa-folder-open-o" /> {projectName}{' '}
                                 </span>
+                            </span>
+                        )}
+                    </div>
+                    <div className="navbar-right col-sm-7 col-xs-5">
+                        <div className="navbar-item pull-right">
+                            {!!user && (
+                                <UserMenu
+                                    model={model}
+                                    showSwitchToLabKey={showSwitchToLabKey}
+                                    signOutUrl={signOutUrl}
+                                    user={user}
+                                />
                             )}
                         </div>
-                        <div className="navbar-right col-sm-7 col-xs-5">
-                            <div className="navbar-item pull-right">{userMenu}</div>
-                            <div className="navbar-item pull-right navbar-item-notification">{notifications}</div>
-                            <div className="navbar-item pull-right hidden-xs">{searchBox}</div>
-                            <div className="navbar-item pull-right visible-xs">
-                                {showSearchBox && (
-                                    <i className="fa fa-search navbar__xs-search-icon" onClick={() => onSearch('')} />
-                                )}
-                            </div>
+                        <div className="navbar-item pull-right navbar-item-notification">{notifications}</div>
+                        <div className="navbar-item pull-right hidden-xs">
+                            {showSearchBox && <SearchBox onSearch={onSearch} placeholder={searchPlaceholder} />}
+                        </div>
+                        <div className="navbar-item pull-right visible-xs">
+                            {showSearchBox && (
+                                <i className="fa fa-search navbar__xs-search-icon" onClick={onSearchIconClick} />
+                            )}
                         </div>
                     </div>
                 </div>
-            </nav>
-        );
-    }
-}
+            </div>
+        </nav>
+    );
+});
+
+NavigationBar.defaultProps = {
+    showSearchBox: false,
+    showSwitchToLabKey: true,
+};

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -24,7 +24,7 @@ import { ServerNotificationsConfig } from '../notifications/model';
 
 import { ProductMenu } from './ProductMenu';
 import { SearchBox } from './SearchBox';
-import { UserMenu } from './UserMenu';
+import { UserMenu, UserMenuProps } from './UserMenu';
 import { MenuSectionConfig } from './ProductMenuSection';
 import { ProductMenuModel } from './model';
 
@@ -37,18 +37,22 @@ interface NavigationBarProps {
     projectName?: string;
     searchPlaceholder?: string;
     showSearchBox?: boolean;
-    showSwitchToLabKey?: boolean;
-    signOutUrl?: string;
     user?: User;
 }
 
-export const NavigationBar: FC<NavigationBarProps> = memo(props => {
+type Props = NavigationBarProps & UserMenuProps;
+
+export const NavigationBar: FC<Props> = memo(props => {
     const {
         brand,
+        extraDevItems,
+        extraUserItems,
         menuSectionConfigs,
         model,
         notificationsConfig,
         onSearch,
+        onSignIn,
+        onSignOut,
         projectName,
         searchPlaceholder,
         showSearchBox,
@@ -85,7 +89,11 @@ export const NavigationBar: FC<NavigationBarProps> = memo(props => {
                         <div className="navbar-item pull-right">
                             {!!user && (
                                 <UserMenu
+                                    extraDevItems={extraDevItems}
+                                    extraUserItems={extraUserItems}
                                     model={model}
+                                    onSignIn={onSignIn}
+                                    onSignOut={onSignOut}
                                     showSwitchToLabKey={showSwitchToLabKey}
                                     signOutUrl={signOutUrl}
                                     user={user}

--- a/packages/components/src/internal/components/navigation/ProductMenu.spec.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.spec.tsx
@@ -29,9 +29,9 @@ describe('ProductMenu render', () => {
             label: 'Sample Set 1',
         },
         {
+            hasActiveJob: true,
             id: 2,
             label: 'Sample Set 2',
-            hasActiveJob: true
         },
         {
             id: 3,
@@ -45,9 +45,9 @@ describe('ProductMenu render', () => {
 
     const assayItems = List<MenuSectionModel>([
         {
+            hasActiveJob: true,
             id: 11,
             label: 'Assay 1',
-            hasActiveJob: true
         },
         {
             id: 12,
@@ -160,7 +160,7 @@ describe('ProductMenu render', () => {
                 url: undefined,
                 items: sampleSetItems,
                 itemLimit: 2,
-                key: 'samples'
+                key: 'samples',
             })
         );
         sections.push(
@@ -184,7 +184,7 @@ describe('ProductMenu render', () => {
             'samples',
             new MenuSectionConfig({
                 iconCls: 'test-icon-cls',
-                showActiveJobIcon: false
+                showActiveJobIcon: false,
             })
         );
         sectionConfigs = sectionConfigs.push(samplesSectionConfigs);

--- a/packages/components/src/internal/components/navigation/ProductMenu.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.tsx
@@ -21,6 +21,7 @@ import { LoadingSpinner } from '../../..';
 
 import { MenuSectionModel, ProductMenuModel } from './model';
 import { MenuSectionConfig, ProductMenuSection } from './ProductMenuSection';
+import { blurActiveElement } from '../../util/utils';
 
 interface ProductMenuProps {
     model: ProductMenuModel;
@@ -39,6 +40,7 @@ export const ProductMenu: FC<ProductMenuProps> = memo(props => {
 
     const toggleMenu = useCallback(() => {
         setMenuOpen(!menuOpen);
+        blurActiveElement();
     }, [menuOpen, setMenuOpen]);
 
     let containerCls = 'product-menu-content ';

--- a/packages/components/src/internal/components/navigation/ProductMenu.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.tsx
@@ -19,9 +19,10 @@ import { DropdownButton } from 'react-bootstrap';
 
 import { LoadingSpinner } from '../../..';
 
+import { blurActiveElement } from '../../util/utils';
+
 import { MenuSectionModel, ProductMenuModel } from './model';
 import { MenuSectionConfig, ProductMenuSection } from './ProductMenuSection';
-import { blurActiveElement } from '../../util/utils';
 
 interface ProductMenuProps {
     model: ProductMenuModel;

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.spec.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.spec.tsx
@@ -31,7 +31,7 @@ describe('ProductMenuSection render', () => {
         {
             id: 2,
             label: 'Sample Set 2',
-            hasActiveJob: true
+            hasActiveJob: true,
         },
         {
             id: 3,
@@ -91,24 +91,20 @@ describe('ProductMenuSection render', () => {
     });
 
     test('empty section with empty text and create link', () => {
+        const config = new MenuSectionConfig({
+            emptyText: 'Test empty text',
+            emptyURL: AppURL.create('sample', 'new'),
+            emptyURLText: 'Test empty link',
+            iconURL: '/testProduct/images/samples.svg',
+        });
         const section = MenuSectionModel.create({
             label: 'Sample Sets',
             items: List<MenuSectionModel>(),
             key: 'samples',
         });
+
         const menuSection = mount(
-            <ProductMenuSection
-                currentProductId="testProduct"
-                section={section}
-                config={
-                    new MenuSectionConfig({
-                        emptyText: 'Test empty text',
-                        iconURL: '/testProduct/images/samples.svg',
-                        emptyURL: AppURL.create('sample', 'new'),
-                        emptyURLText: 'Test empty link',
-                    })
-                }
-            />
+            <ProductMenuSection config={config} currentProductId="testProduct" section={section} />
         );
 
         expect(menuSection.find('li.empty-section').length).toBe(1);
@@ -233,7 +229,7 @@ describe('ProductMenuSection render', () => {
                 section={section}
                 config={
                     new MenuSectionConfig({
-                        showActiveJobIcon: false
+                        showActiveJobIcon: false,
                     })
                 }
             />
@@ -256,7 +252,7 @@ describe('ProductMenuSection render', () => {
                 section={section}
                 config={
                     new MenuSectionConfig({
-                        activeJobIconCls: 'job-running-icon'
+                        activeJobIconCls: 'job-running-icon',
                     })
                 }
             />
@@ -265,6 +261,4 @@ describe('ProductMenuSection render', () => {
         expect(menuSection.find('i.fa-spinner').length).toBe(0);
         expect(menuSection.find('i.job-running-icon').length).toBe(0);
     });
-
-
 });

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
@@ -14,43 +14,43 @@
  * limitations under the License.
  */
 import React, { Component, ReactNode } from 'react';
-import { Record } from 'immutable';
+import { List, Record } from 'immutable';
+import classNames from 'classnames';
 
 import { AppURL, naturalSort, createProductUrlFromParts } from '../../..';
 
-import { MenuSectionModel } from './model';
-import classNames from "classnames";
+import { MenuItemModel, MenuSectionModel } from './model';
 
 function getHref(url: AppURL | string): string {
     return typeof url === 'string' ? url : url.toHref();
 }
 
 export class MenuSectionConfig extends Record({
+    activeJobIconCls: 'fa-spinner fa-pulse',
     emptyText: undefined,
-    iconURL: undefined,
-    iconCls: undefined,
-    maxItemsPerColumn: 12,
-    maxColumns: 1,
-    seeAllURL: undefined,
     emptyURL: undefined,
     emptyURLText: 'Get started...',
     headerURL: undefined,
     headerText: undefined,
+    iconCls: undefined,
+    iconURL: undefined,
+    maxColumns: 1,
+    maxItemsPerColumn: 12,
+    seeAllURL: undefined,
     showActiveJobIcon: true,
-    activeJobIconCls: 'fa-spinner fa-pulse'
 }) {
+    activeJobIconCls?: string;
     emptyText?: string;
-    iconURL?: string;
-    iconCls?: string;
-    maxItemsPerColumn: number;
-    maxColumns: number;
-    seeAllURL?: AppURL | string;
     emptyURL?: AppURL | string;
     emptyURLText: string;
     headerURL: AppURL | string;
     headerText?: string;
+    iconCls?: string;
+    iconURL?: string;
+    maxColumns: number;
+    maxItemsPerColumn: number;
+    seeAllURL?: AppURL | string;
     showActiveJobIcon?: boolean;
-    activeJobIconCls?: string;
 }
 
 interface MenuSectionProps {
@@ -64,54 +64,52 @@ export class ProductMenuSection extends Component<MenuSectionProps> {
         maxColumns: 1,
     };
 
-    renderEmpty = (): ReactNode => {
-        const { config } = this.props;
-        return (
-            <>
-                {config.emptyText && (
-                    <li key="empty" className="empty-section">
-                        {config.emptyText}
-                    </li>
-                )}
-                {config.emptyURL && (
-                    <li key="emptyUrl" className="empty-section-link">
-                        <a href={getHref(config.emptyURL)}>{config.emptyURLText}</a>
-                    </li>
-                )}
-            </>
-        );
-    };
+    renderMenuItemsList = (items: List<MenuItemModel>, columnNumber = 1, totalColumns = 1): ReactNode => {
+        const { config, section } = this.props;
+        const { activeJobIconCls, showActiveJobIcon } = config;
 
-    renderMenuItemsList = (items, columnNumber = 1, totalColumns = 1, withOverflow = false, config?: MenuSectionConfig): ReactNode => {
-        const { section } = this.props;
-        const activeJobCls = config?.activeJobIconCls;
-        const showActiveJobIcon = config?.showActiveJobIcon;
         return (
             <ul className={'col-' + totalColumns} key={section.key + 'col-' + columnNumber}>
-                {items.isEmpty()
-                    ? this.renderEmpty()
-                    : items
-                          .sortBy(item => item.label, naturalSort)
-                          .map(item => {
-                              const labelDisplay = (item.hasActiveJob && showActiveJobIcon) ? (
-                                      <>
-                                          <i className={classNames('fa', activeJobCls)}/>
-                                          <span className={'spacer-left product-menu-item'}>{item.label}</span>
-                                      </>
-                                  ) : item.label;
+                {items.isEmpty() ? (
+                    <>
+                        {config.emptyText && (
+                            <li key="empty" className="empty-section">
+                                {config.emptyText}
+                            </li>
+                        )}
+                        {config.emptyURL && (
+                            <li key="emptyUrl" className="empty-section-link">
+                                <a href={getHref(config.emptyURL)}>{config.emptyURLText}</a>
+                            </li>
+                        )}
+                    </>
+                ) : (
+                    items
+                        .sortBy(item => item.label, naturalSort)
+                        .map(item => {
+                            const labelDisplay =
+                                item.hasActiveJob && showActiveJobIcon ? (
+                                    <>
+                                        <i className={classNames('fa', activeJobIconCls)} />
+                                        <span className="spacer-left product-menu-item">{item.label}</span>
+                                    </>
+                                ) : (
+                                    item.label
+                                );
 
-                              if (item.url) {
-                                  const url = item.url instanceof AppURL ? item.url.toHref() : item.url;
-                                  return (
-                                      <li key={item.label}>
-                                          <a href={url} target={item.key === 'docs' ? '_blank' : '_self'}>
-                                              {labelDisplay}
-                                          </a>
-                                      </li>
-                                  );
-                              }
-                              return <li key={item.label}>{labelDisplay}</li>;
-                          })}
+                            if (item.url) {
+                                const url = item.url instanceof AppURL ? item.url.toHref() : item.url;
+                                return (
+                                    <li key={item.label}>
+                                        <a href={url} target={item.key === 'docs' ? '_blank' : '_self'}>
+                                            {labelDisplay}
+                                        </a>
+                                    </li>
+                                );
+                            }
+                            return <li key={item.label}>{labelDisplay}</li>;
+                        })
+                )}
             </ul>
         );
     };
@@ -136,7 +134,7 @@ export class ProductMenuSection extends Component<MenuSectionProps> {
         } else if (config.iconCls) {
             icon = <span className={(config.iconCls || '') + ' menu-section-icon'} />;
         }
-        const headerText = config.headerText ? config.headerText : section.label;
+        const headerText = config.headerText ?? section.label;
         const label = icon ? (
             <>
                 {icon}&nbsp;{headerText}
@@ -144,7 +142,7 @@ export class ProductMenuSection extends Component<MenuSectionProps> {
         ) : (
             headerText
         );
-        let headerURL = config.headerURL;
+        let { headerURL } = config;
         if (headerURL === undefined) {
             if (section.url) {
                 headerURL = createProductUrlFromParts(
@@ -155,14 +153,6 @@ export class ProductMenuSection extends Component<MenuSectionProps> {
                 );
             }
         }
-        const header = (
-            <>
-                <span className="menu-section-header">
-                    {headerURL ? <a href={getHref(headerURL)}>{label}</a> : <>{label}</>}
-                </span>
-                <hr />
-            </>
-        );
 
         const allItems = section.items;
         const haveOverflow =
@@ -172,26 +162,30 @@ export class ProductMenuSection extends Component<MenuSectionProps> {
         let endIndex = Math.min(config.maxItemsPerColumn, allItems.size);
         const numColumns = Math.min(config.maxColumns, Math.ceil(allItems.size / config.maxItemsPerColumn));
         const columns = [
-            this.renderMenuItemsList(allItems.slice(startIndex, endIndex), columnNum, numColumns, haveOverflow, config),
+            this.renderMenuItemsList(allItems.slice(startIndex, endIndex).toList(), columnNum, numColumns),
         ];
         while (endIndex < allItems.size && columnNum < config.maxColumns) {
             startIndex = endIndex;
             endIndex = Math.min(endIndex + config.maxItemsPerColumn, allItems.size);
             columnNum++;
-            columns.push(this.renderMenuItemsList(allItems.slice(startIndex, endIndex), columnNum, numColumns, false, config));
+            columns.push(
+                this.renderMenuItemsList(allItems.slice(startIndex, endIndex).toList(), columnNum, numColumns)
+            );
         }
         if (haveOverflow) {
-            const seeAllUrl = config.seeAllURL || AppURL.create(section.key);
             columns.push(
                 <span className="overflow-link" key="overflow">
-                    <a href={getHref(seeAllUrl)}>See all {section.totalCount}</a>
+                    <a href={getHref(config.seeAllURL ?? AppURL.create(section.key))}>See all {section.totalCount}</a>
                 </span>
             );
         }
 
         return (
             <>
-                {header}
+                <span className="menu-section-header">
+                    {headerURL ? <a href={getHref(headerURL)}>{label}</a> : <>{label}</>}
+                </span>
+                <hr />
                 {columns}
             </>
         );

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
@@ -98,10 +98,9 @@ export class ProductMenuSection extends Component<MenuSectionProps> {
                                 );
 
                             if (item.url) {
-                                const url = item.url instanceof AppURL ? item.url.toHref() : item.url;
                                 return (
                                     <li key={item.label}>
-                                        <a href={url} target={item.key === 'docs' ? '_blank' : '_self'}>
+                                        <a href={item.getUrlString()} target={item.key === 'docs' ? '_blank' : '_self'}>
                                             {labelDisplay}
                                         </a>
                                     </li>

--- a/packages/components/src/internal/components/navigation/SearchBox.tsx
+++ b/packages/components/src/internal/components/navigation/SearchBox.tsx
@@ -13,54 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ChangeEvent, FC, FormEvent, memo, useCallback, useState } from 'react';
 
 interface Props {
-    onSearch: (value: string) => any;
+    onSearch: (value: string) => void;
     placeholder?: string;
 }
 
-interface State {
-    value?: string;
-}
+export const SearchBox: FC<Props> = memo(({ onSearch, placeholder }) => {
+    const [searchValue, setSearchValue] = useState('');
 
-export class SearchBox extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
+    const onChange = useCallback(
+        (evt: ChangeEvent<HTMLInputElement>) => {
+            setSearchValue(evt.target.value);
+        },
+        [setSearchValue]
+    );
 
-        this.state = {
-            value: '',
-        };
-    }
+    const onSubmit = useCallback(
+        (evt: FormEvent<HTMLFormElement>) => {
+            evt.preventDefault();
+            onSearch(searchValue);
 
-    onSearch = (evt: any) => {
-        evt.preventDefault();
-        this.props.onSearch(this.state.value);
+            // reset the input value after it is has submitted
+            setSearchValue('');
+        },
+        [onSearch]
+    );
 
-        // reset the input value after it is has submitted
-        this.setState(() => ({ value: '' }));
-    };
-
-    handleChange = (evt: any) => {
-        const value = evt.target.value;
-        this.setState(() => ({ value }));
-    };
-
-    render() {
-        return (
-            <form className="navbar__search-form" onSubmit={this.onSearch}>
-                <div className="form-group">
-                    <i className="fa fa-search navbar__search-icon" />
-                    <input
-                        type="text"
-                        placeholder={this.props.placeholder || 'Enter Search Terms'}
-                        className="navbar__search-input"
-                        onChange={this.handleChange}
-                        value={this.state.value}
-                        size={34}
-                    />
-                </div>
-            </form>
-        );
-    }
-}
+    return (
+        <form className="navbar__search-form" onSubmit={onSubmit}>
+            <div className="form-group">
+                <i className="fa fa-search navbar__search-icon" />
+                <input
+                    className="navbar__search-input"
+                    onChange={onChange}
+                    placeholder={placeholder ?? 'Enter Search Terms'}
+                    size={34}
+                    type="text"
+                    value={searchValue}
+                />
+            </div>
+        </form>
+    );
+});

--- a/packages/components/src/internal/components/navigation/SearchBox.tsx
+++ b/packages/components/src/internal/components/navigation/SearchBox.tsx
@@ -38,7 +38,7 @@ export const SearchBox: FC<Props> = memo(({ onSearch, placeholder }) => {
             // reset the input value after it is has submitted
             setSearchValue('');
         },
-        [onSearch]
+        [onSearch, searchValue]
     );
 
     return (

--- a/packages/components/src/internal/components/navigation/UserMenu.spec.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenu.spec.tsx
@@ -16,6 +16,7 @@
 import React from 'react';
 import { List } from 'immutable';
 import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 import { User } from '../../..';
 
@@ -54,8 +55,8 @@ describe('UserMenu', () => {
         const model = new ProductMenuModel({
             productIds: ['testProduct'],
         });
-        const tree = renderer.create(<UserMenu model={model} user={new User()} showSwitchToLabKey={true} />).toJSON();
-        expect(tree).toBe(null);
+        const tree = mount(<UserMenu model={model} user={new User()} showSwitchToLabKey />);
+        expect(tree).toEqual({});
     });
 
     test('user not logged in', () => {
@@ -70,7 +71,7 @@ describe('UserMenu', () => {
             productIds,
             sections: sections.asImmutable(),
         });
-        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey={true} />).toJSON();
+        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey />);
         expect(tree).toMatchSnapshot();
     });
 
@@ -86,7 +87,7 @@ describe('UserMenu', () => {
             productIds,
             sections: sections.asImmutable(),
         });
-        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey={true} />).toJSON();
+        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey />);
         expect(tree).toMatchSnapshot();
     });
 
@@ -102,7 +103,7 @@ describe('UserMenu', () => {
             productIds,
             sections: sections.asImmutable(),
         });
-        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey={true} />).toJSON();
+        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey />);
         expect(tree).toMatchSnapshot();
     });
 
@@ -119,9 +120,9 @@ describe('UserMenu', () => {
             sections: sections.asImmutable(),
         });
         const extraUserItems = [<div key="e1">Extra One</div>, <div key="e2">Extra Two</div>];
-        const tree = renderer
-            .create(<UserMenu model={model} user={user} showSwitchToLabKey={true} extraUserItems={extraUserItems} />)
-            .toJSON();
+        const tree = renderer.create(
+            <UserMenu model={model} user={user} showSwitchToLabKey extraUserItems={extraUserItems} />
+        );
         expect(tree).toMatchSnapshot();
     });
 
@@ -137,7 +138,7 @@ describe('UserMenu', () => {
             productIds,
             sections: sections.asImmutable(),
         });
-        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey={false} />).toJSON();
+        const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey={false} />);
         expect(tree).toMatchSnapshot();
     });
 
@@ -155,17 +156,15 @@ describe('UserMenu', () => {
         });
         const extraUserItems = [<div key="e1">Extra One</div>, <div key="e2">Extra Two</div>];
         const extraDevItems = [<div key="e1">Extra Dev One</div>, <div key="e2">Extra Dev Two</div>];
-        const tree = renderer
-            .create(
-                <UserMenu
-                    model={model}
-                    user={user}
-                    showSwitchToLabKey={true}
-                    extraUserItems={extraUserItems}
-                    extraDevItems={extraDevItems}
-                />
-            )
-            .toJSON();
+        const tree = renderer.create(
+            <UserMenu
+                extraDevItems={extraDevItems}
+                extraUserItems={extraUserItems}
+                model={model}
+                showSwitchToLabKey
+                user={user}
+            />
+        );
         expect(tree).toMatchSnapshot();
     });
 });

--- a/packages/components/src/internal/components/navigation/UserMenu.spec.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenu.spec.tsx
@@ -28,8 +28,7 @@ beforeAll(() => {
 });
 
 describe('UserMenu', () => {
-    const sections = List<MenuSectionModel>().asMutable();
-    sections.push(
+    const sections = List([
         MenuSectionModel.create({
             key: 'user',
             label: 'Your Items',
@@ -48,8 +47,9 @@ describe('UserMenu', () => {
                     requiresLogin: false,
                 },
             ],
-        })
-    );
+            sectionKey: 'user',
+        }),
+    ]);
 
     test('not initialized', () => {
         const model = new ProductMenuModel({
@@ -69,7 +69,7 @@ describe('UserMenu', () => {
             isLoaded: true,
             isLoading: false,
             productIds,
-            sections: sections.asImmutable(),
+            sections,
         });
         const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey />);
         expect(tree).toMatchSnapshot();
@@ -85,7 +85,7 @@ describe('UserMenu', () => {
             isLoaded: true,
             isLoading: false,
             productIds,
-            sections: sections.asImmutable(),
+            sections,
         });
         const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey />);
         expect(tree).toMatchSnapshot();
@@ -101,7 +101,7 @@ describe('UserMenu', () => {
             isLoaded: true,
             isLoading: false,
             productIds,
-            sections: sections.asImmutable(),
+            sections,
         });
         const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey />);
         expect(tree).toMatchSnapshot();
@@ -117,7 +117,7 @@ describe('UserMenu', () => {
             isLoaded: true,
             isLoading: false,
             productIds,
-            sections: sections.asImmutable(),
+            sections,
         });
         const extraUserItems = [<div key="e1">Extra One</div>, <div key="e2">Extra Two</div>];
         const tree = renderer.create(
@@ -136,7 +136,7 @@ describe('UserMenu', () => {
             isLoaded: true,
             isLoading: false,
             productIds,
-            sections: sections.asImmutable(),
+            sections,
         });
         const tree = renderer.create(<UserMenu model={model} user={user} showSwitchToLabKey={false} />);
         expect(tree).toMatchSnapshot();
@@ -152,7 +152,7 @@ describe('UserMenu', () => {
             isLoaded: true,
             isLoading: false,
             productIds,
-            sections: sections.asImmutable(),
+            sections,
         });
         const extraUserItems = [<div key="e1">Extra One</div>, <div key="e2">Extra Two</div>];
         const extraDevItems = [<div key="e1">Extra Dev One</div>, <div key="e2">Extra Dev Two</div>];

--- a/packages/components/src/internal/components/navigation/UserMenu.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenu.tsx
@@ -17,7 +17,7 @@
 import React, { FC, ReactNode, useCallback, useMemo } from 'react';
 import { Dropdown, Image, MenuItem } from 'react-bootstrap';
 
-import { User, devToolsActive, toggleDevTools, buildURL, AppURL } from '../../..';
+import { User, devToolsActive, toggleDevTools, buildURL } from '../../..';
 
 import { ProductMenuModel } from './model';
 import { signOut, signIn } from './actions';
@@ -50,9 +50,9 @@ export const UserMenu: FC<UserMenuProps> = props => {
         return menuSection?.items
             .filter(item => !item.requiresLogin || (item.requiresLogin && user?.isSignedIn))
             .map(item => {
-                const href = item.url instanceof AppURL ? item.url.toHref() : item.url;
+                const target = item.key === 'docs' ? '_blank' : '_self';
                 return (
-                    <MenuItem key={item.key} href={href} target={item.key === 'docs' ? '_blank' : '_self'}>
+                    <MenuItem key={item.key} href={item.getUrlString()} target={target}>
                         {item.label}
                     </MenuItem>
                 );

--- a/packages/components/src/internal/components/navigation/UserMenu.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { FC, ReactNode, useCallback, useMemo } from 'react';
 import { Dropdown, Image, MenuItem } from 'react-bootstrap';
 
 import { User, devToolsActive, toggleDevTools, buildURL, AppURL } from '../../..';
@@ -22,80 +22,93 @@ import { User, devToolsActive, toggleDevTools, buildURL, AppURL } from '../../..
 import { ProductMenuModel } from './model';
 import { signOut, signIn } from './actions';
 
-interface UserMenuProps {
+export interface UserMenuProps {
+    extraDevItems?: ReactNode;
+    extraUserItems?: ReactNode;
     model: ProductMenuModel;
-    user: User;
-    showSwitchToLabKey: boolean;
-    extraDevItems?: any;
-    extraUserItems?: any;
+    onSignIn?: () => void;
+    onSignOut?: (signOutUrl: string) => void;
+    showSwitchToLabKey?: boolean;
     signOutUrl?: string;
+    user?: User;
 }
 
-export class UserMenu extends React.Component<UserMenuProps, any> {
-    render() {
-        const { extraDevItems, extraUserItems, model, user, showSwitchToLabKey, signOutUrl } = this.props;
-        const menuSection = model.getSection('user');
+export const UserMenu: FC<UserMenuProps> = props => {
+    const { extraDevItems, extraUserItems, model, onSignIn, onSignOut, user, showSwitchToLabKey, signOutUrl } = props;
+    const menuSection = useMemo(() => model.getSection('user'), [model]);
 
-        if (menuSection) {
-            const beginUrl = buildURL('project', 'begin', undefined, { returnUrl: false });
-            const switchToLabKeyItem = (
-                <MenuItem key="projectBegin" href={beginUrl}>
-                    Switch to LabKey
-                </MenuItem>
-            );
+    const switchToLabKeyItem = useMemo(() => {
+        const beginUrl = buildURL('project', 'begin', undefined, { returnUrl: false });
+        return (
+            <MenuItem key="projectBegin" href={beginUrl}>
+                Switch to LabKey
+            </MenuItem>
+        );
+    }, []);
 
-            const menuItems = [];
-            menuSection.items.forEach(item => {
-                if ((item.requiresLogin && user.isSignedIn) || !item.requiresLogin) {
-                    const href = item.url instanceof AppURL ? item.url.toHref() : item.url;
-                    menuItems.push(
-                        <MenuItem key={item.key} href={href} target={item.key === 'docs' ? '_blank' : '_self'}>
-                            {item.label}
-                        </MenuItem>
-                    );
-                }
+    const menuItems = useMemo(() => {
+        return menuSection?.items
+            .filter(item => !item.requiresLogin || (item.requiresLogin && user?.isSignedIn))
+            .map(item => {
+                const href = item.url instanceof AppURL ? item.url.toHref() : item.url;
+                return (
+                    <MenuItem key={item.key} href={href} target={item.key === 'docs' ? '_blank' : '_self'}>
+                        {item.label}
+                    </MenuItem>
+                );
             });
+    }, [menuSection?.items, user?.isSignedIn]);
 
-            return (
-                <Dropdown id="user-menu-dropdown">
-                    <Dropdown.Toggle useAnchor={true}>
-                        {user.avatar ? (
-                            <Image src={user.avatar} alt="User Avatar" rounded={true} height={32} width={32} />
-                        ) : (
-                            <span className="navbar-item">
-                                <span className="user-name">
-                                    <span className="fas fa-user-circle" /> {user.displayName}{' '}
-                                </span>
-                            </span>
-                        )}
-                    </Dropdown.Toggle>
+    const handleSignOut = useCallback(() => {
+        onSignOut(signOutUrl);
+    }, [onSignOut, signOutUrl]);
 
-                    <Dropdown.Menu pullRight className="pull-right">
-                        <div className="navbar-connector" />
-                        {menuItems}
-                        {showSwitchToLabKey && switchToLabKeyItem}
-                        {extraUserItems}
-                        {LABKEY.devMode ? (
-                            <>
-                                <MenuItem divider />
-                                <MenuItem header>Dev Tools</MenuItem>
-                                <MenuItem onClick={toggleDevTools}>
-                                    {devToolsActive() ? 'Disable' : 'Enable'} Redux Tools
-                                </MenuItem>
-                                {!showSwitchToLabKey && switchToLabKeyItem}
-                                {extraDevItems}
-                            </>
-                        ) : null}
-                        <MenuItem divider />
-                        {user.isSignedIn ? (
-                            <MenuItem onClick={() => signOut(signOutUrl)}>Sign Out</MenuItem>
-                        ) : (
-                            <MenuItem onClick={signIn}>Sign In</MenuItem>
-                        )}
-                    </Dropdown.Menu>
-                </Dropdown>
-            );
-        }
+    if (!menuSection || !user) {
         return null;
     }
-}
+
+    return (
+        <Dropdown id="user-menu-dropdown">
+            <Dropdown.Toggle useAnchor>
+                {user.avatar ? (
+                    <Image src={user.avatar} alt="User Avatar" rounded height={32} width={32} />
+                ) : (
+                    <span className="navbar-item">
+                        <span className="user-name">
+                            <span className="fas fa-user-circle" /> {user.displayName}{' '}
+                        </span>
+                    </span>
+                )}
+            </Dropdown.Toggle>
+
+            <Dropdown.Menu className="pull-right" pullRight>
+                <div className="navbar-connector" />
+                {menuItems}
+                {showSwitchToLabKey && switchToLabKeyItem}
+                {extraUserItems}
+                {LABKEY.devMode && (
+                    <>
+                        <MenuItem divider />
+                        <MenuItem header>Dev Tools</MenuItem>
+                        <MenuItem onClick={toggleDevTools}>
+                            {devToolsActive() ? 'Disable' : 'Enable'} Redux Tools
+                        </MenuItem>
+                        {!showSwitchToLabKey && switchToLabKeyItem}
+                        {extraDevItems}
+                    </>
+                )}
+                <MenuItem divider />
+                {user.isSignedIn ? (
+                    <MenuItem onClick={handleSignOut}>Sign Out</MenuItem>
+                ) : (
+                    <MenuItem onClick={onSignIn}>Sign In</MenuItem>
+                )}
+            </Dropdown.Menu>
+        </Dropdown>
+    );
+};
+
+UserMenu.defaultProps = {
+    onSignIn: signIn,
+    onSignOut: signOut,
+};

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenu.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenu.spec.tsx.snap
@@ -102,8 +102,7 @@ exports[`ProductMenu render loading 1`] = `
 `;
 
 exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
-<ProductMenu
-  maxColumns={5}
+<Memo()
   model={
     Immutable.Record {
       "isError": false,
@@ -358,18 +357,18 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
                           <ProductMenuSection
                             config={
                               Immutable.Record {
+                                "activeJobIconCls": "fa-spinner fa-pulse",
                                 "emptyText": undefined,
-                                "iconURL": undefined,
-                                "iconCls": undefined,
-                                "maxItemsPerColumn": 12,
-                                "maxColumns": 1,
-                                "seeAllURL": undefined,
                                 "emptyURL": undefined,
                                 "emptyURLText": "Get started...",
                                 "headerURL": undefined,
                                 "headerText": undefined,
+                                "iconCls": undefined,
+                                "iconURL": undefined,
+                                "maxColumns": 1,
+                                "maxItemsPerColumn": 12,
+                                "seeAllURL": undefined,
                                 "showActiveJobIcon": true,
-                                "activeJobIconCls": "fa-spinner fa-pulse",
                               }
                             }
                             maxColumns={1}
@@ -469,18 +468,18 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
                           <ProductMenuSection
                             config={
                               Immutable.Record {
+                                "activeJobIconCls": "fa-spinner fa-pulse",
                                 "emptyText": undefined,
-                                "iconURL": undefined,
-                                "iconCls": undefined,
-                                "maxItemsPerColumn": 12,
-                                "maxColumns": 1,
-                                "seeAllURL": undefined,
                                 "emptyURL": undefined,
                                 "emptyURLText": "Get started...",
                                 "headerURL": undefined,
                                 "headerText": undefined,
+                                "iconCls": undefined,
+                                "iconURL": undefined,
+                                "maxColumns": 1,
+                                "maxItemsPerColumn": 12,
+                                "seeAllURL": undefined,
                                 "showActiveJobIcon": true,
-                                "activeJobIconCls": "fa-spinner fa-pulse",
                               }
                             }
                             maxColumns={1}
@@ -594,18 +593,18 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
                           <ProductMenuSection
                             config={
                               Immutable.Record {
+                                "activeJobIconCls": "fa-spinner fa-pulse",
                                 "emptyText": undefined,
-                                "iconURL": undefined,
-                                "iconCls": undefined,
-                                "maxItemsPerColumn": 12,
-                                "maxColumns": 1,
-                                "seeAllURL": undefined,
                                 "emptyURL": undefined,
                                 "emptyURLText": "Get started...",
                                 "headerURL": undefined,
                                 "headerText": undefined,
+                                "iconCls": undefined,
+                                "iconURL": undefined,
+                                "maxColumns": 1,
+                                "maxItemsPerColumn": 12,
+                                "seeAllURL": undefined,
                                 "showActiveJobIcon": true,
-                                "activeJobIconCls": "fa-spinner fa-pulse",
                               }
                             }
                             maxColumns={1}
@@ -660,12 +659,11 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
       </Uncontrolled(Dropdown)>
     </ForwardRef>
   </DropdownButton>
-</ProductMenu>
+</Memo()>
 `;
 
 exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
-<ProductMenu
-  maxColumns={5}
+<Memo()
   model={
     Immutable.Record {
       "isError": false,
@@ -806,34 +804,34 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
     Immutable.List [
       Immutable.Map {
         "samples": Immutable.Record {
+          "activeJobIconCls": "fa-spinner fa-pulse",
           "emptyText": undefined,
-          "iconURL": undefined,
-          "iconCls": "test-icon-cls",
-          "maxItemsPerColumn": 12,
-          "maxColumns": 1,
-          "seeAllURL": undefined,
           "emptyURL": undefined,
           "emptyURLText": "Get started...",
           "headerURL": undefined,
           "headerText": undefined,
+          "iconCls": "test-icon-cls",
+          "iconURL": undefined,
+          "maxColumns": 1,
+          "maxItemsPerColumn": 12,
+          "seeAllURL": undefined,
           "showActiveJobIcon": false,
-          "activeJobIconCls": "fa-spinner fa-pulse",
         },
       },
       Immutable.Map {
         "assays": Immutable.Record {
+          "activeJobIconCls": "fa-spinner fa-pulse",
           "emptyText": undefined,
-          "iconURL": undefined,
-          "iconCls": "test-icon-cls",
-          "maxItemsPerColumn": 12,
-          "maxColumns": 1,
-          "seeAllURL": undefined,
           "emptyURL": undefined,
           "emptyURLText": "Get started...",
           "headerURL": undefined,
           "headerText": undefined,
+          "iconCls": "test-icon-cls",
+          "iconURL": undefined,
+          "maxColumns": 1,
+          "maxItemsPerColumn": 12,
+          "seeAllURL": undefined,
           "showActiveJobIcon": true,
-          "activeJobIconCls": "fa-spinner fa-pulse",
         },
       },
     ]
@@ -956,18 +954,18 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
                           <ProductMenuSection
                             config={
                               Immutable.Record {
+                                "activeJobIconCls": "fa-spinner fa-pulse",
                                 "emptyText": undefined,
-                                "iconURL": undefined,
-                                "iconCls": "test-icon-cls",
-                                "maxItemsPerColumn": 12,
-                                "maxColumns": 1,
-                                "seeAllURL": undefined,
                                 "emptyURL": undefined,
                                 "emptyURLText": "Get started...",
                                 "headerURL": undefined,
                                 "headerText": undefined,
+                                "iconCls": "test-icon-cls",
+                                "iconURL": undefined,
+                                "maxColumns": 1,
+                                "maxItemsPerColumn": 12,
+                                "seeAllURL": undefined,
                                 "showActiveJobIcon": false,
-                                "activeJobIconCls": "fa-spinner fa-pulse",
                               }
                             }
                             key="samples"
@@ -1065,18 +1063,18 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
                           <ProductMenuSection
                             config={
                               Immutable.Record {
+                                "activeJobIconCls": "fa-spinner fa-pulse",
                                 "emptyText": undefined,
-                                "iconURL": undefined,
-                                "iconCls": "test-icon-cls",
-                                "maxItemsPerColumn": 12,
-                                "maxColumns": 1,
-                                "seeAllURL": undefined,
                                 "emptyURL": undefined,
                                 "emptyURLText": "Get started...",
                                 "headerURL": undefined,
                                 "headerText": undefined,
+                                "iconCls": "test-icon-cls",
+                                "iconURL": undefined,
+                                "maxColumns": 1,
+                                "maxItemsPerColumn": 12,
+                                "seeAllURL": undefined,
                                 "showActiveJobIcon": true,
-                                "activeJobIconCls": "fa-spinner fa-pulse",
                               }
                             }
                             key="assays"
@@ -1199,5 +1197,5 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
       </Uncontrolled(Dropdown)>
     </ForwardRef>
   </DropdownButton>
-</ProductMenu>
+</Memo()>
 `;

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenu.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenu.spec.tsx.snap
@@ -154,6 +154,7 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
           "itemLimit": 2,
           "key": "samples",
           "productId": undefined,
+          "sectionKey": undefined,
         },
         Immutable.Record {
           "label": "Assays",
@@ -209,6 +210,7 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
           "itemLimit": undefined,
           "key": "assays",
           "productId": undefined,
+          "sectionKey": undefined,
         },
         Immutable.Record {
           "label": "Your Items",
@@ -228,6 +230,7 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
           "itemLimit": undefined,
           "key": "user",
           "productId": undefined,
+          "sectionKey": undefined,
         },
       ],
       "message": undefined,
@@ -418,6 +421,7 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
                                 "itemLimit": 2,
                                 "key": "samples",
                                 "productId": undefined,
+                                "sectionKey": undefined,
                               }
                             }
                           >
@@ -538,6 +542,7 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
                                 "itemLimit": undefined,
                                 "key": "assays",
                                 "productId": undefined,
+                                "sectionKey": undefined,
                               }
                             }
                           >
@@ -627,6 +632,7 @@ exports[`ProductMenu render multiple sections no sectionConfigs 1`] = `
                                 "itemLimit": undefined,
                                 "key": "user",
                                 "productId": undefined,
+                                "sectionKey": undefined,
                               }
                             }
                           >
@@ -715,6 +721,7 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
           "itemLimit": 2,
           "key": "samples",
           "productId": undefined,
+          "sectionKey": undefined,
         },
         Immutable.Record {
           "label": "Assays",
@@ -770,6 +777,7 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
           "itemLimit": undefined,
           "key": "assays",
           "productId": undefined,
+          "sectionKey": undefined,
         },
         Immutable.Record {
           "label": "Your Items",
@@ -789,6 +797,7 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
           "itemLimit": undefined,
           "key": "user",
           "productId": undefined,
+          "sectionKey": undefined,
         },
       ],
       "message": undefined,
@@ -1016,6 +1025,7 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
                                 "itemLimit": 2,
                                 "key": "samples",
                                 "productId": undefined,
+                                "sectionKey": undefined,
                               }
                             }
                           >
@@ -1134,6 +1144,7 @@ exports[`ProductMenu render multiple sections with sectionConfigs 1`] = `
                                 "itemLimit": undefined,
                                 "key": "assays",
                                 "productId": undefined,
+                                "sectionKey": undefined,
                               }
                             }
                           >

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
@@ -29,6 +29,7 @@ exports[`ProductMenuSection render empty section no text 1`] = `
       "itemLimit": 2,
       "key": "samples",
       "productId": undefined,
+      "sectionKey": undefined,
     }
   }
 >
@@ -86,6 +87,7 @@ exports[`ProductMenuSection render empty section with empty text and create link
       "itemLimit": undefined,
       "key": "samples",
       "productId": undefined,
+      "sectionKey": undefined,
     }
   }
 >
@@ -193,6 +195,7 @@ exports[`ProductMenuSection render one-column section 1`] = `
       "itemLimit": 2,
       "key": "samples",
       "productId": undefined,
+      "sectionKey": undefined,
     }
   }
 >
@@ -280,6 +283,7 @@ exports[`ProductMenuSection render section with custom headerURL and headerText 
       "itemLimit": 2,
       "key": "samples",
       "productId": undefined,
+      "sectionKey": undefined,
     }
   }
 >
@@ -358,6 +362,7 @@ exports[`ProductMenuSection render two columns with overflow link 1`] = `
       "itemLimit": undefined,
       "key": "assays",
       "productId": undefined,
+      "sectionKey": undefined,
     }
   }
 >
@@ -494,6 +499,7 @@ exports[`ProductMenuSection render two-column section 1`] = `
       "itemLimit": undefined,
       "key": "assays",
       "productId": undefined,
+      "sectionKey": undefined,
     }
   }
 >

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
@@ -4,18 +4,18 @@ exports[`ProductMenuSection render empty section no text 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
+      "activeJobIconCls": "fa-spinner fa-pulse",
       "emptyText": undefined,
-      "iconURL": "/testProduct/images/samples.svg",
-      "iconCls": undefined,
-      "maxItemsPerColumn": 12,
-      "maxColumns": 1,
-      "seeAllURL": undefined,
       "emptyURL": undefined,
       "emptyURLText": "Get started...",
       "headerURL": undefined,
       "headerText": undefined,
+      "iconCls": undefined,
+      "iconURL": "/testProduct/images/samples.svg",
+      "maxColumns": 1,
+      "maxItemsPerColumn": 12,
+      "seeAllURL": undefined,
       "showActiveJobIcon": true,
-      "activeJobIconCls": "fa-spinner fa-pulse",
     }
   }
   currentProductId="testProduct"
@@ -57,12 +57,8 @@ exports[`ProductMenuSection render empty section with empty text and create link
 <ProductMenuSection
   config={
     Immutable.Record {
+      "activeJobIconCls": "fa-spinner fa-pulse",
       "emptyText": "Test empty text",
-      "iconURL": "/testProduct/images/samples.svg",
-      "iconCls": undefined,
-      "maxItemsPerColumn": 12,
-      "maxColumns": 1,
-      "seeAllURL": undefined,
       "emptyURL": Immutable.Record {
         "_baseUrl": "/sample/new",
         "_filters": undefined,
@@ -71,8 +67,12 @@ exports[`ProductMenuSection render empty section with empty text and create link
       "emptyURLText": "Test empty link",
       "headerURL": undefined,
       "headerText": undefined,
+      "iconCls": undefined,
+      "iconURL": "/testProduct/images/samples.svg",
+      "maxColumns": 1,
+      "maxItemsPerColumn": 12,
+      "seeAllURL": undefined,
       "showActiveJobIcon": true,
-      "activeJobIconCls": "fa-spinner fa-pulse",
     }
   }
   currentProductId="testProduct"
@@ -131,18 +131,18 @@ exports[`ProductMenuSection render one-column section 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
+      "activeJobIconCls": "fa-spinner fa-pulse",
       "emptyText": undefined,
-      "iconURL": "/testProduct3Columns/images/samples.svg",
-      "iconCls": undefined,
-      "maxItemsPerColumn": 12,
-      "maxColumns": 1,
-      "seeAllURL": undefined,
       "emptyURL": undefined,
       "emptyURLText": "Get started...",
       "headerURL": undefined,
       "headerText": undefined,
+      "iconCls": undefined,
+      "iconURL": "/testProduct3Columns/images/samples.svg",
+      "maxColumns": 1,
+      "maxItemsPerColumn": 12,
+      "seeAllURL": undefined,
       "showActiveJobIcon": true,
-      "activeJobIconCls": "fa-spinner fa-pulse",
     }
   }
   currentProductId="testProduct3Columns"
@@ -249,12 +249,8 @@ exports[`ProductMenuSection render section with custom headerURL and headerText 
 <ProductMenuSection
   config={
     Immutable.Record {
+      "activeJobIconCls": "fa-spinner fa-pulse",
       "emptyText": undefined,
-      "iconURL": "/testProduct/images/samples.svg",
-      "iconCls": undefined,
-      "maxItemsPerColumn": 12,
-      "maxColumns": 1,
-      "seeAllURL": undefined,
       "emptyURL": undefined,
       "emptyURLText": "Get started...",
       "headerURL": Immutable.Record {
@@ -265,8 +261,12 @@ exports[`ProductMenuSection render section with custom headerURL and headerText 
         },
       },
       "headerText": "Custom Sample Sets",
+      "iconCls": undefined,
+      "iconURL": "/testProduct/images/samples.svg",
+      "maxColumns": 1,
+      "maxItemsPerColumn": 12,
+      "seeAllURL": undefined,
       "showActiveJobIcon": true,
-      "activeJobIconCls": "fa-spinner fa-pulse",
     }
   }
   currentProductId="testProductHeaderUrl"
@@ -312,18 +312,18 @@ exports[`ProductMenuSection render two columns with overflow link 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
+      "activeJobIconCls": "fa-spinner fa-pulse",
       "emptyText": undefined,
-      "iconURL": "/testProductOverflowLink/images/assays.svg",
-      "iconCls": undefined,
-      "maxItemsPerColumn": 2,
-      "maxColumns": 2,
-      "seeAllURL": undefined,
       "emptyURL": undefined,
       "emptyURLText": "Get started...",
       "headerURL": undefined,
       "headerText": undefined,
+      "iconCls": undefined,
+      "iconURL": "/testProductOverflowLink/images/assays.svg",
+      "maxColumns": 2,
+      "maxItemsPerColumn": 2,
+      "seeAllURL": undefined,
       "showActiveJobIcon": true,
-      "activeJobIconCls": "fa-spinner fa-pulse",
     }
   }
   currentProductId="testProductOverflowLink"
@@ -423,18 +423,18 @@ exports[`ProductMenuSection render two-column section 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
+      "activeJobIconCls": "fa-spinner fa-pulse",
       "emptyText": undefined,
-      "iconURL": "/testProduct4Columns/images/assays.svg",
-      "iconCls": undefined,
-      "maxItemsPerColumn": 2,
-      "maxColumns": 2,
-      "seeAllURL": undefined,
       "emptyURL": undefined,
       "emptyURLText": "Get started...",
       "headerURL": undefined,
       "headerText": undefined,
+      "iconCls": undefined,
+      "iconURL": "/testProduct4Columns/images/assays.svg",
+      "maxColumns": 2,
+      "maxItemsPerColumn": 2,
+      "seeAllURL": undefined,
       "showActiveJobIcon": true,
-      "activeJobIconCls": "fa-spinner fa-pulse",
     }
   }
   currentProductId="testProduct4Columns"

--- a/packages/components/src/internal/components/navigation/actions.ts
+++ b/packages/components/src/internal/components/navigation/actions.ts
@@ -2,14 +2,14 @@ import { Ajax, Utils, ActionURL } from '@labkey/api';
 
 import { buildURL } from '../../..';
 
-export function signOut(navigateUrl?: string) {
+export function signOut(navigateUrl?: string): void {
     const startUrl = buildURL('project', 'start', undefined, { returnUrl: false });
 
     // for the redirectUrl to work in the case of CAS logout provider redirect, this URL needs to include the host (Issue 39803)
     const returnUrl = ActionURL.getBaseURL(true) + (navigateUrl || startUrl);
 
     Ajax.request({
-        url: buildURL('login', 'logoutAPI.api', undefined, { returnUrl: returnUrl }),
+        url: buildURL('login', 'logoutAPI.api', undefined, { returnUrl }),
         method: 'POST',
         success: Utils.getCallbackWrapper(response => {
             window.location.href = response.redirectUrl || returnUrl;
@@ -21,6 +21,6 @@ export function signOut(navigateUrl?: string) {
     });
 }
 
-export function signIn() {
+export function signIn(): void {
     window.location.href = buildURL('login', 'login');
 }

--- a/packages/components/src/internal/components/navigation/model.spec.ts
+++ b/packages/components/src/internal/components/navigation/model.spec.ts
@@ -33,6 +33,7 @@ describe('ProductMenuModel', () => {
                 label: 'B',
             },
         ],
+        sectionKey: testSectionKey,
     });
 
     const emptySectionKey = 'empty';
@@ -41,6 +42,7 @@ describe('ProductMenuModel', () => {
         label: 'No Items',
         totalCount: 0,
         items: [],
+        sectionKey: emptySectionKey,
     });
 
     test('hasSectionItems not loaded', () => {

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -27,6 +27,7 @@ export class MenuSectionModel extends Record({
     itemLimit: undefined,
     key: undefined,
     productId: undefined,
+    sectionKey: undefined,
 }) {
     label: string;
     url: string;
@@ -35,13 +36,14 @@ export class MenuSectionModel extends Record({
     itemLimit: number;
     key: string;
     productId: string;
+    sectionKey: string;
 
     static create(rawData: any, currentProductId?: string): MenuSectionModel {
         if (rawData) {
             let items;
 
             if (rawData.items) {
-                items = rawData.items.map(i => MenuItemModel.create(i, rawData.key, currentProductId));
+                items = rawData.items.map(i => MenuItemModel.create(i, rawData.sectionKey, currentProductId));
             }
 
             return new MenuSectionModel(
@@ -84,7 +86,7 @@ export class MenuItemModel extends Record({
                 const subParts = parts[0]
                     .split('/')
                     .filter(val => val !== '')
-                    .map(val => QueryKey.decodePart(val));
+                    .map(QueryKey.decodePart);
 
                 const decodedPart = subParts.join('/');
                 const decodedKey = rawData.key.replace(parts[0], decodedPart);
@@ -146,9 +148,7 @@ export class ProductMenuModel extends Record({
     init(): void {
         if (!this.isLoaded && !this.isLoading) {
             this.getMenuSections()
-                .then(sections => {
-                    return this.setLoadedSections(sections.asImmutable());
-                })
+                .then(this.setLoadedSections)
                 .catch(reason => {
                     console.error('Problem retrieving product menu data.', reason);
                     return this.setError(
@@ -206,19 +206,16 @@ export class ProductMenuModel extends Record({
     }
 
     getSection(key: string): MenuSectionModel {
-        if (this.sections.size > 0) {
-            return this.sections.filter(section => section.key.toLowerCase() === key.toLowerCase()).first();
-        }
+        return this.sections.find(section => section.key.toLowerCase() === key.toLowerCase());
     }
 
     hasSectionItems(key: string): boolean {
-        const section = this.getSection(key);
-        return this.isLoaded && section && section.totalCount > 0;
+        return this.isLoaded && this.getSection(key)?.totalCount > 0;
     }
 
     setNeedsReload(): ProductMenuModel {
         return this.merge({
-            needsReload: true
+            needsReload: true,
         }) as ProductMenuModel;
     }
 }

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -165,7 +165,6 @@ export class ProductMenuModel extends Record({
         return new Promise((resolve, reject) => {
             return Ajax.request({
                 url: buildURL('product', 'menuSections.api'),
-                method: 'GET',
                 params: Object.assign({
                     currentProductId: this.currentProductId,
                     userMenuProductId: this.userMenuProductId,

--- a/packages/components/src/internal/components/notifications/actions.ts
+++ b/packages/components/src/internal/components/notifications/actions.ts
@@ -27,7 +27,7 @@ export type NotificationCreatable = string | NotificationItemProps | Notificatio
  * @param creatable
  * @param notify - Function that handles display of the notification. Default is global.addNotification as used in SampleManagement
  */
-export function createNotification(creatable: NotificationCreatable) {
+export function createNotification(creatable: NotificationCreatable): void {
     let item: NotificationItemModel;
     if (Utils.isString(creatable)) {
         item = NotificationItemModel.create({
@@ -88,7 +88,7 @@ export function getRunningPipelineJobStatuses(filters?: Filter.IFilter[]): Promi
         selectRows({
             schemaName: 'pipeline',
             queryName: 'job',
-            filterArray: [...filters, statusFilter],
+            filterArray: [statusFilter].concat(filters ?? []),
             sort: 'Created',
         })
             .then(response => {

--- a/packages/components/src/internal/components/omnibox/OmniBox.spec.tsx
+++ b/packages/components/src/internal/components/omnibox/OmniBox.spec.tsx
@@ -19,6 +19,8 @@ import { mount, shallow } from 'enzyme';
 
 import { fromJS } from 'immutable';
 
+import { Query } from '@labkey/api';
+
 import { QueryGridModel, QueryInfo } from '../../..';
 
 import { initUnitTests, makeQueryInfo, makeTestData } from '../../testHelpers';
@@ -27,11 +29,10 @@ import mixturesQuery from '../../../test/data/mixtures-getQuery.json';
 
 import { Action, ActionOption, ActionValue, Value } from './actions/Action';
 import { OmniBox, OmniBoxState } from './OmniBox';
-import { Query } from '@labkey/api';
 
 let queryInfo: QueryInfo;
 let model: QueryGridModel;
-const getColumns = (all?) => all ? model.getAllColumns() : model.getDisplayColumns();
+const getColumns = (all?) => (all ? model.getAllColumns() : model.getDisplayColumns());
 const getSelectDistinctOptions = (column: string): Query.SelectDistinctOptions => {
     return {
         column,
@@ -110,14 +111,23 @@ describe('OmniBox component', () => {
     const actions = [new HelloWorldAction()];
 
     test('requires only an action', () => {
-        const component = shallow<OmniBox>(<OmniBox getColumns={getColumns} getSelectDistinctOptions={getSelectDistinctOptions} actions={actions} />);
+        const component = shallow<OmniBox>(
+            <OmniBox getColumns={getColumns} getSelectDistinctOptions={getSelectDistinctOptions} actions={actions} />
+        );
 
         expect(component.find('.OmniBox').length).toBe(1);
     });
 
     test('respects openAfterFocus', () => {
         // True
-        const openComponent = mount<OmniBox>(<OmniBox getColumns={getColumns} getSelectDistinctOptions={getSelectDistinctOptions} actions={actions} openAfterFocus={true} />);
+        const openComponent = mount<OmniBox>(
+            <OmniBox
+                getColumns={getColumns}
+                getSelectDistinctOptions={getSelectDistinctOptions}
+                actions={actions}
+                openAfterFocus={true}
+            />
+        );
         const openControlElement = openComponent.find('.OmniBox-control');
 
         expect(openControlElement.length).toEqual(1);
@@ -129,7 +139,14 @@ describe('OmniBox component', () => {
         expect(openState.options.length).toBe(1);
         // False
 
-        const closedComponent = mount<OmniBox>(<OmniBox getColumns={getColumns} getSelectDistinctOptions={getSelectDistinctOptions} actions={actions} openAfterFocus={false} />);
+        const closedComponent = mount<OmniBox>(
+            <OmniBox
+                getColumns={getColumns}
+                getSelectDistinctOptions={getSelectDistinctOptions}
+                actions={actions}
+                openAfterFocus={false}
+            />
+        );
         const closedControlElement = closedComponent.find('.OmniBox-control');
 
         expect(closedControlElement.length).toEqual(1);

--- a/packages/components/src/internal/components/omnibox/OmniBox.spec.tsx
+++ b/packages/components/src/internal/components/omnibox/OmniBox.spec.tsx
@@ -48,14 +48,13 @@ const getSelectDistinctOptions = (column: string): Query.SelectDistinctOptions =
 beforeAll(() => {
     initUnitTests();
     queryInfo = makeQueryInfo(mixturesQueryInfo);
-    return makeTestData(mixturesQuery).then(mockData => {
-        model = new QueryGridModel({
-            queryInfo,
-            messages: fromJS(mockData.messages),
-            data: fromJS(mockData.rows),
-            dataIds: fromJS(mockData.orderedRows),
-            totalRows: mockData.rowCount,
-        });
+    const mockData = makeTestData(mixturesQuery);
+    model = new QueryGridModel({
+        queryInfo,
+        messages: fromJS(mockData.messages),
+        data: fromJS(mockData.rows),
+        dataIds: fromJS(mockData.orderedRows),
+        totalRows: mockData.rowCount,
     });
 });
 

--- a/packages/components/src/internal/components/omnibox/actions/Filter.spec.tsx
+++ b/packages/components/src/internal/components/omnibox/actions/Filter.spec.tsx
@@ -33,17 +33,16 @@ let getColumns: () => List<QueryColumn>;
 
 beforeAll(() => {
     initUnitTests();
+    const mockData = makeTestData(mixturesQuery);
     queryInfo = makeQueryInfo(mixturesQueryInfo);
-    return makeTestData(mixturesQuery).then(mockData => {
-        const model = new QueryGridModel({
-            queryInfo,
-            messages: fromJS(mockData.messages),
-            data: fromJS(mockData.rows),
-            dataIds: fromJS(mockData.orderedRows),
-            totalRows: mockData.rowCount,
-        });
-        getColumns = (all?) => (all ? model.getAllColumns() : model.getDisplayColumns());
+    const model = new QueryGridModel({
+        queryInfo,
+        messages: fromJS(mockData.messages),
+        data: fromJS(mockData.rows),
+        dataIds: fromJS(mockData.orderedRows),
+        totalRows: mockData.rowCount,
     });
+    getColumns = (all?) => (all ? model.getAllColumns() : model.getDisplayColumns());
 });
 
 const testColumns = List([

--- a/packages/components/src/internal/components/user/UserDetailsPanel.spec.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.spec.tsx
@@ -26,7 +26,7 @@ describe('<UserDetailsPanel/>', () => {
 
         await sleep();
 
-        expect(tree.toJSON()).toMatchSnapshot();
+        expect(tree).toMatchSnapshot();
     });
 
     test('with principal no buttons because of self', async () => {
@@ -41,7 +41,7 @@ describe('<UserDetailsPanel/>', () => {
 
         await sleep();
 
-        expect(tree.toJSON()).toMatchSnapshot();
+        expect(tree).toMatchSnapshot();
     });
 
     test('with principal and buttons', async () => {
@@ -56,7 +56,7 @@ describe('<UserDetailsPanel/>', () => {
 
         await sleep();
 
-        expect(tree.toJSON()).toMatchSnapshot();
+        expect(tree).toMatchSnapshot();
     });
 
     test('with principal and buttons not allowDelete or allowResetPassword', async () => {
@@ -73,6 +73,6 @@ describe('<UserDetailsPanel/>', () => {
 
         await sleep();
 
-        expect(tree.toJSON()).toMatchSnapshot();
+        expect(tree).toMatchSnapshot();
     });
 });

--- a/packages/components/src/internal/testHelpers.ts
+++ b/packages/components/src/internal/testHelpers.ts
@@ -10,13 +10,13 @@ import {
     initLineageMocks,
     initPipelineStatusDetailsMocks,
     initQueryGridMocks,
-    initUserPropsMocks
+    initUserPropsMocks,
 } from '../stories/mock';
 import { initQueryGridState, QueryInfo, ServerContextProvider } from '..';
 
 import { RowsResponse } from '../public/QueryModel/QueryModelLoader';
 
-import { applyQueryMetadata, handle132Response } from './query/api';
+import { applyQueryMetadata, handleSelectRowsResponse } from './query/api';
 import { bindColumnRenderers } from './renderers';
 import { URL_MAPPERS, URLService } from './url/URLResolver';
 
@@ -49,7 +49,11 @@ export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Map
  * Use this method in beforeAll() for your jest tests and you'll have full access
  * to all of the same mock API responses we use in storybook.
  */
-export function initUnitTestMocks(metadata?: Map<string, any>, columnRenderers?: Map<string, any>, includePipeline?: boolean): void {
+export function initUnitTestMocks(
+    metadata?: Map<string, any>,
+    columnRenderers?: Map<string, any>,
+    includePipeline?: boolean
+): void {
     window['__react-beautiful-dnd-disable-dev-warnings'] = true;
     initUnitTests(metadata, columnRenderers);
     mock.setup();
@@ -57,8 +61,9 @@ export function initUnitTestMocks(metadata?: Map<string, any>, columnRenderers?:
     initDomainPropertiesMocks();
     initLineageMocks();
     initUserPropsMocks();
-    if (includePipeline)
+    if (includePipeline) {
         initPipelineStatusDetailsMocks();
+    }
     mock.use(proxy);
 }
 
@@ -89,12 +94,12 @@ export const makeQueryInfo = (getQueryDetailsResponse): QueryInfo => {
  * looks like: { messages: any, rows: any, orderedRows: string[], rowCount: number }
  * @param getQueryResponse: getQuery Response object (e.g. imported from test/data/mixtures-getQuery.json)
  */
-export const makeTestData = async (getQueryResponse): Promise<RowsResponse> => {
+export const makeTestData = (getQueryResponse): RowsResponse => {
     // Hack: need to stringify and parse the query response object because Query.Response modifies the object in place,
     // which causes errors if you try to use the same response object twice.
     const response = new Query.Response(JSON.parse(JSON.stringify(getQueryResponse)));
 
-    const { key, messages, models, orderedModels, rowCount } = await handle132Response(response);
+    const { key, messages, models, orderedModels, rowCount } = handleSelectRowsResponse(response);
 
     return {
         messages: messages.toJS(),

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -146,40 +146,39 @@ describe('URL Resolvers', () => {
         // avoid false positives by defining number of assertions in a test
         expect.assertions(9);
 
-        return resolver.resolveSelectRows(selectRowsResult).then(result => {
-            const newResult = fromJS(result);
+        const result = resolver.resolveSelectRows(selectRowsResult);
+        const newResult = fromJS(result);
 
-            // validate ActionMapper('experiment', 'showDataClass') -- no lookup
-            expect(newResult.getIn(['rows', 0, 'NonLookupExpShowDataClass', 'url'])).toBe(
-                '#/rd/dataclass/NoLookupDataClass'
-            );
+        // validate ActionMapper('experiment', 'showDataClass') -- no lookup
+        expect(newResult.getIn(['rows', 0, 'NonLookupExpShowDataClass', 'url'])).toBe(
+            '#/rd/dataclass/NoLookupDataClass'
+        );
 
-            // validate ActionMapper('experiment', 'showDataClass') -- with lookup
-            expect(newResult.getIn(['rows', 0, 'LookupExpShowDataClass', 'url'])).toBe('#/rd/dataclass/BeepBoop');
+        // validate ActionMapper('experiment', 'showDataClass') -- with lookup
+        expect(newResult.getIn(['rows', 0, 'LookupExpShowDataClass', 'url'])).toBe('#/rd/dataclass/BeepBoop');
 
-            // validate ActionMapper('experiment', 'showData') -- no lookup
-            expect(newResult.getIn(['rows', 0, 'NonLookupExpShowData', 'url'])).toBe('#/rd/expdata/124');
+        // validate ActionMapper('experiment', 'showData') -- no lookup
+        expect(newResult.getIn(['rows', 0, 'NonLookupExpShowData', 'url'])).toBe('#/rd/expdata/124');
 
-            // validate ActionMapper('experiment', 'showData') -- with lookup
-            expect(newResult.getIn(['rows', 0, 'LookupExpShowData', 'url'])).toBe('#/rd/expdata/124');
+        // validate ActionMapper('experiment', 'showData') -- with lookup
+        expect(newResult.getIn(['rows', 0, 'LookupExpShowData', 'url'])).toBe('#/rd/expdata/124');
 
-            // validate LookupMapper('/q/')
-            expect(newResult.getIn(['rows', 0, 'LookupColumn', 'url'])).toBe('#/q/BoomSchema/PowQuery/101');
+        // validate LookupMapper('/q/')
+        expect(newResult.getIn(['rows', 0, 'LookupColumn', 'url'])).toBe('#/q/BoomSchema/PowQuery/101');
 
-            // validate LookupMapper('exp-dataclasses')
-            expect(newResult.getIn(['rows', 0, 'DataClassLookupColumn', 'url'])).toBe('#/rd/dataclass/MyDataClass');
+        // validate LookupMapper('exp-dataclasses')
+        expect(newResult.getIn(['rows', 0, 'DataClassLookupColumn', 'url'])).toBe('#/rd/dataclass/MyDataClass');
 
-            // validate LookupMapper('issues')
-            expect(newResult.getIn(['rows', 0, 'LookupIssues', 'url'])).toBe(
-                '/labkey/biologics/issues-details.view?issueId=523'
-            );
+        // validate LookupMapper('issues')
+        expect(newResult.getIn(['rows', 0, 'LookupIssues', 'url'])).toBe(
+            '/labkey/biologics/issues-details.view?issueId=523'
+        );
 
-            // validate LookupMapper('exp-runs')
-            expect(newResult.getIn(['rows', 0, 'LookupExpRun', 'url'])).toBe('#/rd/assayrun/584');
+        // validate LookupMapper('exp-runs')
+        expect(newResult.getIn(['rows', 0, 'LookupExpRun', 'url'])).toBe('#/rd/assayrun/584');
 
-            // validate ActionMapper('assay-assayResults.view?rowId=94&Data.Run%2FRowId~eq=253')
-            expect(newResult.getIn(['rows', 0, 'LookupExpRun2', 'url'])).toBe('#/rd/assayrun/253');
-        });
+        // validate ActionMapper('assay-assayResults.view?rowId=94&Data.Run%2FRowId~eq=253')
+        expect(newResult.getIn(['rows', 0, 'LookupExpRun2', 'url'])).toBe('#/rd/assayrun/253');
     });
 });
 

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -85,7 +85,7 @@ describe('URL Resolvers', () => {
                         schemaName: 'exp',
                         queryName: 'results',
                     },
-                }
+                },
             ],
         },
         rows: [
@@ -131,7 +131,7 @@ describe('URL Resolvers', () => {
                     displayValue: 'An Assay Run - 2',
                     url: '/labkey/biologics/assay-assayResults.view?rowId=94&Data.Run%2FRowId~eq=253',
                     value: 584,
-                }
+                },
             },
         ],
     });

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -18,6 +18,7 @@ import { ActionURL, Experiment, Filter } from '@labkey/api';
 
 import { AppURL, createProductUrl } from '../..';
 import { LineageLinkMetadata } from '../components/lineage/types';
+
 import { AppRouteResolver } from './AppURLResolver';
 
 const ADD_TABLE_ROUTE = 'application/routing/add-table-route';
@@ -290,8 +291,7 @@ const ASSAY_MAPPERS = [
                 if (filters.length > 0) {
                     for (let i = 0; i < filters.length; i++) {
                         if (filters[i].getColumnName().toLowerCase() === 'run/rowid') {
-                            if (Object.keys(params).length > 2)
-                                console.warn("Params mapping skipped for: " + url);
+                            if (Object.keys(params).length > 2) console.warn('Params mapping skipped for: ' + url);
 
                             const runId = filters[i].getValue();
                             return AppURL.create('rd', 'assayrun', runId);
@@ -422,7 +422,7 @@ const DETAILS_QUERY_ROW_MAPPER = new ActionMapper('query', 'detailsQueryRow', ro
 const EXECUTE_QUERY_MAPPER = new ActionMapper('query', 'executeQuery', () => false);
 
 const USER_DETAILS_MAPPERS = [
-    new ActionMapper('user', 'details', (row, column, schema, query) => {
+    new ActionMapper('user', 'details', row => {
         const url = row.get('url');
         if (url) {
             const params = ActionURL.getParameters(url);
@@ -430,7 +430,7 @@ const USER_DETAILS_MAPPERS = [
         }
     }),
 
-    new ActionMapper('user', 'attachmentDownload', () => false)
+    new ActionMapper('user', 'attachmentDownload', () => false),
 ];
 
 const DOWNLOAD_FILE_LINK_MAPPER = new ActionMapper('core', 'downloadFileLink', () => false);
@@ -450,14 +450,14 @@ const LOOKUP_MAPPER = new LookupMapper('q', {
     issues: () => false, // 33680: Prevent remapping issues lookup
 });
 
-const PIPELINE_MAPPER = new ActionMapper('pipeline-status', 'details', (row) => {
-        const url = row.get('url');
-        if (url) {
-            const params = ActionURL.getParameters(url);
-            return AppURL.create('pipeline', params.rowId);
-        }
-        return false;
-    })
+const PIPELINE_MAPPER = new ActionMapper('pipeline-status', 'details', row => {
+    const url = row.get('url');
+    if (url) {
+        const params = ActionURL.getParameters(url);
+        return AppURL.create('pipeline', params.rowId);
+    }
+    return false;
+});
 
 export const URL_MAPPERS = {
     ASSAY_MAPPERS,
@@ -470,7 +470,7 @@ export const URL_MAPPERS = {
     DOWNLOAD_FILE_LINK_MAPPER,
     AUDIT_DETAILS_MAPPER,
     LOOKUP_MAPPER,
-    PIPELINE_MAPPER
+    PIPELINE_MAPPER,
 };
 
 export class URLResolver {
@@ -548,7 +548,6 @@ export class URLResolver {
 
             // If no url mappers defined then this is a noop. Using URLs as they are.
             if (URLService.getUrlMappers()?.size > 0) {
-
                 if (resolved.get('rows').count()) {
                     const schema = resolved.get('schemaName').toJS().join('.');
                     const query = resolved.get('queryName');
@@ -576,8 +575,7 @@ export class URLResolver {
                             if (List.isList(cell) && cell.size > 0) {
                                 return cell
                                     .map(innerCell => {
-                                        if (Map.isMap(innerCell) && innerCell.has('url'))
-                                        {
+                                        if (Map.isMap(innerCell) && innerCell.has('url')) {
                                             return innerCell.set(
                                                 'url',
                                                 this.mapURL({

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -309,7 +309,6 @@ const ASSAY_MAPPERS = [
 const DATA_CLASS_MAPPERS = [
     new ActionMapper('experiment', 'showDataClass', (row, column) => {
         let identifier: string;
-        console.log('handle experiment-showDataClass', row, column);
 
         // TODO: Deal with junction lookup
         if (row.has('data')) {

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -32,11 +32,7 @@ class TestButtons extends PureComponent<RequiresModelAndActions> {
 beforeAll(() => {
     initUnitTests();
     QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
-
-    // Return so tests don't start till after the promise resolves, so we can guarantee DATA is initialized in tests.
-    return makeTestData(mixturesQuery).then(data => {
-        DATA = data;
-    });
+    DATA = makeTestData(mixturesQuery);
 });
 
 const CHART_MENU_SELECTOR = '.chart-menu';

--- a/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
@@ -38,13 +38,12 @@ const AMINO_ACIDS_SCHEMA_QUERY = SchemaQuery.create('assay.General.Amino Acids',
 let AMINO_ACIDS_QUERY_INFO: QueryInfo;
 let AMINO_ACIDS_DATA: RowsResponse;
 
-beforeAll(async () => {
+beforeAll(() => {
     initUnitTests();
     MIXTURES_QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
     AMINO_ACIDS_QUERY_INFO = makeQueryInfo(aminoAcidsQueryInfo);
-    AMINO_ACIDS_DATA = await makeTestData(aminoAcidsQuery);
-    // Return so tests don't start till after the promise resolves, so we can guarantee MIXTURES_DATA is initialized in tests.
-    return (MIXTURES_DATA = await makeTestData(mixturesQuery));
+    AMINO_ACIDS_DATA = makeTestData(aminoAcidsQuery);
+    MIXTURES_DATA = makeTestData(mixturesQuery);
 });
 
 describe('withQueryModels', () => {

--- a/packages/components/src/stories/OmniBox.stories.tsx
+++ b/packages/components/src/stories/OmniBox.stories.tsx
@@ -41,35 +41,34 @@ class OmniBoxRenderer extends PureComponent<Props, State> {
 
     componentDidMount(): void {
         // Need to load data here so we run makeQueryInfo after initQueryGridState has been called.
-        makeTestData(mixturesQuery).then(mockData => {
-            const queryInfo = makeQueryInfo(mixturesQueryInfo);
-            const model = new QueryGridModel({
-                queryInfo,
-                schema: queryInfo.schemaQuery.schemaName,
-                query: queryInfo.schemaQuery.queryName,
-                view: queryInfo.schemaQuery.viewName,
-                messages: fromJS(mockData.messages),
-                data: fromJS(mockData.rows),
-                dataIds: fromJS(mockData.orderedRows),
-                totalRows: mockData.rowCount,
-            });
-            const actions = this.props.actions.map(action => {
-                switch (action) {
-                    case 'search':
-                        return new SearchAction('q');
-                    case 'sort':
-                        return new SortAction('s', this.getColumns);
-                    case 'filter':
-                        return new FilterAction('f', this.getColumns);
-                    case 'view':
-                        return new ViewAction('v', this.getColumns, this.getQueryInfo);
-                }
-            });
+        const mockData = makeTestData(mixturesQuery);
+        const queryInfo = makeQueryInfo(mixturesQueryInfo);
+        const model = new QueryGridModel({
+            queryInfo,
+            schema: queryInfo.schemaQuery.schemaName,
+            query: queryInfo.schemaQuery.queryName,
+            view: queryInfo.schemaQuery.viewName,
+            messages: fromJS(mockData.messages),
+            data: fromJS(mockData.rows),
+            dataIds: fromJS(mockData.orderedRows),
+            totalRows: mockData.rowCount,
+        });
+        const actions = this.props.actions.map(action => {
+            switch (action) {
+                case 'search':
+                    return new SearchAction('q');
+                case 'sort':
+                    return new SortAction('s', this.getColumns);
+                case 'filter':
+                    return new FilterAction('f', this.getColumns);
+                case 'view':
+                    return new ViewAction('v', this.getColumns, this.getQueryInfo);
+            }
+        });
 
-            this.setState({
-                model,
-                actions,
-            });
+        this.setState({
+            model,
+            actions,
         });
     }
 


### PR DESCRIPTION
#### Rationale
To support of using the `<NavigationBar />` and subsequent components in other applications. This is a backwards compatible change with the addition for support of `sectionKey` on `MenuItemModel`.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/787
* https://github.com/LabKey/sampleManagement/pull/479
* https://github.com/LabKey/platform/pull/1968
* https://github.com/LabKey/inventory/pull/186

#### Changes
* Refactor navigation components to functional components.
* Add support for `sectionKey` in menu items.
* Make resolving URLs implementation non-async. Promises were not needed. This affected `makeTestData` in the same way.
* Rename `handle132Response` to `handleSelectRowsResponse` as a part of moving to non-async.
* Lint. This caused many changes since linting was missed on many of these files in previous PRs.
