### PR TITLE
NavigationBar: showNotifications, showProductNav flags

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.0",
+  "version": "2.6.1-fb-213-fix-42589.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.1-fb-213-fix-42589.0",
+  "version": "2.6.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.6.1
+*Released*: 2 March 2021
+* Issue 42589: Product Menu attempts to load before application initialized
+* Add and respect `showNotifications` and `showProductNav` props to `<NavigationBar />`
+
 ### version 2.6.0
 *Released*: 27 February 2021
 * Item 8583: Ontology concept picker usages in Field Editor for field concept annotation

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -40,6 +40,8 @@ interface NavigationBarProps {
     projectName?: string;
     searchPlaceholder?: string;
     showNavMenu?: boolean;
+    showNotifications?: boolean;
+    showProductNav?: boolean;
     showSearchBox?: boolean;
     user?: User;
 }
@@ -60,6 +62,8 @@ export const NavigationBar: FC<Props> = memo(props => {
         projectName,
         searchPlaceholder,
         showNavMenu,
+        showNotifications,
+        showProductNav,
         showSearchBox,
         signOutUrl,
         user,
@@ -69,9 +73,8 @@ export const NavigationBar: FC<Props> = memo(props => {
         onSearch('');
     }, [onSearch]);
 
-    const notifications =
-        !!notificationsConfig && user && !user.isGuest ? <ServerNotifications {...notificationsConfig} /> : null;
-    const productNav = hasPremiumModule() || getServerContext().devMode ? <ProductNavigation /> : null;
+    const _showNotifications = showNotifications !== false && !!notificationsConfig && user && !user.isGuest;
+    const _showProductNav = (hasPremiumModule() || getServerContext().devMode) && showProductNav !== false;
 
     return (
         <nav className="navbar navbar-container test-loc-nav-header">
@@ -106,8 +109,16 @@ export const NavigationBar: FC<Props> = memo(props => {
                                 />
                             )}
                         </div>
-                        <div className="navbar-item pull-right navbar-item-notification">{notifications}</div>
-                        <div className="navbar-item pull-right navbar-item-product-navigation">{productNav}</div>
+                        {_showNotifications && (
+                            <div className="navbar-item pull-right navbar-item-notification">
+                                <ServerNotifications {...notificationsConfig} />
+                            </div>
+                        )}
+                        {_showProductNav && (
+                            <div className="navbar-item pull-right navbar-item-product-navigation">
+                                <ProductNavigation />
+                            </div>
+                        )}
                         <div className="navbar-item pull-right hidden-xs">
                             {showSearchBox && <SearchBox onSearch={onSearch} placeholder={searchPlaceholder} />}
                         </div>
@@ -125,5 +136,9 @@ export const NavigationBar: FC<Props> = memo(props => {
 
 NavigationBar.defaultProps = {
     showNavMenu: true,
+    showNotifications: true,
+    showProductNav: true,
     showSearchBox: false,
 };
+
+NavigationBar.displayName = 'NavigationBar';

--- a/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
@@ -27,12 +27,6 @@ exports[`<NavigationBar/> default props 1`] = `
           className="navbar-item pull-right"
         />
         <div
-          className="navbar-item pull-right navbar-item-notification"
-        />
-        <div
-          className="navbar-item pull-right navbar-item-product-navigation"
-        />
-        <div
           className="navbar-item pull-right hidden-xs"
         />
         <div
@@ -69,12 +63,6 @@ exports[`<NavigationBar/> with search box 1`] = `
       >
         <div
           className="navbar-item pull-right"
-        />
-        <div
-          className="navbar-item pull-right navbar-item-notification"
-        />
-        <div
-          className="navbar-item pull-right navbar-item-product-navigation"
         />
         <div
           className="navbar-item pull-right hidden-xs"


### PR DESCRIPTION
#### Rationale
This PR introduces two new flags, `showNotifications` and `showProductNav` to the `<NavigationBar/>` component props. These give our apps more fine-grain control over what is being displayed. Both default to `true`. This is targeted for `release21.3` as part of a fix for issue [#42589](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42589).

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/807

#### Changes
* Add and respect `showNotifications` and `showProductNav` props to `<NavigationBar />`.
