### PR TITLE
Detail: Support editColumns

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.11.1",
+  "version": "2.11.2-fb-detail-edit-columns.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/src/internal/components/forms/detail/Detail.tsx
+++ b/packages/components/src/internal/components/forms/detail/Detail.tsx
@@ -21,12 +21,13 @@ import { LoadingSpinner, QueryColumn, QueryGridModel } from '../../../..';
 import { DetailDisplay, DetailDisplaySharedProps } from './DetailDisplay';
 
 interface DetailProps extends DetailDisplaySharedProps {
+    editColumns?: List<QueryColumn>;
     queryColumns?: List<QueryColumn>;
     queryModel?: QueryGridModel;
 }
 
 export const Detail: FC<DetailProps> = memo(props => {
-    const { queryColumns, queryModel, ...detailDisplayProps } = props;
+    const { editColumns, queryColumns, queryModel, ...detailDisplayProps } = props;
 
     if (!queryModel?.isLoaded) {
         return <LoadingSpinner />;
@@ -38,7 +39,11 @@ export const Detail: FC<DetailProps> = memo(props => {
         displayColumns = queryColumns;
     } else {
         if (props.editingMode) {
-            displayColumns = queryModel.getUpdateDisplayColumns();
+            if (editColumns) {
+                displayColumns = editColumns;
+            } else {
+                displayColumns = queryModel.getUpdateDisplayColumns();
+            }
         } else {
             displayColumns = queryModel.getDetailsDisplayColumns();
         }

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -31,6 +31,7 @@ interface Props {
     auditBehavior?: AuditBehaviorTypes;
     cancelText?: string;
     canUpdate: boolean;
+    editColumns?: List<QueryColumn>;
     onEditToggle?: (editing: boolean) => void;
     onUpdate?: () => void;
     queryColumns?: List<QueryColumn>;
@@ -145,6 +146,7 @@ export class DetailEditing extends Component<Props, State> {
     render(): ReactNode {
         const {
             cancelText,
+            editColumns,
             queryModel,
             queryColumns,
             canUpdate,
@@ -187,7 +189,12 @@ export class DetailEditing extends Component<Props, State> {
                         <Panel.Body>
                             <div className="detail__editing">
                                 {error && <Alert>{error}</Alert>}
-                                <Detail editingMode queryColumns={queryColumns} queryModel={queryModel} />
+                                <Detail
+                                    editColumns={editColumns}
+                                    editingMode
+                                    queryColumns={queryColumns}
+                                    queryModel={queryModel}
+                                />
                             </div>
                         </Panel.Body>
                     </Panel>

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -29,6 +29,7 @@ import {
 import { DetailDisplay, DetailDisplaySharedProps } from '../../internal/components/forms/detail/DetailDisplay';
 
 interface DetailPanelProps extends DetailDisplaySharedProps, RequiresModelAndActions {
+    editColumns?: QueryColumn[];
     queryColumns?: QueryColumn[];
 }
 
@@ -36,7 +37,8 @@ interface DetailPanelProps extends DetailDisplaySharedProps, RequiresModelAndAct
  * Render a QueryModel with a single row of a data. For in-depth documentation and examples see
  * components/docs/QueryModel.md.
  */
-export const DetailPanel: FC<DetailPanelProps> = memo(({ actions, model, queryColumns, ...detailDisplayProps }) => {
+export const DetailPanel: FC<DetailPanelProps> = memo(props => {
+    const { actions, editColumns, model, queryColumns, ...detailDisplayProps } = props;
     // ignoring actions so we don't pass to DetailDisplay
     const { editingMode } = detailDisplayProps;
     const error = model.queryInfoError ?? model.rowsError;
@@ -52,7 +54,15 @@ export const DetailPanel: FC<DetailPanelProps> = memo(({ actions, model, queryCo
     if (queryColumns !== undefined) {
         displayColumns = List(queryColumns);
     } else {
-        displayColumns = List(editingMode ? model.updateColumns : model.detailColumns);
+        if (editingMode) {
+            if (editColumns) {
+                displayColumns = List(editColumns);
+            } else {
+                displayColumns = List(model.updateColumns);
+            }
+        } else {
+            displayColumns = List(model.detailColumns);
+        }
     }
 
     return <DetailDisplay {...detailDisplayProps} data={fromJS(model.gridData)} displayColumns={displayColumns} />;

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -15,6 +15,7 @@ interface EditableDetailPanelProps extends RequiresModelAndActions {
     auditBehavior?: AuditBehaviorTypes;
     cancelText?: string;
     canUpdate: boolean;
+    editColumns?: QueryColumn[];
     onEditToggle?: (editing: boolean) => void;
     onUpdate: () => void;
     queryColumns?: QueryColumn[];
@@ -116,6 +117,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
             asSubPanel,
             cancelText,
             canUpdate,
+            editColumns,
             model,
             queryColumns,
             submitText,
@@ -144,9 +146,10 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
                     <DetailPanel
                         actions={actions}
+                        editColumns={editColumns}
                         editingMode={editing}
                         model={model}
-                        queryColumns={editing ? undefined : queryColumns}
+                        queryColumns={queryColumns}
                     />
                 </div>
             </div>


### PR DESCRIPTION
#### Rationale
This allows `<Detail/>` and `<DetailEditing/>` components to have the set of `editColumns` explicitly supplied by the user. This is similar to the already available `queryColumns` property which allows a user to override the set of non-editing columns.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add `editColumns` property to `<Detail/>`, `<DetailEditing/>` for `QueryGridModel` support.
* Add `editColumns` property to `<DetailPanel/>`, `<EditableDetailPanel/>` for `QueryModel` support.
