### PR TITLE
Jest tests for Ontology related changes to NameAndLinkingOptions and FileTree components

### DIFF
--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
@@ -1,5 +1,5 @@
-import { mount } from 'enzyme';
 import React from 'react';
+import { mount } from 'enzyme';
 
 import { createFormInputId } from './actions';
 import {
@@ -12,26 +12,35 @@ import {
 
 import { DomainField } from './models';
 import { NameAndLinkingOptions } from './NameAndLinkingOptions';
+import { OntologyConceptAnnotation } from "../ontology/OntologyConceptAnnotation";
+
+const _description = 'This is a description';
+const _label = 'This is a label';
+const _importAliases = 'This is an alias';
+const _URL = 'This is a URL';
+
+const field = DomainField.create({
+    name: 'key',
+    rangeURI: STRING_RANGE_URI,
+    propertyId: 1,
+    description: _description,
+    label: _label,
+    importAliases: _importAliases,
+    URL: _URL,
+    propertyURI: 'test',
+});
+
+const DEFAULT_PROPS = {
+    index: 1,
+    domainIndex: 1,
+    field,
+    onChange: jest.fn,
+    appPropertiesOnly: false,
+};
 
 describe('NameAndLinkingOptions', () => {
     test('Name and Linking options', () => {
-        const _description = 'This is a description';
-        const _label = 'This is a label';
-        const _importAliases = 'This is an alias';
-        const _URL = 'This is a URL';
-
-        const field = DomainField.create({
-            name: 'key',
-            rangeURI: STRING_RANGE_URI,
-            propertyId: 1,
-            description: _description,
-            label: _label,
-            importAliases: _importAliases,
-            URL: _URL,
-            propertyURI: 'test',
-        });
-
-        const numeric = mount(<NameAndLinkingOptions index={1} domainIndex={1} field={field} onChange={jest.fn()} />);
+        const numeric = mount(<NameAndLinkingOptions {...DEFAULT_PROPS} />);
 
         // Verify section label
         const sectionLabel = numeric.find({ className: 'domain-field-section-heading domain-field-section-hdr' });
@@ -67,5 +76,16 @@ describe('NameAndLinkingOptions', () => {
 
         expect(numeric).toMatchSnapshot();
         numeric.unmount();
+    });
+
+    test('appPropertiesOnly and ontology module', () => {
+        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
+        let wrapper = mount(<NameAndLinkingOptions {...DEFAULT_PROPS} appPropertiesOnly={true} />);
+        expect(wrapper.find(OntologyConceptAnnotation)).toHaveLength(0);
+        wrapper.unmount();
+
+        wrapper = mount(<NameAndLinkingOptions {...DEFAULT_PROPS} appPropertiesOnly={false} />);
+        expect(wrapper.find(OntologyConceptAnnotation)).toHaveLength(1);
+        wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`NameAndLinkingOptions Name and Linking options 1`] = `
 <NameAndLinkingOptions
+  appPropertiesOnly={false}
   domainIndex={1}
   field={
     Immutable.Record {
@@ -89,7 +90,7 @@ exports[`NameAndLinkingOptions Name and Linking options 1`] = `
     }
   }
   index={1}
-  onChange={[MockFunction]}
+  onChange={[Function]}
 >
   <div>
     <Row

--- a/packages/components/src/internal/components/files/FileTree.spec.tsx
+++ b/packages/components/src/internal/components/files/FileTree.spec.tsx
@@ -192,10 +192,10 @@ describe('Header', () => {
         wrapper.unmount();
     });
 
-    test('customStyles and selected', () => {
+    test('customStyles and not selected', () => {
         const title = { fontWeight: 'normal' };
         const customTitle = { fontWeight: 'bold' };
-        let wrapper = mount(
+        const wrapper = mount(
             <Header
                 {...DEFAULT_PROPS}
                 node={{
@@ -212,8 +212,12 @@ describe('Header', () => {
         validate(wrapper);
         expect(wrapper.find('.filetree-resource-row').prop('style')).toStrictEqual(title);
         wrapper.unmount();
+    });
 
-        wrapper = mount(
+    test('customStyles and selected', () => {
+        const title = { fontWeight: 'normal' };
+        const customTitle = { fontWeight: 'bold' };
+        const wrapper = mount(
             <Header
                 {...DEFAULT_PROPS}
                 node={{

--- a/packages/components/src/internal/components/files/FileTree.spec.tsx
+++ b/packages/components/src/internal/components/files/FileTree.spec.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { Checkbox } from 'react-bootstrap';
+import { mount, ReactWrapper, shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFolder, faFileAlt, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 
-import { FileTree } from './FileTree';
+import { LoadingSpinner } from '../../..';
+
+import { FileTree, NodeIcon, Header, EMPTY_FILE_NAME, LOADING_FILE_NAME } from './FileTree';
 import { fetchFileTestTree } from './FileTreeTest';
 
 const waitForLoad = jest.fn(component => Promise.resolve(!component.state().loading));
@@ -20,14 +25,16 @@ describe('FileTree', () => {
 
             return waitForLoad(tree).then(() => {
                 expect(tree.state()['data']['children'].length).toEqual(4);
-                expect(renderer.create(tree.getElement()).toJSON()).toMatchSnapshot();
+                expect(renderer.create(tree.getElement())).toMatchSnapshot();
                 tree.unmount();
             });
         });
     });
 
     test('with data allowMultiSelect false', () => {
-        const component = <FileTree allowMultiSelect={false} loadData={fetchFileTestTree} onFileSelect={jest.fn(() => true)} />;
+        const component = (
+            <FileTree allowMultiSelect={false} loadData={fetchFileTestTree} onFileSelect={jest.fn(() => true)} />
+        );
         const tree = shallow(component);
 
         return waitForLoad(tree).then(() => {
@@ -38,9 +45,190 @@ describe('FileTree', () => {
 
             return waitForLoad(tree).then(() => {
                 expect(tree.state()['data']['children'].length).toEqual(4);
-                expect(renderer.create(tree.getElement()).toJSON()).toMatchSnapshot();
+                expect(renderer.create(tree.getElement())).toMatchSnapshot();
                 tree.unmount();
             });
         });
+    });
+});
+
+describe('NodeIcon', () => {
+    const DEFAULT_PROPS = {
+        isDirectory: false,
+        useFileIconCls: false,
+        node: {},
+    };
+
+    test('default props', () => {
+        const wrapper = mount(<NodeIcon {...DEFAULT_PROPS} />);
+        expect(wrapper.find('i')).toHaveLength(0);
+        expect(wrapper.find(FontAwesomeIcon)).toHaveLength(1);
+        expect(wrapper.find(FontAwesomeIcon).prop('icon')).toBe(faFileAlt);
+        wrapper.unmount();
+    });
+
+    test('isDirectory', () => {
+        const wrapper = mount(<NodeIcon {...DEFAULT_PROPS} isDirectory={true} />);
+        expect(wrapper.find('i')).toHaveLength(0);
+        expect(wrapper.find(FontAwesomeIcon)).toHaveLength(1);
+        expect(wrapper.find(FontAwesomeIcon).prop('icon')).toBe(faFolder);
+        wrapper.unmount();
+    });
+
+    test('isDirectory toggled', () => {
+        const wrapper = mount(<NodeIcon {...DEFAULT_PROPS} isDirectory node={{toggled: true}} />);
+        expect(wrapper.find('i')).toHaveLength(0);
+        expect(wrapper.find(FontAwesomeIcon)).toHaveLength(1);
+        expect(wrapper.find(FontAwesomeIcon).prop('icon')).toBe(faFolderOpen);
+        wrapper.unmount();
+    });
+
+    test('useFileIconCls and iconFontCls', () => {
+        let wrapper = mount(<NodeIcon {...DEFAULT_PROPS} useFileIconCls />);
+        expect(wrapper.find('i')).toHaveLength(0);
+        expect(wrapper.find(FontAwesomeIcon)).toHaveLength(1);
+        expect(wrapper.find(FontAwesomeIcon).prop('className')).toBe('filetree-folder-icon');
+        wrapper.unmount();
+
+        wrapper = mount(<NodeIcon {...DEFAULT_PROPS} useFileIconCls node={{ data: { iconFontCls: 'test-cls' } }} />);
+        expect(wrapper.find('i')).toHaveLength(1);
+        expect(wrapper.find(FontAwesomeIcon)).toHaveLength(0);
+        expect(wrapper.find('i').prop('className')).toBe('test-cls filetree-folder-icon');
+        wrapper.unmount();
+    });
+});
+
+describe('Header', () => {
+    const DEFAULT_PROPS = {
+        node: { id: 'test-id', active: false, children: undefined, name: 'test name' },
+        style: { base: {} },
+        showNodeIcon: true,
+    };
+
+    function validate(
+        wrapper: ReactWrapper,
+        isEmpty = false,
+        loading = false,
+        hasCheckbox = false,
+        showNodeIcon = true,
+        isDirectory = false
+    ): void {
+        expect(wrapper.find('.filetree-empty-directory')).toHaveLength(isEmpty ? 1 : 0);
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(loading ? 1 : 0);
+
+        const rendered = !isEmpty && !loading;
+        expect(wrapper.find('.filetree-checkbox-container')).toHaveLength(rendered ? 1 : 0);
+        expect(wrapper.find(Checkbox)).toHaveLength(rendered && hasCheckbox ? 1 : 0);
+        expect(wrapper.find('.filetree-resource-row')).toHaveLength(rendered ? 1 : 0);
+        expect(wrapper.find(NodeIcon)).toHaveLength(rendered && showNodeIcon ? 1 : 0);
+        expect(wrapper.find('.filetree-file-name')).toHaveLength(rendered && !isDirectory ? 1 : 0);
+        expect(wrapper.find('.filetree-directory-name')).toHaveLength(rendered && isDirectory ? 1 : 0);
+    }
+
+    test('file node, no checkbox', () => {
+        const wrapper = mount(<Header {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        expect(wrapper.find('.filetree-leaf-node')).toHaveLength(1);
+        expect(wrapper.find('.active')).toHaveLength(0);
+        expect(wrapper.find('.filetree-resource-row').prop('title')).toBe('test name');
+        expect(wrapper.find('.filetree-file-name').text()).toBe('test name');
+        wrapper.unmount();
+    });
+
+    test('file node, with checkbox', () => {
+        const wrapper = mount(<Header {...DEFAULT_PROPS} handleCheckbox={jest.fn} />);
+        validate(wrapper, false, false, true);
+        wrapper.unmount();
+    });
+
+    test('directory node', () => {
+        const wrapper = mount(
+            <Header {...DEFAULT_PROPS} node={{ id: 'test-id', active: false, children: [], name: 'test name' }} />
+        );
+        validate(wrapper, false, false, false, true, true);
+        expect(wrapper.find('.filetree-leaf-node')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('showNodeIcon false', () => {
+        const wrapper = mount(<Header {...DEFAULT_PROPS} showNodeIcon={false} />);
+        validate(wrapper, false, false, false, false);
+        wrapper.unmount();
+    });
+
+    test('active and not allowMultiSelect', () => {
+        const wrapper = mount(
+            <Header {...DEFAULT_PROPS} node={{ id: 'test-id', active: true, children: undefined, name: 'test name' }} />
+        );
+        validate(wrapper);
+        expect(wrapper.find('.active')).toHaveLength(1);
+        expect(wrapper.find('.lk-text-theme-dark')).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    test('active and allowMultiSelect', () => {
+        const wrapper = mount(
+            <Header
+                {...DEFAULT_PROPS}
+                node={{ id: 'test-id', active: true, children: undefined, name: 'test name' }}
+                allowMultiSelect
+            />
+        );
+        validate(wrapper);
+        expect(wrapper.find('.active')).toHaveLength(1);
+        expect(wrapper.find('.lk-text-theme-dark')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('empty node', () => {
+        const wrapper = mount(<Header {...DEFAULT_PROPS} node={{ id: 'test|' + EMPTY_FILE_NAME }} />);
+        validate(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('loading node', () => {
+        const wrapper = mount(<Header {...DEFAULT_PROPS} node={{ id: 'test|' + LOADING_FILE_NAME }} />);
+        validate(wrapper, true, true);
+        wrapper.unmount();
+    });
+
+    test('customStyles and selected', () => {
+        const title = { fontWeight: 'normal' };
+        const customTitle = { fontWeight: 'bold' };
+        let wrapper = mount(
+            <Header
+                {...DEFAULT_PROPS}
+                node={{
+                    id: 'test-id',
+                    active: false,
+                    children: undefined,
+                    name: 'test name',
+                    selected: false,
+                }}
+                style={{ base: {}, title }}
+                customStyles={{ header: { title: customTitle } }}
+            />
+        );
+        validate(wrapper);
+        expect(wrapper.find('.filetree-resource-row').prop('style')).toStrictEqual(title);
+        wrapper.unmount();
+
+        wrapper = mount(
+            <Header
+                {...DEFAULT_PROPS}
+                node={{
+                    id: 'test-id',
+                    active: false,
+                    children: undefined,
+                    name: 'test name',
+                    selected: true,
+                    style: { base: {}, title },
+                }}
+                customStyles={{ header: { title: customTitle } }}
+            />
+        );
+        validate(wrapper);
+        expect(wrapper.find('.filetree-resource-row').prop('style')).toStrictEqual(customTitle);
+        wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/files/FileTree.tsx
+++ b/packages/components/src/internal/components/files/FileTree.tsx
@@ -93,8 +93,8 @@ const DEFAULT_ROOT_PREFIX = '|root';
 const CHECK_ID_PREFIX = 'filetree-check-';
 
 // Place holder names for empty or loading display.  Uses asterisk which will never be in a file name.
-const EMPTY_FILE_NAME = '*empty';
-const LOADING_FILE_NAME = '*loading';
+export const EMPTY_FILE_NAME = '*empty';
+export const LOADING_FILE_NAME = '*loading';
 
 const nodeIsLoading = (id: string): boolean => {
     return id.endsWith('|' + LOADING_FILE_NAME);
@@ -104,7 +104,8 @@ const nodeIsEmpty = (id: string): boolean => {
     return id.endsWith('|' + EMPTY_FILE_NAME);
 };
 
-const NodeIcon = props => {
+// exported for jest testing
+export const NodeIcon = props => {
     const { isDirectory, useFileIconCls, node } = props;
     const icon = isDirectory ? (node.toggled ? faFolderOpen : faFolder) : faFileAlt;
 
@@ -119,7 +120,8 @@ const NodeIcon = props => {
     );
 };
 
-const Header = props => {
+// exported for jest testing
+export const Header = props => {
     const {
         style,
         onSelect,
@@ -178,7 +180,12 @@ const Header = props => {
                         {showNodeIcon && (
                             <NodeIcon useFileIconCls={useFileIconCls} isDirectory={isDirectory} node={node} />
                         )}
-                        <div className={classNames({'filetree-file-name': !isDirectory, 'filetree-directory-name': isDirectory })}>
+                        <div
+                            className={classNames({
+                                'filetree-file-name': !isDirectory,
+                                'filetree-directory-name': isDirectory,
+                            })}
+                        >
                             {node.name}
                         </div>
                     </div>


### PR DESCRIPTION
#### Rationale
Jest test additions related to recent ontology related components changes.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/439
* https://github.com/LabKey/labkey-ui-components/pull/452

#### Changes
* Jest test for NameAndLinkingOptions component usage of OntologyConceptAnnotation
* Jest test for FileTree NodeIcon and Header sub-components
