### PR TITLE
@labkey/build: fix file path parsing in lib.template.xml

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "2.0.0",
+  "version": "2.0.1-fb-fix-lib-template-xml.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "2.0.1-fb-fix-lib-template-xml.1",
+  "version": "2.0.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "2.0.1-fb-fix-lib-template-xml.0",
+  "version": "2.0.1-fb-fix-lib-template-xml.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
 ### version 2.0.1
-*Released # March 2021*
+*Released 5 March 2021*
 * Fix generation of file paths in lib.template.xml
 
 ### version 2.0.0

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,9 @@
 # @labkey/build
 
+### version 2.0.1
+*Released # March 2021*
+* Fix generation of file paths in lib.template.xml
+
 ### version 2.0.0
 *Released 4 March 2021*
 * Upgrade to Webpack 5

--- a/packages/build/webpack/lib.template.xml
+++ b/packages/build/webpack/lib.template.xml
@@ -7,7 +7,7 @@
             // This could theoretically be done by poking the "compilation" object from webpack but I could not
             // find a strategy that works.
             [...files.css, ...files.js].forEach((filePath) => {
-                if (filePath.indexOf('/vendors~') > -1 || filePath.indexOf(options.name) > -1) {
+                if (filePath.indexOf('vendors') > -1 || filePath.indexOf(options.name) > -1) {
         %>
         <dependency path="<%= filePath.replace(publicPath, modulePath) %>"/>
         <%  }}); %>

--- a/packages/build/webpack/lib.template.xml
+++ b/packages/build/webpack/lib.template.xml
@@ -7,10 +7,7 @@
             // This could theoretically be done by poking the "compilation" object from webpack but I could not
             // find a strategy that works.
             [...files.css, ...files.js].forEach((filePath) => {
-                if (filePath.indexOf('/vendors~') > -1 ||
-                    filePath.indexOf('/' + options.name + '~') > -1 ||
-                    filePath.indexOf('/' + options.name + '.css') > -1 ||
-                    filePath.indexOf('/' + options.name + '.js') > -1) {
+                if (filePath.indexOf('/vendors~') > -1 || filePath.indexOf(options.name) > -1) {
         %>
         <dependency path="<%= filePath.replace(publicPath, modulePath) %>"/>
         <%  }}); %>


### PR DESCRIPTION
#### Rationale
Minor fix to allow `generateLib: true` to work in app entryPoints.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2063

#### Changes
* Apply same parsing logic to `lib.template.xml` as was applied to `app.view.template.xml` in https://github.com/LabKey/labkey-ui-components/pull/461.
