### PR TITLE
Item 8583: Ontology concept picker integration with Field Editor for field concept annotation (principalConceptCode)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.4",
+  "version": "2.5.1-fb-ontFieldAnnotation.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.6",
+  "version": "2.5.1-fb-ontFieldAnnotation.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.8",
+  "version": "2.5.1-fb-ontFieldAnnotation.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.7",
+  "version": "2.5.1-fb-ontFieldAnnotation.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.3",
+  "version": "2.5.1-fb-ontFieldAnnotation.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.2-fb-ontFieldAnnotation.0",
+  "version": "2.6.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.2",
+  "version": "2.5.1-fb-ontFieldAnnotation.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.0",
+  "version": "2.5.1-fb-ontFieldAnnotation.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1",
+  "version": "2.5.1-fb-ontFieldAnnotation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.2",
+  "version": "2.5.2-fb-ontFieldAnnotation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.1",
+  "version": "2.5.1-fb-ontFieldAnnotation.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.5.1-fb-ontFieldAnnotation.5",
+  "version": "2.5.1-fb-ontFieldAnnotation.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 8583: Ontology concept picker usages in Field Editor for field concept annotation
+
 ### version 2.5.1
 *Released*: 25 February 2021
 * @labkey/components package bundle optimizations

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,12 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Item 8583: Ontology concept picker usages in Field Editor for field concept annotation
+    - Add principalConceptCode to DomainField model
+    - Add field editor expanded row input for OntologyConceptAnnotation with button to open the Ontology Concept Browser in modal dialog
+    - Move components related to ontology from /domainproperties to /ontology
+    - Expose OntologyConceptOverviewPanel for use in ontology module
+    - Add OntologyBrowserModal to wrap the browser in a modal with cancel and apply buttons
+    - Factor out OntologyTextDomainFieldSelect from OntologyLookupOptions component
 
 ### version 2.5.1
 *Released*: 25 February 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.6.0
+*Released*: 27 February 2021
 * Item 8583: Ontology concept picker usages in Field Editor for field concept annotation
     - Add principalConceptCode to DomainField model
     - Add field editor expanded row input for OntologyConceptAnnotation with button to open the Ontology Concept Browser in modal dialog

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -468,6 +468,7 @@ import {
 } from './internal/components/samples/models';
 import { createMockWithRouterProps } from './test/mockUtils';
 import { OntologyBrowserPanel } from './internal/components/ontology/OntologyBrowserPanel';
+import { OntologyConceptOverviewPanel } from './internal/components/ontology/ConceptOverviewPanel';
 
 // See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 enableMapSet();
@@ -988,4 +989,5 @@ export {
     createMockWithRouterProps,
     // Ontology
     OntologyBrowserPanel,
+    OntologyConceptOverviewPanel,
 };

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
+import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
+
 import { DomainRowExpandedOptions } from './DomainRowExpandedOptions';
 import { DomainField } from './models';
 import { DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS, DOMAIN_FIELD_FULLY_LOCKED } from './constants';
@@ -15,7 +17,6 @@ import {
     SAMPLE_TYPE,
     TEXT_TYPE,
 } from './PropDescType';
-import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
 import { TextFieldOptions } from './TextFieldOptions';
 import { BooleanFieldOptions } from './BooleanFieldOptions';
 import { DateTimeFieldOptions } from './DateTimeFieldOptions';

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.spec.tsx
@@ -15,7 +15,7 @@ import {
     SAMPLE_TYPE,
     TEXT_TYPE,
 } from './PropDescType';
-import { OntologyLookupOptions } from './OntologyLookupOptions';
+import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
 import { TextFieldOptions } from './TextFieldOptions';
 import { BooleanFieldOptions } from './BooleanFieldOptions';
 import { DateTimeFieldOptions } from './DateTimeFieldOptions';

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -19,6 +19,8 @@ import { List } from 'immutable';
 
 import { Col } from 'react-bootstrap';
 
+import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
+
 import { DomainField, IDomainFormDisplayOptions, IFieldChange } from './models';
 import { NameAndLinkingOptions } from './NameAndLinkingOptions';
 import { TextFieldOptions } from './TextFieldOptions';
@@ -29,7 +31,6 @@ import { LookupFieldOptions } from './LookupFieldOptions';
 import { ConditionalFormattingAndValidation } from './ConditionalFormattingAndValidation';
 import { isFieldFullyLocked } from './propertiesUtil';
 import { SampleFieldOptions } from './SampleFieldOptions';
-import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
 
 interface IDomainRowExpandedOptionsProps {
     field: DomainField;

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -34,9 +34,9 @@ import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
 interface IDomainRowExpandedOptionsProps {
     field: DomainField;
     index: number;
-    onChange: (fieldId: string, value: any, index?: number, expand?: boolean) => any;
+    onChange: (fieldId: string, value: any, index?: number, expand?: boolean) => void;
     onMultiChange: (changes: List<IFieldChange>) => void;
-    showingModal: (boolean) => any;
+    showingModal: (boolean) => void;
     appPropertiesOnly?: boolean;
     domainIndex: number;
     successBsStyle?: string;
@@ -217,6 +217,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                             domainIndex={domainIndex}
                             field={field}
                             onChange={onChange}
+                            appPropertiesOnly={appPropertiesOnly}
                         />
                     </Col>
                     {!isFieldFullyLocked(field.lockType) && (

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -211,7 +211,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                 <div className="domain-row-container-expand-spacer" />
                 <div className="domain-row-container-expanded">
                     <Col xs={12}>{this.typeDependentOptions()}</Col>
-                    <Col xs={12} lg={10}>
+                    <Col xs={12}>
                         <NameAndLinkingOptions
                             index={index}
                             domainIndex={domainIndex}

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -29,7 +29,7 @@ import { LookupFieldOptions } from './LookupFieldOptions';
 import { ConditionalFormattingAndValidation } from './ConditionalFormattingAndValidation';
 import { isFieldFullyLocked } from './propertiesUtil';
 import { SampleFieldOptions } from './SampleFieldOptions';
-import { OntologyLookupOptions } from './OntologyLookupOptions';
+import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
 
 interface IDomainRowExpandedOptionsProps {
     field: DomainField;

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -1,19 +1,21 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 
 import { helpLinkNode, URL_ENCODING_TOPIC } from '../../util/helpLinks';
 
 import { isFieldFullyLocked } from './propertiesUtil';
-import { createFormInputId, createFormInputName } from './actions';
+import { createFormInputId, createFormInputName, hasActiveModule } from './actions';
 import {
     DOMAIN_FIELD_DESCRIPTION,
     DOMAIN_FIELD_IMPORTALIASES,
     DOMAIN_FIELD_LABEL,
+    DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT,
     DOMAIN_FIELD_URL,
 } from './constants';
 import { DomainField } from './models';
 import { SectionHeading } from './SectionHeading';
 import { DomainFieldLabel } from './DomainFieldLabel';
+import { OntologyConceptAnnotation } from '../ontology/OntologyConceptAnnotation';
 
 interface NameAndLinkingProps {
     index: number;
@@ -23,15 +25,15 @@ interface NameAndLinkingProps {
 }
 
 export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingProps, any> {
-    handleChange = (evt: any) => {
-        const { onChange } = this.props;
-
-        if (onChange) {
-            onChange(evt.target.id, evt.target.value);
-        }
+    handleChange = (evt: any): void => {
+        this.onChange(evt.target.id, evt.target.value);
     };
 
-    getImportAliasHelpText = () => {
+    onChange = (id: string, value: any): void => {
+        this.props?.onChange(id, value);
+    };
+
+    getImportAliasHelpText = (): ReactNode => {
         return (
             <>
                 Define alternate field names to be used when importing from a file.
@@ -43,7 +45,7 @@ export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingPro
         );
     };
 
-    getURLHelpText = () => {
+    getURLHelpText = (): ReactNode => {
         return (
             <>
                 Use this to change the display of the field value within a data grid into a link. Multiple formats are
@@ -55,7 +57,7 @@ export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingPro
         );
     };
 
-    render() {
+    render(): ReactNode {
         const { index, field, domainIndex } = this.props;
 
         return (
@@ -114,6 +116,13 @@ export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingPro
                                 onChange={this.handleChange}
                                 disabled={isFieldFullyLocked(field.lockType)}
                             />
+                            {hasActiveModule('Ontology') && (
+                                <OntologyConceptAnnotation
+                                    id={createFormInputId(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT, domainIndex, index)}
+                                    field={field}
+                                    onChange={this.onChange}
+                                />
+                            )}
                         </Col>
                     </div>
                 </Row>

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -68,63 +68,61 @@ export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingPro
                     </Col>
                 </Row>
                 <Row>
-                    <div>
-                        <Col xs={5}>
-                            <div className="domain-field-label">Description</div>
-                            <FormControl
-                                componentClass="textarea"
-                                className="form-control textarea-noresize"
-                                rows={4}
-                                value={field.description || ''}
-                                id={createFormInputId(DOMAIN_FIELD_DESCRIPTION, domainIndex, index)}
-                                name={createFormInputName(DOMAIN_FIELD_DESCRIPTION)}
-                                onChange={this.handleChange}
-                                disabled={isFieldFullyLocked(field.lockType)}
+                    <Col xs={5}>
+                        <div className="domain-field-label">Description</div>
+                        <FormControl
+                            componentClass="textarea"
+                            className="form-control textarea-noresize"
+                            rows={4}
+                            value={field.description || ''}
+                            id={createFormInputId(DOMAIN_FIELD_DESCRIPTION, domainIndex, index)}
+                            name={createFormInputName(DOMAIN_FIELD_DESCRIPTION)}
+                            onChange={this.handleChange}
+                            disabled={isFieldFullyLocked(field.lockType)}
+                        />
+                    </Col>
+                    <Col xs={3}>
+                        <div className="domain-field-label">Label</div>
+                        <FormControl
+                            type="text"
+                            value={field.label || ''}
+                            id={createFormInputId(DOMAIN_FIELD_LABEL, domainIndex, index)}
+                            name={createFormInputName(DOMAIN_FIELD_LABEL)}
+                            onChange={this.handleChange}
+                            disabled={isFieldFullyLocked(field.lockType)}
+                        />
+                        <div className="domain-field-label">
+                            <DomainFieldLabel label="Import Aliases" helpTipBody={this.getImportAliasHelpText()} />
+                        </div>
+                        <FormControl
+                            type="text"
+                            value={field.importAliases || ''}
+                            id={createFormInputId(DOMAIN_FIELD_IMPORTALIASES, domainIndex, index)}
+                            name={createFormInputName(DOMAIN_FIELD_IMPORTALIASES)}
+                            onChange={this.handleChange}
+                            disabled={isFieldFullyLocked(field.lockType)}
+                        />
+                    </Col>
+                    <Col xs={4}>
+                        <div className="domain-field-label">
+                            <DomainFieldLabel label="URL" helpTipBody={this.getURLHelpText()} />
+                        </div>
+                        <FormControl
+                            type="text"
+                            value={field.URL || ''}
+                            id={createFormInputId(DOMAIN_FIELD_URL, domainIndex, index)}
+                            name={createFormInputName(DOMAIN_FIELD_URL)}
+                            onChange={this.handleChange}
+                            disabled={isFieldFullyLocked(field.lockType)}
+                        />
+                        {hasActiveModule('Ontology') && (
+                            <OntologyConceptAnnotation
+                                id={createFormInputId(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT, domainIndex, index)}
+                                field={field}
+                                onChange={this.onChange}
                             />
-                        </Col>
-                        <Col xs={3}>
-                            <div className="domain-field-label">Label</div>
-                            <FormControl
-                                type="text"
-                                value={field.label || ''}
-                                id={createFormInputId(DOMAIN_FIELD_LABEL, domainIndex, index)}
-                                name={createFormInputName(DOMAIN_FIELD_LABEL)}
-                                onChange={this.handleChange}
-                                disabled={isFieldFullyLocked(field.lockType)}
-                            />
-                            <div className="domain-field-label">
-                                <DomainFieldLabel label="Import Aliases" helpTipBody={this.getImportAliasHelpText()} />
-                            </div>
-                            <FormControl
-                                type="text"
-                                value={field.importAliases || ''}
-                                id={createFormInputId(DOMAIN_FIELD_IMPORTALIASES, domainIndex, index)}
-                                name={createFormInputName(DOMAIN_FIELD_IMPORTALIASES)}
-                                onChange={this.handleChange}
-                                disabled={isFieldFullyLocked(field.lockType)}
-                            />
-                        </Col>
-                        <Col xs={4}>
-                            <div className="domain-field-label">
-                                <DomainFieldLabel label="URL" helpTipBody={this.getURLHelpText()} />
-                            </div>
-                            <FormControl
-                                type="text"
-                                value={field.URL || ''}
-                                id={createFormInputId(DOMAIN_FIELD_URL, domainIndex, index)}
-                                name={createFormInputName(DOMAIN_FIELD_URL)}
-                                onChange={this.handleChange}
-                                disabled={isFieldFullyLocked(field.lockType)}
-                            />
-                            {hasActiveModule('Ontology') && (
-                                <OntologyConceptAnnotation
-                                    id={createFormInputId(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT, domainIndex, index)}
-                                    field={field}
-                                    onChange={this.onChange}
-                                />
-                            )}
-                        </Col>
-                    </div>
+                        )}
+                    </Col>
                 </Row>
             </div>
         );

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -3,6 +3,8 @@ import { Col, FormControl, Row } from 'react-bootstrap';
 
 import { helpLinkNode, URL_ENCODING_TOPIC } from '../../util/helpLinks';
 
+import { OntologyConceptAnnotation } from '../ontology/OntologyConceptAnnotation';
+
 import { isFieldFullyLocked } from './propertiesUtil';
 import { createFormInputId, createFormInputName, hasActiveModule } from './actions';
 import {
@@ -15,7 +17,6 @@ import {
 import { DomainField } from './models';
 import { SectionHeading } from './SectionHeading';
 import { DomainFieldLabel } from './DomainFieldLabel';
-import { OntologyConceptAnnotation } from '../ontology/OntologyConceptAnnotation';
 
 interface NameAndLinkingProps {
     index: number;

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, PureComponent } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 
 import { helpLinkNode, URL_ENCODING_TOPIC } from '../../util/helpLinks';
@@ -21,10 +21,11 @@ interface NameAndLinkingProps {
     index: number;
     domainIndex: number;
     field: DomainField;
-    onChange: (string, any) => any;
+    onChange: (string, any) => void;
+    appPropertiesOnly?: boolean;
 }
 
-export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingProps, any> {
+export class NameAndLinkingOptions extends PureComponent<NameAndLinkingProps> {
     handleChange = (evt: any): void => {
         this.onChange(evt.target.id, evt.target.value);
     };
@@ -58,7 +59,7 @@ export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingPro
     };
 
     render(): ReactNode {
-        const { index, field, domainIndex } = this.props;
+        const { index, field, domainIndex, appPropertiesOnly } = this.props;
 
         return (
             <div>
@@ -115,7 +116,7 @@ export class NameAndLinkingOptions extends React.PureComponent<NameAndLinkingPro
                             onChange={this.handleChange}
                             disabled={isFieldFullyLocked(field.lockType)}
                         />
-                        {hasActiveModule('Ontology') && (
+                        {!appPropertiesOnly && hasActiveModule('Ontology') && (
                             <OntologyConceptAnnotation
                                 id={createFormInputId(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT, domainIndex, index)}
                                 field={field}

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/ConditionalFormattingAndValidation.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/ConditionalFormattingAndValidation.spec.tsx.snap
@@ -113,6 +113,7 @@ exports[`ConditionalFormattingAndValidation Multiple validators or formats 1`] =
       "sourceOntology": undefined,
       "conceptLabelColumn": undefined,
       "conceptImportColumn": undefined,
+      "principalConceptCode": undefined,
       "selected": false,
     }
   }
@@ -586,6 +587,7 @@ exports[`ConditionalFormattingAndValidation No validators 1`] = `
       "sourceOntology": undefined,
       "conceptLabelColumn": undefined,
       "conceptImportColumn": undefined,
+      "principalConceptCode": undefined,
       "selected": false,
     }
   }
@@ -883,6 +885,7 @@ exports[`ConditionalFormattingAndValidation No validators or formats 1`] = `
       "sourceOntology": undefined,
       "conceptLabelColumn": undefined,
       "conceptImportColumn": undefined,
+      "principalConceptCode": undefined,
       "selected": false,
     }
   }

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
@@ -334,6 +334,7 @@ exports[`DomainRow Sample Field 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -521,6 +522,7 @@ exports[`DomainRow Sample Field 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -1106,6 +1108,7 @@ exports[`DomainRow Sample Field 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -1468,6 +1471,7 @@ exports[`DomainRow Sample Field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -1945,6 +1949,7 @@ exports[`DomainRow Sample Field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -2504,6 +2509,7 @@ exports[`DomainRow client side warning on field 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -2703,6 +2709,7 @@ exports[`DomainRow client side warning on field 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -3465,6 +3472,7 @@ exports[`DomainRow client side warning on field 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -3583,6 +3591,7 @@ exports[`DomainRow client side warning on field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -4060,6 +4069,7 @@ exports[`DomainRow client side warning on field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -4619,6 +4629,7 @@ exports[`DomainRow date time field 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -4806,6 +4817,7 @@ exports[`DomainRow date time field 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -5371,6 +5383,7 @@ exports[`DomainRow date time field 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -5710,6 +5723,7 @@ exports[`DomainRow date time field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -6187,6 +6201,7 @@ exports[`DomainRow date time field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -6886,6 +6901,7 @@ exports[`DomainRow decimal field 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -7073,6 +7089,7 @@ exports[`DomainRow decimal field 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -7638,6 +7655,7 @@ exports[`DomainRow decimal field 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -8012,6 +8030,7 @@ exports[`DomainRow decimal field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -8489,6 +8508,7 @@ exports[`DomainRow decimal field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -9188,6 +9208,7 @@ exports[`DomainRow participant id field 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -9375,6 +9396,7 @@ exports[`DomainRow participant id field 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -9970,6 +9992,7 @@ exports[`DomainRow participant id field 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -10088,6 +10111,7 @@ exports[`DomainRow participant id field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -10565,6 +10589,7 @@ exports[`DomainRow participant id field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -11264,6 +11289,7 @@ exports[`DomainRow server side error on reserved field 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -11463,6 +11489,7 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -12114,6 +12141,7 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -12232,6 +12260,7 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -12709,6 +12738,7 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -13268,6 +13298,7 @@ exports[`DomainRow string field test 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -13455,6 +13486,7 @@ exports[`DomainRow string field test 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -14050,6 +14082,7 @@ exports[`DomainRow string field test 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -14478,6 +14511,7 @@ exports[`DomainRow string field test 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -14955,6 +14989,7 @@ exports[`DomainRow string field test 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -15654,6 +15689,7 @@ exports[`DomainRow with empty domain form 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   }
                 }
@@ -15841,6 +15877,7 @@ exports[`DomainRow with empty domain form 1`] = `
                                     "sourceOntology": undefined,
                                     "conceptLabelColumn": undefined,
                                     "conceptImportColumn": undefined,
+                                    "principalConceptCode": undefined,
                                     "selected": false,
                                   }
                                 }
@@ -16485,6 +16522,7 @@ exports[`DomainRow with empty domain form 1`] = `
                                       "sourceOntology": undefined,
                                       "conceptLabelColumn": undefined,
                                       "conceptImportColumn": undefined,
+                                      "principalConceptCode": undefined,
                                       "selected": false,
                                     }
                                   }
@@ -16913,6 +16951,7 @@ exports[`DomainRow with empty domain form 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }
@@ -17390,6 +17429,7 @@ exports[`DomainRow with empty domain form 1`] = `
                                                 "sourceOntology": undefined,
                                                 "conceptLabelColumn": undefined,
                                                 "conceptImportColumn": undefined,
+                                                "principalConceptCode": undefined,
                                                 "selected": false,
                                               }
                                             }

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
@@ -1382,11 +1382,10 @@ exports[`DomainRow Sample Field 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -1515,331 +1514,329 @@ exports[`DomainRow Sample Field 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-0"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-0"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-0"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-0"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-0"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-0"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-0"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-0"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-0"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-0"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-0"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-0"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>
@@ -3502,11 +3499,10 @@ exports[`DomainRow client side warning on field 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -3635,331 +3631,329 @@ exports[`DomainRow client side warning on field 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-1"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-1"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-1"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-1"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-1"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-1"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-1"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-1"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-1"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-1"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-1"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>
@@ -5634,11 +5628,10 @@ exports[`DomainRow date time field 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -5767,331 +5760,329 @@ exports[`DomainRow date time field 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-0"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-0"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-0"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-0"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-0"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-0"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-0"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-0"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-0"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-0"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-0"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-0"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>
@@ -7941,11 +7932,10 @@ exports[`DomainRow decimal field 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -8074,331 +8064,329 @@ exports[`DomainRow decimal field 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-2"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-2"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-2"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-2"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-2"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-2"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-2"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-2"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-2"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-2"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-2"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-2"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>
@@ -10022,11 +10010,10 @@ exports[`DomainRow participant id field 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -10155,331 +10142,329 @@ exports[`DomainRow participant id field 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-0"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-0"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-0"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-0"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-0"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-0"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-0"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-0"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-0"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-0"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-0"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-0"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>
@@ -12171,11 +12156,10 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -12304,331 +12288,329 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-1"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-1"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-1"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-1"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-1"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-1"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-1"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-1"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-1"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-1"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-1"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>
@@ -14422,11 +14404,10 @@ exports[`DomainRow string field test 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -14555,331 +14536,329 @@ exports[`DomainRow string field test 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-1"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-1"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-1"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-1"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-1"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-1"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-1"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-1"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-1"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-1"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-1"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>
@@ -16862,11 +16841,10 @@ exports[`DomainRow with empty domain form 1`] = `
                                       <Col
                                         bsClass="col"
                                         componentClass="div"
-                                        lg={10}
                                         xs={12}
                                       >
                                         <div
-                                          className="col-lg-10 col-xs-12"
+                                          className="col-xs-12"
                                         >
                                           <NameAndLinkingOptions
                                             domainIndex={1}
@@ -16995,331 +16973,329 @@ exports[`DomainRow with empty domain form 1`] = `
                                                 <div
                                                   className="row"
                                                 >
-                                                  <div>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={5}
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={5}
+                                                  >
+                                                    <div
+                                                      className="col-xs-5"
                                                     >
                                                       <div
-                                                        className="col-xs-5"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Description
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          className="form-control textarea-noresize"
-                                                          componentClass="textarea"
+                                                        Description
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        className="form-control textarea-noresize"
+                                                        componentClass="textarea"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-description-1-1"
+                                                        name="domainpropertiesrow-description"
+                                                        onChange={[Function]}
+                                                        rows={4}
+                                                        value=""
+                                                      >
+                                                        <textarea
+                                                          className="form-control textarea-noresize form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"
                                                           onChange={[Function]}
                                                           rows={4}
                                                           value=""
-                                                        >
-                                                          <textarea
-                                                            className="form-control textarea-noresize form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-description-1-1"
-                                                            name="domainpropertiesrow-description"
-                                                            onChange={[Function]}
-                                                            rows={4}
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={3}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={3}
+                                                  >
+                                                    <div
+                                                      className="col-xs-3"
                                                     >
                                                       <div
-                                                        className="col-xs-3"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          Label
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                        Label
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-label-1-1"
+                                                        name="domainpropertiesrow-label"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-label-1-1"
                                                           name="domainpropertiesrow-label"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
+                                                        />
+                                                      </FormControl>
+                                                      <div
+                                                        className="domain-field-label"
+                                                      >
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Define alternate field names to be used when importing from a file.
+                                                              <br />
+                                                              <br />
+                                                              Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                            </React.Fragment>
+                                                          }
+                                                          label="Import Aliases"
                                                         >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-label-1-1"
-                                                            name="domainpropertiesrow-label"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Define alternate field names to be used when importing from a file.
-                                                                <br />
-                                                                <br />
-                                                                Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                              </React.Fragment>
-                                                            }
-                                                            label="Import Aliases"
+                                                          Import 
+                                                          <span
+                                                            className="domain-no-wrap"
                                                           >
-                                                            Import 
-                                                            <span
-                                                              className="domain-no-wrap"
+                                                            Aliases
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="Import Aliases"
                                                             >
-                                                              Aliases
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="Import Aliases"
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-importAliases-1-1"
+                                                        name="domainpropertiesrow-importAliases"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-importAliases-1-1"
                                                           name="domainpropertiesrow-importAliases"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-importAliases-1-1"
-                                                            name="domainpropertiesrow-importAliases"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                    <Col
-                                                      bsClass="col"
-                                                      componentClass="div"
-                                                      xs={4}
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
+                                                  <Col
+                                                    bsClass="col"
+                                                    componentClass="div"
+                                                    xs={4}
+                                                  >
+                                                    <div
+                                                      className="col-xs-4"
                                                     >
                                                       <div
-                                                        className="col-xs-4"
+                                                        className="domain-field-label"
                                                       >
-                                                        <div
-                                                          className="domain-field-label"
-                                                        >
-                                                          <Component
-                                                            helpTipBody={
-                                                              <React.Fragment>
-                                                                Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                <br />
-                                                                <br />
-                                                                Learn more about using 
-                                                                <a
-                                                                  href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                  target="_blank"
-                                                                >
-                                                                  URL Formatting Options
-                                                                </a>
-                                                                .
-                                                              </React.Fragment>
-                                                            }
-                                                            label="URL"
-                                                          >
-                                                            <span
-                                                              className="domain-no-wrap"
-                                                            >
-                                                              URL
-                                                              <Component
-                                                                customStyle={Object {}}
-                                                                id="tooltip"
-                                                                size="1x"
-                                                                title="URL"
+                                                        <Component
+                                                          helpTipBody={
+                                                            <React.Fragment>
+                                                              Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                              <br />
+                                                              <br />
+                                                              Learn more about using 
+                                                              <a
+                                                                href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                target="_blank"
                                                               >
-                                                                <span
-                                                                  className="label-help-target"
-                                                                  onMouseOut={[Function]}
-                                                                  onMouseOver={[Function]}
-                                                                >
-                                                                  <FontAwesomeIcon
-                                                                    border={false}
-                                                                    className="label-help-icon"
-                                                                    fixedWidth={false}
-                                                                    flip={null}
-                                                                    icon={
-                                                                      Object {
-                                                                        "icon": Array [
-                                                                          512,
-                                                                          512,
-                                                                          Array [],
-                                                                          "f059",
-                                                                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                        ],
-                                                                        "iconName": "question-circle",
-                                                                        "prefix": "fas",
-                                                                      }
+                                                                URL Formatting Options
+                                                              </a>
+                                                              .
+                                                            </React.Fragment>
+                                                          }
+                                                          label="URL"
+                                                        >
+                                                          <span
+                                                            className="domain-no-wrap"
+                                                          >
+                                                            URL
+                                                            <Component
+                                                              customStyle={Object {}}
+                                                              id="tooltip"
+                                                              size="1x"
+                                                              title="URL"
+                                                            >
+                                                              <span
+                                                                className="label-help-target"
+                                                                onMouseOut={[Function]}
+                                                                onMouseOver={[Function]}
+                                                              >
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className="label-help-icon"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f059",
+                                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                      ],
+                                                                      "iconName": "question-circle",
+                                                                      "prefix": "fas",
                                                                     }
-                                                                    inverse={false}
-                                                                    listItem={false}
-                                                                    mask={null}
-                                                                    pull={null}
-                                                                    pulse={false}
-                                                                    rotation={null}
-                                                                    size="1x"
-                                                                    spin={false}
+                                                                  }
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size="1x"
+                                                                  spin={false}
+                                                                  style={Object {}}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                    data-icon="question-circle"
+                                                                    data-prefix="fas"
+                                                                    focusable="false"
+                                                                    role="img"
                                                                     style={Object {}}
-                                                                    swapOpacity={false}
-                                                                    symbol={false}
-                                                                    title=""
-                                                                    transform={null}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                      data-icon="question-circle"
-                                                                      data-prefix="fas"
-                                                                      focusable="false"
-                                                                      role="img"
+                                                                    <path
+                                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                      fill="currentColor"
                                                                       style={Object {}}
-                                                                      viewBox="0 0 512 512"
-                                                                      xmlns="http://www.w3.org/2000/svg"
-                                                                    >
-                                                                      <path
-                                                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                        fill="currentColor"
-                                                                        style={Object {}}
-                                                                      />
-                                                                    </svg>
-                                                                  </FontAwesomeIcon>
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <Overlay
+                                                                  animation={[Function]}
+                                                                  placement="right"
+                                                                  rootClose={false}
+                                                                  show={false}
+                                                                >
                                                                   <Overlay
-                                                                    animation={[Function]}
                                                                     placement="right"
                                                                     rootClose={false}
                                                                     show={false}
-                                                                  >
-                                                                    <Overlay
-                                                                      placement="right"
-                                                                      rootClose={false}
-                                                                      show={false}
-                                                                      transition={[Function]}
-                                                                    />
-                                                                  </Overlay>
-                                                                </span>
-                                                              </Component>
-                                                            </span>
-                                                          </Component>
-                                                        </div>
-                                                        <FormControl
-                                                          bsClass="form-control"
-                                                          componentClass="input"
+                                                                    transition={[Function]}
+                                                                  />
+                                                                </Overlay>
+                                                              </span>
+                                                            </Component>
+                                                          </span>
+                                                        </Component>
+                                                      </div>
+                                                      <FormControl
+                                                        bsClass="form-control"
+                                                        componentClass="input"
+                                                        disabled={false}
+                                                        id="domainpropertiesrow-URL-1-1"
+                                                        name="domainpropertiesrow-URL"
+                                                        onChange={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      >
+                                                        <input
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-URL-1-1"
                                                           name="domainpropertiesrow-URL"
                                                           onChange={[Function]}
                                                           type="text"
                                                           value=""
-                                                        >
-                                                          <input
-                                                            className="form-control"
-                                                            disabled={false}
-                                                            id="domainpropertiesrow-URL-1-1"
-                                                            name="domainpropertiesrow-URL"
-                                                            onChange={[Function]}
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </FormControl>
-                                                      </div>
-                                                    </Col>
-                                                  </div>
+                                                        />
+                                                      </FormControl>
+                                                    </div>
+                                                  </Col>
                                                 </div>
                                               </Row>
                                             </div>

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
@@ -93,6 +93,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
         "sourceOntology": undefined,
         "conceptLabelColumn": undefined,
         "conceptImportColumn": undefined,
+        "principalConceptCode": undefined,
         "selected": false,
       }
     }
@@ -644,6 +645,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
         "sourceOntology": undefined,
         "conceptLabelColumn": undefined,
         "conceptImportColumn": undefined,
+        "principalConceptCode": undefined,
         "selected": false,
       }
     }
@@ -1298,6 +1300,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
         "sourceOntology": undefined,
         "conceptLabelColumn": undefined,
         "conceptImportColumn": undefined,
+        "principalConceptCode": undefined,
         "selected": false,
       }
     }
@@ -1952,6 +1955,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
         "sourceOntology": undefined,
         "conceptLabelColumn": undefined,
         "conceptImportColumn": undefined,
+        "principalConceptCode": undefined,
         "selected": false,
       }
     }

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
@@ -84,6 +84,7 @@ exports[`NameAndLinkingOptions Name and Linking options 1`] = `
       "sourceOntology": undefined,
       "conceptLabelColumn": undefined,
       "conceptImportColumn": undefined,
+      "principalConceptCode": undefined,
       "selected": false,
     }
   }

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
@@ -128,331 +128,329 @@ exports[`NameAndLinkingOptions Name and Linking options 1`] = `
       <div
         className="row"
       >
-        <div>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            xs={5}
+        <Col
+          bsClass="col"
+          componentClass="div"
+          xs={5}
+        >
+          <div
+            className="col-xs-5"
           >
             <div
-              className="col-xs-5"
+              className="domain-field-label"
             >
-              <div
-                className="domain-field-label"
-              >
-                Description
-              </div>
-              <FormControl
-                bsClass="form-control"
-                className="form-control textarea-noresize"
-                componentClass="textarea"
+              Description
+            </div>
+            <FormControl
+              bsClass="form-control"
+              className="form-control textarea-noresize"
+              componentClass="textarea"
+              disabled={false}
+              id="domainpropertiesrow-description-1-1"
+              name="domainpropertiesrow-description"
+              onChange={[Function]}
+              rows={4}
+              value="This is a description"
+            >
+              <textarea
+                className="form-control textarea-noresize form-control"
                 disabled={false}
                 id="domainpropertiesrow-description-1-1"
                 name="domainpropertiesrow-description"
                 onChange={[Function]}
                 rows={4}
                 value="This is a description"
-              >
-                <textarea
-                  className="form-control textarea-noresize form-control"
-                  disabled={false}
-                  id="domainpropertiesrow-description-1-1"
-                  name="domainpropertiesrow-description"
-                  onChange={[Function]}
-                  rows={4}
-                  value="This is a description"
-                />
-              </FormControl>
-            </div>
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            xs={3}
+              />
+            </FormControl>
+          </div>
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          xs={3}
+        >
+          <div
+            className="col-xs-3"
           >
             <div
-              className="col-xs-3"
+              className="domain-field-label"
             >
-              <div
-                className="domain-field-label"
-              >
-                Label
-              </div>
-              <FormControl
-                bsClass="form-control"
-                componentClass="input"
+              Label
+            </div>
+            <FormControl
+              bsClass="form-control"
+              componentClass="input"
+              disabled={false}
+              id="domainpropertiesrow-label-1-1"
+              name="domainpropertiesrow-label"
+              onChange={[Function]}
+              type="text"
+              value="This is a label"
+            >
+              <input
+                className="form-control"
                 disabled={false}
                 id="domainpropertiesrow-label-1-1"
                 name="domainpropertiesrow-label"
                 onChange={[Function]}
                 type="text"
                 value="This is a label"
+              />
+            </FormControl>
+            <div
+              className="domain-field-label"
+            >
+              <Component
+                helpTipBody={
+                  <React.Fragment>
+                    Define alternate field names to be used when importing from a file.
+                    <br />
+                    <br />
+                    Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                  </React.Fragment>
+                }
+                label="Import Aliases"
               >
-                <input
-                  className="form-control"
-                  disabled={false}
-                  id="domainpropertiesrow-label-1-1"
-                  name="domainpropertiesrow-label"
-                  onChange={[Function]}
-                  type="text"
-                  value="This is a label"
-                />
-              </FormControl>
-              <div
-                className="domain-field-label"
-              >
-                <Component
-                  helpTipBody={
-                    <React.Fragment>
-                      Define alternate field names to be used when importing from a file.
-                      <br />
-                      <br />
-                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                    </React.Fragment>
-                  }
-                  label="Import Aliases"
+                Import 
+                <span
+                  className="domain-no-wrap"
                 >
-                  Import 
-                  <span
-                    className="domain-no-wrap"
+                  Aliases
+                  <Component
+                    customStyle={Object {}}
+                    id="tooltip"
+                    size="1x"
+                    title="Import Aliases"
                   >
-                    Aliases
-                    <Component
-                      customStyle={Object {}}
-                      id="tooltip"
-                      size="1x"
-                      title="Import Aliases"
+                    <span
+                      className="label-help-target"
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
                     >
-                      <span
-                        className="label-help-target"
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                      >
-                        <FontAwesomeIcon
-                          border={false}
-                          className="label-help-icon"
-                          fixedWidth={false}
-                          flip={null}
-                          icon={
-                            Object {
-                              "icon": Array [
-                                512,
-                                512,
-                                Array [],
-                                "f059",
-                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                              ],
-                              "iconName": "question-circle",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        border={false}
+                        className="label-help-icon"
+                        fixedWidth={false}
+                        flip={null}
+                        icon={
+                          Object {
+                            "icon": Array [
+                              512,
+                              512,
+                              Array [],
+                              "f059",
+                              "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                            ],
+                            "iconName": "question-circle",
+                            "prefix": "fas",
                           }
-                          inverse={false}
-                          listItem={false}
-                          mask={null}
-                          pull={null}
-                          pulse={false}
-                          rotation={null}
-                          size="1x"
-                          spin={false}
+                        }
+                        inverse={false}
+                        listItem={false}
+                        mask={null}
+                        pull={null}
+                        pulse={false}
+                        rotation={null}
+                        size="1x"
+                        spin={false}
+                        style={Object {}}
+                        swapOpacity={false}
+                        symbol={false}
+                        title=""
+                        transform={null}
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                          data-icon="question-circle"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
                           style={Object {}}
-                          swapOpacity={false}
-                          symbol={false}
-                          title=""
-                          transform={null}
+                          viewBox="0 0 512 512"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-hidden="true"
-                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                            data-icon="question-circle"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
+                          <path
+                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                            fill="currentColor"
                             style={Object {}}
-                            viewBox="0 0 512 512"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                              fill="currentColor"
-                              style={Object {}}
-                            />
-                          </svg>
-                        </FontAwesomeIcon>
+                          />
+                        </svg>
+                      </FontAwesomeIcon>
+                      <Overlay
+                        animation={[Function]}
+                        placement="right"
+                        rootClose={false}
+                        show={false}
+                      >
                         <Overlay
-                          animation={[Function]}
                           placement="right"
                           rootClose={false}
                           show={false}
-                        >
-                          <Overlay
-                            placement="right"
-                            rootClose={false}
-                            show={false}
-                            transition={[Function]}
-                          />
-                        </Overlay>
-                      </span>
-                    </Component>
-                  </span>
-                </Component>
-              </div>
-              <FormControl
-                bsClass="form-control"
-                componentClass="input"
+                          transition={[Function]}
+                        />
+                      </Overlay>
+                    </span>
+                  </Component>
+                </span>
+              </Component>
+            </div>
+            <FormControl
+              bsClass="form-control"
+              componentClass="input"
+              disabled={false}
+              id="domainpropertiesrow-importAliases-1-1"
+              name="domainpropertiesrow-importAliases"
+              onChange={[Function]}
+              type="text"
+              value="This is an alias"
+            >
+              <input
+                className="form-control"
                 disabled={false}
                 id="domainpropertiesrow-importAliases-1-1"
                 name="domainpropertiesrow-importAliases"
                 onChange={[Function]}
                 type="text"
                 value="This is an alias"
-              >
-                <input
-                  className="form-control"
-                  disabled={false}
-                  id="domainpropertiesrow-importAliases-1-1"
-                  name="domainpropertiesrow-importAliases"
-                  onChange={[Function]}
-                  type="text"
-                  value="This is an alias"
-                />
-              </FormControl>
-            </div>
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            xs={4}
+              />
+            </FormControl>
+          </div>
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          xs={4}
+        >
+          <div
+            className="col-xs-4"
           >
             <div
-              className="col-xs-4"
+              className="domain-field-label"
             >
-              <div
-                className="domain-field-label"
-              >
-                <Component
-                  helpTipBody={
-                    <React.Fragment>
-                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                      <br />
-                      <br />
-                      Learn more about using 
-                      <a
-                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                        target="_blank"
-                      >
-                        URL Formatting Options
-                      </a>
-                      .
-                    </React.Fragment>
-                  }
-                  label="URL"
-                >
-                  <span
-                    className="domain-no-wrap"
-                  >
-                    URL
-                    <Component
-                      customStyle={Object {}}
-                      id="tooltip"
-                      size="1x"
-                      title="URL"
+              <Component
+                helpTipBody={
+                  <React.Fragment>
+                    Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                    <br />
+                    <br />
+                    Learn more about using 
+                    <a
+                      href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                      target="_blank"
                     >
-                      <span
-                        className="label-help-target"
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                      >
-                        <FontAwesomeIcon
-                          border={false}
-                          className="label-help-icon"
-                          fixedWidth={false}
-                          flip={null}
-                          icon={
-                            Object {
-                              "icon": Array [
-                                512,
-                                512,
-                                Array [],
-                                "f059",
-                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                              ],
-                              "iconName": "question-circle",
-                              "prefix": "fas",
-                            }
+                      URL Formatting Options
+                    </a>
+                    .
+                  </React.Fragment>
+                }
+                label="URL"
+              >
+                <span
+                  className="domain-no-wrap"
+                >
+                  URL
+                  <Component
+                    customStyle={Object {}}
+                    id="tooltip"
+                    size="1x"
+                    title="URL"
+                  >
+                    <span
+                      className="label-help-target"
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <FontAwesomeIcon
+                        border={false}
+                        className="label-help-icon"
+                        fixedWidth={false}
+                        flip={null}
+                        icon={
+                          Object {
+                            "icon": Array [
+                              512,
+                              512,
+                              Array [],
+                              "f059",
+                              "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                            ],
+                            "iconName": "question-circle",
+                            "prefix": "fas",
                           }
-                          inverse={false}
-                          listItem={false}
-                          mask={null}
-                          pull={null}
-                          pulse={false}
-                          rotation={null}
-                          size="1x"
-                          spin={false}
+                        }
+                        inverse={false}
+                        listItem={false}
+                        mask={null}
+                        pull={null}
+                        pulse={false}
+                        rotation={null}
+                        size="1x"
+                        spin={false}
+                        style={Object {}}
+                        swapOpacity={false}
+                        symbol={false}
+                        title=""
+                        transform={null}
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                          data-icon="question-circle"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
                           style={Object {}}
-                          swapOpacity={false}
-                          symbol={false}
-                          title=""
-                          transform={null}
+                          viewBox="0 0 512 512"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-hidden="true"
-                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                            data-icon="question-circle"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
+                          <path
+                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                            fill="currentColor"
                             style={Object {}}
-                            viewBox="0 0 512 512"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                              fill="currentColor"
-                              style={Object {}}
-                            />
-                          </svg>
-                        </FontAwesomeIcon>
+                          />
+                        </svg>
+                      </FontAwesomeIcon>
+                      <Overlay
+                        animation={[Function]}
+                        placement="right"
+                        rootClose={false}
+                        show={false}
+                      >
                         <Overlay
-                          animation={[Function]}
                           placement="right"
                           rootClose={false}
                           show={false}
-                        >
-                          <Overlay
-                            placement="right"
-                            rootClose={false}
-                            show={false}
-                            transition={[Function]}
-                          />
-                        </Overlay>
-                      </span>
-                    </Component>
-                  </span>
-                </Component>
-              </div>
-              <FormControl
-                bsClass="form-control"
-                componentClass="input"
+                          transition={[Function]}
+                        />
+                      </Overlay>
+                    </span>
+                  </Component>
+                </span>
+              </Component>
+            </div>
+            <FormControl
+              bsClass="form-control"
+              componentClass="input"
+              disabled={false}
+              id="domainpropertiesrow-URL-1-1"
+              name="domainpropertiesrow-URL"
+              onChange={[Function]}
+              type="text"
+              value="This is a URL"
+            >
+              <input
+                className="form-control"
                 disabled={false}
                 id="domainpropertiesrow-URL-1-1"
                 name="domainpropertiesrow-URL"
                 onChange={[Function]}
                 type="text"
                 value="This is a URL"
-              >
-                <input
-                  className="form-control"
-                  disabled={false}
-                  id="domainpropertiesrow-URL-1-1"
-                  name="domainpropertiesrow-URL"
-                  onChange={[Function]}
-                  type="text"
-                  value="This is a URL"
-                />
-              </FormControl>
-            </div>
-          </Col>
-        </div>
+              />
+            </FormControl>
+          </div>
+        </Col>
       </div>
     </Row>
   </div>

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -34,7 +34,6 @@ import {
     IBannerMessage,
     IDomainField,
     IFieldChange,
-    OntologyModel,
     QueryInfoLite,
     updateSampleField,
 } from './models';
@@ -60,6 +59,7 @@ import {
     SEVERITY_LEVEL_ERROR,
     SEVERITY_LEVEL_WARN,
 } from './constants';
+import { OntologyModel } from '../ontology/models';
 
 let sharedCache = Map<string, Promise<any>>();
 

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -23,6 +23,8 @@ import { processSchemas } from '../../schemas';
 
 import { SimpleResponse } from '../files/models';
 
+import { OntologyModel } from '../ontology/models';
+
 import {
     decodeLookup,
     DomainDesign,
@@ -59,7 +61,6 @@ import {
     SEVERITY_LEVEL_ERROR,
     SEVERITY_LEVEL_WARN,
 } from './constants';
-import { OntologyModel } from '../ontology/models';
 
 let sharedCache = Map<string, Promise<any>>();
 
@@ -942,7 +943,9 @@ export function getOntologyUpdatedFieldName(
 
     // check for a field removal prior to the ontology lookup field
     const propFieldRemoved = removedFieldIndexes
-        ? removedFieldIndexes.some(removedField => removedField.originalIndex === origFieldIndex && removedField.newIndex === undefined)
+        ? removedFieldIndexes.some(
+              removedField => removedField.originalIndex === origFieldIndex && removedField.newIndex === undefined
+          )
         : removedFieldIndexes;
 
     if (removedFieldIndexes) {

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
@@ -12592,11 +12592,10 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -12725,331 +12724,329 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-0"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-0"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-0"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-0"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-0"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-0"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-0"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-0"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-0"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-0"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-0"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-0"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -14680,11 +14677,10 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -14813,331 +14809,329 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-1"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-1"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-1"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-1"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-1"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-1"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-1"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-1"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-1"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-1"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-1"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-1"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -16733,11 +16727,10 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -16866,331 +16859,329 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-2"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-2"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-2"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-2"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-2"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-2"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-2"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-2"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-2"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-2"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-2"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-2"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -33792,11 +33783,10 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -33925,331 +33915,329 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-0"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-0"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-0"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-0"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-0"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-0"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-0"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-0"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-0"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-0"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-0"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-0"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -36038,11 +36026,10 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -36171,331 +36158,329 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-1"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-1"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-1"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-1"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-1"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-1"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-1"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-1"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-1"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-1"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-1"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-1"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -38249,11 +38234,10 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -38382,331 +38366,329 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-2"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-2"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-2"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-2"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-2"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-2"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-2"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-2"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-2"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-2"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-2"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-2"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -48910,11 +48892,10 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -49043,331 +49024,329 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-0"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-0"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-0"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-0"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-0"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-0"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-0"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-0"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-0"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-0"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-0"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-0"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -51156,11 +51135,10 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -51289,331 +51267,329 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-1"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-1"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-1"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-1"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-1"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-1"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-1"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-1"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-1"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-1"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-1"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-1"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -53367,11 +53343,10 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={1}
@@ -53500,331 +53475,329 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-1-2"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-1-2"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-1-2"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-1-2"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-1-2"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-1-2"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-1-2"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-1-2"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-1-2"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-1-2"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-1-2"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-1-2"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
@@ -4096,6 +4096,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -4178,6 +4179,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -4260,6 +4262,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
           ],
@@ -4428,6 +4431,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -4510,6 +4514,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -4592,6 +4597,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -4748,6 +4754,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -4830,6 +4837,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -4912,6 +4920,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -5067,6 +5076,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -5149,6 +5159,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -5231,6 +5242,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -5402,6 +5414,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -5484,6 +5497,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -5566,6 +5580,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -5739,6 +5754,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                       Immutable.Record {
@@ -5821,6 +5837,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                       Immutable.Record {
@@ -5903,6 +5920,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                     ],
@@ -6333,6 +6351,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -6415,6 +6434,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -6497,6 +6517,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -6819,6 +6840,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -6901,6 +6923,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -6983,6 +7006,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -7300,6 +7324,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -7382,6 +7407,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -7464,6 +7490,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -7769,6 +7796,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -7851,6 +7879,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -7933,6 +7962,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -8283,6 +8313,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -8365,6 +8396,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -8447,6 +8479,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
               ],
@@ -8631,6 +8664,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -8713,6 +8747,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -8795,6 +8830,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -9389,6 +9425,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -9471,6 +9508,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -9553,6 +9591,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -9687,6 +9726,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -9769,6 +9809,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -9851,6 +9892,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
               ],
@@ -9971,6 +10013,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -10053,6 +10096,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -10135,6 +10179,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -10282,6 +10327,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -10364,6 +10410,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -10446,6 +10493,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -11399,6 +11447,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -11589,6 +11638,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -12200,6 +12250,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -12630,6 +12681,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -13107,6 +13159,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -13536,6 +13589,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -13726,6 +13780,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -14337,6 +14392,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -14713,6 +14769,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -15190,6 +15247,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -15619,6 +15677,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -15809,6 +15868,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -16420,6 +16480,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -16761,6 +16822,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -17238,6 +17300,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -25407,6 +25470,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -25489,6 +25553,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -25571,6 +25636,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
           ],
@@ -25739,6 +25805,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -25821,6 +25888,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -25903,6 +25971,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -26059,6 +26128,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -26141,6 +26211,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -26223,6 +26294,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -26377,6 +26449,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -26459,6 +26532,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -26541,6 +26615,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -26712,6 +26787,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -26794,6 +26870,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -26876,6 +26953,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -27049,6 +27127,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                       Immutable.Record {
@@ -27131,6 +27210,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                       Immutable.Record {
@@ -27213,6 +27293,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                     ],
@@ -27643,6 +27724,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -27725,6 +27807,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -27807,6 +27890,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -28129,6 +28213,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -28211,6 +28296,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -28293,6 +28379,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -28610,6 +28697,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -28692,6 +28780,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -28774,6 +28863,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -29079,6 +29169,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -29161,6 +29252,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -29243,6 +29335,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -29571,6 +29664,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -29653,6 +29747,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -29735,6 +29830,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -30057,6 +30153,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -30139,6 +30236,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -30221,6 +30319,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -30508,6 +30607,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -30590,6 +30690,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -30672,6 +30773,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -30806,6 +30908,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -30888,6 +30991,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -30970,6 +31074,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
               ],
@@ -31090,6 +31195,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -31172,6 +31278,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -31254,6 +31361,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -31401,6 +31509,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -31483,6 +31592,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -31565,6 +31675,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -32518,6 +32629,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -32708,6 +32820,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -33337,6 +33450,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -33767,6 +33881,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -34244,6 +34359,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -34813,6 +34929,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -35003,6 +35120,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -35632,6 +35750,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -36008,6 +36127,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -36485,6 +36605,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -37054,6 +37175,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -37244,6 +37366,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -37873,6 +37996,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -38214,6 +38338,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -38691,6 +38816,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -39301,6 +39427,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -39383,6 +39510,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -39465,6 +39593,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
           ],
@@ -39632,6 +39761,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -39714,6 +39844,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -39796,6 +39927,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -39952,6 +40084,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -40034,6 +40167,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -40116,6 +40250,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -40270,6 +40405,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -40352,6 +40488,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -40434,6 +40571,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -40605,6 +40743,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -40687,6 +40826,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -40769,6 +40909,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -40942,6 +41083,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                       Immutable.Record {
@@ -41024,6 +41166,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                       Immutable.Record {
@@ -41106,6 +41249,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                         "sourceOntology": undefined,
                         "conceptLabelColumn": undefined,
                         "conceptImportColumn": undefined,
+                        "principalConceptCode": undefined,
                         "selected": false,
                       },
                     ],
@@ -41536,6 +41680,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -41618,6 +41763,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -41700,6 +41846,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -42022,6 +42169,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -42104,6 +42252,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -42186,6 +42335,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -42503,6 +42653,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -42585,6 +42736,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -42667,6 +42819,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -42972,6 +43125,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -43054,6 +43208,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -43136,6 +43291,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -43464,6 +43620,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -43546,6 +43703,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -43628,6 +43786,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -43950,6 +44109,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -44032,6 +44192,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                       Immutable.Record {
@@ -44114,6 +44275,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         "sourceOntology": undefined,
                                                         "conceptLabelColumn": undefined,
                                                         "conceptImportColumn": undefined,
+                                                        "principalConceptCode": undefined,
                                                         "selected": false,
                                                       },
                                                     ],
@@ -44452,6 +44614,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -44534,6 +44697,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -44616,6 +44780,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
               ],
@@ -44800,6 +44965,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -44882,6 +45048,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -44964,6 +45131,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -45557,6 +45725,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -45639,6 +45808,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -45721,6 +45891,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -45855,6 +46026,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -45937,6 +46109,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -46019,6 +46192,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
               ],
@@ -46139,6 +46313,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -46221,6 +46396,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -46303,6 +46479,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -46450,6 +46627,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -46532,6 +46710,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -46614,6 +46793,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -47567,6 +47747,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -47757,6 +47938,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -48386,6 +48568,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -48816,6 +48999,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -49293,6 +49477,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -49862,6 +50047,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -50052,6 +50238,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -50681,6 +50868,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -51057,6 +51245,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -51534,6 +51723,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -52103,6 +52293,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -52293,6 +52484,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -52922,6 +53114,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -53263,6 +53456,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -53740,6 +53934,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
@@ -12598,6 +12598,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={true}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -14683,6 +14684,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={true}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -16733,6 +16735,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={true}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -33789,6 +33792,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -36032,6 +36036,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -38240,6 +38245,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -48898,6 +48904,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -51141,6 +51148,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -53349,6 +53357,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={1}
                                                                                     field={
                                                                                       Immutable.Record {

--- a/packages/components/src/internal/components/domainproperties/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/constants.ts
@@ -52,6 +52,7 @@ export const DOMAIN_FIELD_DEFAULT_DISPLAY_VALUE = 'defaultDisplayValue';
 export const DOMAIN_FIELD_ONTOLOGY_SOURCE = 'sourceOntology';
 export const DOMAIN_FIELD_ONTOLOGY_LABEL_COL = 'conceptLabelColumn';
 export const DOMAIN_FIELD_ONTOLOGY_IMPORT_COL = 'conceptImportColumn';
+export const DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT = 'principalConceptCode';
 
 // TextFieldOptions
 export const DOMAIN_FIELD_MAX_LENGTH = 'maxLength';

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -1156,6 +1156,7 @@ exports[`DataClassDesigner initModel 1`] = `
             "sourceOntology": undefined,
             "conceptLabelColumn": undefined,
             "conceptImportColumn": undefined,
+            "principalConceptCode": undefined,
             "selected": false,
           },
           Immutable.Record {
@@ -1238,6 +1239,7 @@ exports[`DataClassDesigner initModel 1`] = `
             "sourceOntology": undefined,
             "conceptLabelColumn": undefined,
             "conceptImportColumn": undefined,
+            "principalConceptCode": undefined,
             "selected": false,
           },
           Immutable.Record {
@@ -1320,6 +1322,7 @@ exports[`DataClassDesigner initModel 1`] = `
             "sourceOntology": undefined,
             "conceptLabelColumn": undefined,
             "conceptImportColumn": undefined,
+            "principalConceptCode": undefined,
             "selected": false,
           },
         ],
@@ -1458,6 +1461,7 @@ exports[`DataClassDesigner initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -1540,6 +1544,7 @@ exports[`DataClassDesigner initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
             Immutable.Record {
@@ -1622,6 +1627,7 @@ exports[`DataClassDesigner initModel 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
           ],
@@ -1763,6 +1769,7 @@ exports[`DataClassDesigner initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -1845,6 +1852,7 @@ exports[`DataClassDesigner initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -1927,6 +1935,7 @@ exports[`DataClassDesigner initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -2062,6 +2071,7 @@ exports[`DataClassDesigner initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -2144,6 +2154,7 @@ exports[`DataClassDesigner initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
                 Immutable.Record {
@@ -2226,6 +2237,7 @@ exports[`DataClassDesigner initModel 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
               ],
@@ -2369,6 +2381,7 @@ exports[`DataClassDesigner initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -2451,6 +2464,7 @@ exports[`DataClassDesigner initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -2533,6 +2547,7 @@ exports[`DataClassDesigner initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -2680,6 +2695,7 @@ exports[`DataClassDesigner initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -2762,6 +2778,7 @@ exports[`DataClassDesigner initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                     Immutable.Record {
@@ -2844,6 +2861,7 @@ exports[`DataClassDesigner initModel 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -4174,6 +4192,7 @@ exports[`DataClassDesigner initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -4256,6 +4275,7 @@ exports[`DataClassDesigner initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
               Immutable.Record {
@@ -4338,6 +4358,7 @@ exports[`DataClassDesigner initModel 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -4475,6 +4496,7 @@ exports[`DataClassDesigner initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -4557,6 +4579,7 @@ exports[`DataClassDesigner initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                   Immutable.Record {
@@ -4639,6 +4662,7 @@ exports[`DataClassDesigner initModel 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -5543,6 +5567,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -5749,6 +5774,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -6351,6 +6377,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -6792,6 +6819,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -7280,6 +7308,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -7865,6 +7894,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -8060,6 +8090,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -8645,6 +8676,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -9025,6 +9057,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -9502,6 +9535,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -10087,6 +10121,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -10282,6 +10317,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -10849,6 +10885,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -11191,6 +11228,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -11668,6 +11706,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -6719,11 +6719,10 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={0}
@@ -6863,331 +6862,329 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-0-0"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-0-0"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-0-0"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-0-0"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-0-0"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-0-0"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-0-0"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-0-0"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-0-0"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-0-0"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-0-0"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-0-0"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -8968,11 +8965,10 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={0}
@@ -9101,331 +9097,329 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-0-1"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-0-1"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-0-1"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-0-1"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-0-1"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-0-1"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-0-1"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-0-1"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-0-1"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-0-1"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-0-1"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-0-1"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>
@@ -11139,11 +11133,10 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={0}
@@ -11272,331 +11265,329 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-0-2"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-0-2"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-0-2"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-0-2"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-0-2"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-0-2"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-0-2"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-0-2"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-0-2"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-0-2"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-0-2"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-0-2"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -6725,6 +6725,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={0}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -8971,6 +8972,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={0}
                                                                                     field={
                                                                                       Immutable.Record {
@@ -11139,6 +11141,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={false}
                                                                                     domainIndex={0}
                                                                                     field={
                                                                                       Immutable.Record {

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -54,44 +54,71 @@ import {
     DOMAIN_FIELD_FULLY_LOCKED,
 } from './constants';
 
-const gridDataConst = [
+const GRID_DATA = DomainDesign.create({
+    fields: [{
+        name: 'a',
+        rangeURI: INTEGER_TYPE.rangeURI,
+        sourceOntology: 'b',
+        conceptImportColumn: 'c',
+        conceptLabelColumn: 'd',
+        principalConceptCode: 'e',
+        wrappedColumnName: 'f',
+        propertyId: 123,
+    }],
+});
+const gridDataAppPropsOnlyConst = [
     {
-        excludeFromShifting: 'false',
-        shownInUpdateView: 'true',
         lockType: 'NotLocked',
-        dimension: '',
-        lookupContainer: '',
         isPrimaryKey: 'false',
         defaultScale: '',
         scale: 4000,
-        hidden: 'false',
-        defaultValueType: '',
         name: 'a',
-        lookupQuery: '',
         URL: '',
         conceptURI: '',
         rangeURI: 'http://www.w3.org/2001/XMLSchema#int',
-        defaultDisplayValue: '',
-        defaultValue: '',
-        shownInDetailsView: 'true',
         PHI: '',
         visible: true,
         label: '',
-        shownInInsertView: 'true',
-        conditionalFormats: '',
         propertyValidators: '',
-        recommendedVariable: 'false',
         format: '',
-        mvEnabled: 'false',
         fieldIndex: 0,
         importAliases: '',
         selected: '',
-        lookupSchema: '',
         description: '',
-        measure: '',
         required: 'false',
     },
 ];
+const gridDataConst = [
+    {
+        ...gridDataAppPropsOnlyConst[0],
+        excludeFromShifting: 'false',
+        shownInUpdateView: 'true',
+        dimension: '',
+        lookupContainer: '',
+        hidden: 'false',
+        defaultValueType: '',
+        lookupQuery: '',
+        defaultDisplayValue: '',
+        defaultValue: '',
+        shownInDetailsView: 'true',
+        shownInInsertView: 'true',
+        conditionalFormats: '',
+        recommendedVariable: 'false',
+        mvEnabled: 'false',
+        lookupSchema: '',
+        measure: '',
+    },
+];
+const gridDataConstWithOntology = [
+    {
+        ...gridDataConst[0],
+        sourceOntology: 'b',
+        conceptImportColumn: 'c',
+        conceptLabelColumn: 'd',
+        principalConceptCode: 'e',
+    },
+];
+
 const selectionCol = new GridColumn({
     index: GRID_SELECTION_INDEX,
     title: GRID_SELECTION_INDEX,
@@ -544,11 +571,27 @@ describe('DomainDesign', () => {
         expect(fieldDetails.detailsInfo['text2']).toBe(undefined);
     });
 
-    test('getGridData', () => {
-        const gridData = DomainDesign.create({
-            fields: [{ name: 'a', rangeURI: INTEGER_TYPE.rangeURI }],
-        }).getGridData(false);
+    test('getGridData with ontology', () => {
+        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
+        const gridData = GRID_DATA.getGridData(false);
+        expect(gridData.toJS()).toStrictEqual(gridDataConstWithOntology);
+    });
+
+    test('getGridData without ontology', () => {
+        LABKEY.container.activeModules = ['Core', 'Query'];
+        const gridData = GRID_DATA.getGridData(false);
         expect(gridData.toJS()).toStrictEqual(gridDataConst);
+    });
+
+    test('getGridData appPropertiesOnly', () => {
+        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
+        let gridData = GRID_DATA.getGridData(true);
+        expect(gridData.toJS()).toStrictEqual(gridDataAppPropsOnlyConst);
+
+        // should be the same with or without the Ontology module in this case
+        LABKEY.container.activeModules = ['Core', 'Query'];
+        gridData = GRID_DATA.getGridData(true);
+        expect(gridData.toJS()).toStrictEqual(gridDataAppPropsOnlyConst);
     });
 
     test('getGridColumns', () => {

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -55,16 +55,18 @@ import {
 } from './constants';
 
 const GRID_DATA = DomainDesign.create({
-    fields: [{
-        name: 'a',
-        rangeURI: INTEGER_TYPE.rangeURI,
-        sourceOntology: 'b',
-        conceptImportColumn: 'c',
-        conceptLabelColumn: 'd',
-        principalConceptCode: 'e',
-        wrappedColumnName: 'f',
-        propertyId: 123,
-    }],
+    fields: [
+        {
+            name: 'a',
+            rangeURI: INTEGER_TYPE.rangeURI,
+            sourceOntology: 'b',
+            conceptImportColumn: 'c',
+            conceptLabelColumn: 'd',
+            principalConceptCode: 'e',
+            wrappedColumnName: 'f',
+            propertyId: 123,
+        },
+    ],
 });
 const gridDataAppPropsOnlyConst = [
     {
@@ -720,12 +722,17 @@ describe('DomainField', () => {
         field = field.merge({ lockType: DOMAIN_FIELD_FULLY_LOCKED }) as DomainField;
         expect(field.getDetailsTextArray().join('')).toBe('Updated. SRC. Primary Key. Locked');
 
+        field = field.merge({ principalConceptCode: 'abc:123' }) as DomainField;
+        expect(field.getDetailsTextArray().join('')).toBe(
+            'Updated. SRC. Concept Annotation: abc:123. Primary Key. Locked'
+        );
+
         expect(field.getDetailsTextArray({ test: 'Additional Info' }).join('')).toBe(
-            'Updated. SRC. Primary Key. Locked. Additional Info'
+            'Updated. SRC. Concept Annotation: abc:123. Primary Key. Locked. Additional Info'
         );
         field = field.merge({ name: '' }) as DomainField;
         expect(field.getDetailsTextArray({ test: 'Additional Info' }).join('')).toBe(
-            'Updated. SRC. Primary Key. Locked'
+            'Updated. SRC. Concept Annotation: abc:123. Primary Key. Locked'
         );
     });
 });

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -42,7 +42,6 @@ import {
     DomainField,
     FieldErrors,
     isPropertyTypeAllowed,
-    OntologyModel,
 } from './models';
 import {
     CONCEPT_CODE_CONCEPT_URI,
@@ -685,24 +684,5 @@ describe('DomainField', () => {
         expect(field.getDetailsTextArray({ test: 'Additional Info' }).join('')).toBe(
             'Updated. SRC. Primary Key. Locked'
         );
-    });
-});
-
-describe('OntologyModel', () => {
-    test('create', () => {
-        expect(OntologyModel.create({}).name).toBe(undefined);
-        expect(OntologyModel.create({ name: {} }).name).toBe(undefined);
-        expect(OntologyModel.create({ Name: {} }).name).toBe(undefined);
-        expect(OntologyModel.create({ name: { value: 'test' } }).name).toBe('test');
-        expect(OntologyModel.create({ Name: { value: 'test' } }).name).toBe('test');
-    });
-
-    test('getLabel', () => {
-        expect(
-            OntologyModel.create({
-                Name: { value: 'test' },
-                Abbreviation: { value: 'T' },
-            }).getLabel()
-        ).toBe('test (T)');
     });
 });

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -36,13 +36,7 @@ import {
     USERS_TYPE,
 } from './PropDescType';
 
-import {
-    acceptablePropertyType,
-    DomainDesign,
-    DomainField,
-    FieldErrors,
-    isPropertyTypeAllowed,
-} from './models';
+import { acceptablePropertyType, DomainDesign, DomainField, FieldErrors, isPropertyTypeAllowed } from './models';
 import {
     CONCEPT_CODE_CONCEPT_URI,
     DOMAIN_FIELD_NOT_LOCKED,

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -67,8 +67,8 @@ import {
     removeFalseyObjKeys,
     removeUnusedOntologyProperties,
     reorderSummaryColumns,
-    removeNonAppProperties
-} from "./propertiesUtil";
+    removeNonAppProperties,
+} from './propertiesUtil';
 
 export interface IFieldChange {
     id: string;
@@ -346,7 +346,7 @@ export class DomainDesign
                         value = JSON.stringify(value.map(cf => removeFalseyObjKeys(cf)));
                     }
 
-                    if (key === 'fieldIndex' && value === "") {
+                    if (key === 'fieldIndex' && value === '') {
                         value = 0;
                     }
                     return [key, value];
@@ -390,7 +390,7 @@ export class DomainDesign
         const nameCol = new GridColumn({
             index: GRID_NAME_INDEX,
             title: GRID_NAME_INDEX,
-            raw: {index: 'name', caption: 'Name', sortable: true},
+            raw: { index: 'name', caption: 'Name', sortable: true },
             cell: (data: any, row: any) => {
                 const text = row.get('name');
                 const fieldIndex = row.get('fieldIndex');

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -661,6 +661,7 @@ export interface IDomainField {
     sourceOntology?: string;
     conceptLabelColumn?: string;
     conceptImportColumn?: string;
+    principalConceptCode?: string;
 }
 
 export class DomainField
@@ -713,6 +714,7 @@ export class DomainField
         sourceOntology: undefined,
         conceptLabelColumn: undefined,
         conceptImportColumn: undefined,
+        principalConceptCode: undefined,
         selected: false,
     })
     implements IDomainField {
@@ -764,6 +766,7 @@ export class DomainField
     sourceOntology?: string;
     conceptLabelColumn?: string;
     conceptImportColumn?: string;
+    principalConceptCode?: string;
     selected: boolean;
 
     static create(rawField: any, shouldApplyDefaultValues?: boolean, mandatoryFieldNames?: List<string>): DomainField {

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1668,30 +1668,6 @@ export interface DomainFieldIndexChange {
     newIndex: number;
 }
 
-export class OntologyModel {
-    [immerable] = true;
-
-    rowId: number;
-    abbreviation: string;
-    name: string;
-
-    constructor(values?: Partial<OntologyModel>) {
-        Object.assign(this, values);
-    }
-
-    static create(raw: any): OntologyModel {
-        return new OntologyModel({
-            rowId: caseInsensitive(raw, 'RowId')?.value,
-            name: caseInsensitive(raw, 'Name')?.value,
-            abbreviation: caseInsensitive(raw, 'Abbreviation')?.value,
-        });
-    }
-
-    getLabel() {
-        return this.name + ' (' + this.abbreviation + ')';
-    }
-}
-
 export interface BulkDeleteConfirmInfo {
     deletableSelectedFields: number[];
     undeletableFields: number[];

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1052,6 +1052,11 @@ export class DomainField
             period = '. ';
         }
 
+        if (this.principalConceptCode) {
+            details.push(period + 'Concept Annotation: ' + this.principalConceptCode);
+            period = '. ';
+        }
+
         if (this.wrappedColumnName) {
             details.push(period + 'Wrapped column - ' + this.wrappedColumnName);
             period = '. ';

--- a/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
+++ b/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
@@ -201,6 +201,13 @@ export function removeNonAppProperties(obj) {
     delete obj.recommendedVariable;
     delete obj.mvEnabled;
 
+    // this props are always removed for appPropertiesOnly and then also conditionally removed for
+    // containers that dont' have the Ontology module enabled (see removeUnusedOntologyProperties)
+    delete obj.sourceOntology;
+    delete obj.conceptImportColumn;
+    delete obj.conceptLabelColumn;
+    delete obj.principalConceptCode;
+
     delete obj.lookupContainer;
     delete obj.lookupSchema;
     delete obj.lookupQuery;

--- a/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
+++ b/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
@@ -136,6 +136,7 @@ export function reorderSummaryColumns(a: DomainPropertiesGridColumn, b: DomainPr
         'sourceOntology',
         'conceptImportColumn',
         'conceptLabelColumn',
+        'principalConceptCode',
         // Other expanded field options
         'conceptURI', // ParticipantId, Flag, Sample, and Ontology Lookup
         'scale',
@@ -178,6 +179,7 @@ export function removeUnusedOntologyProperties(obj) {
         delete obj.sourceOntology;
         delete obj.conceptImportColumn;
         delete obj.conceptLabelColumn;
+        delete obj.principalConceptCode;
     }
     return obj;
 }

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -5013,6 +5013,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                                   className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
+                                                                                    appPropertiesOnly={true}
                                                                                     domainIndex={0}
                                                                                     field={
                                                                                       Immutable.Record {

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -1031,6 +1031,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
             "sourceOntology": undefined,
             "conceptLabelColumn": undefined,
             "conceptImportColumn": undefined,
+            "principalConceptCode": undefined,
             "selected": false,
           },
         ],
@@ -1180,6 +1181,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
               "sourceOntology": undefined,
               "conceptLabelColumn": undefined,
               "conceptImportColumn": undefined,
+              "principalConceptCode": undefined,
               "selected": false,
             },
           ],
@@ -1306,6 +1308,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -1438,6 +1441,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                   "sourceOntology": undefined,
                   "conceptLabelColumn": undefined,
                   "conceptImportColumn": undefined,
+                  "principalConceptCode": undefined,
                   "selected": false,
                 },
               ],
@@ -1585,6 +1589,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -1738,6 +1743,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                       "sourceOntology": undefined,
                       "conceptLabelColumn": undefined,
                       "conceptImportColumn": undefined,
+                      "principalConceptCode": undefined,
                       "selected": false,
                     },
                   ],
@@ -2083,6 +2089,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                             "sourceOntology": undefined,
                                             "conceptLabelColumn": undefined,
                                             "conceptImportColumn": undefined,
+                                            "principalConceptCode": undefined,
                                             "selected": false,
                                           },
                                         ],
@@ -2787,6 +2794,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                 "sourceOntology": undefined,
                 "conceptLabelColumn": undefined,
                 "conceptImportColumn": undefined,
+                "principalConceptCode": undefined,
                 "selected": false,
               },
             ],
@@ -2911,6 +2919,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                     "sourceOntology": undefined,
                     "conceptLabelColumn": undefined,
                     "conceptImportColumn": undefined,
+                    "principalConceptCode": undefined,
                     "selected": false,
                   },
                 ],
@@ -3854,6 +3863,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                             "sourceOntology": undefined,
                                                             "conceptLabelColumn": undefined,
                                                             "conceptImportColumn": undefined,
+                                                            "principalConceptCode": undefined,
                                                             "selected": false,
                                                           }
                                                         }
@@ -4043,6 +4053,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                             "sourceOntology": undefined,
                                                                             "conceptLabelColumn": undefined,
                                                                             "conceptImportColumn": undefined,
+                                                                            "principalConceptCode": undefined,
                                                                             "selected": false,
                                                                           }
                                                                         }
@@ -4654,6 +4665,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                               "sourceOntology": undefined,
                                                                               "conceptLabelColumn": undefined,
                                                                               "conceptImportColumn": undefined,
+                                                                              "principalConceptCode": undefined,
                                                                               "selected": false,
                                                                             }
                                                                           }
@@ -5084,6 +5096,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }
@@ -5561,6 +5574,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                                         "sourceOntology": undefined,
                                                                                         "conceptLabelColumn": undefined,
                                                                                         "conceptImportColumn": undefined,
+                                                                                        "principalConceptCode": undefined,
                                                                                         "selected": false,
                                                                                       }
                                                                                     }

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -5007,11 +5007,10 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                               <Col
                                                                                 bsClass="col"
                                                                                 componentClass="div"
-                                                                                lg={10}
                                                                                 xs={12}
                                                                               >
                                                                                 <div
-                                                                                  className="col-lg-10 col-xs-12"
+                                                                                  className="col-xs-12"
                                                                                 >
                                                                                   <NameAndLinkingOptions
                                                                                     domainIndex={0}
@@ -5140,331 +5139,329 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                                         <div
                                                                                           className="row"
                                                                                         >
-                                                                                          <div>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={5}
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={5}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-5"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-5"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Description
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  className="form-control textarea-noresize"
-                                                                                                  componentClass="textarea"
+                                                                                                Description
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                className="form-control textarea-noresize"
+                                                                                                componentClass="textarea"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-description-0-0"
+                                                                                                name="domainpropertiesrow-description"
+                                                                                                onChange={[Function]}
+                                                                                                rows={4}
+                                                                                                value=""
+                                                                                              >
+                                                                                                <textarea
+                                                                                                  className="form-control textarea-noresize form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-description-0-0"
                                                                                                   name="domainpropertiesrow-description"
                                                                                                   onChange={[Function]}
                                                                                                   rows={4}
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <textarea
-                                                                                                    className="form-control textarea-noresize form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-description-0-0"
-                                                                                                    name="domainpropertiesrow-description"
-                                                                                                    onChange={[Function]}
-                                                                                                    rows={4}
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={3}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={3}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-3"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-3"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  Label
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                Label
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-label-0-0"
+                                                                                                name="domainpropertiesrow-label"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-label-0-0"
                                                                                                   name="domainpropertiesrow-label"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                              <div
+                                                                                                className="domain-field-label"
+                                                                                              >
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Define alternate field names to be used when importing from a file.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="Import Aliases"
                                                                                                 >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-label-0-0"
-                                                                                                    name="domainpropertiesrow-label"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Define alternate field names to be used when importing from a file.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Multiple aliases may be separated by spaces or commas. To define an alias that contains spaces, use double-quotes (") around it.
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="Import Aliases"
+                                                                                                  Import 
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
                                                                                                   >
-                                                                                                    Import 
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
+                                                                                                    Aliases
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="Import Aliases"
                                                                                                     >
-                                                                                                      Aliases
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="Import Aliases"
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-importAliases-0-0"
+                                                                                                name="domainpropertiesrow-importAliases"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-importAliases-0-0"
                                                                                                   name="domainpropertiesrow-importAliases"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-importAliases-0-0"
-                                                                                                    name="domainpropertiesrow-importAliases"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                            <Col
-                                                                                              bsClass="col"
-                                                                                              componentClass="div"
-                                                                                              xs={4}
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
+                                                                                          <Col
+                                                                                            bsClass="col"
+                                                                                            componentClass="div"
+                                                                                            xs={4}
+                                                                                          >
+                                                                                            <div
+                                                                                              className="col-xs-4"
                                                                                             >
                                                                                               <div
-                                                                                                className="col-xs-4"
+                                                                                                className="domain-field-label"
                                                                                               >
-                                                                                                <div
-                                                                                                  className="domain-field-label"
-                                                                                                >
-                                                                                                  <Component
-                                                                                                    helpTipBody={
-                                                                                                      <React.Fragment>
-                                                                                                        Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
-                                                                                                        <br />
-                                                                                                        <br />
-                                                                                                        Learn more about using 
-                                                                                                        <a
-                                                                                                          href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
-                                                                                                          target="_blank"
-                                                                                                        >
-                                                                                                          URL Formatting Options
-                                                                                                        </a>
-                                                                                                        .
-                                                                                                      </React.Fragment>
-                                                                                                    }
-                                                                                                    label="URL"
-                                                                                                  >
-                                                                                                    <span
-                                                                                                      className="domain-no-wrap"
-                                                                                                    >
-                                                                                                      URL
-                                                                                                      <Component
-                                                                                                        customStyle={Object {}}
-                                                                                                        id="tooltip"
-                                                                                                        size="1x"
-                                                                                                        title="URL"
+                                                                                                <Component
+                                                                                                  helpTipBody={
+                                                                                                    <React.Fragment>
+                                                                                                      Use this to change the display of the field value within a data grid into a link. Multiple formats are supported, which allows ways to easily substitute and link to other locations in LabKey.
+                                                                                                      <br />
+                                                                                                      <br />
+                                                                                                      Learn more about using 
+                                                                                                      <a
+                                                                                                        href="https://www.labkey.org/Documentation/wiki-page.view?name=urlEncoding"
+                                                                                                        target="_blank"
                                                                                                       >
-                                                                                                        <span
-                                                                                                          className="label-help-target"
-                                                                                                          onMouseOut={[Function]}
-                                                                                                          onMouseOver={[Function]}
-                                                                                                        >
-                                                                                                          <FontAwesomeIcon
-                                                                                                            border={false}
-                                                                                                            className="label-help-icon"
-                                                                                                            fixedWidth={false}
-                                                                                                            flip={null}
-                                                                                                            icon={
-                                                                                                              Object {
-                                                                                                                "icon": Array [
-                                                                                                                  512,
-                                                                                                                  512,
-                                                                                                                  Array [],
-                                                                                                                  "f059",
-                                                                                                                  "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                                                                                ],
-                                                                                                                "iconName": "question-circle",
-                                                                                                                "prefix": "fas",
-                                                                                                              }
+                                                                                                        URL Formatting Options
+                                                                                                      </a>
+                                                                                                      .
+                                                                                                    </React.Fragment>
+                                                                                                  }
+                                                                                                  label="URL"
+                                                                                                >
+                                                                                                  <span
+                                                                                                    className="domain-no-wrap"
+                                                                                                  >
+                                                                                                    URL
+                                                                                                    <Component
+                                                                                                      customStyle={Object {}}
+                                                                                                      id="tooltip"
+                                                                                                      size="1x"
+                                                                                                      title="URL"
+                                                                                                    >
+                                                                                                      <span
+                                                                                                        className="label-help-target"
+                                                                                                        onMouseOut={[Function]}
+                                                                                                        onMouseOver={[Function]}
+                                                                                                      >
+                                                                                                        <FontAwesomeIcon
+                                                                                                          border={false}
+                                                                                                          className="label-help-icon"
+                                                                                                          fixedWidth={false}
+                                                                                                          flip={null}
+                                                                                                          icon={
+                                                                                                            Object {
+                                                                                                              "icon": Array [
+                                                                                                                512,
+                                                                                                                512,
+                                                                                                                Array [],
+                                                                                                                "f059",
+                                                                                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                                                                              ],
+                                                                                                              "iconName": "question-circle",
+                                                                                                              "prefix": "fas",
                                                                                                             }
-                                                                                                            inverse={false}
-                                                                                                            listItem={false}
-                                                                                                            mask={null}
-                                                                                                            pull={null}
-                                                                                                            pulse={false}
-                                                                                                            rotation={null}
-                                                                                                            size="1x"
-                                                                                                            spin={false}
+                                                                                                          }
+                                                                                                          inverse={false}
+                                                                                                          listItem={false}
+                                                                                                          mask={null}
+                                                                                                          pull={null}
+                                                                                                          pulse={false}
+                                                                                                          rotation={null}
+                                                                                                          size="1x"
+                                                                                                          spin={false}
+                                                                                                          style={Object {}}
+                                                                                                          swapOpacity={false}
+                                                                                                          symbol={false}
+                                                                                                          title=""
+                                                                                                          transform={null}
+                                                                                                        >
+                                                                                                          <svg
+                                                                                                            aria-hidden="true"
+                                                                                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                                                                            data-icon="question-circle"
+                                                                                                            data-prefix="fas"
+                                                                                                            focusable="false"
+                                                                                                            role="img"
                                                                                                             style={Object {}}
-                                                                                                            swapOpacity={false}
-                                                                                                            symbol={false}
-                                                                                                            title=""
-                                                                                                            transform={null}
+                                                                                                            viewBox="0 0 512 512"
+                                                                                                            xmlns="http://www.w3.org/2000/svg"
                                                                                                           >
-                                                                                                            <svg
-                                                                                                              aria-hidden="true"
-                                                                                                              className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                                                                              data-icon="question-circle"
-                                                                                                              data-prefix="fas"
-                                                                                                              focusable="false"
-                                                                                                              role="img"
+                                                                                                            <path
+                                                                                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                                                                              fill="currentColor"
                                                                                                               style={Object {}}
-                                                                                                              viewBox="0 0 512 512"
-                                                                                                              xmlns="http://www.w3.org/2000/svg"
-                                                                                                            >
-                                                                                                              <path
-                                                                                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                                                                                fill="currentColor"
-                                                                                                                style={Object {}}
-                                                                                                              />
-                                                                                                            </svg>
-                                                                                                          </FontAwesomeIcon>
+                                                                                                            />
+                                                                                                          </svg>
+                                                                                                        </FontAwesomeIcon>
+                                                                                                        <Overlay
+                                                                                                          animation={[Function]}
+                                                                                                          placement="right"
+                                                                                                          rootClose={false}
+                                                                                                          show={false}
+                                                                                                        >
                                                                                                           <Overlay
-                                                                                                            animation={[Function]}
                                                                                                             placement="right"
                                                                                                             rootClose={false}
                                                                                                             show={false}
-                                                                                                          >
-                                                                                                            <Overlay
-                                                                                                              placement="right"
-                                                                                                              rootClose={false}
-                                                                                                              show={false}
-                                                                                                              transition={[Function]}
-                                                                                                            />
-                                                                                                          </Overlay>
-                                                                                                        </span>
-                                                                                                      </Component>
-                                                                                                    </span>
-                                                                                                  </Component>
-                                                                                                </div>
-                                                                                                <FormControl
-                                                                                                  bsClass="form-control"
-                                                                                                  componentClass="input"
+                                                                                                            transition={[Function]}
+                                                                                                          />
+                                                                                                        </Overlay>
+                                                                                                      </span>
+                                                                                                    </Component>
+                                                                                                  </span>
+                                                                                                </Component>
+                                                                                              </div>
+                                                                                              <FormControl
+                                                                                                bsClass="form-control"
+                                                                                                componentClass="input"
+                                                                                                disabled={false}
+                                                                                                id="domainpropertiesrow-URL-0-0"
+                                                                                                name="domainpropertiesrow-URL"
+                                                                                                onChange={[Function]}
+                                                                                                type="text"
+                                                                                                value=""
+                                                                                              >
+                                                                                                <input
+                                                                                                  className="form-control"
                                                                                                   disabled={false}
                                                                                                   id="domainpropertiesrow-URL-0-0"
                                                                                                   name="domainpropertiesrow-URL"
                                                                                                   onChange={[Function]}
                                                                                                   type="text"
                                                                                                   value=""
-                                                                                                >
-                                                                                                  <input
-                                                                                                    className="form-control"
-                                                                                                    disabled={false}
-                                                                                                    id="domainpropertiesrow-URL-0-0"
-                                                                                                    name="domainpropertiesrow-URL"
-                                                                                                    onChange={[Function]}
-                                                                                                    type="text"
-                                                                                                    value=""
-                                                                                                  />
-                                                                                                </FormControl>
-                                                                                              </div>
-                                                                                            </Col>
-                                                                                          </div>
+                                                                                                />
+                                                                                              </FormControl>
+                                                                                            </div>
+                                                                                          </Col>
                                                                                         </div>
                                                                                       </Row>
                                                                                     </div>

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { NavItem, Tab } from 'react-bootstrap';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { ConceptInformationTabs, ConceptInfoTabs } from './ConceptInformationTabs';
+import { ConceptOverviewPanelImpl } from './ConceptOverviewPanel';
+import { ConceptModel } from './models';
+
+const DEFAULT_PROPS = {
+    concept: undefined,
+};
+
+describe('ConceptInformationTabs', () => {
+    function validate(wrapper: ReactWrapper) {
+        expect(wrapper.find(Tab.Container)).toHaveLength(1);
+        expect(wrapper.find(NavItem)).toHaveLength(2);
+        expect(wrapper.find('.ontology-concept-overview-container')).toHaveLength(2);
+        expect(wrapper.find(ConceptOverviewPanelImpl)).toHaveLength(1);
+        expect(wrapper.find('.ontology-concept-pathinfo-container')).toHaveLength(2);
+        expect(wrapper.find('.placeholder')).toHaveLength(1);
+    }
+
+    test('no concept', () => {
+        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        expect(wrapper.find(ConceptOverviewPanelImpl).prop('concept')).toBe(undefined);
+        wrapper.unmount();
+    });
+
+    test('with concept', () => {
+        const concept = new ConceptModel({ code: 'a', label: 'b' });
+        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} concept={concept} />);
+        validate(wrapper);
+        expect(wrapper.find(ConceptOverviewPanelImpl).prop('concept')).toBe(concept);
+        wrapper.unmount();
+    });
+
+    test('activeTab and defaultActiveKey', () => {
+        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        expect(wrapper.find(Tab.Container).prop('defaultActiveKey')).toBe(ConceptInfoTabs.CONCEPT_OVERVIEW_TAB);
+        expect(wrapper.find(Tab.Container).prop('activeKey')).toBe(ConceptInfoTabs.CONCEPT_OVERVIEW_TAB);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
@@ -8,7 +8,7 @@ interface ConceptInformationTabsProps {
     concept?: ConceptModel;
 }
 
-const enum ConceptInfoTabs {
+export const enum ConceptInfoTabs {
     CONCEPT_OVERVIEW_TAB = 'overview',
     PATH_INFO_TAB = 'pathinfo',
 }
@@ -26,41 +26,37 @@ export const ConceptInformationTabs: FC<ConceptInformationTabsProps> = memo(prop
     );
 
     return (
-        <>
-            <div>
-                <Tab.Container
-                    id="concept-information-tabs"
-                    className="concept-information-tabs"
-                    onSelect={onSelectionChange}
-                    activeKey={activeTab}
-                    defaultActiveKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
-                >
-                    <Row className="clearfix">
-                        <Col>
-                            <Nav bsStyle="tabs">
-                                <NavItem eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}>Overview</NavItem>
-                                <NavItem eventKey={ConceptInfoTabs.PATH_INFO_TAB}>Path Information</NavItem>
-                            </Nav>
-                        </Col>
-                        <Col>
-                            <Tab.Content animation>
-                                <Tab.Pane
-                                    className="ontology-concept-overview-container"
-                                    eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
-                                >
-                                    <ConceptOverviewPanelImpl concept={concept} />
-                                </Tab.Pane>
-                                <Tab.Pane
-                                    className="ontology-concept-pathinfo-container"
-                                    eventKey={ConceptInfoTabs.PATH_INFO_TAB}
-                                >
-                                    <div className="placeholder">Coming soon...</div>
-                                </Tab.Pane>
-                            </Tab.Content>
-                        </Col>
-                    </Row>
-                </Tab.Container>
-            </div>
-        </>
+        <Tab.Container
+            id="concept-information-tabs"
+            className="concept-information-tabs"
+            onSelect={onSelectionChange}
+            activeKey={activeTab}
+            defaultActiveKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
+        >
+            <Row className="clearfix">
+                <Col>
+                    <Nav bsStyle="tabs">
+                        <NavItem eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}>Overview</NavItem>
+                        <NavItem eventKey={ConceptInfoTabs.PATH_INFO_TAB}>Path Information</NavItem>
+                    </Nav>
+                </Col>
+                <Col>
+                    <Tab.Content animation>
+                        <Tab.Pane
+                            className="ontology-concept-overview-container"
+                            eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
+                        >
+                            <ConceptOverviewPanelImpl concept={concept} />
+                        </Tab.Pane>
+                        <Tab.Pane
+                            className="ontology-concept-pathinfo-container"
+                            eventKey={ConceptInfoTabs.PATH_INFO_TAB}
+                        >
+                            <div className="placeholder">Coming soon...</div>
+                        </Tab.Pane>
+                    </Tab.Content>
+                </Col>
+            </Row>
+        </Tab.Container>
     );
 });

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
@@ -2,7 +2,7 @@ import React, { FC, memo, SyntheticEvent, useCallback, useState } from 'react';
 import { Col, Nav, NavItem, Row, Tab, TabContainer } from 'react-bootstrap';
 
 import { ConceptModel } from './models';
-import { ConceptOverviewPanel } from './ConceptOverviewPanel';
+import { ConceptOverviewPanelImpl } from './ConceptOverviewPanel';
 
 interface ConceptInformationTabsProps {
     concept?: ConceptModel;
@@ -48,7 +48,7 @@ export const ConceptInformationTabs: FC<ConceptInformationTabsProps> = memo(prop
                                     className="ontology-concept-overview-container"
                                     eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
                                 >
-                                    <ConceptOverviewPanel concept={concept} />
+                                    <ConceptOverviewPanelImpl concept={concept} />
                                 </Tab.Pane>
                                 <Tab.Pane
                                     className="ontology-concept-pathinfo-container"

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
@@ -2,6 +2,7 @@ import React, { FC, memo, SyntheticEvent, useCallback, useState } from 'react';
 import { Col, Nav, NavItem, Row, Tab, TabContainer } from 'react-bootstrap';
 
 import { ConceptModel } from './models';
+import { ConceptOverviewPanel } from './ConceptOverviewPanel';
 
 interface ConceptInformationTabsProps {
     concept?: ConceptModel;
@@ -60,30 +61,6 @@ export const ConceptInformationTabs: FC<ConceptInformationTabsProps> = memo(prop
                     </Row>
                 </Tab.Container>
             </div>
-        </>
-    );
-});
-
-// Read-only element displaying the concept's details
-const ConceptOverviewPanel: FC<{ concept: ConceptModel }> = memo(props => {
-    const { concept } = props;
-
-    if (!concept) {
-        return <div className="none-selected">No concept selected</div>;
-    }
-
-    const { code, label, description } = concept;
-
-    return (
-        <>
-            {label && <div className="title margin-bottom">{label}</div>}
-            {code && <span className="code">{code}</span>}
-            {description && (
-                <div>
-                    <div className="description-title">Description</div>
-                    <p className="description-text">{description}</p>
-                </div>
-            )}
         </>
     );
 });

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { Alert } from '../../..';
+
+import { ConceptOverviewModal, ConceptOverviewPanelImpl, OntologyConceptOverviewPanel } from './ConceptOverviewPanel';
+import { ConceptModel } from './models';
+
+const TEST_CONCEPT = new ConceptModel({ code: 'a', label: 'b', description: 'c' });
+
+describe('OntologyConceptOverviewPanel', () => {
+    test('without code prop', () => {
+        const wrapper = mount(<OntologyConceptOverviewPanel code={undefined} />);
+        expect(wrapper.find(Alert)).toHaveLength(1);
+        expect(wrapper.find(Alert).text()).toBe('');
+        expect(wrapper.find(ConceptOverviewPanelImpl)).toHaveLength(0);
+        wrapper.unmount();
+    });
+});
+
+describe('ConceptOverviewPanelImpl', () => {
+    function validate(wrapper: ReactWrapper, isEmpty: boolean, divCount = 1): void {
+        expect(wrapper.find('.none-selected')).toHaveLength(isEmpty ? 1 : 0);
+        expect(wrapper.find('div')).toHaveLength(divCount);
+    }
+
+    test('no concept', () => {
+        const wrapper = mount(<ConceptOverviewPanelImpl concept={undefined} />);
+        validate(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('with concept', () => {
+        const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT} />);
+        validate(wrapper, false, 3);
+        expect(wrapper.find('.title').text()).toBe(TEST_CONCEPT.label);
+        expect(wrapper.find('.code').text()).toBe(TEST_CONCEPT.code);
+        expect(wrapper.find('.description-title').text()).toBe('Description');
+        expect(wrapper.find('.description-text').text()).toBe(TEST_CONCEPT.description);
+        wrapper.unmount();
+    });
+});
+
+describe('ConceptOverviewModal', () => {
+    const onCloseFn = jest.fn;
+
+    function validate(wrapper: ReactWrapper, errorTxt?: string): void {
+        expect(wrapper.find(Modal)).toHaveLength(1);
+        expect(wrapper.find(Modal).prop('onHide')).toBe(onCloseFn);
+        expect(wrapper.find(Modal.Header).prop('closeButton')).toBe(true);
+        expect(wrapper.find(Alert)).toHaveLength(1);
+        expect(wrapper.find(Alert).text()).toBe(errorTxt ?? '');
+        expect(wrapper.find('.ontology-concept-overview-container')).toHaveLength(!errorTxt ? 1 : 0);
+        expect(wrapper.find(ConceptOverviewPanelImpl)).toHaveLength(!errorTxt ? 1 : 0);
+    }
+
+    test('no concept', () => {
+        const wrapper = mount(<ConceptOverviewModal concept={undefined} onClose={onCloseFn} />);
+        validate(wrapper);
+        expect(wrapper.find(ConceptOverviewPanelImpl).prop('concept')).toBe(undefined);
+        wrapper.unmount();
+    });
+
+    test('with concept', () => {
+        const wrapper = mount(<ConceptOverviewModal concept={TEST_CONCEPT} onClose={onCloseFn} />);
+        validate(wrapper);
+        expect(wrapper.find(ConceptOverviewPanelImpl).prop('concept')).toBe(TEST_CONCEPT);
+        wrapper.unmount();
+    });
+
+    test('error', () => {
+        const wrapper = mount(<ConceptOverviewModal error={'test error'} concept={TEST_CONCEPT} onClose={onCloseFn} />);
+        validate(wrapper, 'test error');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
@@ -70,7 +70,7 @@ describe('ConceptOverviewModal', () => {
     });
 
     test('error', () => {
-        const wrapper = mount(<ConceptOverviewModal error={'test error'} concept={TEST_CONCEPT} onClose={onCloseFn} />);
+        const wrapper = mount(<ConceptOverviewModal error="test error" concept={TEST_CONCEPT} onClose={onCloseFn} />);
         validate(wrapper, 'test error');
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -19,10 +19,8 @@ export const OntologyConceptOverviewPanel: FC<ConceptOverviewPanelProps> = memo(
         if (code) {
             fetchConceptForCode(code)
                 .then(setConcept)
-                .catch(reason => {
-                    setError(
-                        'Error: unable to get concept information for ' + code + '. '
-                    );
+                .catch(() => {
+                    setError('Error: unable to get concept information for ' + code + '. ');
                 });
         }
     }, [code, setConcept, setError]);
@@ -30,7 +28,7 @@ export const OntologyConceptOverviewPanel: FC<ConceptOverviewPanelProps> = memo(
     return (
         <>
             <Alert>{error}</Alert>
-            {concept && <ConceptOverviewPanelImpl concept={concept}/>}
+            {concept && <ConceptOverviewPanelImpl concept={concept} />}
         </>
     );
 });

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -7,10 +7,39 @@ import { ConceptModel } from './models';
 import { fetchConceptForCode } from './actions';
 
 interface ConceptOverviewPanelProps {
+    code: string;
+}
+
+export const OntologyConceptOverviewPanel: FC<ConceptOverviewPanelProps> = memo(props => {
+    const { code } = props;
+    const [error, setError] = useState<string>();
+    const [concept, setConcept] = useState<ConceptModel>();
+
+    useEffect(() => {
+        if (code) {
+            fetchConceptForCode(code)
+                .then(setConcept)
+                .catch(reason => {
+                    setError(
+                        'Error: unable to get concept information for ' + code + '. '
+                    );
+                });
+        }
+    }, [code, setConcept, setError]);
+
+    return (
+        <>
+            <Alert>{error}</Alert>
+            {concept && <ConceptOverviewPanelImpl concept={concept}/>}
+        </>
+    );
+});
+
+interface ConceptOverviewPanelImplProps {
     concept: ConceptModel;
 }
 
-export const ConceptOverviewPanel: FC<ConceptOverviewPanelProps> = memo(props => {
+export const ConceptOverviewPanelImpl: FC<ConceptOverviewPanelImplProps> = memo(props => {
     const { concept } = props;
 
     if (!concept) {
@@ -51,7 +80,7 @@ export const ConceptOverviewModal: FC<ConceptOverviewModalProps> = memo(props =>
                 <Alert>{error}</Alert>
                 {!error && (
                     <div className="ontology-concept-overview-container">
-                        <ConceptOverviewPanel concept={concept} />
+                        <ConceptOverviewPanelImpl concept={concept} />
                     </div>
                 )}
             </Modal.Body>

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -1,0 +1,67 @@
+import React, { FC, memo, useEffect, useState } from 'react';
+import { Modal } from 'react-bootstrap';
+
+import { Alert } from '../../..';
+
+import { ConceptModel } from './models';
+import { fetchConceptForCode } from './actions';
+
+interface ConceptOverviewPanelProps {
+    concept: ConceptModel;
+}
+
+export const ConceptOverviewPanel: FC<ConceptOverviewPanelProps> = memo(props => {
+    const { concept } = props;
+
+    if (!concept) {
+        return <div className="none-selected">No concept selected</div>;
+    }
+
+    const { code, label, description } = concept;
+
+    return (
+        <>
+            {label && <div className="title margin-bottom">{label}</div>}
+            {code && <span className="code">{code}</span>}
+            {description && (
+                <div>
+                    <div className="description-title">Description</div>
+                    <p className="description-text">{description}</p>
+                </div>
+            )}
+        </>
+    );
+});
+
+interface ConceptOverviewModalProps {
+    code: string;
+    onClose: () => void;
+}
+
+export const ConceptOverviewModal: FC<ConceptOverviewModalProps> = memo(props => {
+    const { onClose, code } = props;
+    const [error, setError] = useState<string>();
+    const [concept, setConcept] = useState<ConceptModel>();
+
+    useEffect(() => {
+        fetchConceptForCode(code)
+            .then(setConcept)
+            .catch(reason => {
+                setError('Error: unable to get concept information for ' + code + '. ' + reason?.exception);
+            });
+    }, [code, setConcept, setError]);
+
+    return (
+        <Modal show={true} onHide={onClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>Concept Overview</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Alert>{error}</Alert>
+                <div className="ontology-concept-overview-container">
+                    <ConceptOverviewPanel concept={concept} />
+                </div>
+            </Modal.Body>
+        </Modal>
+    );
+});

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -10,6 +10,10 @@ interface ConceptOverviewPanelProps {
     code: string;
 }
 
+/**
+ * An ontology concept overview panel that takes in a concept code as a prop and will load the concept details
+ * to show in the ConceptOverviewPanelImpl.
+ */
 export const OntologyConceptOverviewPanel: FC<ConceptOverviewPanelProps> = memo(props => {
     const { code } = props;
     const [error, setError] = useState<string>();
@@ -37,6 +41,10 @@ interface ConceptOverviewPanelImplProps {
     concept: ConceptModel;
 }
 
+/**
+ * The ontology concept overview display panel that takes in the concept prop (i.e. ConceptModel) and displays
+ * the information about the concept label, code, description, etc.
+ */
 export const ConceptOverviewPanelImpl: FC<ConceptOverviewPanelImplProps> = memo(props => {
     const { concept } = props;
 
@@ -66,6 +74,10 @@ interface ConceptOverviewModalProps {
     onClose: () => void;
 }
 
+/**
+ * A modal dialog version that will display the same concept overview display panel from ConceptOverviewPanelImpl
+ * but in a modal dialog. This component takes in the concept (i.e. ConceptModel) as a prop.
+ */
 export const ConceptOverviewModal: FC<ConceptOverviewModalProps> = memo(props => {
     const { onClose, concept, error } = props;
 

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -34,22 +34,13 @@ export const ConceptOverviewPanel: FC<ConceptOverviewPanelProps> = memo(props =>
 });
 
 interface ConceptOverviewModalProps {
-    code: string;
+    concept: ConceptModel;
+    error?: string;
     onClose: () => void;
 }
 
 export const ConceptOverviewModal: FC<ConceptOverviewModalProps> = memo(props => {
-    const { onClose, code } = props;
-    const [error, setError] = useState<string>();
-    const [concept, setConcept] = useState<ConceptModel>();
-
-    useEffect(() => {
-        fetchConceptForCode(code)
-            .then(setConcept)
-            .catch(reason => {
-                setError('Error: unable to get concept information for ' + code + '. ' + reason?.exception);
-            });
-    }, [code, setConcept, setError]);
+    const { onClose, concept, error } = props;
 
     return (
         <Modal show={true} onHide={onClose}>
@@ -58,9 +49,11 @@ export const ConceptOverviewModal: FC<ConceptOverviewModalProps> = memo(props =>
             </Modal.Header>
             <Modal.Body>
                 <Alert>{error}</Alert>
-                <div className="ontology-concept-overview-container">
-                    <ConceptOverviewPanel concept={concept} />
-                </div>
+                {!error && (
+                    <div className="ontology-concept-overview-container">
+                        <ConceptOverviewPanel concept={concept} />
+                    </div>
+                )}
             </Modal.Body>
         </Modal>
     );

--- a/packages/components/src/internal/components/ontology/OntologyBrowserModal.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserModal.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+import { mount, ReactWrapper, shallow } from 'enzyme';
+
+import { OntologyBrowserModal } from './OntologyBrowserModal';
+import { OntologyBrowserPanel } from './OntologyBrowserPanel';
+
+const onCancel = jest.fn;
+
+const DEFAULT_PROPS = {
+    title: 'Test title',
+    onCancel,
+    onApply: jest.fn,
+};
+
+describe('OntologyBrowserModal', () => {
+    function validate(wrapper: ReactWrapper): void {
+        expect(wrapper.find(Modal).prop('bsSize')).toBe('large');
+        expect(wrapper.find(Modal).prop('onHide')).toBe(onCancel);
+        expect(wrapper.find(Modal.Header).prop('closeButton')).toBe(true);
+        expect(wrapper.find(Modal.Title).text()).toBe(DEFAULT_PROPS.title);
+        expect(wrapper.find(OntologyBrowserPanel)).toHaveLength(1);
+        expect(wrapper.find(Button)).toHaveLength(2);
+    }
+
+    test('default props', () => {
+        const wrapper = mount(<OntologyBrowserModal {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        expect(wrapper.find(Button).last().prop('bsStyle')).toBe('success');
+        wrapper.unmount();
+    });
+
+    test('OntologyBrowserPanel props', () => {
+        const wrapper = shallow(<OntologyBrowserModal {...DEFAULT_PROPS} initOntologyId="testOntId" />);
+        const panel = wrapper.find(OntologyBrowserPanel);
+        expect(panel.prop('asPanel')).toBe(false);
+        expect(panel.prop('initOntologyId')).toBe('testOntId');
+        wrapper.unmount();
+    });
+
+    test('apply button props', () => {
+        const wrapper = shallow(<OntologyBrowserModal {...DEFAULT_PROPS} successBsStyle="primary" />);
+        const applyBtn = wrapper.find(Button).last();
+        expect(applyBtn.prop('disabled')).toBe(true);
+        expect(applyBtn.prop('bsStyle')).toBe('primary');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/ontology/OntologyBrowserModal.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserModal.tsx
@@ -1,0 +1,61 @@
+import React, { FC, memo, useCallback, useState } from 'react';
+import { Button, Modal } from 'react-bootstrap';
+
+import { OntologyBrowserPanel } from './OntologyBrowserPanel';
+import { ConceptModel } from './models';
+
+interface OntologyBrowserModalProps {
+    title: string;
+    initOntologyId?: string;
+    successBsStyle?: string;
+    onCancel: () => void;
+    onApply: (concept: ConceptModel) => void;
+}
+
+export const OntologyBrowserModal: FC<OntologyBrowserModalProps> = memo(props => {
+    const { title, initOntologyId, successBsStyle, onCancel, onApply } = props;
+    const [selectedConcept, setSelectedConcept] = useState<ConceptModel>();
+
+    const onApplyClick = useCallback(() => {
+        onApply(selectedConcept);
+    }, [onApply, selectedConcept]);
+
+    const onConceptSelect = useCallback(
+        (concept: ConceptModel) => {
+            setSelectedConcept(concept);
+        },
+        [setSelectedConcept]
+    );
+
+    return (
+        <Modal bsSize="large" show={true} onHide={onCancel}>
+            <Modal.Header closeButton>
+                <Modal.Title>{title}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <OntologyBrowserPanel
+                    asPanel={false}
+                    initOntologyId={initOntologyId}
+                    onConceptSelect={onConceptSelect}
+                />
+            </Modal.Body>
+            <Modal.Footer>
+                <Button onClick={onCancel} className="domain-adv-footer domain-adv-cancel-btn">
+                    Cancel
+                </Button>
+                <Button
+                    className="domain-adv-footer domain-adv-apply-btn pull-right"
+                    disabled={!selectedConcept}
+                    onClick={onApplyClick}
+                    bsStyle={successBsStyle}
+                >
+                    Apply
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+});
+
+OntologyBrowserModal.defaultProps = {
+    successBsStyle: 'success',
+};

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
@@ -46,7 +46,12 @@ const DEFAULT_PROPS = {
     asPanel: false,
 };
 
-const TEST_ONTOLOGY = new OntologyModel({ abbreviation: 't', name: 'test name', conceptCount: 100, description: 'test desc' });
+const TEST_ONTOLOGY = new OntologyModel({
+    abbreviation: 't',
+    name: 'test name',
+    conceptCount: 100,
+    description: 'test desc',
+});
 const TEST_CONCEPT = new ConceptModel({ code: 'a', label: 'b' });
 
 describe('OntologyBrowserPanelImpl', () => {
@@ -78,7 +83,9 @@ describe('OntologyBrowserPanelImpl', () => {
     });
 
     test('selectedConcept', () => {
-        const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} selectedConcept={TEST_CONCEPT} />);
+        const wrapper = mount(
+            <OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} selectedConcept={TEST_CONCEPT} />
+        );
         validate(wrapper, false);
         expect(wrapper.find(ConceptInformationTabs).prop('concept')).toBe(TEST_CONCEPT);
         wrapper.unmount();

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
@@ -1,24 +1,93 @@
-/** Tests describing the OntologyBrowser **/
-
-import { mount } from 'enzyme';
 import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
 
-import { initUnitTestMocks } from '../../testHelperMocks';
-import { LoadingSpinner } from '../base/LoadingSpinner';
+import { Alert, LoadingSpinner } from '../../..';
 
-import { OntologyBrowserPanel } from './OntologyBrowserPanel';
-
-//TODO Lots todo...
-
-beforeAll(() => {
-    initUnitTestMocks();
-});
+import { OntologyBrowserPanel, OntologyBrowserPanelImpl } from './OntologyBrowserPanel';
+import { OntologySelectionPanel } from './OntologySelectionPanel';
+import { OntologyTreePanel } from './OntologyTreePanel';
+import { ConceptInformationTabs } from './ConceptInformationTabs';
+import { ConceptModel, OntologyModel } from './models';
 
 describe('OntologyBrowserPanel', () => {
-    test('Ontology id not provided', () => {
-        const component = mount(<OntologyBrowserPanel />);
+    function validate(wrapper: ReactWrapper, hasOntologyId: boolean): void {
+        expect(wrapper.find(Alert)).toHaveLength(hasOntologyId ? 1 : 2);
+        expect(wrapper.find(Alert).first().text()).toBe('');
+        expect(wrapper.find(OntologySelectionPanel)).toHaveLength(!hasOntologyId ? 1 : 0);
+        expect(wrapper.find(OntologyBrowserPanelImpl)).toHaveLength(hasOntologyId ? 1 : 0);
+    }
 
-        expect(component.find(LoadingSpinner)).toHaveLength(1);
-        component.unmount();
+    test('no initOntologyId', () => {
+        const wrapper = mount(<OntologyBrowserPanel />);
+        validate(wrapper, false);
+        expect(wrapper.find(OntologySelectionPanel).prop('asPanel')).toBeTruthy();
+        wrapper.unmount();
+    });
+
+    test('with initOntologyId', () => {
+        const wrapper = mount(<OntologyBrowserPanel initOntologyId="testOntId" />);
+        validate(wrapper, true);
+        expect(wrapper.find(OntologyBrowserPanelImpl).prop('asPanel')).toBeTruthy();
+        wrapper.unmount();
+    });
+
+    test('asPanel false', () => {
+        const wrapper = mount(<OntologyBrowserPanel asPanel={false} />);
+        validate(wrapper, false);
+        expect(wrapper.find(OntologySelectionPanel).prop('asPanel')).toBeFalsy();
+        wrapper.unmount();
+    });
+});
+
+const DEFAULT_PROPS = {
+    ontology: undefined,
+    selectedConcept: undefined,
+    setSelectedConcept: jest.fn,
+    asPanel: false,
+};
+
+const TEST_ONTOLOGY = new OntologyModel({ abbreviation: 't', name: 'test name', conceptCount: 100, description: 'test desc' });
+const TEST_CONCEPT = new ConceptModel({ code: 'a', label: 'b' });
+
+describe('OntologyBrowserPanelImpl', () => {
+    function validate(wrapper: ReactWrapper, loading: boolean, asPanel = false): void {
+        expect(wrapper.find('.ontology-browser-container')).toHaveLength(!loading ? 1 : 0);
+        expect(wrapper.find('.ontology-description')).toHaveLength(!loading ? 1 : 0);
+        expect(wrapper.find('.ontology-concept-count')).toHaveLength(!loading ? 1 : 0);
+        expect(wrapper.find('.left-panel')).toHaveLength(!loading ? 2 : 0);
+        expect(wrapper.find('.right-panel')).toHaveLength(!loading ? 2 : 0);
+        expect(wrapper.find(OntologyTreePanel)).toHaveLength(!loading ? 1 : 0);
+        expect(wrapper.find(ConceptInformationTabs)).toHaveLength(!loading ? 1 : 0);
+        expect(wrapper.find('.panel-body')).toHaveLength(asPanel ? 1 : 0);
+    }
+
+    test('loading', () => {
+        const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} />);
+        validate(wrapper, true);
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    test('ontology', () => {
+        const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} />);
+        validate(wrapper, false);
+        expect(wrapper.find('.ontology-description').text()).toBe(TEST_ONTOLOGY.description);
+        expect(wrapper.find('.ontology-concept-count').text()).toBe(TEST_ONTOLOGY.conceptCount + ' total concepts');
+        expect(wrapper.find(OntologyTreePanel).prop('root').label).toBe(TEST_ONTOLOGY.name);
+        wrapper.unmount();
+    });
+
+    test('selectedConcept', () => {
+        const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} selectedConcept={TEST_CONCEPT} />);
+        validate(wrapper, false);
+        expect(wrapper.find(ConceptInformationTabs).prop('concept')).toBe(TEST_CONCEPT);
+        wrapper.unmount();
+    });
+
+    test('asPanel', () => {
+        const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} asPanel={true} />);
+        validate(wrapper, false, true);
+        expect(wrapper.find('.panel-heading').text()).toBe('Browse test name (t)');
+        wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
@@ -12,10 +12,11 @@ import { OntologySelectionPanel } from './OntologySelectionPanel';
 export interface OntologyBrowserProps {
     initOntologyId?: string;
     asPanel?: boolean;
+    onConceptSelect?: (concept: ConceptModel) => void;
 }
 
 export const OntologyBrowserPanel: FC<OntologyBrowserProps> = memo(props => {
-    const { initOntologyId, asPanel } = props;
+    const { initOntologyId, asPanel, onConceptSelect } = props;
     const [error, setError] = useState<string>();
     const [selectedOntologyId, setSelectedOntologyId] = useState<string>();
     const [ontology, setOntologyModel] = useState<OntologyModel>();
@@ -44,7 +45,7 @@ export const OntologyBrowserPanel: FC<OntologyBrowserProps> = memo(props => {
             }
             setSelectedCode(selectedCode);
         },
-        [setSelectedConcept, conceptCache]
+        [setSelectedCode, conceptCache]
     );
 
     const onOntologySelection = useCallback(
@@ -58,7 +59,7 @@ export const OntologyBrowserPanel: FC<OntologyBrowserProps> = memo(props => {
         if (ontologyId) {
             getOntologyDetails(ontologyId)
                 .then(setOntologyModel)
-                .catch(reason => {
+                .catch(() => {
                     setError('Error: unable to load ontology concept information for ' + ontologyId + '.');
                     setSelectedOntologyId(undefined);
                 });
@@ -68,15 +69,15 @@ export const OntologyBrowserPanel: FC<OntologyBrowserProps> = memo(props => {
     }, [setOntologyModel, selectedOntologyId, setSelectedOntologyId, setError]);
 
     useEffect(() => {
-        setSelectedConcept(conceptCache.get(selectedConceptCode));
-    }, [selectedConceptCode, conceptCache, setSelectedConcept]);
+        const concept = conceptCache.get(selectedConceptCode);
+        setSelectedConcept(concept);
+        onConceptSelect?.(concept);
+    }, [selectedConceptCode, conceptCache, setSelectedConcept, onConceptSelect]);
 
     return (
         <>
             <Alert>{error}</Alert>
-            {!ontologyId && (
-                <OntologySelectionPanel onOntologySelection={onOntologySelection} asPanel={asPanel} />
-            )}
+            {!ontologyId && <OntologySelectionPanel onOntologySelection={onOntologySelection} asPanel={asPanel} />}
             {ontologyId && (
                 <OntologyBrowserPanelImpl
                     ontology={ontology}
@@ -126,7 +127,7 @@ const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(props =
     );
 
     if (!asPanel) {
-        return body;
+        return <div className="ontology-browser-container">{body}</div>;
     }
 
     return (

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
@@ -101,7 +101,8 @@ interface OntologyBrowserPanelImplProps {
     asPanel: boolean;
 }
 
-const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(props => {
+// exported for jest testing
+export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(props => {
     const { ontology, selectedConcept, setSelectedConcept, asPanel } = props;
 
     if (!ontology) {
@@ -113,10 +114,10 @@ const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(props =
 
     const body = (
         <>
-            {description && <p>{description}</p>}
+            {description && <p className="ontology-description">{description}</p>}
             <Row>
                 <Col xs={6} className="left-panel">
-                    <p>{conceptCount} total concepts</p>
+                    <p className="ontology-concept-count">{conceptCount} total concepts</p>
                     <OntologyTreePanel root={root} onNodeSelection={setSelectedConcept} />
                 </Col>
                 <Col xs={6} className="right-panel">

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.spec.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { DomainField, DomainFieldLabel } from '../../..';
+
+import { ConceptModel } from './models';
+import { DOMAIN_FIELD_FULLY_LOCKED } from '../domainproperties/constants';
+import { OntologyConceptAnnotationImpl } from './OntologyConceptAnnotation';
+import { OntologyBrowserModal } from './OntologyBrowserModal';
+import { ConceptOverviewModal } from './ConceptOverviewPanel';
+
+const DEFAULT_PROPS = {
+    id: 'testId',
+    field: new DomainField(),
+    onChange: jest.fn,
+    successBsStyle: 'success',
+    error: undefined,
+    concept: undefined,
+};
+
+const TEST_FIELD = new DomainField({ principalConceptCode: 'code:123', sourceOntology: 'ontSource' });
+const TEST_CONCEPT = new ConceptModel({ code: 'a', label: 'b' });
+
+describe('OntologyConceptAnnotation', () => {
+    function validate(wrapper: ReactWrapper, hasCode: boolean, canRemove = true): void {
+        expect(wrapper.find(DomainFieldLabel)).toHaveLength(1);
+        expect(wrapper.find('.domain-annotation-table')).toHaveLength(1);
+        expect(wrapper.find('.domain-validation-button')).toHaveLength(2);
+        expect(getSelectButton(wrapper).text()).toBe('Select Concept');
+        expect(wrapper.find('.domain-text-label')).toHaveLength(!hasCode ? 1 : 0);
+        expect(wrapper.find('.content')).toHaveLength(hasCode && canRemove ? 2 : 1);
+        expect(wrapper.find('.domain-annotation-item')).toHaveLength(hasCode ? 1 : 0);
+    }
+
+    function getSelectButton(wrapper: ReactWrapper): ReactWrapper {
+        return wrapper.find('.domain-validation-button').first();
+    }
+
+    test('no concept', () => {
+        const wrapper = mount(<OntologyConceptAnnotationImpl {...DEFAULT_PROPS} />);
+        validate(wrapper, false);
+        expect(wrapper.find('.domain-text-label').text()).toBe('None Set');
+        wrapper.unmount();
+    });
+
+    test('principalConceptCode, no concept', () => {
+        const wrapper = mount(<OntologyConceptAnnotationImpl {...DEFAULT_PROPS} field={TEST_FIELD} />);
+        validate(wrapper, true);
+        expect(wrapper.find('.domain-annotation-item').text()).toBe(TEST_FIELD.principalConceptCode);
+        expect(wrapper.find('.fa-remove')).toHaveLength(1);
+        expect(getSelectButton(wrapper).prop('disabled')).toBeFalsy();
+        wrapper.unmount();
+    });
+
+    test('principalConceptCode, with concept', () => {
+        const wrapper = mount(<OntologyConceptAnnotationImpl {...DEFAULT_PROPS} field={TEST_FIELD} concept={TEST_CONCEPT} />);
+        validate(wrapper, true);
+        expect(wrapper.find('.domain-annotation-item').text()).toBe(TEST_CONCEPT.getDisplayLabel());
+        expect(wrapper.find('.fa-remove')).toHaveLength(1);
+        expect(getSelectButton(wrapper).prop('disabled')).toBeFalsy();
+        wrapper.unmount();
+    });
+
+    test('isFieldLocked and select button props', () => {
+        const field = TEST_FIELD.merge({ lockType: DOMAIN_FIELD_FULLY_LOCKED }) as DomainField;
+        const wrapper = mount(<OntologyConceptAnnotationImpl {...DEFAULT_PROPS} field={field} />);
+        validate(wrapper, true, false);
+        expect(wrapper.find('.fa-remove')).toHaveLength(0);
+        expect(getSelectButton(wrapper).prop('disabled')).toBeTruthy();
+        expect(getSelectButton(wrapper).prop('id')).toBe(DEFAULT_PROPS.id);
+        expect(getSelectButton(wrapper).prop('name')).toBe('domainpropertiesrow-principalConceptCode');
+        wrapper.unmount();
+    });
+
+    test('showSelectModal', () => {
+        const wrapper = mount(<OntologyConceptAnnotationImpl {...DEFAULT_PROPS} field={TEST_FIELD} />);
+        validate(wrapper, true);
+        expect(wrapper.find(OntologyBrowserModal)).toHaveLength(0);
+        getSelectButton(wrapper).simulate('click');
+        expect(wrapper.find(OntologyBrowserModal)).toHaveLength(1);
+        expect(wrapper.find(OntologyBrowserModal).prop('title')).toBe('Select Concept');
+        expect(wrapper.find(OntologyBrowserModal).prop('initOntologyId')).toBe(TEST_FIELD.sourceOntology);
+        expect(wrapper.find(OntologyBrowserModal).prop('successBsStyle')).toBe(DEFAULT_PROPS.successBsStyle);
+        wrapper.unmount();
+    });
+
+    test('showConceptModal', () => {
+        const wrapper = mount(
+            <OntologyConceptAnnotationImpl
+                {...DEFAULT_PROPS}
+                field={TEST_FIELD}
+                concept={TEST_CONCEPT}
+                error={'test error'}
+            />
+        );
+        validate(wrapper, true);
+        expect(wrapper.find(ConceptOverviewModal)).toHaveLength(0);
+        wrapper.find('.domain-annotation-item').simulate('click');
+        expect(wrapper.find(ConceptOverviewModal)).toHaveLength(1);
+        expect(wrapper.find(ConceptOverviewModal).prop('concept')).toBe(TEST_CONCEPT);
+        expect(wrapper.find(ConceptOverviewModal).prop('error')).toBe('test error');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.spec.tsx
@@ -3,8 +3,9 @@ import { mount, ReactWrapper } from 'enzyme';
 
 import { DomainField, DomainFieldLabel } from '../../..';
 
-import { ConceptModel } from './models';
 import { DOMAIN_FIELD_FULLY_LOCKED } from '../domainproperties/constants';
+
+import { ConceptModel } from './models';
 import { OntologyConceptAnnotationImpl } from './OntologyConceptAnnotation';
 import { OntologyBrowserModal } from './OntologyBrowserModal';
 import { ConceptOverviewModal } from './ConceptOverviewPanel';
@@ -53,7 +54,9 @@ describe('OntologyConceptAnnotation', () => {
     });
 
     test('principalConceptCode, with concept', () => {
-        const wrapper = mount(<OntologyConceptAnnotationImpl {...DEFAULT_PROPS} field={TEST_FIELD} concept={TEST_CONCEPT} />);
+        const wrapper = mount(
+            <OntologyConceptAnnotationImpl {...DEFAULT_PROPS} field={TEST_FIELD} concept={TEST_CONCEPT} />
+        );
         validate(wrapper, true);
         expect(wrapper.find('.domain-annotation-item').text()).toBe(TEST_CONCEPT.getDisplayLabel());
         expect(wrapper.find('.fa-remove')).toHaveLength(1);
@@ -90,7 +93,7 @@ describe('OntologyConceptAnnotation', () => {
                 {...DEFAULT_PROPS}
                 field={TEST_FIELD}
                 concept={TEST_CONCEPT}
-                error={'test error'}
+                error="test error"
             />
         );
         validate(wrapper, true);

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -127,6 +127,7 @@ function getOntologyConceptAnnotationHelpTipBody(): ReactNode {
             {/* TODO anything else to add?*/}
             <br />
             <br />
+            {/*TODO update link topic once annotation case is added to docs page*/}
             Learn more about {helpLinkNode(ONTOLOGY_TOPIC, 'ontology integration')} in LabKey.
         </>
     );

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -1,17 +1,18 @@
 import React, { ReactNode, FC, memo, useState, useCallback, useMemo } from 'react';
 import { Button } from 'react-bootstrap';
 
-import { DomainField, DomainFieldLabel, Tip } from '../../..';
+import { DomainField, DomainFieldLabel } from '../../..';
 
 import { helpLinkNode, ONTOLOGY_TOPIC } from '../../util/helpLinks';
 import { createFormInputName } from '../domainproperties/actions';
 import { DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT } from '../domainproperties/constants';
 import { isFieldFullyLocked } from '../domainproperties/propertiesUtil';
 import { OntologyBrowserModal } from './OntologyBrowserModal';
-import { ConceptModel } from "./models";
+import { ConceptOverviewModal } from './ConceptOverviewPanel';
+import { ConceptModel } from './models';
 
 interface OntologyConceptAnnotationProps {
-    id: string,
+    id: string;
     field: DomainField;
     onChange: (id: string, value: any) => void;
     successBsStyle?: string;
@@ -20,20 +21,25 @@ interface OntologyConceptAnnotationProps {
 export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = memo(props => {
     const { id, field, successBsStyle, onChange } = props;
     const { principalConceptCode, lockType } = field;
-    const [showModal, setShowModal] = useState<boolean>();
+    const [showSelectModal, setShowSelectModal] = useState<boolean>();
+    const [showConceptModal, setShowConceptModal] = useState<boolean>();
     const title = 'Select Concept'; //useMemo(() => (principalConceptCode ? 'Edit' : 'Select') + ' Concept', [principalConceptCode]);
     const isFieldLocked = useMemo(() => isFieldFullyLocked(lockType), [lockType]);
 
-    const toggleModal = useCallback(() => {
-        setShowModal(!showModal);
-    }, [showModal, setShowModal]);
+    const toggleSelectModal = useCallback(() => {
+        setShowSelectModal(!showSelectModal);
+    }, [showSelectModal, setShowSelectModal]);
+
+    const toggleConceptModal = useCallback(() => {
+        setShowConceptModal(!showConceptModal);
+    }, [showConceptModal, setShowConceptModal]);
 
     const onApply = useCallback(
         (concept: ConceptModel) => {
             onChange(id, concept?.code);
-            setShowModal(false);
+            setShowSelectModal(false);
         },
-        [onChange, id, setShowModal]
+        [onChange, id, setShowSelectModal]
     );
 
     return (
@@ -47,7 +53,7 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
                     name={createFormInputName(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT)}
                     id={id}
                     disabled={isFieldLocked}
-                    onClick={toggleModal}
+                    onClick={toggleSelectModal}
                 >
                     {title}
                 </Button>
@@ -59,21 +65,22 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
                                 <i className="fa fa-remove" />
                             </a>
                         )}
-                        <a className="domain-validator-link" onClick={() => {}}>
+                        <a className="domain-validator-link" onClick={toggleConceptModal}>
                             {principalConceptCode}
                         </a>
                     </>
                 )}
             </div>
-            {showModal && (
+            {showSelectModal && (
                 <OntologyBrowserModal
                     title={title}
                     initOntologyId={field.sourceOntology}
-                    onCancel={toggleModal}
+                    onCancel={toggleSelectModal}
                     onApply={onApply}
                     successBsStyle={successBsStyle}
                 />
             )}
+            {showConceptModal && <ConceptOverviewModal code={principalConceptCode} onClose={toggleConceptModal} />}
         </>
     );
 });

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -1,0 +1,85 @@
+import React, { ReactNode, FC, memo, useState, useCallback, useMemo } from 'react';
+import { Button } from 'react-bootstrap';
+
+import { createFormInputId, DomainField, DomainFieldLabel } from '../../..';
+
+import { helpLinkNode, ONTOLOGY_TOPIC } from '../../util/helpLinks';
+import { createFormInputName } from '../domainproperties/actions';
+import { DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT } from '../domainproperties/constants';
+import { isFieldFullyLocked } from '../domainproperties/propertiesUtil';
+import { OntologyBrowserModal } from './OntologyBrowserModal';
+import { ConceptModel } from "./models";
+
+interface OntologyConceptAnnotationProps {
+    id: string,
+    field: DomainField;
+    onChange: (id: string, value: any) => void;
+    successBsStyle?: string;
+}
+
+export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = memo(props => {
+    const { id, field, successBsStyle, onChange } = props;
+    const { principalConceptCode } = field;
+    const [showModal, setShowModal] = useState<boolean>();
+    const title = useMemo(() => (principalConceptCode ? 'Edit' : 'Select') + ' Concept', [principalConceptCode]);
+
+    const toggleModal = useCallback(() => {
+        setShowModal(!showModal);
+    }, [showModal, setShowModal]);
+
+    const onApply = useCallback(
+        (concept: ConceptModel) => {
+            onChange(id, concept?.code);
+            setShowModal(false);
+        },
+        [onChange, id, setShowModal]
+    );
+
+    return (
+        <>
+            <div className="domain-field-label">
+                <DomainFieldLabel label="Concept Annotation" helpTipBody={getOntologyConceptAnnotationHelpTipBody()} />
+            </div>
+            <div>
+                <Button
+                    className="domain-validation-button"
+                    name={createFormInputName(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT)}
+                    id={id}
+                    disabled={isFieldFullyLocked(field.lockType)}
+                    onClick={toggleModal}
+                >
+                    {title}
+                </Button>
+                {!principalConceptCode && <span className="domain-text-label">None Set</span>}
+                {principalConceptCode && (
+                    <a
+                        className="domain-validator-link"
+                        onClick={isFieldFullyLocked(field.lockType) ? () => {} : toggleModal}
+                    >
+                        {principalConceptCode}
+                    </a>
+                )}
+            </div>
+            {showModal && (
+                <OntologyBrowserModal
+                    title={title}
+                    initOntologyId={field.sourceOntology}
+                    onCancel={toggleModal}
+                    onApply={onApply}
+                    successBsStyle={successBsStyle}
+                />
+            )}
+        </>
+    );
+});
+
+function getOntologyConceptAnnotationHelpTipBody(): ReactNode {
+    return (
+        <>
+            Select an ontology concept to attach to this field which will be used for ...TODO...
+            <br />
+            <br />
+            Learn more about {helpLinkNode(ONTOLOGY_TOPIC, 'ontology integration')} in LabKey.
+        </>
+    );
+}

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -124,7 +124,6 @@ function getOntologyConceptAnnotationHelpTipBody(): ReactNode {
     return (
         <>
             Select an ontology concept to use as an annotation for this field.
-            {/* TODO anything else to add?*/}
             <br />
             <br />
             {/*TODO update link topic once annotation case is added to docs page*/}

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, FC, memo, useState, useCallback, useMemo } from 'react';
 import { Button } from 'react-bootstrap';
 
-import { createFormInputId, DomainField, DomainFieldLabel } from '../../..';
+import { DomainField, DomainFieldLabel, Tip } from '../../..';
 
 import { helpLinkNode, ONTOLOGY_TOPIC } from '../../util/helpLinks';
 import { createFormInputName } from '../domainproperties/actions';
@@ -19,9 +19,10 @@ interface OntologyConceptAnnotationProps {
 
 export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = memo(props => {
     const { id, field, successBsStyle, onChange } = props;
-    const { principalConceptCode } = field;
+    const { principalConceptCode, lockType } = field;
     const [showModal, setShowModal] = useState<boolean>();
-    const title = useMemo(() => (principalConceptCode ? 'Edit' : 'Select') + ' Concept', [principalConceptCode]);
+    const title = 'Select Concept'; //useMemo(() => (principalConceptCode ? 'Edit' : 'Select') + ' Concept', [principalConceptCode]);
+    const isFieldLocked = useMemo(() => isFieldFullyLocked(lockType), [lockType]);
 
     const toggleModal = useCallback(() => {
         setShowModal(!showModal);
@@ -45,19 +46,23 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
                     className="domain-validation-button"
                     name={createFormInputName(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT)}
                     id={id}
-                    disabled={isFieldFullyLocked(field.lockType)}
+                    disabled={isFieldLocked}
                     onClick={toggleModal}
                 >
                     {title}
                 </Button>
                 {!principalConceptCode && <span className="domain-text-label">None Set</span>}
                 {principalConceptCode && (
-                    <a
-                        className="domain-validator-link"
-                        onClick={isFieldFullyLocked(field.lockType) ? () => {} : toggleModal}
-                    >
-                        {principalConceptCode}
-                    </a>
+                    <>
+                        {!isFieldLocked && (
+                            <a className="domain-validator-link" onClick={() => onApply(undefined)}>
+                                <i className="fa fa-remove" />
+                            </a>
+                        )}
+                        <a className="domain-validator-link" onClick={() => {}}>
+                            {principalConceptCode}
+                        </a>
+                    </>
                 )}
             </div>
             {showModal && (

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -76,7 +76,7 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
                             </Button>
                         </td>
                         {!principalConceptCode && (
-                            <td>
+                            <td className="content">
                                 <span className="domain-text-label">None Set</span>
                             </td>
                         )}

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -31,13 +31,17 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
     const isFieldLocked = useMemo(() => isFieldFullyLocked(lockType), [lockType]);
 
     useEffect(() => {
-        fetchConceptForCode(principalConceptCode)
-            .then(setConcept)
-            .catch(reason => {
-                setError(
-                    'Error: unable to get concept information for ' + principalConceptCode + '. '
-                );
-            });
+        if (!principalConceptCode) {
+            setConcept(undefined);
+        } else {
+            fetchConceptForCode(principalConceptCode)
+                .then(setConcept)
+                .catch(reason => {
+                    setError(
+                        'Error: unable to get concept information for ' + principalConceptCode + '. '
+                    );
+                });
+        }
     }, [principalConceptCode, setConcept, setError]);
 
     const toggleSelectModal = useCallback(() => {

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -35,7 +35,7 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
             .then(setConcept)
             .catch(reason => {
                 setError(
-                    'Error: unable to get concept information for ' + principalConceptCode + '. ' + reason?.exception
+                    'Error: unable to get concept information for ' + principalConceptCode + '. '
                 );
             });
     }, [principalConceptCode, setConcept, setError]);

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -21,14 +21,10 @@ interface OntologyConceptAnnotationProps {
 }
 
 export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = memo(props => {
-    const { id, field, successBsStyle, onChange } = props;
-    const { principalConceptCode, lockType } = field;
-    const [showSelectModal, setShowSelectModal] = useState<boolean>();
-    const [showConceptModal, setShowConceptModal] = useState<boolean>();
+    const { field } = props;
+    const { principalConceptCode } = field;
     const [error, setError] = useState<string>();
     const [concept, setConcept] = useState<ConceptModel>();
-    const title = 'Select Concept'; // useMemo(() => (principalConceptCode ? 'Edit' : 'Select') + ' Concept', [principalConceptCode]);
-    const isFieldLocked = useMemo(() => isFieldFullyLocked(lockType), [lockType]);
 
     useEffect(() => {
         if (!principalConceptCode) {
@@ -36,13 +32,28 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
         } else {
             fetchConceptForCode(principalConceptCode)
                 .then(setConcept)
-                .catch(reason => {
-                    setError(
-                        'Error: unable to get concept information for ' + principalConceptCode + '. '
-                    );
+                .catch(() => {
+                    setError('Error: unable to get concept information for ' + principalConceptCode + '. ');
                 });
         }
     }, [principalConceptCode, setConcept, setError]);
+
+    return <OntologyConceptAnnotationImpl {...props} error={error} concept={concept} />;
+});
+
+interface OntologyConceptAnnotationImplProps extends OntologyConceptAnnotationProps {
+    error: string;
+    concept: ConceptModel;
+}
+
+// exported for jest testing
+export const OntologyConceptAnnotationImpl: FC<OntologyConceptAnnotationImplProps> = memo(props => {
+    const { id, field, successBsStyle, onChange, error, concept } = props;
+    const { principalConceptCode, lockType } = field;
+    const [showSelectModal, setShowSelectModal] = useState<boolean>();
+    const [showConceptModal, setShowConceptModal] = useState<boolean>();
+    const isFieldLocked = useMemo(() => isFieldFullyLocked(lockType), [lockType]);
+    const title = 'Select Concept';
 
     const toggleSelectModal = useCallback(() => {
         setShowSelectModal(!showSelectModal);
@@ -53,8 +64,8 @@ export const OntologyConceptAnnotation: FC<OntologyConceptAnnotationProps> = mem
     }, [showConceptModal, setShowConceptModal]);
 
     const onApply = useCallback(
-        (concept: ConceptModel) => {
-            onChange(id, concept?.code);
+        (selectedConcept: ConceptModel) => {
+            onChange(id, selectedConcept?.code);
             setShowSelectModal(false);
         },
         [onChange, id, setShowSelectModal]
@@ -126,7 +137,7 @@ function getOntologyConceptAnnotationHelpTipBody(): ReactNode {
             Select an ontology concept to use as an annotation for this field.
             <br />
             <br />
-            {/*TODO update link topic once annotation case is added to docs page*/}
+            {/* TODO update link topic once annotation case is added to docs page*/}
             Learn more about {helpLinkNode(ONTOLOGY_TOPIC, 'ontology integration')} in LabKey.
         </>
     );

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.spec.tsx
@@ -6,10 +6,10 @@ import { sleep } from '../../testHelpers';
 import { initUnitTestMocks } from '../../testHelperMocks';
 
 import { OntologyLookupOptions } from './OntologyLookupOptions';
-import { DomainField } from './models';
-import { SectionHeading } from './SectionHeading';
-import { INTEGER_TYPE, ONTOLOGY_LOOKUP_TYPE, TEXT_TYPE } from './PropDescType';
-import { DOMAIN_FIELD_FULLY_LOCKED } from './constants';
+import { DomainField } from '../domainproperties/models';
+import { SectionHeading } from '../domainproperties/SectionHeading';
+import { INTEGER_TYPE, ONTOLOGY_LOOKUP_TYPE, TEXT_TYPE } from '../domainproperties/PropDescType';
+import { DOMAIN_FIELD_FULLY_LOCKED } from '../domainproperties/constants';
 
 const DEFAULT_PROPS = {
     index: 0,

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.spec.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import { List } from 'immutable';
 
+import { DomainField } from '../../..';
 import { sleep } from '../../testHelpers';
 import { initUnitTestMocks } from '../../testHelperMocks';
 
-import { OntologyLookupOptions } from './OntologyLookupOptions';
-import { DomainField } from '../domainproperties/models';
 import { SectionHeading } from '../domainproperties/SectionHeading';
 import { INTEGER_TYPE, ONTOLOGY_LOOKUP_TYPE, TEXT_TYPE } from '../domainproperties/PropDescType';
 import { DOMAIN_FIELD_FULLY_LOCKED } from '../domainproperties/constants';
+
+import { OntologyLookupOptions } from './OntologyLookupOptions';
 
 const DEFAULT_PROPS = {
     index: 0,
@@ -54,12 +55,12 @@ beforeAll(() => {
 
 describe('OntologyLookupOptions', () => {
     function validate(
-        wrapper: any,
+        wrapper: ReactWrapper,
         disabled: boolean,
         selectedSource: string,
         importOptions: string[],
         labelOptions: string[]
-    ) {
+    ): void {
         expect(wrapper.find(SectionHeading)).toHaveLength(1);
         expect(wrapper.find('.domain-field-label')).toHaveLength(3);
 

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, ReactNode } from 'react';
+import React, { PureComponent, ReactNode, FC, memo } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 import { List } from 'immutable';
 import { getServerContext } from '@labkey/api';
@@ -6,15 +6,15 @@ import { getServerContext } from '@labkey/api';
 import { DomainField, LabelHelpTip } from '../../..';
 import { helpLinkNode, ONTOLOGY_TOPIC } from '../../util/helpLinks';
 
-import { isFieldFullyLocked } from './propertiesUtil';
-import { createFormInputId, fetchOntologies } from './actions';
+import { isFieldFullyLocked } from '../domainproperties/propertiesUtil';
+import { createFormInputId, fetchOntologies } from '../domainproperties/actions';
 import {
     DOMAIN_FIELD_ONTOLOGY_IMPORT_COL,
     DOMAIN_FIELD_ONTOLOGY_LABEL_COL,
     DOMAIN_FIELD_ONTOLOGY_SOURCE,
-} from './constants';
-import { ITypeDependentProps, OntologyModel } from './models';
-import { SectionHeading } from './SectionHeading';
+} from '../domainproperties/constants';
+import { ITypeDependentProps, OntologyModel } from '../domainproperties/models';
+import { SectionHeading } from '../domainproperties/SectionHeading';
 
 interface Props extends ITypeDependentProps {
     field: DomainField;
@@ -77,38 +77,8 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
         return createFormInputId(DOMAIN_FIELD_ONTOLOGY_SOURCE, domainIndex, index);
     }
 
-    renderTextDomainFieldSelect(id: string, value: string, filterValue: string): ReactNode {
-        const { domainFields, lockType, field } = this.props;
-
-        return (
-            <FormControl
-                componentClass="select"
-                id={id}
-                key={id}
-                disabled={isFieldFullyLocked(lockType)}
-                onChange={this.onFieldChange}
-                value={value}
-            >
-                <option value={null} />
-                {domainFields.map((df, index) => {
-                    // Need to preserve index so don't filter, but return null for those fields we don't want as options
-                    // (i.e. don't show self, fields with no name, fields not of type string, or field selected as the other lookup option)
-                    if (df === field || df.hasInvalidName() || !df.dataType.isString() || df.name === filterValue) {
-                        return null;
-                    }
-
-                    return (
-                        <option key={index} value={df.name}>
-                            {df.name}
-                        </option>
-                    );
-                })}
-            </FormControl>
-        );
-    }
-
     render(): ReactNode {
-        const { index, label, lockType, domainIndex, field } = this.props;
+        const { index, label, lockType, domainIndex, field, domainFields } = this.props;
         const { loading, ontologies } = this.state;
         const sourceId = this.getSourceInputId();
         const labelColId = createFormInputId(DOMAIN_FIELD_ONTOLOGY_LABEL_COL, domainIndex, index);
@@ -200,21 +170,69 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                         </FormControl>
                     </Col>
                     <Col xs={3}>
-                        {this.renderTextDomainFieldSelect(
-                            importColId,
-                            field.conceptImportColumn,
-                            field.conceptLabelColumn
-                        )}
+                        <OntologyTextDomainFieldSelect
+                            field={field}
+                            domainFields={domainFields}
+                            lockType={lockType}
+                            id={importColId}
+                            value={field.conceptImportColumn}
+                            filterValue={field.conceptLabelColumn}
+                            onFieldChange={this.onFieldChange}
+                        />
                     </Col>
                     <Col xs={3}>
-                        {this.renderTextDomainFieldSelect(
-                            labelColId,
-                            field.conceptLabelColumn,
-                            field.conceptImportColumn
-                        )}
+                        <OntologyTextDomainFieldSelect
+                            field={field}
+                            domainFields={domainFields}
+                            lockType={lockType}
+                            id={labelColId}
+                            value={field.conceptLabelColumn}
+                            filterValue={field.conceptImportColumn}
+                            onFieldChange={this.onFieldChange}
+                        />
                     </Col>
                 </Row>
             </div>
         );
     }
 }
+
+interface OntologyTextDomainFieldSelectProps {
+    field: DomainField;
+    domainFields: List<DomainField>;
+    lockType: string;
+    id: string;
+    value: string;
+    filterValue: string;
+    onFieldChange: (evt: any) => void;
+}
+
+const OntologyTextDomainFieldSelect: FC<OntologyTextDomainFieldSelectProps> = memo(props => {
+    const { domainFields, lockType, field, id, value, filterValue, onFieldChange } = props;
+
+    return (
+        <FormControl
+            componentClass="select"
+            id={id}
+            key={id}
+            disabled={isFieldFullyLocked(lockType)}
+            onChange={onFieldChange}
+            value={value}
+        >
+            <option value={null} />
+            {domainFields.map((df, index) => {
+                // Need to preserve index so don't filter, but return null for those fields we don't want as options
+                // (i.e. don't show self, fields with no name, fields not of type string, or field selected as the other lookup option)
+                if (df === field || df.hasInvalidName() || !df.dataType.isString() || df.name === filterValue) {
+                    return null;
+                }
+
+                return (
+                    <option key={index} value={df.name}>
+                        {df.name}
+                    </option>
+                );
+            })}
+        </FormControl>
+    );
+});

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -13,8 +13,9 @@ import {
     DOMAIN_FIELD_ONTOLOGY_LABEL_COL,
     DOMAIN_FIELD_ONTOLOGY_SOURCE,
 } from '../domainproperties/constants';
-import { ITypeDependentProps, OntologyModel } from '../domainproperties/models';
+import { ITypeDependentProps } from '../domainproperties/models';
 import { SectionHeading } from '../domainproperties/SectionHeading';
+import { OntologyModel } from './models';
 
 interface Props extends ITypeDependentProps {
     field: DomainField;
@@ -163,7 +164,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                 ontologies.map(ontology => {
                                     return (
                                         <option key={ontology.abbreviation} value={ontology.abbreviation}>
-                                            {ontology.getLabel()}
+                                            {ontology.getDisplayName()}
                                         </option>
                                     );
                                 })}

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -101,8 +101,8 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                     <p>
                                         <i>
                                             This is currently an experimental feature and is not officially supported.
-                                            By using this feature By using this feature you acknowledge that these
-                                            functions may change, possibly affecting your possibly affecting your data.
+                                            By using this feature you acknowledge that these functions may change,
+                                            possibly affecting your data.
                                         </i>
                                     </p>
                                     <p>Choose which ontology to use to lookup concept codes and preferred names.</p>

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -107,7 +107,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                     </p>
                                     <p>Choose which ontology to use to lookup concept codes and preferred names.</p>
                                     <p>
-                                        Learn more about {helpLinkNode(ONTOLOGY_TOPIC, 'ontology integration')} in
+                                        Learn more about {helpLinkNode(ONTOLOGY_TOPIC + '#lookup', 'ontology integration')} in
                                         LabKey.
                                     </p>
                                 </>
@@ -122,7 +122,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                     Choose which text field to use when looking up a code against the selected ontology.
                                 </p>
                                 <p>
-                                    Learn more about {helpLinkNode(ONTOLOGY_TOPIC, 'ontology integration')} in LabKey.
+                                    Learn more about {helpLinkNode(ONTOLOGY_TOPIC + '#lookup', 'ontology integration')} in LabKey.
                                 </p>
                             </LabelHelpTip>
                         </div>
@@ -133,7 +133,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                             <LabelHelpTip title="Experimental Feature">
                                 <p>Choose which text field to store the preferred name of the concept.</p>
                                 <p>
-                                    Learn more about {helpLinkNode(ONTOLOGY_TOPIC, 'ontology integration')} in LabKey.
+                                    Learn more about {helpLinkNode(ONTOLOGY_TOPIC + '#lookup', 'ontology integration')} in LabKey.
                                 </p>
                             </LabelHelpTip>
                         </div>

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
@@ -29,6 +29,7 @@ describe('OntologySelectionPanel', () => {
     });
 
     test('no ontologies, non root admin', () => {
+        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
         const ontologies = [];
         const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
         validate(wrapper, 0);
@@ -38,6 +39,17 @@ describe('OntologySelectionPanel', () => {
     });
 
     test('no ontologies, as root admin', () => {
+        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
+        LABKEY.user.isRootAdmin = true;
+        const ontologies = [];
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
+        validate(wrapper, 0);
+        expect(wrapper.find('.alert-warning').text()).toContain('Click here to get started.');
+        wrapper.unmount();
+    });
+
+    test('no ontologies, as root admin without ontology module', () => {
+        LABKEY.container.activeModules = ['Core', 'Query'];
         LABKEY.user.isRootAdmin = true;
         const ontologies = [];
         const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
@@ -74,7 +74,7 @@ describe('OntologySelectionPanel', () => {
     });
 
     test('error', () => {
-        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={[]} error={'test error'} />);
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={[]} error="test error" />);
         validate(wrapper, 0, 'test error');
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
@@ -54,7 +54,7 @@ describe('OntologySelectionPanel', () => {
         const ontologies = [];
         const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
         validate(wrapper, 0);
-        expect(wrapper.find('.alert-warning').text()).toContain('Click here to get started.');
+        expect(wrapper.find('.alert-warning').text()).toBe('No ontologies have been loaded for this server.');
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { Alert, LoadingSpinner, SelectInput } from '../../..';
+
+import { OntologySelectionPanelImpl } from './OntologySelectionPanel';
+import { PathModel } from './models';
+
+const DEFAULT_PROPS = {
+    error: undefined,
+    ontologies: undefined,
+    asPanel: false,
+    onOntologySelection: jest.fn,
+};
+
+describe('OntologySelectionPanel', () => {
+    function validate(wrapper: ReactWrapper, ontCount?: number, errorTxt?: string, asPanel = false): void {
+        expect(wrapper.find(Alert).first().text()).toBe(errorTxt ?? '');
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(ontCount === undefined ? 1 : 0);
+        expect(wrapper.find('.alert-warning')).toHaveLength(ontCount !== undefined && ontCount === 0 ? 1 : 0);
+        expect(wrapper.find(SelectInput)).toHaveLength(ontCount !== undefined ? 1 : 0);
+        expect(wrapper.find('.ontology-browser-container')).toHaveLength(asPanel ? 1 : 0);
+    }
+
+    test('loading', () => {
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('no ontologies, non root admin', () => {
+        const ontologies = [];
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
+        validate(wrapper, 0);
+        expect(wrapper.find('.alert-warning').text()).toBe('No ontologies have been loaded for this server.');
+        expect(wrapper.find(SelectInput).prop('options')).toBe(ontologies);
+        wrapper.unmount();
+    });
+
+    test('no ontologies, as root admin', () => {
+        LABKEY.user.isRootAdmin = true;
+        const ontologies = [];
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
+        validate(wrapper, 0);
+        expect(wrapper.find('.alert-warning').text()).toContain('Click here to get started.');
+        wrapper.unmount();
+    });
+
+    test('with ontologies', () => {
+        const ontologies = [new PathModel()];
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
+        validate(wrapper, ontologies.length);
+        expect(wrapper.find(SelectInput).prop('options')).toBe(ontologies);
+        wrapper.unmount();
+    });
+
+    test('asPanel', () => {
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={[]} asPanel={true} />);
+        validate(wrapper, 0, undefined, true);
+        expect(wrapper.find('.panel-body')).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    test('error', () => {
+        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={[]} error={'test error'} />);
+        validate(wrapper, 0, 'test error');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo, useEffect, useState } from 'react';
+import { getServerContext } from '@labkey/api';
 
-import { LoadingSpinner, Alert, SelectInput } from '../../..';
+import { LoadingSpinner, Alert, SelectInput, buildURL } from '../../..';
 
 import { fetchChildPaths } from './actions';
 import { PathModel } from './models';
@@ -17,8 +18,8 @@ export const OntologySelectionPanel: FC<OntologySelectionPanelProps> = memo(prop
 
     useEffect(() => {
         fetchChildPaths('/')
-            .then(ontologies => {
-                setOntologies(ontologies.children);
+            .then(response => {
+                setOntologies(response.children);
             })
             .catch(reason => {
                 setError('Error: unable to load ontology information for selection. ' + reason?.exception);
@@ -30,6 +31,16 @@ export const OntologySelectionPanel: FC<OntologySelectionPanelProps> = memo(prop
         <>
             <Alert>{error}</Alert>
             {!ontologies && <LoadingSpinner msg="Loading ontologies..." />}
+            {ontologies?.length === 0 && (
+                <Alert bsStyle="warning">
+                    No ontologies have been loaded for this server.
+                    {getServerContext().user.isRootAdmin && (
+                        <>
+                            &nbsp;Click <a href={buildURL('ontology', 'begin')}>here</a> to get started.
+                        </>
+                    )}
+                </Alert>
+            )}
             {ontologies && (
                 <SelectInput
                     key="ontology-select"

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -12,7 +12,7 @@ interface OntologySelectionPanelProps {
 }
 
 export const OntologySelectionPanel: FC<OntologySelectionPanelProps> = memo(props => {
-    const { onOntologySelection, asPanel } = props;
+    const { onOntologySelection } = props;
     const [error, setError] = useState<string>();
     const [ontologies, setOntologies] = useState<PathModel[]>();
 
@@ -31,6 +31,18 @@ export const OntologySelectionPanel: FC<OntologySelectionPanelProps> = memo(prop
                 setOntologies([]);
             });
     }, [setOntologies, setError, onOntologySelection]);
+
+    return <OntologySelectionPanelImpl {...props} error={error} ontologies={ontologies} />;
+});
+
+interface OntologySelectionPanelImplProps extends OntologySelectionPanelProps {
+    error: string;
+    ontologies: PathModel[];
+}
+
+// exported for jest testing
+export const OntologySelectionPanelImpl: FC<OntologySelectionPanelImplProps> = memo(props => {
+    const { onOntologySelection, asPanel, error, ontologies } = props;
 
     const body = (
         <>

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -3,9 +3,10 @@ import { getServerContext } from '@labkey/api';
 
 import { LoadingSpinner, Alert, SelectInput, buildURL } from '../../..';
 
+import { hasActiveModule } from '../domainproperties/actions';
+
 import { fetchChildPaths } from './actions';
 import { PathModel } from './models';
-import { hasActiveModule } from '../domainproperties/actions';
 
 interface OntologySelectionPanelProps {
     onOntologySelection: (name: string, value: string, model: PathModel) => void;

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -21,7 +21,7 @@ export const OntologySelectionPanel: FC<OntologySelectionPanelProps> = memo(prop
                 setOntologies(ontologies.children);
             })
             .catch(reason => {
-                setError('Error: unable to load ontology information for selection.');
+                setError('Error: unable to load ontology information for selection. ' + reason?.exception);
                 setOntologies([]);
             });
     }, [setOntologies, setError]);

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -5,6 +5,7 @@ import { LoadingSpinner, Alert, SelectInput, buildURL } from '../../..';
 
 import { fetchChildPaths } from './actions';
 import { PathModel } from './models';
+import { hasActiveModule } from '../domainproperties/actions';
 
 interface OntologySelectionPanelProps {
     onOntologySelection: (name: string, value: string, model: PathModel) => void;
@@ -51,7 +52,7 @@ export const OntologySelectionPanelImpl: FC<OntologySelectionPanelImplProps> = m
             {ontologies?.length === 0 && (
                 <Alert bsStyle="warning">
                     No ontologies have been loaded for this server.
-                    {getServerContext().user.isRootAdmin && (
+                    {getServerContext().user.isRootAdmin && hasActiveModule('Ontology') && (
                         <>
                             &nbsp;Click <a href={buildURL('ontology', 'begin')}>here</a> to get started.
                         </>

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -19,13 +19,18 @@ export const OntologySelectionPanel: FC<OntologySelectionPanelProps> = memo(prop
     useEffect(() => {
         fetchChildPaths('/')
             .then(response => {
-                setOntologies(response.children);
+                // if only one ontology present, just select it
+                if (response.children.length === 1) {
+                    onOntologySelection('ontology-select', undefined, response.children[0]);
+                } else {
+                    setOntologies(response.children);
+                }
             })
             .catch(reason => {
                 setError('Error: unable to load ontology information for selection. ' + reason?.exception);
                 setOntologies([]);
             });
-    }, [setOntologies, setError]);
+    }, [setOntologies, setError, onOntologySelection]);
 
     const body = (
         <>

--- a/packages/components/src/internal/components/ontology/OntologyTreePanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreePanel.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { FileTree } from '../../..';
+
+import { OntologyTreePanel } from './OntologyTreePanel';
+import { PathModel } from './models';
+
+const DEFAULT_PROPS = {
+    root: new PathModel({ label: 'test label' }),
+    onNodeSelection: jest.fn,
+};
+
+describe('OntologyTreePanel', () => {
+    test('default props', () => {
+        const wrapper = mount(<OntologyTreePanel {...DEFAULT_PROPS} />);
+        const fileTree = wrapper.find(FileTree);
+        expect(fileTree.prop('allowMultiSelect')).toBe(false);
+        expect(fileTree.prop('showNodeIcon')).toBe(false);
+        expect(fileTree.prop('defaultRootName')).toBe(DEFAULT_PROPS.root.label);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/ontology/models.spec.ts
+++ b/packages/components/src/internal/components/ontology/models.spec.ts
@@ -1,4 +1,4 @@
-import { OntologyModel } from './models';
+import { ConceptModel, OntologyModel } from './models';
 
 describe('OntologyModel', () => {
     test('create', () => {
@@ -23,5 +23,12 @@ describe('OntologyModel', () => {
                 Abbreviation: { value: 'test' },
             }).getDisplayName()
         ).toBe('test');
+    });
+});
+
+describe('ConceptModel', () => {
+    test('getDisplayLabel', () => {
+        expect(new ConceptModel({}).getDisplayLabel()).toBe('undefined (undefined)');
+        expect(new ConceptModel({ code: 'a', label: 'b' }).getDisplayLabel()).toBe('b (a)');
     });
 });

--- a/packages/components/src/internal/components/ontology/models.spec.ts
+++ b/packages/components/src/internal/components/ontology/models.spec.ts
@@ -1,0 +1,27 @@
+import { OntologyModel } from './models';
+
+describe('OntologyModel', () => {
+    test('create', () => {
+        expect(OntologyModel.create({}).name).toBe(undefined);
+        expect(OntologyModel.create({ name: {} }).name).toBe(undefined);
+        expect(OntologyModel.create({ Name: {} }).name).toBe(undefined);
+        expect(OntologyModel.create({ name: { value: 'test' } }).name).toBe('test');
+        expect(OntologyModel.create({ Name: { value: 'test' } }).name).toBe('test');
+    });
+
+    test('getDisplayName', () => {
+        expect(
+            OntologyModel.create({
+                Name: { value: 'test' },
+                Abbreviation: { value: 'T' },
+            }).getDisplayName()
+        ).toBe('test (T)');
+
+        expect(
+            OntologyModel.create({
+                Name: { value: 'test' },
+                Abbreviation: { value: 'test' },
+            }).getDisplayName()
+        ).toBe('test');
+    });
+});

--- a/packages/components/src/internal/components/ontology/models.ts
+++ b/packages/components/src/internal/components/ontology/models.ts
@@ -1,4 +1,5 @@
 import { immerable } from 'immer';
+
 import { caseInsensitive } from '../../..';
 
 export class ConceptModel {

--- a/packages/components/src/internal/components/ontology/models.ts
+++ b/packages/components/src/internal/components/ontology/models.ts
@@ -1,4 +1,5 @@
-import { immerable } from "immer";
+import { immerable } from 'immer';
+import { caseInsensitive } from '../../..';
 
 export class ConceptModel {
     [immerable] = true;
@@ -40,6 +41,14 @@ export class OntologyModel {
 
     constructor(values?: Partial<OntologyModel>) {
         Object.assign(this, values);
+    }
+
+    static create(raw: any): OntologyModel {
+        return new OntologyModel({
+            rowId: caseInsensitive(raw, 'RowId')?.value,
+            name: caseInsensitive(raw, 'Name')?.value,
+            abbreviation: caseInsensitive(raw, 'Abbreviation')?.value,
+        });
     }
 
     getPathModel(): PathModel {

--- a/packages/components/src/internal/components/ontology/models.ts
+++ b/packages/components/src/internal/components/ontology/models.ts
@@ -12,6 +12,10 @@ export class ConceptModel {
     constructor(values?: Partial<ConceptModel>) {
         Object.assign(this, values);
     }
+
+    getDisplayLabel(): string {
+        return this.label + ' (' + this.code + ')';
+    }
 }
 
 export class PathModel {

--- a/packages/components/src/internal/testHelpers.ts
+++ b/packages/components/src/internal/testHelpers.ts
@@ -32,7 +32,8 @@ export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Map
                 dateTimeFormat: 'yyyy-MM-dd HH:mm',
                 numberFormat: null,
             },
-            activeModules: ['Core', 'Query', 'Ontology'],
+            activeModules: ['Core', 'Query'],
+            // activeModules: ['Core', 'Query', 'Ontology'],
         },
         contextPath: 'labkey',
     });

--- a/packages/components/src/internal/testHelpers.ts
+++ b/packages/components/src/internal/testHelpers.ts
@@ -32,7 +32,7 @@ export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Map
                 dateTimeFormat: 'yyyy-MM-dd HH:mm',
                 numberFormat: null,
             },
-            activeModules: ['Core', 'Query'],
+            activeModules: ['Core', 'Query', 'Ontology'],
         },
         contextPath: 'labkey',
     });

--- a/packages/components/src/internal/testHelpers.ts
+++ b/packages/components/src/internal/testHelpers.ts
@@ -32,8 +32,7 @@ export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Map
                 dateTimeFormat: 'yyyy-MM-dd HH:mm',
                 numberFormat: null,
             },
-            activeModules: ['Core', 'Query'],
-            // activeModules: ['Core', 'Query', 'Ontology'],
+            activeModules: ['Core', 'Query'], // add in the Ontology module if you want to test the Field Editor integrations
         },
         contextPath: 'labkey',
     });

--- a/packages/components/src/stories/OntologyBrowserPanel.stories.tsx
+++ b/packages/components/src/stories/OntologyBrowserPanel.stories.tsx
@@ -12,14 +12,12 @@ export default {
     component: OntologyBrowserPanel,
     argTypes: {
         initOntologyId: disableControls(),
+        onConceptSelect: disableControls(),
     },
 } as Meta;
 
 export const OntologyBrowserPanelStory: Story<OntologyBrowserProps> = props => (
-    <OntologyBrowserPanel
-        {...props}
-        initOntologyId={props.withOntology ? 'NCIT' : undefined}
-    />
+    <OntologyBrowserPanel {...props} initOntologyId={props.withOntology ? 'NCIT' : undefined} />
 );
 
 OntologyBrowserPanelStory.storyName = 'OntologyBrowserPanel';

--- a/packages/components/src/stories/OntologyBrowserPanel.stories.tsx
+++ b/packages/components/src/stories/OntologyBrowserPanel.stories.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { disableControls } from './storyUtils';
 
-import {
-    OntologyBrowserPanel,
-    OntologyBrowserProps,
-} from '../internal/components/ontology/OntologyBrowserPanel';
+import { OntologyBrowserPanel, OntologyBrowserProps } from '../internal/components/ontology/OntologyBrowserPanel';
+
+import { disableControls } from './storyUtils';
 
 export default {
     title: 'Components/OntologyBrowserPanel',

--- a/packages/components/src/test/data/property-getDomain.json
+++ b/packages/components/src/test/data/property-getDomain.json
@@ -74,7 +74,8 @@
     } ],
     "excludeFromShifting" : false,
     "URL" : null,
-    "PHI" : "NotPHI"
+    "PHI" : "NotPHI",
+    "principalConceptCode" : "NCIT:ST1000016"
   }, {
     "propertyId" : 392740,
     "propertyURI" : "urn:lsid:labkey.com:Study.Project-556:Study#FieldInteger",

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -597,6 +597,14 @@
   float: right;
 }
 
+.domain-annotation-table td {
+    vertical-align: top;
+
+    &.content {
+        padding-top: 5px;
+    }
+}
+
 .domain-color-preview {
   height: 25px;
   width: 25px;

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -559,7 +559,8 @@
 }
 
 .domain-validator-link {
-  cursor: pointer;
+    cursor: pointer;
+    padding-right: 5px;
 }
 
 .domain-validator-filter-row {

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -6,6 +6,10 @@
     .concept-information-tabs {
         padding-right: 15px;
     }
+
+    .filetree-directory-name {
+        max-width: unset;
+    }
 }
 
 /* CONCEPT OVERVIEW */


### PR DESCRIPTION
#### Rationale
Now that we have an Ontology Browser panel component, this PR makes use of that shared component within the Field Editor to allow for a field to have a Concept Annotation. This PR does some refactoring to move related field editor code into the /ontology code dir and then adds the new components for that integration.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/452
* https://github.com/LabKey/platform/pull/2037
* https://github.com/LabKey/ontology/pull/22
* https://github.com/LabKey/sampleManagement/pull/496

#### Changes
* Add principalConceptCode to DomainField model
* Add field editor expanded row input for OntologyConceptAnnotation with button to open the Ontology Concept Browser in modal dialog
* Move components related to ontology from /domainproperties to /ontology
* Expose OntologyConceptOverviewPanel for use in ontology module
* Add OntologyBrowserModal to wrap the browser in a modal with cancel and apply buttons
* Factor out OntologyTextDomainFieldSelect from OntologyLookupOptions component
