### PR TITLE
8049: Summary View Manual Testing Tweaks

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.3.0-fb-summaryviewmanualtesttweaks.1",
+  "version": "2.3.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.3.0",
+  "version": "2.3.0-fb-summaryViewManualTestTweaks.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.3.0-fb-summaryViewManualTestTweaks.0",
+  "version": "2.3.0-fb-summaryviewmanualtesttweaks.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Make 'auto-scroll to field' functionality in Summary View also expand given field
+* Display rangeURI values in Summary View for new fields
+
 ### version 2.3.0
 *Released*: 23 February 2021
 * Field Editor Summary View

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.3.1
+*Released*: 24 February 2021
 * Make 'auto-scroll to field' functionality in Summary View also expand given field
 * Display rangeURI values in Summary View for new fields
 

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1173,7 +1173,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     }
 
     scrollFunction = (i: number): void => {
-        this.setState({ summaryViewMode: false }, () => {
+        this.setState({ summaryViewMode: false, expandedRowIndex: i }, () => {
             this.refsArray[i].scrollIntoView();
         });
     };

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.spec.tsx
@@ -6,12 +6,13 @@ import { DomainPropertiesGrid } from './DomainPropertiesGrid';
 
 import { DomainDesign } from './models';
 
-import { INTEGER_TYPE, TEXT_TYPE } from './PropDescType';
+import { INTEGER_TYPE, DATETIME_TYPE } from './PropDescType';
 
 const DOMAIN = DomainDesign.create({
     fields: [
         { name: 'a', rangeURI: INTEGER_TYPE.rangeURI },
-        { name: 'b', rangeURI: TEXT_TYPE.rangeURI },
+        { name: 'b', rangeURI: DATETIME_TYPE.rangeURI },
+        { name: 'c' }
     ],
 });
 const ACTIONS = {
@@ -40,6 +41,10 @@ describe('DomainPropertiesGrid', () => {
         expect(text).toContain('Description');
         expect(text).toContain('Conditional Formats');
         expect(text).toContain('Property Validators');
+
+        expect(text).toContain('http://www.w3.org/2001/XMLSchema#int'); // rangeURI of field 'a'
+        expect(text).toContain('http://www.w3.org/2001/XMLSchema#dateTime'); // rangeURI of field 'b'
+        expect(text).toContain('http://www.w3.org/2001/XMLSchema#string'); //rangeURI of field 'c' -- string is default
 
         // Removed column, as this information does not surface in UI
         expect(text).not.toContain('Property URI');

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -313,6 +313,7 @@ export class DomainDesign
     getGridData(appPropertiesOnly: boolean): List<any> {
         return this.fields.map((field, i) => {
             let fieldSerial = DomainField.serialize(field);
+            const dataType = field.dataType;
             fieldSerial = removeUnusedProperties(fieldSerial);
             fieldSerial = removeUnusedOntologyProperties(fieldSerial);
             if (appPropertiesOnly) {
@@ -329,6 +330,11 @@ export class DomainDesign
                     const rawVal = fieldSerial[key];
                     const valueType = typeof rawVal;
                     let value = valueIsEmpty(rawVal) ? '' : rawVal;
+
+                    // Since rangeURI is not set on field creation, pull rangeURI value from dataType
+                    if (key === 'rangeURI' && value === '') {
+                        value = dataType.rangeURI;
+                    }
 
                     // Make bools render as strings sortable within their column
                     if (key !== 'visible' && key !== 'selected' && valueType === 'boolean') {


### PR DESCRIPTION
#### Rationale
Catch two tweaks/bugs from manual testing of Summary View feature.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2026
* https://github.com/LabKey/sampleManagement/pull/494

#### Changes
* Makes auto-scroll feature in Summary View 'name' column expand corresponding field in detail mode
* Populates 'Range URI' column in Summary View for new fields
