### PR TITLE
42608: Bulk Insert erroneously transposes columns

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.2-fb-fix-42608.0",
+  "version": "2.6.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.1",
+  "version": "2.6.2-fb-fix-42608.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.6.#
-*Released*: # March 2021
+### version 2.6.2
+*Released*: 4 March 2021
 * 42608: Bulk Insert erroneously transposes columns
 
 ### version 2.6.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.6.#
+*Released*: # March 2021
+* 42608: Bulk Insert erroneously transposes columns
+
 ### version 2.6.1
 *Released*: 2 March 2021
 * Issue 42589: Product Menu attempts to load before application initialized

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -144,10 +144,10 @@ export interface EditableColumnMetadata {
 }
 
 export interface BulkAddData {
-    pivotKey?: string,
-    pivotValues?: Array<string>
-    totalItems?: number,
-    validationMsg?: ReactNode,
+    pivotKey?: string;
+    pivotValues?: string[];
+    totalItems?: number;
+    validationMsg?: ReactNode;
 }
 
 export interface EditableGridProps {
@@ -157,7 +157,7 @@ export interface EditableGridProps {
     allowBulkUpdate?: boolean;
     allowFieldDisable?: boolean;
     bordered?: boolean;
-    onBulkAdd?: (data: OrderedMap<string, any>) => BulkAddData
+    onBulkAdd?: (data: OrderedMap<string, any>) => BulkAddData;
     bulkAddProps?: Partial<QueryInfoFormProps>;
     bulkUpdateProps?: Partial<QueryInfoFormProps>;
     condensed?: boolean;
@@ -710,7 +710,7 @@ export class EditableGrid extends ReactN.PureComponent<EditableGridProps, Editab
     }
 
     bulkAdd = (data: OrderedMap<string, any>): Promise<any> => {
-        const { addControlProps, bulkAddProps, onBulkAdd  } = this.props;
+        const { addControlProps, bulkAddProps, onBulkAdd } = this.props;
         const { nounSingular, nounPlural } = addControlProps;
         const model = this.getModel(this.props);
 
@@ -724,10 +724,10 @@ export class EditableGrid extends ReactN.PureComponent<EditableGridProps, Editab
             });
         }
 
-        let bulkAddData = undefined;
+        let bulkAddData;
         let totalItems = 0;
         if (onBulkAdd) {
-            bulkAddData  = onBulkAdd(data);
+            bulkAddData = onBulkAdd(data);
             if (bulkAddData.validationMsg) {
                 return new Promise((resolve, reject) => {
                     reject({
@@ -740,16 +740,14 @@ export class EditableGrid extends ReactN.PureComponent<EditableGridProps, Editab
 
         let updatedData = data.delete('numItems').delete('creationType');
 
-        if (totalItems === 0)
-            totalItems = numItems;
+        if (totalItems === 0) totalItems = numItems;
 
         if (bulkAddProps.columnFilter) {
             updatedData = this.restoreBulkInsertData(model, updatedData);
         }
         if (bulkAddData?.pivotKey && bulkAddData?.pivotValues?.length > 0) {
             addRowsPerPivotValue(model, numItems, bulkAddData?.pivotKey, bulkAddData?.pivotValues, updatedData);
-        }
-        else {
+        } else {
             addRows(model, numItems, updatedData);
         }
         this.onRowCountChange();

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -738,8 +738,7 @@ export class EditableGrid extends ReactN.PureComponent<EditableGridProps, Editab
             totalItems = bulkAddData.totalItems;
         }
 
-        let updatedData = data.delete('numItems');
-        updatedData = data.delete('creationType');
+        let updatedData = data.delete('numItems').delete('creationType');
 
         if (totalItems === 0)
             totalItems = numItems;


### PR DESCRIPTION
#### Rationale
This PR addresses [Issue 42608](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42608) to fix the inadvertent copy of invalid keys in bulk edited data. See the ticket for detailed more information.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/814
* https://github.com/LabKey/sampleManagement/pull/505

#### Changes
* Remove both `numItems` and `creationType` metadata keys from the bulk data before continuing processing.
* Lint.
