### PR TITLE
TabbedGridPanel

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.7.0
+*Released*: 1 March 2021
+* Add TabbedGridPanel component
+* Add "title" field to QueryModel
+
 ### version 2.6.0
 *Released*: 27 February 2021
 * Item 8583: Ontology concept picker usages in Field Editor for field concept annotation

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.7.0
 *Released*: 1 March 2021
 * Add TabbedGridPanel component
+  * To be used as a replacement for QueryGridPanel's tabbed mode
 * Add "title" field to QueryModel
 
 ### version 2.6.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -452,6 +452,7 @@ import {
     withQueryModels,
 } from './public/QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './public/QueryModel/GridPanel';
+import { TabbedGridPanel } from './public/QueryModel/TabbedGridPanel';
 import { DetailPanel, DetailPanelWithModel } from './public/QueryModel/DetailPanel';
 import { makeTestActions, makeTestQueryModel } from './public/QueryModel/testUtils';
 import { QueryDetailPage } from './internal/components/listing/pages/QueryDetailPage';
@@ -964,6 +965,7 @@ export {
     DetailPanel,
     DetailPanelWithModel,
     EditableDetailPanel,
+    TabbedGridPanel,
     runDetailsColumnsForQueryModel,
     flattenValuesFromRow,
     Pagination,

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -14,8 +14,10 @@ import {
     QueryInfo,
     QuerySort,
     Pagination,
+    DataViewInfoTypes,
 } from '../..';
 import { GRID_SELECTION_INDEX } from '../../internal/constants';
+import { DataViewInfo } from '../../internal/models';
 import { headerCell, headerSelectionCell } from '../../internal/renderers';
 import { ActionValue } from '../../internal/components/omnibox/actions/Action';
 import { FilterAction } from '../../internal/components/omnibox/actions/Filter';
@@ -33,7 +35,7 @@ import { ChartMenu } from './ChartMenu';
 import { actionValuesToString, filtersEqual, sortsEqual } from './utils';
 import { createQueryModelId } from './QueryModel';
 
-interface GridPanelProps<ButtonsComponentProps> {
+export interface GridPanelProps<ButtonsComponentProps> {
     allowSelections?: boolean;
     allowSorting?: boolean;
     asPanel?: boolean;
@@ -43,6 +45,8 @@ interface GridPanelProps<ButtonsComponentProps> {
     emptyText?: string;
     hideEmptyChartMenu?: boolean;
     hideEmptyViewMenu?: boolean;
+    onChartClicked?: (chart: DataViewInfo) => boolean;
+    onCreateReportClicked?: (type: DataViewInfoTypes) => void;
     pageSizes?: number[];
     title?: string;
     showButtonBar?: boolean;
@@ -96,6 +100,8 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
             ButtonsComponent,
             hideEmptyChartMenu,
             hideEmptyViewMenu,
+            onChartClicked,
+            onCreateReportClicked,
             onViewSelect,
             pageSizes,
             showChartMenu,
@@ -126,6 +132,8 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
                                 hideEmptyChartMenu={hideEmptyChartMenu}
                                 actions={actions}
                                 model={model}
+                                onChartClicked={onChartClicked}
+                                onCreateReportClicked={onCreateReportClicked}
                                 showSampleComparisonReports={showSampleComparisonReports}
                             />
                         )}

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -114,6 +114,10 @@ export interface QueryConfig {
      */
     sorts?: QuerySort[];
     /**
+     * String value to use in grid panel header.
+     */
+    title?: string;
+    /**
      * Prefix string value to use in url parameters when bindURL is true. Defaults to "query".
      */
     urlPrefix?: string;
@@ -217,6 +221,10 @@ export class QueryModel {
      * Array of [[QuerySort]] objects to use for the QueryModel data load.
      */
     readonly sorts: QuerySort[];
+    /**
+     * String value to use in grid panel header.
+     */
+    readonly title?: string;
     /**
      * Prefix string value to use in url parameters when bindURL is true. Defaults to "query".
      */
@@ -350,6 +358,7 @@ export class QueryModel {
         this.selections = undefined;
         this.selectionsError = undefined;
         this.selectionsLoadingState = LoadingState.INITIALIZED;
+        this.title = queryConfig.title;
         this.urlPrefix = queryConfig.urlPrefix ?? 'query'; // match Data Region defaults
         this.charts = undefined;
         this.chartsError = undefined;

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { initUnitTests, makeQueryInfo, makeTestData } from '../../internal/testHelpers';
+import aminoAcidsQuery from '../../test/data/assayAminoAcidsData-getQuery.json';
+import aminoAcidsQueryInfo from '../../test/data/assayAminoAcidsData-getQueryDetails.json';
+import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
+import mixturesQuery from '../../test/data/mixtures-getQueryPaging.json';
+import { QueryInfo } from '../QueryInfo';
+import { SchemaQuery } from '../SchemaQuery';
+
+import { QueryModel } from './QueryModel';
+
+import { RowsResponse } from './QueryModelLoader';
+import { TabbedGridPanel } from './TabbedGridPanel';
+import { makeTestActions, makeTestQueryModel } from './testUtils';
+
+let MIXTURES_QUERY_INFO: QueryInfo;
+let MIXTURES_DATA: RowsResponse;
+let AMINO_ACIDS_QUERY_INFO: QueryInfo;
+let AMINO_ACIDS_DATA: RowsResponse;
+const AMINO_ACIDS_TITLE = 'My Amino Acids';
+const MIXTURES_TITLE = 'Mixtures';
+
+beforeAll(() => {
+    MIXTURES_QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
+    AMINO_ACIDS_QUERY_INFO = makeQueryInfo(aminoAcidsQueryInfo);
+    AMINO_ACIDS_DATA = makeTestData(aminoAcidsQuery);
+    MIXTURES_DATA = makeTestData(mixturesQuery);
+});
+
+describe('TabbedGridPanel', () => {
+    let tabOrder;
+    let queryModels;
+    let mixturesModel: QueryModel;
+    let aminoAcidsModel: QueryModel;
+    let actions;
+
+    beforeEach(() => {
+        mixturesModel = makeTestQueryModel(
+            SchemaQuery.create('exp.data', 'mixtures'),
+            MIXTURES_QUERY_INFO,
+            MIXTURES_DATA.rows,
+            MIXTURES_DATA.orderedRows,
+            MIXTURES_DATA.rowCount,
+            'mixtures'
+        );
+        aminoAcidsModel = makeTestQueryModel(
+            SchemaQuery.create('assay.General.Amino Acids', 'Runs'),
+            AMINO_ACIDS_QUERY_INFO,
+            AMINO_ACIDS_DATA.rows,
+            AMINO_ACIDS_DATA.orderedRows,
+            AMINO_ACIDS_DATA.rowCount,
+            'aminoAcids'
+        ).mutate({ title: AMINO_ACIDS_TITLE });
+        tabOrder = ['mixtures', 'aminoAcids'];
+        queryModels = {
+            mixtures: mixturesModel,
+            aminoAcids: aminoAcidsModel,
+        };
+        actions = makeTestActions();
+    });
+
+    const expectTabs = (wrapper: ReactWrapper, activeTab: string): void => {
+        const tabs = wrapper.find('.nav-tabs li');
+        expect(tabs.length).toEqual(2);
+
+        [MIXTURES_TITLE, AMINO_ACIDS_TITLE].forEach((tab, index) => {
+            expect(tabs.at(index).text()).toEqual(tab);
+
+            if (tab === activeTab) {
+                expect(tabs.at(index).props().className).toContain('active');
+            } else {
+                expect(tabs.at(index).props().className).not.toContain('active');
+            }
+        });
+    };
+
+    const clickTab = (wrapper: ReactWrapper, index: number) => {
+        wrapper.find('.nav-tabs li a').at(index).simulate('click');
+    };
+
+    test('default render', () => {
+        const wrapper = mount(<TabbedGridPanel tabOrder={tabOrder} queryModels={queryModels} actions={actions} />);
+        const tabs = wrapper.find('.nav-tabs li');
+
+        // Here we test that tab order is honored, and that by default we set the first tab to active
+        expect(tabs.length).toEqual(2);
+        expect(tabs.at(0).text()).toEqual('Mixtures');
+        expect(tabs.at(0).props().className).toContain('active');
+        // Model title should get priority for tab title over QueryInfo attributes.
+        expect(tabs.at(1).text()).toEqual(AMINO_ACIDS_TITLE);
+        expect(tabs.at(1).props().className).not.toContain('active');
+    });
+
+    test('activeTab', () => {
+        const wrapper = mount(
+            <TabbedGridPanel
+                activeModelId="aminoAcids"
+                tabOrder={tabOrder}
+                queryModels={queryModels}
+                actions={actions}
+            />
+        );
+
+        expectTabs(wrapper, AMINO_ACIDS_TITLE);
+        clickTab(wrapper, 0);
+        expectTabs(wrapper, MIXTURES_TITLE);
+    });
+
+    test('asPanel', () => {
+        const title = 'My Tabbed Grid';
+        const wrapper = mount(
+            <TabbedGridPanel tabOrder={tabOrder} title={title} queryModels={queryModels} actions={actions} />
+        );
+
+        // When asPanel is true we should render the title
+        expect(wrapper.find('.tabbed-grid-panel.panel-default').exists()).toEqual(true);
+        expect(wrapper.find('.tabbed-grid-panel__title').text()).toEqual(title);
+
+        // When asPanel is false we should not render the title
+        wrapper.setProps({ asPanel: false });
+        expect(wrapper.find('.tabbed-grid-panel.panel-default').exists()).toEqual(false);
+        expect(wrapper.find('.tabbed-grid-panel__title').exists()).toEqual(false);
+    });
+
+    test('single model', () => {
+        const wrapper = mount(
+            <TabbedGridPanel tabOrder={['mixtures']} queryModels={{ mixtures: mixturesModel }} actions={actions} />
+        );
+
+        // Hide the tabs if we only have one model.
+        expect(wrapper.find('.nav-tabs').exists()).toEqual(false);
+    });
+
+    test('controlled', () => {
+        const onTabSelect = jest.fn();
+        const wrapper = mount(
+            <TabbedGridPanel
+                actions={actions}
+                activeModelId="aminoAcids"
+                onTabSelect={onTabSelect}
+                queryModels={queryModels}
+                tabOrder={tabOrder}
+            />
+        );
+        expectTabs(wrapper, AMINO_ACIDS_TITLE);
+        clickTab(wrapper, 0);
+        expect(onTabSelect).toHaveBeenCalledWith('mixtures');
+        // This is a controlled component, and we didn't change the activeModelId prop, so the tab shouldn't change
+        // after click.
+        expectTabs(wrapper, AMINO_ACIDS_TITLE);
+        wrapper.setProps({ activeModelId: 'mixtures' });
+        expectTabs(wrapper, MIXTURES_TITLE);
+    });
+});

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -102,11 +102,7 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
 
     return (
         <div className={classNames('tabbed-grid-panel', { panel: asPanel, 'panel-default': asPanel })}>
-            {title !== undefined && asPanel && (
-                <div className="tabbed-grid-panel__title panel-heading">
-                    <span>{title}</span>
-                </div>
-            )}
+            {title !== undefined && asPanel && <div className="tabbed-grid-panel__title panel-heading">{title}</div>}
 
             <div className={classNames('tabbed-grid-panel__body', { 'panel-body': asPanel })}>
                 {tabOrder.length > 1 && (

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { FC, memo, useCallback, useState } from 'react';
+import classNames from 'classnames';
+
+import { QueryModel } from './QueryModel';
+import { InjectedQueryModels } from './withQueryModels';
+import { GridPanel, GridPanelProps } from './GridPanel';
+
+interface GridTabProps {
+    isActive: boolean;
+    model: QueryModel;
+    onSelect: (id: string) => void;
+    pullRight: boolean;
+}
+
+const GridTab: FC<GridTabProps> = memo(({ isActive, model, onSelect, pullRight }) => {
+    const { id, queryInfo, title } = model;
+    const className = classNames({
+        active: isActive,
+        'pull-right': pullRight,
+    });
+    const onClick = useCallback(() => onSelect(id), [id, onSelect]);
+
+    return (
+        <li className={className}>
+            <a onClick={onClick}>{title || queryInfo.queryLabel || queryInfo.name}</a>
+        </li>
+    );
+});
+
+interface TabbedGridPanelProps<T = {}> extends GridPanelProps<T> {
+    /**
+     * The id of the model you want to render. Required if you are using onTabSelect. If passed when not using
+     * onTabSelect it will be used as the initial active tab.
+     */
+    activeModelId?: string;
+    /**
+     * Defaults to true. Determines if we render the TabbedGridPanel as a Bootstrap panel.
+     */
+    asPanel?: boolean;
+    /**
+     * Optional, if used the TabbedGridPanel will act as a controlled component, requiring you to always pass the
+     * activeModelId. If not passed the TabbedGridPanel will maintain the activeModelId state internally.
+     * @param string
+     */
+    onTabSelect?: (modelId: string) => void;
+    /**
+     * The model IDs you want to render as tabs that are pulled to the right side of the tabs.
+     */
+    rightTabs?: string[];
+    /**
+     * Array of model ids representing the order you want the tabs in. This component will only render Tabs and
+     * GridPanels for Query Models in the TabOrder array.
+     */
+    tabOrder: string[];
+    /**
+     * The title to render, only used if asPanel is true.
+     */
+    title?: string;
+}
+
+export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = memo(props => {
+    const {
+        activeModelId,
+        actions,
+        asPanel = true,
+        onTabSelect,
+        queryModels,
+        rightTabs = [],
+        title,
+        tabOrder,
+        ...rest
+    } = props;
+    const [internalActiveId, setInternalActiveId] = useState<string>(activeModelId ?? tabOrder[0]);
+    const onSelect = useCallback(
+        (modelId: string) => {
+            if (onTabSelect !== undefined) {
+                onTabSelect(modelId);
+            } else {
+                setInternalActiveId(modelId);
+            }
+        },
+        [onTabSelect]
+    );
+    // If the component is passed onTabSelect we will only honor the activeModelId passed to this component.
+    const activeId = onTabSelect === undefined ? internalActiveId : activeModelId;
+    const activeModel = queryModels[activeId];
+
+    return (
+        <div className={classNames('tabbed-grid-panel', { panel: asPanel, 'panel-default': asPanel })}>
+            {title !== undefined && asPanel && (
+                <div className="tabbed-grid-panel__title panel-heading">
+                    <span>{title}</span>
+                </div>
+            )}
+
+            <div className={classNames('tabbed-grid-panel__body', { 'panel-body': asPanel })}>
+                {tabOrder.length > 1 && (
+                    <ul className="nav nav-tabs">
+                        {tabOrder.map(modelId => (
+                            <GridTab
+                                key={modelId}
+                                model={queryModels[modelId]}
+                                isActive={activeId === modelId}
+                                onSelect={onSelect}
+                                pullRight={rightTabs.indexOf(modelId) > -1}
+                            />
+                        ))}
+                    </ul>
+                )}
+
+                <GridPanel key={activeId} actions={actions} asPanel={false} model={activeModel} {...rest} />
+            </div>
+        </div>
+    );
+});

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -443,3 +443,7 @@ $table-cell-selection-bg-color: #EDF3FF;
 .chart-menu-label {
   margin-left: 10px;
 }
+
+.tabbed-grid-panel .nav-tabs {
+    margin-bottom: 30px;
+}


### PR DESCRIPTION
#### Rationale
This PR adds a new component TabbedGridPanel, which can be used to replace old usages of QueryGridPanel that used the tabbed mode by passing multiple QueryGridModels. This component is however pretty different from QueryGridPanel's tabbed use case:

- QGP would by default hide empty tabs, TabbedGridPanel does not do this. This feature only worked properly if you also waited for all of your models to load before rendering the QGP so it wouldn't accidentally render an empty grid in the case that your first tab was empty. TabbedGridPanel expects consumers to filter out the tabs they want to hide.
- QGP would let you disable tab rendering via `showTabs`, this was only used to hide tabs in the rare case that we were using QGP in tabbed mode, but only passing it a single model to render. TabbedGridPanel will now automatically hide the tabs if there is only one model to be rendered.

Though this component is different, it should still meet the needs of all current use-cases of tabbed QueryGridPanels. If we feel like it does not I can change it.

#### Related Pull Requests
* n/a

#### Changes
* Expose onChartClicked, onCreateReportClicked on GridPanel
* Add TabbedGridPanel component
* Add title to QueryModel and QueryConfig
* TODO: Add unit tests for TabbedGridPanel