### PR TITLE
Support QuerySelect in Detail Editing

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.8.0",
+  "version": "2.8.1-fb-query-form-inputs.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.8.1-fb-query-form-inputs.0",
+  "version": "2.9.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,6 +2,14 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 
+### version 2.9.0
+*Released*: 4 March 2021
+* Replace `<LookupSelectInput/>` with `<QuerySelect/>` in detail editing.
+* Configures a `QuerySelect` component for detail editing.
+* Support defaults for `detailRenderer` and `titleRenderer` on `DetailDisplay`.
+* No longer publicly export `resolveDetailEditRenderer` or `titleRenderer`.
+* Improve types for our rendering methods.
+
 ### version 2.8.0
 *Released*: 3 March 2021
 * Add isSampleAliquotEnabled experimental flag

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -238,11 +238,7 @@ import { QuerySelect, QuerySelectOwnProps } from './internal/components/forms/Qu
 import { PageDetailHeader } from './internal/components/forms/PageDetailHeader';
 import { DetailEditing } from './internal/components/forms/detail/DetailEditing';
 
-import {
-    resolveDetailEditRenderer,
-    resolveDetailRenderer,
-    titleRenderer,
-} from './internal/components/forms/detail/DetailEditRenderer';
+import { resolveDetailRenderer } from './internal/components/forms/detail/DetailEditRenderer';
 import { Detail } from './internal/components/forms/detail/Detail';
 import { getUsersWithPermissions, handleInputTab, handleTabKeyOnTextArea } from './internal/components/forms/actions';
 import { ISelectInitData } from './internal/components/forms/model';
@@ -564,9 +560,7 @@ export {
     LabelColorRenderer,
     MultiValueRenderer,
     StorageStatusRenderer,
-    resolveDetailEditRenderer,
     resolveDetailRenderer,
-    titleRenderer,
     resolveRenderer,
     // form related items
     BulkAddUpdateForm,

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -3638,6 +3638,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                           componentId="entity-category"
                                           delimiter=","
                                           displayColumn="Value"
+                                          filterOptions={[Function]}
                                           fireQSChangeOnInit={false}
                                           formsy={false}
                                           loadOnChange={true}
@@ -3920,6 +3921,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                         <QuerySelect
                                           componentId="entity-sampleSet"
                                           delimiter=","
+                                          filterOptions={[Function]}
                                           fireQSChangeOnInit={false}
                                           formsy={false}
                                           loadOnChange={true}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -189,7 +189,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             return columns
                 .filter(filter)
                 .valueSeq()
-                .map((col: QueryColumn, i: number) => {
+                .map((col, i) => {
                     const shouldDisableField =
                         initiallyDisableFields || disabledFields.contains(col.name.toLowerCase());
                     if (!shouldDisableField) {
@@ -237,7 +237,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         if (col.displayAsLookup !== false) {
                             const multiple = col.isJunctionLookup();
                             const joinValues = multiple;
-                            const id = col.fieldKey + i + (componentKey ? componentKey : '');
+                            const id = col.fieldKey + i + (componentKey ?? '');
 
                             return (
                                 <React.Fragment key={i}>

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -180,7 +180,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             showQuerySelectPreviewOptions,
         } = this.props;
 
-        const filter = columnFilter ? columnFilter : insertColumnFilter;
+        const filter = columnFilter ?? insertColumnFilter;
         const columns = queryInfo ? queryInfo.columns : queryColumns;
 
         // CONSIDER: separately establishing the set of columns and allow

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -75,6 +75,7 @@ interface State {
     labels: any;
 }
 
+// TODO: Merge this functionality with resolveDetailEditRenderer()
 export class QueryFormInputs extends React.Component<QueryFormInputsProps, State> {
     static defaultProps: Partial<QueryFormInputsProps> = {
         checkRequiredFields: true,
@@ -135,9 +136,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             }));
         }
 
-        if (onQSChange) {
-            onQSChange(name, value, items);
-        }
+        onQSChange?.(name, value, items);
     };
 
     onToggleDisable = (disabled: boolean): void => {
@@ -146,9 +145,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
         } else {
             this._fieldEnabledCount++;
         }
-        if (this.props.onFieldsEnabledChange) {
-            this.props.onFieldsEnabledChange(this._fieldEnabledCount);
-        }
+        this.props.onFieldsEnabledChange?.(this._fieldEnabledCount);
     };
 
     renderLabelField = (col: QueryColumn): ReactNode => {

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -30,7 +30,9 @@ function getValue(model: QuerySelectModel, props: QuerySelectOwnProps): any {
     const { rawSelectedValue } = model;
 
     if (rawSelectedValue !== undefined && !Utils.isString(rawSelectedValue)) {
-        if (List.isList(rawSelectedValue)) {
+        if (Array.isArray(rawSelectedValue)) {
+            return rawSelectedValue;
+        } else if (List.isList(rawSelectedValue)) {
             return rawSelectedValue.toArray();
         } else if (isNaN(rawSelectedValue)) {
             console.warn('QuerySelect: NaN is not a valid value', rawSelectedValue);

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -28,9 +28,10 @@ import {
     selectRows,
 } from '../../..';
 
+import { similaritySortFactory } from '../../util/similaritySortFactory';
+
 import { QuerySelectModel, QuerySelectModelProps } from './model';
 import { FOCUS_FLAG } from './constants';
-import { similaritySortFactory } from '../../util/similaritySortFactory';
 
 const emptyMap = Map<string, any>();
 
@@ -66,15 +67,24 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                     const displayColumn = initDisplayColumn(queryInfo, props.displayColumn);
 
                     if (props.value !== undefined && props.value !== null) {
-                        let filter = Filter.create(valueColumn, props.value);
+                        let filter: Filter.IFilter;
 
-                        if (props.multiple && typeof props.value === 'string') {
-                            // Allow for setting multiValue value.
-                            // This requires updating the filter and the string
-                            const inputArr = props.value.split(props.delimiter);
-                            if (inputArr.length > 1) {
-                                filter = Filter.create(valueColumn, inputArr, Filter.Types.IN);
+                        if (props.multiple) {
+                            if (Array.isArray(props.value)) {
+                                filter = Filter.create(valueColumn, props.value, Filter.Types.IN);
+                            } else if (typeof props.value === 'string') {
+                                // Allow for setting multiValue value.
+                                // This requires updating the filter and the string
+                                filter = Filter.create(
+                                    valueColumn,
+                                    props.value.split(props.delimiter),
+                                    Filter.Types.IN
+                                );
                             }
+                        }
+
+                        if (!filter) {
+                            filter = Filter.create(valueColumn, props.value);
                         }
 
                         selectRows({

--- a/packages/components/src/internal/components/forms/detail/Detail.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/Detail.spec.tsx
@@ -49,8 +49,7 @@ beforeAll(() => {
 describe('<Detail/>', () => {
     test('loading', () => {
         const tree = renderer.create(<Detail />);
-
-        expect(tree.toJSON()).toMatchSnapshot();
+        expect(tree).toMatchSnapshot();
     });
 
     test('with QueryGridModel', () => {
@@ -73,7 +72,7 @@ describe('<Detail/>', () => {
         const model = getQueryGridModel(MODEL_ID);
         const tree = renderer.create(<Detail asPanel={true} queryModel={model} />);
 
-        expect(tree.toJSON()).toMatchSnapshot();
+        expect(tree).toMatchSnapshot();
     });
 
     test('titleRenderer', () => {

--- a/packages/components/src/internal/components/forms/detail/Detail.tsx
+++ b/packages/components/src/internal/components/forms/detail/Detail.tsx
@@ -21,9 +21,9 @@ import { LoadingSpinner, QueryColumn, QueryGridModel } from '../../../..';
 import { DetailDisplay, DetailDisplaySharedProps } from './DetailDisplay';
 
 interface DetailProps extends DetailDisplaySharedProps {
-    queryModel?: QueryGridModel;
-    queryColumns?: List<QueryColumn>;
     getUpdateDisplayColumns?: () => List<QueryColumn>;
+    queryColumns?: List<QueryColumn>;
+    queryModel?: QueryGridModel;
 }
 
 export class Detail extends PureComponent<DetailProps> {
@@ -35,7 +35,7 @@ export class Detail extends PureComponent<DetailProps> {
     render() {
         const { editingMode, queryColumns, queryModel, getUpdateDisplayColumns } = this.props;
 
-        if (queryModel && queryModel.isLoaded) {
+        if (queryModel?.isLoaded) {
             let displayColumns: List<QueryColumn>;
             if (queryColumns) {
                 displayColumns = queryColumns;

--- a/packages/components/src/internal/components/forms/detail/Detail.tsx
+++ b/packages/components/src/internal/components/forms/detail/Detail.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { PureComponent } from 'react';
+import React, { FC, memo } from 'react';
 import { List } from 'immutable';
 
 import { LoadingSpinner, QueryColumn, QueryGridModel } from '../../../..';
@@ -21,40 +21,28 @@ import { LoadingSpinner, QueryColumn, QueryGridModel } from '../../../..';
 import { DetailDisplay, DetailDisplaySharedProps } from './DetailDisplay';
 
 interface DetailProps extends DetailDisplaySharedProps {
-    getUpdateDisplayColumns?: () => List<QueryColumn>;
     queryColumns?: List<QueryColumn>;
     queryModel?: QueryGridModel;
 }
 
-export class Detail extends PureComponent<DetailProps> {
-    get detailDisplayProps(): DetailDisplaySharedProps {
-        const { queryColumns, queryModel, ...detailDisplayProps } = this.props;
-        return detailDisplayProps;
-    }
+export const Detail: FC<DetailProps> = memo(props => {
+    const { queryColumns, queryModel, ...detailDisplayProps } = props;
 
-    render() {
-        const { editingMode, queryColumns, queryModel, getUpdateDisplayColumns } = this.props;
-
-        if (queryModel?.isLoaded) {
-            let displayColumns: List<QueryColumn>;
-            if (queryColumns) {
-                displayColumns = queryColumns;
-            } else if (editingMode) {
-                if (getUpdateDisplayColumns) displayColumns = getUpdateDisplayColumns();
-                else displayColumns = queryModel.getUpdateDisplayColumns();
-            } else {
-                displayColumns = queryModel.getDetailsDisplayColumns();
-            }
-
-            return (
-                <DetailDisplay
-                    {...this.detailDisplayProps}
-                    data={queryModel.getData()}
-                    displayColumns={displayColumns}
-                />
-            );
-        }
-
+    if (!queryModel?.isLoaded) {
         return <LoadingSpinner />;
     }
-}
+
+    // This logic should be kept consistent with corollary logic in <DetailPanel/>
+    let displayColumns: List<QueryColumn>;
+    if (queryColumns) {
+        displayColumns = queryColumns;
+    } else {
+        if (props.editingMode) {
+            displayColumns = queryModel.getUpdateDisplayColumns();
+        } else {
+            displayColumns = queryModel.getDetailsDisplayColumns();
+        }
+    }
+
+    return <DetailDisplay {...detailDisplayProps} data={queryModel.getData()} displayColumns={displayColumns} />;
+});

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -16,7 +16,6 @@ export type Renderer = (data: any, row?: any) => ReactNode;
 
 export interface RenderOptions {
     useDatePicker?: boolean;
-    useQuerySelect?: boolean;
 }
 
 export type DetailRenderer = (column: QueryColumn, options?: RenderOptions) => Renderer;
@@ -93,7 +92,7 @@ interface DetailDisplayProps extends DetailDisplaySharedProps {
 }
 
 export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
-    const { asPanel, data, displayColumns, editingMode, useDatePicker, useQuerySelect } = props;
+    const { asPanel, data, displayColumns, editingMode, useDatePicker } = props;
 
     const detailRenderer = useMemo(() => {
         return props.detailRenderer ?? (editingMode ? resolveDetailEditRenderer : resolveDetailRenderer);
@@ -108,7 +107,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
     if (data.size === 0) {
         body = <div>No data available.</div>;
     } else {
-        const fields = processFields(displayColumns, detailRenderer, titleRenderer, { useDatePicker, useQuerySelect });
+        const fields = processFields(displayColumns, detailRenderer, titleRenderer, { useDatePicker });
 
         body = (
             <div>

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -45,6 +45,7 @@ export function titleRenderer(col: QueryColumn): React.ReactNode {
     return <LabelOverlay column={col} />;
 }
 
+// TODO: Merge this functionality with <QueryFormInputs />
 export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boolean): React.ReactNode {
     return data => {
         const editable = col.isEditable();
@@ -89,7 +90,7 @@ export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boole
             }
         }
 
-        if (col.inputType == 'textarea') {
+        if (col.inputType === 'textarea') {
             return (
                 <Textarea
                     changeDebounceInterval={0}
@@ -172,7 +173,7 @@ export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boole
 export function resolveDetailRenderer(column: QueryColumn) {
     let renderer; // defaults to undefined -- leave it up to the details
 
-    if (column && column.detailRenderer) {
+    if (column?.detailRenderer) {
         switch (column.detailRenderer.toLowerCase()) {
             case 'multivaluedetailrenderer':
                 renderer = d => <MultiValueRenderer data={d} />;

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -26,15 +26,17 @@ import {
     LookupSelectInput,
     QueryColumn,
     LabelColorRenderer,
+    SchemaQuery,
 } from '../../../..';
 
+import { QuerySelect } from '../QuerySelect';
 import { resolveDetailFieldValue, resolveRenderer } from '../renderers';
 
 import { AssayRunReferenceRenderer } from '../../../renderers/AssayRunReferenceRenderer';
 
 import { getUnFormattedNumber } from '../../../util/Date';
 
-import { _defaultRenderer, Renderer } from './DetailDisplay';
+import { _defaultRenderer, Renderer, RenderOptions } from './DetailDisplay';
 
 export function titleRenderer(col: QueryColumn): React.ReactNode {
     // If the column cannot be edited, return the label as is
@@ -46,7 +48,7 @@ export function titleRenderer(col: QueryColumn): React.ReactNode {
 }
 
 // TODO: Merge this functionality with <QueryFormInputs />
-export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boolean): Renderer {
+export function resolveDetailEditRenderer(col: QueryColumn, options?: RenderOptions): Renderer {
     return data => {
         const editable = col.isEditable();
 
@@ -75,6 +77,30 @@ export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boole
                 // 29232: When displaying a lookup, always use the value
                 const multiple = col.isJunctionLookup(),
                     joinValues = multiple && !col.isDataInput();
+
+                if (options?.useQuerySelect) {
+                    return (
+                        <QuerySelect
+                            componentId={col.fieldKey}
+                            displayColumn={col.lookup.displayColumn}
+                            inputClass="col-sm-12"
+                            joinValues={joinValues}
+                            label={col.caption}
+                            loadOnChange
+                            loadOnFocus
+                            maxRows={10}
+                            multiple={multiple}
+                            name={col.name}
+                            placeholder="Select or type to search..."
+                            preLoad
+                            required={col.required}
+                            schemaQuery={SchemaQuery.create(col.lookup.schemaName, col.lookup.queryName)}
+                            value={resolveDetailFieldValue(data, true)}
+                            valueColumn={col.lookup.keyColumn}
+                        />
+                    );
+                }
+
                 return (
                     <LookupSelectInput
                         containerClass="form-group row"
@@ -119,7 +145,7 @@ export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boole
                     />
                 );
             case 'date':
-                if (useDatePicker && (!value || typeof value === 'string')) {
+                if (options?.useDatePicker && (!value || typeof value === 'string')) {
                     return (
                         <DatePickerInput
                             showLabel={false}

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -34,7 +34,7 @@ import { AssayRunReferenceRenderer } from '../../../renderers/AssayRunReferenceR
 
 import { getUnFormattedNumber } from '../../../util/Date';
 
-import { _defaultRenderer } from './DetailDisplay';
+import { _defaultRenderer, Renderer } from './DetailDisplay';
 
 export function titleRenderer(col: QueryColumn): React.ReactNode {
     // If the column cannot be edited, return the label as is
@@ -46,7 +46,7 @@ export function titleRenderer(col: QueryColumn): React.ReactNode {
 }
 
 // TODO: Merge this functionality with <QueryFormInputs />
-export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boolean): React.ReactNode {
+export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boolean): Renderer {
     return data => {
         const editable = col.isEditable();
 
@@ -170,7 +170,7 @@ export function resolveDetailEditRenderer(col: QueryColumn, useDatePicker: boole
     };
 }
 
-export function resolveDetailRenderer(column: QueryColumn) {
+export function resolveDetailRenderer(column: QueryColumn): Renderer {
     let renderer; // defaults to undefined -- leave it up to the details
 
     if (column?.detailRenderer) {

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -23,7 +23,6 @@ import {
     MultiValueRenderer,
     AliasRenderer,
     AppendUnits,
-    LookupSelectInput,
     QueryColumn,
     LabelColorRenderer,
     SchemaQuery,
@@ -75,42 +74,27 @@ export function resolveDetailEditRenderer(col: QueryColumn, options?: RenderOpti
             // Must be explicitly false to prevent drop-down.
             if (col.displayAsLookup !== false) {
                 // 29232: When displaying a lookup, always use the value
-                const multiple = col.isJunctionLookup(),
-                    joinValues = multiple && !col.isDataInput();
-
-                if (options?.useQuerySelect) {
-                    return (
-                        <QuerySelect
-                            componentId={col.fieldKey}
-                            displayColumn={col.lookup.displayColumn}
-                            inputClass="col-sm-12"
-                            joinValues={joinValues}
-                            label={col.caption}
-                            loadOnChange
-                            loadOnFocus
-                            maxRows={10}
-                            multiple={multiple}
-                            name={col.name}
-                            placeholder="Select or type to search..."
-                            preLoad
-                            required={col.required}
-                            schemaQuery={SchemaQuery.create(col.lookup.schemaName, col.lookup.queryName)}
-                            value={resolveDetailFieldValue(data, true)}
-                            valueColumn={col.lookup.keyColumn}
-                        />
-                    );
-                }
+                const multiple = col.isJunctionLookup();
+                const joinValues = multiple && !col.isDataInput();
 
                 return (
-                    <LookupSelectInput
-                        containerClass="form-group row"
+                    <QuerySelect
+                        componentId={col.fieldKey}
+                        displayColumn={col.lookup.displayColumn}
                         inputClass="col-sm-12"
                         joinValues={joinValues}
-                        key={col.name}
+                        label={col.caption}
+                        loadOnChange
+                        loadOnFocus
+                        maxRows={10}
                         multiple={multiple}
-                        queryColumn={col}
-                        value={resolveDetailFieldValue(data, true)}
+                        name={col.name}
+                        placeholder="Select or type to search..."
+                        preLoad
                         required={col.required}
+                        schemaQuery={SchemaQuery.create(col.lookup.schemaName, col.lookup.queryName)}
+                        value={resolveDetailFieldValue(data, true)}
+                        valueColumn={col.lookup.keyColumn}
                     />
                 );
             }

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.spec.tsx
@@ -103,7 +103,7 @@ describe('<DetailEditing/>', () => {
         expect(editButton.find('i')).toHaveLength(1);
         editButton.hostNodes().simulate('click');
         expect(wrapper.find(headingSelector).text()).toBe('Editing Details');
-        expect(wrapper.find('.form-group')).toHaveLength(6);
+        expect(wrapper.find('.form-group')).toHaveLength(7);
 
         // find the save button and click it
         expect(wrapper.find('.edit__warning')).toHaveLength(0);

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -21,7 +21,6 @@ import { AuditBehaviorTypes } from '@labkey/api';
 
 import { updateRows, Alert, resolveErrorMessage, QueryColumn, QueryGridModel } from '../../../..';
 
-import { resolveDetailEditRenderer, resolveDetailRenderer, titleRenderer } from './DetailEditRenderer';
 import { Detail } from './Detail';
 import { DetailPanelHeader } from './DetailPanelHeader';
 import { extractChanges } from './utils';
@@ -191,11 +190,9 @@ export class DetailEditing extends Component<DetailEditingProps, DetailEditingSt
                             <div className="detail__editing">
                                 {error && <Alert>{error}</Alert>}
                                 <Detail
-                                    detailRenderer={resolveDetailEditRenderer}
                                     editingMode
                                     getUpdateDisplayColumns={getUpdateDisplayColumns}
                                     queryModel={queryModel}
-                                    titleRenderer={titleRenderer}
                                 />
                             </div>
                         </Panel.Body>
@@ -222,11 +219,7 @@ export class DetailEditing extends Component<DetailEditingProps, DetailEditingSt
             <Panel>
                 <Panel.Heading>{header}</Panel.Heading>
                 <Panel.Body>
-                    <Detail
-                        queryModel={queryModel}
-                        queryColumns={queryColumns}
-                        detailRenderer={resolveDetailRenderer}
-                    />
+                    <Detail queryColumns={queryColumns} queryModel={queryModel} />
                 </Panel.Body>
             </Panel>
         );

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -25,38 +25,37 @@ import { Detail } from './Detail';
 import { DetailPanelHeader } from './DetailPanelHeader';
 import { extractChanges } from './utils';
 
-interface DetailEditingProps {
-    queryModel: QueryGridModel;
-    queryColumns?: List<QueryColumn>;
-    canUpdate: boolean;
-    onUpdate?: () => void;
-    useEditIcon: boolean;
+interface Props {
     appEditable?: boolean;
     asSubPanel?: boolean;
-    title?: string;
-    cancelText?: string;
-    submitText?: string;
-    onEditToggle?: (editing: boolean) => void;
     auditBehavior?: AuditBehaviorTypes;
-    getUpdateDisplayColumns?: () => List<QueryColumn>;
+    cancelText?: string;
+    canUpdate: boolean;
+    onEditToggle?: (editing: boolean) => void;
+    onUpdate?: () => void;
+    queryColumns?: List<QueryColumn>;
+    queryModel: QueryGridModel;
+    submitText?: string;
+    title?: string;
+    useEditIcon: boolean;
 }
 
-interface DetailEditingState {
-    canSubmit?: boolean;
-    editing?: boolean;
-    warning?: string;
-    error?: ReactNode;
-    isSubmitting?: boolean;
+interface State {
+    canSubmit: boolean;
+    editing: boolean;
+    error: ReactNode;
+    isSubmitting: boolean;
+    warning: string;
 }
 
-export class DetailEditing extends Component<DetailEditingProps, DetailEditingState> {
+export class DetailEditing extends Component<Props, State> {
     static defaultProps = {
         useEditIcon: true,
         cancelText: 'Cancel',
         submitText: 'Save',
     };
 
-    state: Readonly<DetailEditingState> = {
+    state: Readonly<State> = {
         canSubmit: false,
         editing: false,
         warning: undefined,
@@ -154,7 +153,6 @@ export class DetailEditing extends Component<DetailEditingProps, DetailEditingSt
             asSubPanel,
             submitText,
             title,
-            getUpdateDisplayColumns,
         } = this.props;
         const { canSubmit, editing, isSubmitting, warning, error } = this.state;
 
@@ -189,11 +187,7 @@ export class DetailEditing extends Component<DetailEditingProps, DetailEditingSt
                         <Panel.Body>
                             <div className="detail__editing">
                                 {error && <Alert>{error}</Alert>}
-                                <Detail
-                                    editingMode
-                                    getUpdateDisplayColumns={getUpdateDisplayColumns}
-                                    queryModel={queryModel}
-                                />
+                                <Detail editingMode queryColumns={queryColumns} queryModel={queryModel} />
                             </div>
                         </Panel.Body>
                     </Panel>

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { Component, ReactNode } from 'react';
 import { Button, Panel } from 'react-bootstrap';
 import { List } from 'immutable';
 import Formsy from 'formsy-react';
-import { AuditBehaviorTypes, Utils } from '@labkey/api';
+import { AuditBehaviorTypes } from '@labkey/api';
 
 import { updateRows, Alert, resolveErrorMessage, QueryColumn, QueryGridModel } from '../../../..';
 
@@ -37,7 +37,7 @@ interface DetailEditingProps {
     title?: string;
     cancelText?: string;
     submitText?: string;
-    onEditToggle?: (editing: boolean) => any;
+    onEditToggle?: (editing: boolean) => void;
     auditBehavior?: AuditBehaviorTypes;
     getUpdateDisplayColumns?: () => List<QueryColumn>;
 }
@@ -46,41 +46,35 @@ interface DetailEditingState {
     canSubmit?: boolean;
     editing?: boolean;
     warning?: string;
-    error?: React.ReactNode;
+    error?: ReactNode;
     isSubmitting?: boolean;
 }
 
-export class DetailEditing extends React.Component<DetailEditingProps, DetailEditingState> {
+export class DetailEditing extends Component<DetailEditingProps, DetailEditingState> {
     static defaultProps = {
         useEditIcon: true,
         cancelText: 'Cancel',
         submitText: 'Save',
     };
 
-    constructor(props: DetailEditingProps) {
-        super(props);
-
-        this.state = {
-            canSubmit: false,
-            editing: false,
-            warning: undefined,
-            error: undefined,
-            isSubmitting: false,
-        };
-    }
-
-    disableSubmitButton = () => {
-        this.setState(() => ({ canSubmit: false }));
+    state: Readonly<DetailEditingState> = {
+        canSubmit: false,
+        editing: false,
+        warning: undefined,
+        error: undefined,
+        isSubmitting: false,
     };
 
-    enableSubmitButton = () => {
-        this.setState(() => ({ canSubmit: true }));
+    disableSubmitButton = (): void => {
+        this.setState({ canSubmit: false });
     };
 
-    handleClick = () => {
-        if (Utils.isFunction(this.props.onEditToggle)) {
-            this.props.onEditToggle(!this.state.editing);
-        }
+    enableSubmitButton = (): void => {
+        this.setState({ canSubmit: true });
+    };
+
+    handleClick = (): void => {
+        this.props.onEditToggle?.(!this.state.editing);
 
         this.setState(state => ({
             editing: !state.editing,
@@ -89,7 +83,7 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
         }));
     };
 
-    handleFormChange = () => {
+    handleFormChange = (): void => {
         const { warning } = this.state;
         if (warning) {
             this.setState(() => ({ warning: undefined }));
@@ -99,7 +93,7 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
     handleSubmit = values => {
         this.setState(() => ({ isSubmitting: true }));
 
-        const { auditBehavior, queryModel, onUpdate } = this.props;
+        const { auditBehavior, queryModel, onEditToggle, onUpdate } = this.props;
         const queryData = queryModel.getRow();
         const queryInfo = queryModel.queryInfo;
         const schemaQuery = queryInfo.schemaQuery;
@@ -127,10 +121,8 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
                     this.setState(
                         () => ({ isSubmitting: false, editing: false }),
                         () => {
-                            if (onUpdate) {
-                                onUpdate();
-                            }
-                            if (Utils.isFunction(this.props.onEditToggle)) this.props.onEditToggle(false);
+                            onUpdate?.();
+                            onEditToggle?.(false);
                         }
                     );
                 })
@@ -143,45 +135,32 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
                     }));
                 });
         } else {
-            this.setState(() => ({
+            this.setState({
                 canSubmit: false,
                 warning: 'No changes detected. Please update the form and click save.',
                 error: undefined,
                 isSubmitting: false,
-            }));
+            });
         }
     };
 
-    renderEditControls(): ReactNode {
-        const { cancelText, submitText } = this.props;
-        const { canSubmit, isSubmitting } = this.state;
-        return (
-            <div className="full-width bottom-spacing">
-                <Button className="pull-left" onClick={this.handleClick}>
-                    {cancelText}
-                </Button>
-                <Button className="pull-right" bsStyle="success" type="submit" disabled={!canSubmit || isSubmitting}>
-                    {submitText}
-                </Button>
-            </div>
-        );
-    }
-
     render(): ReactNode {
         const {
+            cancelText,
             queryModel,
             queryColumns,
             canUpdate,
             useEditIcon,
             appEditable,
             asSubPanel,
+            submitText,
             title,
             getUpdateDisplayColumns,
         } = this.props;
-        const { editing, warning, error } = this.state;
+        const { canSubmit, editing, isSubmitting, warning, error } = this.state;
 
         let isEditable = false;
-        if (queryModel && queryModel.queryInfo) {
+        if (queryModel?.queryInfo) {
             const hasData = queryModel.getData().size > 0;
             isEditable = hasData && (queryModel.queryInfo.isAppEditable() || appEditable);
         }
@@ -212,16 +191,28 @@ export class DetailEditing extends React.Component<DetailEditingProps, DetailEdi
                             <div className="detail__editing">
                                 {error && <Alert>{error}</Alert>}
                                 <Detail
-                                    queryModel={queryModel}
-                                    editingMode={true}
                                     detailRenderer={resolveDetailEditRenderer}
-                                    titleRenderer={titleRenderer}
+                                    editingMode
                                     getUpdateDisplayColumns={getUpdateDisplayColumns}
+                                    queryModel={queryModel}
+                                    titleRenderer={titleRenderer}
                                 />
                             </div>
                         </Panel.Body>
                     </Panel>
-                    {this.renderEditControls()}
+                    <div className="full-width bottom-spacing">
+                        <Button className="pull-left" onClick={this.handleClick}>
+                            {cancelText}
+                        </Button>
+                        <Button
+                            className="pull-right"
+                            bsStyle="success"
+                            type="submit"
+                            disabled={!canSubmit || isSubmitting}
+                        >
+                            {submitText}
+                        </Button>
+                    </div>
                     {asSubPanel && <div className="panel-divider-spacing" />}
                 </Formsy>
             );

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { withFormsy } from 'formsy-react';
 import { Utils } from '@labkey/api';
 
@@ -80,9 +80,7 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
                 };
             },
             () => {
-                if (this.props.onToggleDisable) {
-                    this.props.onToggleDisable(this.state.isDisabled);
-                }
+                this.props.onToggleDisable?.(this.state.isDisabled);
             }
         );
     };
@@ -120,7 +118,7 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
                 <div className="col-sm-9 col-xs-12">
                     <input
                         disabled={this.state.isDisabled}
-                        name={name ? name : queryColumn.name}
+                        name={name ?? queryColumn.name}
                         required={queryColumn.required}
                         type="checkbox"
                         value={this.props.formsy ? this.props.getValue() : this.state.checked}
@@ -139,24 +137,15 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
  */
 const CheckboxInputFormsy = withFormsy(CheckboxInputImpl);
 
-export class CheckboxInput extends React.Component<CheckboxInputProps, any> {
-    static defaultProps = {
-        formsy: true,
-    };
-
-    constructor(props: CheckboxInputProps) {
-        super(props);
+export const CheckboxInput: FC<CheckboxInputProps> = props => {
+    if (props.formsy) {
+        return <CheckboxInputFormsy name={props.name ?? props.queryColumn.name} {...props} />;
     }
+    return <CheckboxInputImpl {...props} />;
+};
 
-    render() {
-        if (this.props.formsy) {
-            return (
-                <CheckboxInputFormsy
-                    name={this.props.name ? this.props.name : this.props.queryColumn.name}
-                    {...this.props}
-                />
-            );
-        }
-        return <CheckboxInputImpl {...this.props} />;
-    }
-}
+CheckboxInput.defaultProps = {
+    formsy: true,
+};
+
+CheckboxInput.displayName = 'CheckboxInput';

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -85,12 +85,12 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
         );
     }
 
-    onChange = (name, value) => {
-        const { onChange } = this.props;
+    onChange = (name, value): void => {
+        if (this.props.allowDisable) {
+            this.setState({ inputValue: value });
+        }
 
-        if (this.props.allowDisable) this.setState({ inputValue: value });
-
-        if (onChange) onChange(value);
+        this.props.onChange?.(value);
     };
 
     render() {

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -25,7 +25,7 @@ import { AliasInput } from './input/AliasInput';
 export function resolveRenderer(column: QueryColumn) {
     let inputRenderer;
 
-    if (column && column.inputRenderer) {
+    if (column?.inputRenderer) {
         switch (column.inputRenderer.toLowerCase()) {
             case 'experimentalias':
                 inputRenderer = (

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ReactNode, ReactText } from 'react';
 import { List, Map } from 'immutable';
 import { Input } from 'formsy-react-components';
 
@@ -22,69 +22,75 @@ import { QueryColumn } from '../../..';
 import { LabelOverlay } from './LabelOverlay';
 import { AliasInput } from './input/AliasInput';
 
-export function resolveRenderer(column: QueryColumn) {
-    let inputRenderer;
+type InputRenderer = (
+    col: QueryColumn,
+    key: ReactText,
+    value?: any,
+    editing?: boolean,
+    allowFieldDisable?: boolean,
+    initiallyDisabled?: boolean,
+    onToggleDisable?: (disabled: boolean) => void
+) => ReactNode;
 
+const AliasInputRenderer: InputRenderer = (
+    col: QueryColumn,
+    key: ReactText,
+    value?: any,
+    editing?: boolean,
+    allowFieldDisable = false,
+    initiallyDisabled = false,
+    onToggleDisable?: (disabled: boolean) => void
+) => (
+    <AliasInput
+        col={col}
+        editing={editing}
+        key={key}
+        value={value}
+        allowDisable={allowFieldDisable}
+        initiallyDisabled={initiallyDisabled}
+        onToggleDisable={onToggleDisable}
+    />
+);
+
+const AppendUnitsInputRenderer: InputRenderer = (
+    col: QueryColumn,
+    key: ReactText,
+    value?: any,
+    editing?: boolean,
+    allowFieldDisable = false,
+    initiallyDisabled = false
+) => (
+    <Input
+        allowDisable={allowFieldDisable}
+        disabled={initiallyDisabled}
+        addonAfter={<span>{col.units}</span>}
+        changeDebounceInterval={0}
+        elementWrapperClassName={editing ? [{ 'col-sm-9': false }, 'col-sm-12'] : undefined}
+        id={col.name}
+        key={key}
+        label={<LabelOverlay column={col} inputId={col.name} />}
+        labelClassName="control-label text-left"
+        name={col.name}
+        required={col.required}
+        type="text"
+        value={value}
+        validations="isNumericWithError"
+    />
+);
+
+export function resolveRenderer(column: QueryColumn): InputRenderer {
     if (column?.inputRenderer) {
         switch (column.inputRenderer.toLowerCase()) {
             case 'experimentalias':
-                inputRenderer = (
-                    col: QueryColumn,
-                    key: any,
-                    value?: string,
-                    editing?: boolean,
-                    allowFieldDisable = false,
-                    initiallyDisabled = false,
-                    onToggleDisable?: (disabled: boolean) => void
-                ) => {
-                    return (
-                        <AliasInput
-                            col={col}
-                            editing={editing}
-                            key={key}
-                            value={value}
-                            allowDisable={allowFieldDisable}
-                            initiallyDisabled={initiallyDisabled}
-                            onToggleDisable={onToggleDisable}
-                        />
-                    );
-                };
-                break;
+                return AliasInputRenderer;
             case 'appendunitsinput':
-                inputRenderer = (
-                    col: QueryColumn,
-                    key: any,
-                    val?: string,
-                    editing?: boolean,
-                    allowFieldDisable = false,
-                    initiallyDisabled = false
-                ) => {
-                    return (
-                        <Input
-                            allowDisable={allowFieldDisable}
-                            disabled={initiallyDisabled}
-                            addonAfter={<span>{col.units}</span>}
-                            changeDebounceInterval={0}
-                            elementWrapperClassName={editing ? [{ 'col-sm-9': false }, 'col-sm-12'] : undefined}
-                            id={col.name}
-                            key={key}
-                            label={<LabelOverlay column={col} inputId={col.name} />}
-                            labelClassName="control-label text-left"
-                            name={col.name}
-                            required={col.required}
-                            type="text"
-                            value={val}
-                            validations="isNumericWithError"
-                        />
-                    );
-                };
-                break;
+                return AppendUnitsInputRenderer;
             default:
                 break;
         }
     }
 
-    return inputRenderer;
+    return undefined;
 }
 
 interface FieldValue {

--- a/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
+++ b/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
@@ -3,7 +3,6 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import React, { FC, PureComponent, memo, ReactNode, useMemo } from 'react';
-import { fromJS } from 'immutable';
 import { Link, WithRouterProps } from 'react-router';
 
 import {

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -122,7 +122,7 @@ export function bindColumnRenderers(columns: OrderedMap<string, QueryColumn>): O
     if (columns) {
         const columnRenderers: Map<string, any> = getQueryColumnRenderers();
 
-        return columns.map((col: QueryColumn) => {
+        return columns.map(col => {
             let node = DefaultRenderer;
             if (col && col.columnRenderer && columnRenderers.has(col.columnRenderer.toLowerCase())) {
                 node = columnRenderers.get(col.columnRenderer.toLowerCase());

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { FC, memo } from 'react';
 import { List } from 'immutable';
 
 import { MultiValueRenderer } from './MultiValueRenderer';
@@ -21,34 +21,31 @@ import { MultiValueRenderer } from './MultiValueRenderer';
 /**
  * This is the default cell renderer for Details/Grids using a QueryGridModel.
  */
-export class DefaultRenderer extends React.PureComponent<any> {
-    render(): ReactNode {
-        const { data } = this.props;
+export const DefaultRenderer: FC<any> = memo(({ data }) => {
+    let display = null;
 
-        let display = null;
-        if (data) {
-            if (typeof data === 'string') {
-                display = data;
-            } else if (typeof data === 'boolean') {
-                display = data ? 'true' : 'false';
-            } else if (List.isList(data)) {
-                // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
-                return <MultiValueRenderer data={data} />;
+    if (data) {
+        if (typeof data === 'string') {
+            display = data;
+        } else if (typeof data === 'boolean') {
+            display = data ? 'true' : 'false';
+        } else if (List.isList(data)) {
+            // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
+            return <MultiValueRenderer data={data} />;
+        } else {
+            if (data.has('formattedValue')) {
+                display = data.get('formattedValue');
             } else {
-                if (data.has('formattedValue')) {
-                    display = data.get('formattedValue');
-                } else {
-                    const o = data.has('displayValue') ? data.get('displayValue') : data.get('value');
-                    display = o !== null && o !== undefined ? o.toString() : null;
-                }
+                const o = data.has('displayValue') ? data.get('displayValue') : data.get('value');
+                display = o !== null && o !== undefined ? o.toString() : null;
+            }
 
-                if (data.get('url')) {
-                    return <a href={data.get('url')}>{display}</a>;
-                }
+            if (data.get('url')) {
+                return <a href={data.get('url')}>{display}</a>;
             }
         }
-
-        // Issue 36941: when using the default renderer, add css so that line breaks as preserved
-        return <span className="detail-display">{display}</span>;
     }
-}
+
+    // Issue 36941: when using the default renderer, add css so that line breaks as preserved
+    return <span className="detail-display">{display}</span>;
+});

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -17,7 +17,14 @@ import React, { FC, memo, useMemo } from 'react';
 import { fromJS, List } from 'immutable';
 import { Alert } from 'react-bootstrap';
 
-import { InjectedQueryModels, LoadingSpinner, QueryColumn, QueryConfig, RequiresModelAndActions, withQueryModels } from '../..';
+import {
+    InjectedQueryModels,
+    LoadingSpinner,
+    QueryColumn,
+    QueryConfig,
+    RequiresModelAndActions,
+    withQueryModels,
+} from '../..';
 
 import { DetailDisplay, DetailDisplaySharedProps } from '../../internal/components/forms/detail/DetailDisplay';
 
@@ -54,9 +61,11 @@ interface DetailPanelBodyProps extends DetailDisplaySharedProps {
     queryColumns?: QueryColumn[];
 }
 
-const DetailPanelWithModelBodyImpl: FC<DetailPanelBodyProps & InjectedQueryModels> = memo(({ queryModels, ...rest }) => {
-    return <DetailPanel {...rest} model={queryModels.model} />;
-});
+const DetailPanelWithModelBodyImpl: FC<DetailPanelBodyProps & InjectedQueryModels> = memo(
+    ({ queryModels, ...rest }) => {
+        return <DetailPanel {...rest} model={queryModels.model} />;
+    }
+);
 
 const DetailPanelWithModelBody = withQueryModels<DetailPanelBodyProps>(DetailPanelWithModelBodyImpl);
 
@@ -64,8 +73,9 @@ interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
     queryConfig: QueryConfig;
 }
 
-export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(({ asPanel, detailRenderer, editingMode, titleRenderer, useDatePicker, queryConfig }) => {
-    const queryConfigs = useMemo(() => ({ model: queryConfig }), [ queryConfig ]);
+export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props => {
+    const { asPanel, detailRenderer, editingMode, titleRenderer, useDatePicker, queryConfig } = props;
+    const queryConfigs = useMemo(() => ({ model: queryConfig }), [queryConfig]);
     const { keyValue, schemaQuery } = queryConfig;
     const { schemaName, queryName } = schemaQuery;
     // Key is used here to ensure we re-mount the DetailPanel when the queryConfig changes

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -74,7 +74,7 @@ interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
 }
 
 export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props => {
-    const { asPanel, detailRenderer, editingMode, titleRenderer, useDatePicker, queryConfig } = props;
+    const { asPanel, detailRenderer, editingMode, titleRenderer, useDatePicker, useQuerySelect, queryConfig } = props;
     const queryConfigs = useMemo(() => ({ model: queryConfig }), [queryConfig]);
     const { keyValue, schemaQuery } = queryConfig;
     const { schemaName, queryName } = schemaQuery;
@@ -91,6 +91,7 @@ export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props =>
             queryConfigs={queryConfigs}
             titleRenderer={titleRenderer}
             useDatePicker={useDatePicker}
+            useQuerySelect={useQuerySelect}
         />
     );
 });

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -74,7 +74,7 @@ interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
 }
 
 export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props => {
-    const { asPanel, detailRenderer, editingMode, titleRenderer, useDatePicker, useQuerySelect, queryConfig } = props;
+    const { asPanel, detailRenderer, editingMode, titleRenderer, useDatePicker, queryConfig } = props;
     const queryConfigs = useMemo(() => ({ model: queryConfig }), [queryConfig]);
     const { keyValue, schemaQuery } = queryConfig;
     const { schemaName, queryName } = schemaQuery;
@@ -91,7 +91,6 @@ export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props =>
             queryConfigs={queryConfigs}
             titleRenderer={titleRenderer}
             useDatePicker={useDatePicker}
-            useQuerySelect={useQuerySelect}
         />
     );
 });

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -48,6 +48,7 @@ export const DetailPanel: FC<DetailPanelProps> = memo(({ actions, model, queryCo
         return <LoadingSpinner />;
     }
 
+    // This logic should be kept consistent with corollary logic in <Detail/>
     if (queryColumns !== undefined) {
         displayColumns = List(queryColumns);
     } else {

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -133,12 +133,10 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
             useEditIcon,
         } = this.props;
         const { canSubmit, editing, error, warning } = this.state;
-        const panelClass = editing ? 'panel-info' : 'panel-default';
-        const renderer = editing ? resolveDetailEditRenderer : resolveDetailRenderer;
         const isEditable = !model.isLoading && model.hasRows && (model.queryInfo?.isAppEditable() || appEditable);
 
         const panel = (
-            <div className={`panel ${panelClass}`}>
+            <div className={`panel ${editing ? 'panel-info' : 'panel-default'}`}>
                 <div className="panel-heading">
                     <DetailPanelHeader
                         useEditIcon={useEditIcon}
@@ -156,7 +154,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
                     <DetailPanel
                         actions={actions}
-                        detailRenderer={renderer}
+                        detailRenderer={editing ? resolveDetailEditRenderer : resolveDetailRenderer}
                         editingMode={editing}
                         model={model}
                         queryColumns={editing ? undefined : queryColumns}

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -7,17 +7,7 @@ import { AuditBehaviorTypes } from '@labkey/api';
 import { DetailPanelHeader } from '../../internal/components/forms/detail/DetailPanelHeader';
 import { extractChanges } from '../../internal/components/forms/detail/utils';
 
-import {
-    Alert,
-    DetailPanel,
-    QueryColumn,
-    RequiresModelAndActions,
-    resolveDetailEditRenderer,
-    resolveDetailRenderer,
-    resolveErrorMessage,
-    titleRenderer,
-    updateRows,
-} from '../..';
+import { Alert, DetailPanel, QueryColumn, RequiresModelAndActions, resolveErrorMessage, updateRows } from '../..';
 
 interface EditableDetailPanelProps extends RequiresModelAndActions {
     appEditable?: boolean;
@@ -154,11 +144,9 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
                     <DetailPanel
                         actions={actions}
-                        detailRenderer={editing ? resolveDetailEditRenderer : resolveDetailRenderer}
                         editingMode={editing}
                         model={model}
                         queryColumns={editing ? undefined : queryColumns}
-                        titleRenderer={editing ? titleRenderer : undefined}
                     />
                 </div>
             </div>


### PR DESCRIPTION
#### Rationale
[Issue 42310](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42310) indicates users having performance problems with detail pages when lookups are backed by large result sets. This PR addresses this by making `useQuerySelect` an option for use in detail edit rendering. The reason `QuerySelect` is useful is that it is built to handle larger result sets and allow the user to search through those results dynamically without having to front-load all the underlying data.

Something to note here is that `QueryFormInputs` already uses a `QuerySelect`. The configuration of the input components is very similar between `resolveDetailEditRenderer` and `QueryFormInputs` - so much so that I've put in a note to indicate these should likely be merged into one implementation in the future.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/806
* https://github.com/LabKey/sampleManagement/pull/501

#### Changes
* Replace `<LookupSelectInput/>` with `<QuerySelect/>` in detail editing.
* Configures a `QuerySelect` component for detail editing.
* Support defaults for `detailRenderer` and `titleRenderer` on `DetailDisplay`. 
* No longer publicly export `resolveDetailEditRenderer` or `titleRenderer`.
* Improve types for our rendering methods.