### PR TITLE
QueryModel-based SingleParentEntityPanel

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.13.2
+*Released*: 11 March 2021
+* Convert `<SingleParentEntityPanel/>` to use `QueryModel`.
+* Update `<ParentEntityEditPanel/>` to no longer invalidate `QueryGridModel`s for underlying single parent panels.
 
 ### version 2.13.1
 *Released*: 11 March 2021

--- a/packages/components/src/internal/components/QueryGrid.tsx
+++ b/packages/components/src/internal/components/QueryGrid.tsx
@@ -87,7 +87,7 @@ export class QueryGrid extends ReactN.Component<QueryGridProps, QueryGridState, 
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.initModel(this.props);
         this.initUrlRouteListener();
     }
@@ -103,22 +103,19 @@ export class QueryGrid extends ReactN.Component<QueryGridProps, QueryGridState, 
         }
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         this.removeUrlRouteListener();
     }
 
-    removeUrlRouteListener() {
-        const { unlisten } = this.state;
-        if (unlisten) {
-            unlisten();
-        }
-    }
+    removeUrlRouteListener = (): void => {
+        this.state.unlisten?.();
+    };
 
     initUrlRouteListener() {
         // make sure to remove any previous route listeners by calling their unlisten() function
         this.removeUrlRouteListener();
 
-        if (this.props.model && this.props.model.bindURL) {
+        if (this.props.model?.bindURL) {
             const unlisten = getBrowserHistory().listen((location, action) => {
                 // this listener only applies if we are staying on the same route, exit early if we are navigating
                 const originalRoute = getRouteFromLocationHash(this.state.locationHash);

--- a/packages/components/src/internal/components/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteModal.tsx
@@ -64,9 +64,7 @@ export const EntityDeleteModal: React.FC<Props> = props => {
     function onConfirm(rowsToDelete: any[], rowsToKeep: any[]): void {
         setNumConfirmed(rowsToDelete.length);
         setShowProgress(true);
-        if (beforeDelete) {
-            beforeDelete();
-        }
+        beforeDelete?.();
         const noun = ' ' + getNoun(rowsToDelete.length);
 
         const schemaQuery = SchemaQuery.create(model.schema, model.query);

--- a/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
@@ -12,7 +12,6 @@ import {
     EntityDataType,
     getActionErrorMessage,
     getQueryGridModel,
-    gridIdInvalidate,
     LoadingSpinner,
     Progress,
     QueryGridModel,
@@ -26,13 +25,7 @@ import { DELIMITER } from '../forms/input/SelectInput';
 import { getEntityTypeOptions } from './actions';
 import { EntityChoice, IEntityTypeOption } from './models';
 import { SingleParentEntityPanel } from './SingleParentEntityPanel';
-
-import {
-    getInitialParentChoices,
-    getParentGridPrefix,
-    getUpdatedRowForParentChanges,
-    parentValuesDiffer,
-} from './utils';
+import { getInitialParentChoices, getUpdatedRowForParentChanges, parentValuesDiffer } from './utils';
 
 interface Props {
     auditBehavior?: AuditBehaviorTypes;
@@ -80,10 +73,6 @@ export class ParentEntityEditPanel extends Component<Props, State> {
         this.init();
     }
 
-    componentWillUnmount(): void {
-        this.invalidate();
-    }
-
     init = async (): Promise<void> => {
         const { parentDataType } = this.props;
         const { typeListingSchemaQuery } = parentDataType;
@@ -109,10 +98,6 @@ export class ParentEntityEditPanel extends Component<Props, State> {
                 ),
             });
         }
-    };
-
-    invalidate = (): void => {
-        gridIdInvalidate(getParentGridPrefix(this.props.parentDataType), true);
     };
 
     getChildModel = (): QueryGridModel => {
@@ -201,7 +186,6 @@ export class ParentEntityEditPanel extends Component<Props, State> {
                         editing: false,
                     }),
                     () => {
-                        this.invalidate();
                         onUpdate?.();
                         this.props.onEditToggle?.(false);
                     }

--- a/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
@@ -1,5 +1,4 @@
-import React, { ReactNode } from 'react';
-import ReactN from 'reactn';
+import React, { Component, ReactNode } from 'react';
 import { Button, Panel } from 'react-bootstrap';
 
 import { List } from 'immutable';
@@ -24,8 +23,6 @@ import { DetailPanelHeader } from '../forms/detail/DetailPanelHeader';
 
 import { DELIMITER } from '../forms/input/SelectInput';
 
-import { GlobalAppState } from '../../global';
-
 import { getEntityTypeOptions } from './actions';
 import { EntityChoice, IEntityTypeOption } from './models';
 import { SingleParentEntityPanel } from './SingleParentEntityPanel';
@@ -38,95 +35,89 @@ import {
 } from './utils';
 
 interface Props {
+    auditBehavior?: AuditBehaviorTypes;
+    cancelText?: string;
     canUpdate: boolean;
     childName: string;
     childNounSingular: string;
     childModel: QueryGridModel;
     onUpdate?: () => void;
-    onEditToggle?: (editing: boolean) => any;
+    onEditToggle?: (editing: boolean) => void;
     parentDataType: EntityDataType;
-    title: string;
-    cancelText?: string;
     submitText?: string;
-    auditBehavior?: AuditBehaviorTypes;
+    title: string;
 }
 
 interface State {
+    currentParents: List<EntityChoice>;
     editing: boolean;
     error: ReactNode;
     loading: boolean;
+    originalParents: List<EntityChoice>;
+    originalValueLoaded: List<boolean>;
     parentTypeOptions: List<IEntityTypeOption>;
     submitting: boolean;
-    originalParents: List<EntityChoice>;
-    currentParents: List<EntityChoice>;
-    originalValueLoaded: List<boolean>;
 }
 
-export class ParentEntityEditPanel extends ReactN.Component<Props, State, GlobalAppState> {
+export class ParentEntityEditPanel extends Component<Props, State> {
     static defaultProps = {
         cancelText: 'Cancel',
         submitText: 'Save',
     };
 
-    constructor() {
-        super();
+    state: Readonly<State> = {
+        currentParents: undefined,
+        editing: false,
+        error: undefined,
+        loading: true,
+        originalParents: undefined,
+        originalValueLoaded: List<boolean>(),
+        parentTypeOptions: undefined,
+        submitting: false,
+    };
 
-        this.state = {
-            editing: false,
-            error: undefined,
-            loading: true,
-            parentTypeOptions: undefined,
-            submitting: false,
-            originalParents: undefined,
-            currentParents: undefined,
-            originalValueLoaded: List<boolean>(),
-        };
-    }
-
-    UNSAFE_componentWillMount(): void {
+    componentDidMount(): void {
         this.init();
     }
 
-    componentWillUnmount() {
-        gridIdInvalidate(getParentGridPrefix(this.props.parentDataType), true);
+    componentWillUnmount(): void {
+        this.invalidate();
     }
 
-    init = (): void => {
+    init = async (): Promise<void> => {
         const { parentDataType } = this.props;
         const { typeListingSchemaQuery } = parentDataType;
 
-        getEntityTypeOptions(parentDataType)
-            .then(optionsMap => {
-                const parentTypeOptions = optionsMap.get(typeListingSchemaQuery.queryName);
-                const originalParents = getInitialParentChoices(
-                    parentTypeOptions,
-                    parentDataType,
-                    this.getChildModel()
-                );
-                const currentParents = originalParents.reduce((list, parent) => {
-                    return list.push({ ...parent });
-                }, List<EntityChoice>());
+        try {
+            const optionsMap = await getEntityTypeOptions(parentDataType);
 
-                this.setState(() => ({
-                    loading: false,
-                    parentTypeOptions,
-                    originalParents,
-                    currentParents,
-                }));
-            })
-            .catch(reason => {
-                this.setState(() => ({
-                    error: getActionErrorMessage(
-                        'Unable to load ' + parentDataType.descriptionSingular + ' data.',
-                        parentDataType.descriptionPlural,
-                        true
-                    ),
-                }));
+            const parentTypeOptions = optionsMap.get(typeListingSchemaQuery.queryName);
+            const originalParents = getInitialParentChoices(parentTypeOptions, parentDataType, this.getChildModel());
+
+            this.setState({
+                currentParents: originalParents,
+                loading: false,
+                originalParents,
+                parentTypeOptions,
             });
+        } catch (reason) {
+            this.setState({
+                error: getActionErrorMessage(
+                    'Unable to load ' + parentDataType.descriptionSingular + ' data.',
+                    parentDataType.descriptionPlural,
+                    true
+                ),
+            });
+        }
+    };
+
+    invalidate = (): void => {
+        gridIdInvalidate(getParentGridPrefix(this.props.parentDataType), true);
     };
 
     getChildModel = (): QueryGridModel => {
-        return getQueryGridModel(this.props.childModel.getId());
+        const { childModel } = this.props;
+        return getQueryGridModel(childModel.getId()) || childModel;
     };
 
     hasParents = (): boolean => {
@@ -134,23 +125,18 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
     };
 
     toggleEdit = (): void => {
-        if (this.props.onEditToggle) {
-            this.props.onEditToggle(!this.state.editing);
-        }
+        this.props.onEditToggle?.(!this.state.editing);
         this.setState(state => ({ editing: !state.editing }));
     };
 
     changeEntityType = (fieldName: string, formValue: any, selectedOption: IEntityTypeOption, index): void => {
-        this.setState(state => {
-            const updatedParents = state.currentParents.set(index, {
+        this.setState(state => ({
+            currentParents: state.currentParents.set(index, {
                 type: selectedOption,
                 value: undefined,
                 ids: undefined,
-            });
-            return {
-                currentParents: updatedParents,
-            };
-        });
+            }),
+        }));
     };
 
     onParentValueChange = (name: string, value: string | any[], index: number): void => {
@@ -182,13 +168,11 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
         this.setState(
             state => ({
                 currentParents: state.originalParents,
-                originalValueLoaded: List<boolean>(),
                 editing: false,
+                originalValueLoaded: List<boolean>(),
             }),
             () => {
-                if (this.props.onEditToggle) {
-                    this.props.onEditToggle(false);
-                }
+                this.props.onEditToggle?.(false);
             }
         );
     };
@@ -196,7 +180,7 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
     onSubmit = (): Promise<any> => {
         if (!this.canSubmit()) return;
 
-        this.setState(() => ({ submitting: true }));
+        this.setState({ submitting: true });
 
         const { auditBehavior, parentDataType, onUpdate } = this.props;
         const { currentParents, originalParents } = this.state;
@@ -217,23 +201,18 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
                         editing: false,
                     }),
                     () => {
-                        gridIdInvalidate(getParentGridPrefix(this.props.parentDataType), true);
-
-                        if (onUpdate) {
-                            onUpdate();
-                        }
-                        if (this.props.onEditToggle) {
-                            this.props.onEditToggle(false);
-                        }
+                        this.invalidate();
+                        onUpdate?.();
+                        this.props.onEditToggle?.(false);
                     }
                 );
             })
             .catch(error => {
                 console.error(error);
-                this.setState(() => ({
-                    submitting: false,
+                this.setState({
                     error: resolveErrorMessage(error, 'data', undefined, 'update'),
-                }));
+                    submitting: false,
+                });
             });
     };
 
@@ -257,65 +236,37 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
         );
     };
 
-    renderEditControls = (): ReactNode => {
-        const { cancelText, submitText } = this.props;
-        const { submitting } = this.state;
-
-        return (
-            <div className="full-width bottom-spacing">
-                <Button className="pull-left" onClick={this.onCancel}>
-                    {cancelText}
-                </Button>
-                <Button
-                    className="pull-right"
-                    bsStyle="success"
-                    type="submit"
-                    disabled={submitting || !this.canSubmit()}
-                    onClick={this.onSubmit}
-                >
-                    {submitText}
-                </Button>
-            </div>
-        );
-    };
-
     getParentTypeOptions = (currentIndex: number): List<IEntityTypeOption> => {
         const { currentParents, parentTypeOptions } = this.state;
         // include the current parent type as a choice, but not the others already chosen
-        let toRemove = List<string>();
-        currentParents.forEach((parent, index) => {
-            if (index !== currentIndex && parent.type) {
-                toRemove = toRemove.push(parent.type.label);
-            }
-        });
+        const toRemove = currentParents
+            .filter((parent, idx) => idx !== currentIndex && !!parent.type)
+            .map(parent => parent.type.label)
+            .toList();
+
         return parentTypeOptions.filter(option => !toRemove.contains(option.label)).toList();
     };
 
     onRemoveParentType = (index: number): void => {
-        this.setState(state => {
-            return {
-                currentParents: state.currentParents.delete(index),
-            };
-        });
+        this.setState(state => ({ currentParents: state.currentParents.delete(index) }));
     };
 
-    renderSingleParentPanels = (): ReactNode => {
-        const { parentDataType } = this.props;
+    renderParentData = (): ReactNode => {
+        const { parentDataType, childNounSingular } = this.props;
+        const { editing } = this.state;
 
-        return this.state.currentParents
-            .map((choice, index) => {
-                const key = choice.type ? choice.type.label + '-' + index : 'unknown-' + index;
-                return (
-                    <div key={key}>
-                        {this.state.editing && <hr />}
+        if (this.hasParents()) {
+            return this.state.currentParents
+                .map((choice, index) => (
+                    <div key={choice.type ? choice.type.label + '-' + index : 'unknown-' + index}>
+                        {editing && <hr />}
                         <SingleParentEntityPanel
-                            key={key}
                             parentDataType={parentDataType}
                             parentTypeOptions={this.getParentTypeOptions(index)}
                             parentTypeQueryName={choice.type ? choice.type.label : undefined}
                             parentLSIDs={choice.ids}
                             index={index}
-                            editing={this.state.editing}
+                            editing={editing}
                             chosenValue={choice.value}
                             onChangeParentType={this.changeEntityType}
                             onChangeParentValue={this.onParentValueChange}
@@ -323,32 +274,25 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
                             onRemoveParentType={this.onRemoveParentType}
                         />
                     </div>
-                );
-            })
-            .toArray();
-    };
-
-    renderParentData = (): ReactNode => {
-        const { parentDataType, childNounSingular } = this.props;
-        if (this.hasParents()) {
-            return this.renderSingleParentPanels();
-        } else {
-            return (
-                <div key={1}>
-                    <hr />
-                    <SingleParentEntityPanel
-                        editing={this.state.editing}
-                        parentTypeOptions={this.state.parentTypeOptions}
-                        parentDataType={parentDataType}
-                        childNounSingular={childNounSingular}
-                        index={0}
-                        onChangeParentType={this.changeEntityType}
-                        onChangeParentValue={this.onParentValueChange}
-                        onInitialParentValue={this.onInitialParentValue}
-                    />
-                </div>
-            );
+                ))
+                .toArray();
         }
+
+        return (
+            <div>
+                <hr />
+                <SingleParentEntityPanel
+                    editing={editing}
+                    parentTypeOptions={this.state.parentTypeOptions}
+                    parentDataType={parentDataType}
+                    childNounSingular={childNounSingular}
+                    index={0}
+                    onChangeParentType={this.changeEntityType}
+                    onChangeParentValue={this.onParentValueChange}
+                    onInitialParentValue={this.onInitialParentValue}
+                />
+            </div>
+        );
     };
 
     onAddParent = (): void => {
@@ -358,56 +302,52 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
     };
 
     renderAddParentButton = (): ReactNode => {
-        const { parentTypeOptions } = this.state;
-        if (!parentTypeOptions || parentTypeOptions.size === 0) return null;
-        else {
-            const { parentDataType } = this.props;
-            const { currentParents } = this.state;
+        const { parentDataType } = this.props;
+        const { currentParents, parentTypeOptions } = this.state;
 
-            const disabled = parentTypeOptions.size <= currentParents.size;
-            const title = disabled
-                ? 'Only ' +
-                  parentTypeOptions.size +
-                  ' ' +
-                  (parentTypeOptions.size === 1
-                      ? parentDataType.descriptionSingular
-                      : parentDataType.descriptionPlural) +
-                  ' available.'
-                : undefined;
-
-            return (
-                <AddEntityButton
-                    containerClass="top-spacing"
-                    onClick={this.onAddParent}
-                    title={title}
-                    disabled={disabled}
-                    entity={this.props.parentDataType.nounSingular}
-                />
-            );
+        if (!parentTypeOptions || parentTypeOptions.size === 0) {
+            return null;
         }
+
+        const disabled = parentTypeOptions.size <= currentParents.size;
+        const title = disabled
+            ? 'Only ' +
+              parentTypeOptions.size +
+              ' ' +
+              (parentTypeOptions.size === 1 ? parentDataType.descriptionSingular : parentDataType.descriptionPlural) +
+              ' available.'
+            : undefined;
+
+        return (
+            <AddEntityButton
+                containerClass="top-spacing"
+                onClick={this.onAddParent}
+                title={title}
+                disabled={disabled}
+                entity={this.props.parentDataType.nounSingular}
+            />
+        );
     };
 
     render() {
-        const { parentDataType, title, canUpdate, childName } = this.props;
-        const { editing, error, loading } = this.state;
-
-        const heading = (
-            <DetailPanelHeader
-                useEditIcon={true}
-                isEditable={!loading && canUpdate}
-                canUpdate={canUpdate}
-                editing={editing}
-                title={title}
-                onClickFn={this.toggleEdit}
-            />
-        );
+        const { cancelText, parentDataType, title, canUpdate, childName, submitText } = this.props;
+        const { editing, error, loading, submitting } = this.state;
 
         return (
             <>
                 <Panel bsStyle={editing ? 'info' : 'default'}>
-                    <Panel.Heading>{heading}</Panel.Heading>
+                    <Panel.Heading>
+                        <DetailPanelHeader
+                            canUpdate={canUpdate}
+                            editing={editing}
+                            isEditable={!loading && canUpdate}
+                            onClickFn={this.toggleEdit}
+                            title={title}
+                            useEditIcon
+                        />
+                    </Panel.Heading>
                     <Panel.Body>
-                        {error && <Alert>{error}</Alert>}
+                        <Alert>{error}</Alert>
                         <div className="bottom-spacing">
                             <b>
                                 {capitalizeFirstChar(parentDataType.nounPlural)} for {childName}
@@ -417,7 +357,22 @@ export class ParentEntityEditPanel extends ReactN.Component<Props, State, Global
                         {editing && this.renderAddParentButton()}
                     </Panel.Body>
                 </Panel>
-                {editing && this.renderEditControls()}
+                {editing && (
+                    <div className="full-width bottom-spacing">
+                        <Button className="pull-left" onClick={this.onCancel}>
+                            {cancelText}
+                        </Button>
+                        <Button
+                            className="pull-right"
+                            bsStyle="success"
+                            type="submit"
+                            disabled={submitting || !this.canSubmit()}
+                            onClick={this.onSubmit}
+                        >
+                            {submitText}
+                        </Button>
+                    </div>
+                )}
                 {editing && this.renderProgress()}
             </>
         );

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
@@ -6,14 +6,11 @@ import { mount } from 'enzyme';
 
 import { initUnitTestMocks } from '../../testHelperMocks';
 
-import { QueryGridPanel, SelectInput } from '../../..';
+import { GridPanel, SelectInput } from '../../..';
 
 import { IEntityTypeOption } from './models';
 import { DataClassDataType } from './constants';
 import { SingleParentEntityPanel } from './SingleParentEntityPanel';
-
-// Mock all the actions to test just the rendering parts for QueryGrid itself
-jest.mock('./actions');
 
 beforeAll(() => {
     initUnitTestMocks();
@@ -94,7 +91,7 @@ describe('<SingleParentEntityPanel>', () => {
                 }}
             />
         );
-        expect(wrapper.find(QueryGridPanel)).toHaveLength(1);
+        expect(wrapper.find(GridPanel)).toHaveLength(1);
         expect(wrapper.find(SelectInput)).toHaveLength(0);
         expect(wrapper).toMatchSnapshot();
     });

--- a/packages/components/src/internal/components/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
@@ -135,6 +135,9 @@ exports[`<ParentEntityEditPanel> editing, no data 1`] = `
             <div
               className="panel-body"
             >
+              <Alert
+                bsStyle="danger"
+              />
               <div
                 className="bottom-spacing"
               >
@@ -144,11 +147,9 @@ exports[`<ParentEntityEditPanel> editing, no data 1`] = `
                   Test
                 </b>
               </div>
-              <div
-                key="1"
-              >
+              <div>
                 <hr />
-                <SingleParentEntityPanel
+                <Memo()
                   childNounSingular="Testing"
                   editing={true}
                   index={0}
@@ -180,22 +181,170 @@ exports[`<ParentEntityEditPanel> editing, no data 1`] = `
                     }
                   }
                 >
-                  <LoadingSpinner
-                    msg="Loading..."
-                    wrapperClassName=""
+                  <withRouter(ComponentWithQueryModels)
+                    childNounSingular="Testing"
+                    editing={true}
+                    index={0}
+                    onChangeParentType={[Function]}
+                    onChangeParentValue={[Function]}
+                    onInitialParentValue={[Function]}
+                    onTypeChange={[Function]}
+                    onValueChange={[Function]}
+                    parentDataType={
+                      Object {
+                        "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+                        "deleteHelpLinkTopic": "dataClass",
+                        "dependencyText": "derived sample dependencies",
+                        "descriptionPlural": "parent types",
+                        "descriptionSingular": "parent type",
+                        "inputColumnName": "Inputs/Data/First",
+                        "inputTypeColumnName": "Inputs/Data/First/DataClass",
+                        "inputTypeValueField": "rowId",
+                        "insertColumnNamePrefix": "DataInputs/",
+                        "instanceSchemaName": "exp.data",
+                        "nounAsParentSingular": "Parent",
+                        "nounPlural": "data",
+                        "nounSingular": "data",
+                        "typeListingSchemaQuery": Immutable.Record {
+                          "schemaName": "exp",
+                          "queryName": "DataClasses",
+                          "viewName": undefined,
+                        },
+                        "typeNounSingular": "Data Type",
+                        "uniqueFieldKey": "Name",
+                      }
+                    }
+                    queryConfigs={Object {}}
                   >
-                    <span
-                      className=""
+                    <ComponentWithQueryModels
+                      autoLoad={false}
+                      childNounSingular="Testing"
+                      editing={true}
+                      index={0}
+                      modelLoader={
+                        Object {
+                          "clearSelections": [Function],
+                          "loadCharts": [Function],
+                          "loadQueryInfo": [Function],
+                          "loadRows": [Function],
+                          "loadSelections": [Function],
+                          "replaceSelections": [Function],
+                          "selectAllRows": [Function],
+                          "setSelections": [Function],
+                        }
+                      }
+                      onChangeParentType={[Function]}
+                      onChangeParentValue={[Function]}
+                      onInitialParentValue={[Function]}
+                      onTypeChange={[Function]}
+                      onValueChange={[Function]}
+                      parentDataType={
+                        Object {
+                          "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+                          "deleteHelpLinkTopic": "dataClass",
+                          "dependencyText": "derived sample dependencies",
+                          "descriptionPlural": "parent types",
+                          "descriptionSingular": "parent type",
+                          "inputColumnName": "Inputs/Data/First",
+                          "inputTypeColumnName": "Inputs/Data/First/DataClass",
+                          "inputTypeValueField": "rowId",
+                          "insertColumnNamePrefix": "DataInputs/",
+                          "instanceSchemaName": "exp.data",
+                          "nounAsParentSingular": "Parent",
+                          "nounPlural": "data",
+                          "nounSingular": "data",
+                          "typeListingSchemaQuery": Immutable.Record {
+                            "schemaName": "exp",
+                            "queryName": "DataClasses",
+                            "viewName": undefined,
+                          },
+                          "typeNounSingular": "Data Type",
+                          "uniqueFieldKey": "Name",
+                        }
+                      }
+                      queryConfigs={Object {}}
                     >
-                      <i
-                        aria-hidden="true"
-                        className="fa fa-spinner fa-pulse"
-                      />
-                       
-                      Loading...
-                    </span>
-                  </LoadingSpinner>
-                </SingleParentEntityPanel>
+                      <SingleParentEntity
+                        actions={
+                          Object {
+                            "addModel": [Function],
+                            "clearSelections": [Function],
+                            "loadAllModels": [Function],
+                            "loadCharts": [Function],
+                            "loadFirstPage": [Function],
+                            "loadLastPage": [Function],
+                            "loadModel": [Function],
+                            "loadNextPage": [Function],
+                            "loadPreviousPage": [Function],
+                            "loadRows": [Function],
+                            "replaceSelections": [Function],
+                            "selectAllRows": [Function],
+                            "selectPage": [Function],
+                            "selectReport": [Function],
+                            "selectRow": [Function],
+                            "setFilters": [Function],
+                            "setMaxRows": [Function],
+                            "setOffset": [Function],
+                            "setSchemaQuery": [Function],
+                            "setSelections": [Function],
+                            "setSorts": [Function],
+                            "setView": [Function],
+                          }
+                        }
+                        autoLoad={false}
+                        childNounSingular="Testing"
+                        editing={true}
+                        index={0}
+                        onChangeParentType={[Function]}
+                        onChangeParentValue={[Function]}
+                        onInitialParentValue={[Function]}
+                        onTypeChange={[Function]}
+                        onValueChange={[Function]}
+                        parentDataType={
+                          Object {
+                            "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+                            "deleteHelpLinkTopic": "dataClass",
+                            "dependencyText": "derived sample dependencies",
+                            "descriptionPlural": "parent types",
+                            "descriptionSingular": "parent type",
+                            "inputColumnName": "Inputs/Data/First",
+                            "inputTypeColumnName": "Inputs/Data/First/DataClass",
+                            "inputTypeValueField": "rowId",
+                            "insertColumnNamePrefix": "DataInputs/",
+                            "instanceSchemaName": "exp.data",
+                            "nounAsParentSingular": "Parent",
+                            "nounPlural": "data",
+                            "nounSingular": "data",
+                            "typeListingSchemaQuery": Immutable.Record {
+                              "schemaName": "exp",
+                              "queryName": "DataClasses",
+                              "viewName": undefined,
+                            },
+                            "typeNounSingular": "Data Type",
+                            "uniqueFieldKey": "Name",
+                          }
+                        }
+                        queryModels={Object {}}
+                      >
+                        <LoadingSpinner
+                          msg="Loading..."
+                          wrapperClassName=""
+                        >
+                          <span
+                            className=""
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="fa fa-spinner fa-pulse"
+                            />
+                             
+                            Loading...
+                          </span>
+                        </LoadingSpinner>
+                      </SingleParentEntity>
+                    </ComponentWithQueryModels>
+                  </withRouter(ComponentWithQueryModels)>
+                </Memo()>
               </div>
             </div>
           </PanelBody>
@@ -471,11 +620,9 @@ exports[`<ParentEntityEditPanel> error state 1`] = `
                   Test
                 </b>
               </div>
-              <div
-                key="1"
-              >
+              <div>
                 <hr />
-                <SingleParentEntityPanel
+                <Memo()
                   childNounSingular="Testing"
                   editing={false}
                   index={0}
@@ -507,46 +654,194 @@ exports[`<ParentEntityEditPanel> error state 1`] = `
                     }
                   }
                 >
-                  <div
-                    className="top-spacing"
-                    key="grid-0"
+                  <withRouter(ComponentWithQueryModels)
+                    childNounSingular="Testing"
+                    editing={false}
+                    index={0}
+                    onChangeParentType={[Function]}
+                    onChangeParentValue={[Function]}
+                    onInitialParentValue={[Function]}
+                    onTypeChange={[Function]}
+                    onValueChange={[Function]}
+                    parentDataType={
+                      Object {
+                        "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+                        "deleteHelpLinkTopic": "dataClass",
+                        "dependencyText": "derived sample dependencies",
+                        "descriptionPlural": "parent types",
+                        "descriptionSingular": "parent type",
+                        "inputColumnName": "Inputs/Data/First",
+                        "inputTypeColumnName": "Inputs/Data/First/DataClass",
+                        "inputTypeValueField": "rowId",
+                        "insertColumnNamePrefix": "DataInputs/",
+                        "instanceSchemaName": "exp.data",
+                        "nounAsParentSingular": "Parent",
+                        "nounPlural": "data",
+                        "nounSingular": "data",
+                        "typeListingSchemaQuery": Immutable.Record {
+                          "schemaName": "exp",
+                          "queryName": "DataClasses",
+                          "viewName": undefined,
+                        },
+                        "typeNounSingular": "Data Type",
+                        "uniqueFieldKey": "Name",
+                      }
+                    }
+                    queryConfigs={Object {}}
                   >
-                    <table
-                      className="table table-responsive table-condensed detail-component--table__fixed"
+                    <ComponentWithQueryModels
+                      autoLoad={false}
+                      childNounSingular="Testing"
+                      editing={false}
+                      index={0}
+                      modelLoader={
+                        Object {
+                          "clearSelections": [Function],
+                          "loadCharts": [Function],
+                          "loadQueryInfo": [Function],
+                          "loadRows": [Function],
+                          "loadSelections": [Function],
+                          "replaceSelections": [Function],
+                          "selectAllRows": [Function],
+                          "setSelections": [Function],
+                        }
+                      }
+                      onChangeParentType={[Function]}
+                      onChangeParentValue={[Function]}
+                      onInitialParentValue={[Function]}
+                      onTypeChange={[Function]}
+                      onValueChange={[Function]}
+                      parentDataType={
+                        Object {
+                          "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+                          "deleteHelpLinkTopic": "dataClass",
+                          "dependencyText": "derived sample dependencies",
+                          "descriptionPlural": "parent types",
+                          "descriptionSingular": "parent type",
+                          "inputColumnName": "Inputs/Data/First",
+                          "inputTypeColumnName": "Inputs/Data/First/DataClass",
+                          "inputTypeValueField": "rowId",
+                          "insertColumnNamePrefix": "DataInputs/",
+                          "instanceSchemaName": "exp.data",
+                          "nounAsParentSingular": "Parent",
+                          "nounPlural": "data",
+                          "nounSingular": "data",
+                          "typeListingSchemaQuery": Immutable.Record {
+                            "schemaName": "exp",
+                            "queryName": "DataClasses",
+                            "viewName": undefined,
+                          },
+                          "typeNounSingular": "Data Type",
+                          "uniqueFieldKey": "Name",
+                        }
+                      }
+                      queryConfigs={Object {}}
                     >
-                      <tbody>
-                        <tr
-                          key="type-name"
+                      <SingleParentEntity
+                        actions={
+                          Object {
+                            "addModel": [Function],
+                            "clearSelections": [Function],
+                            "loadAllModels": [Function],
+                            "loadCharts": [Function],
+                            "loadFirstPage": [Function],
+                            "loadLastPage": [Function],
+                            "loadModel": [Function],
+                            "loadNextPage": [Function],
+                            "loadPreviousPage": [Function],
+                            "loadRows": [Function],
+                            "replaceSelections": [Function],
+                            "selectAllRows": [Function],
+                            "selectPage": [Function],
+                            "selectReport": [Function],
+                            "selectRow": [Function],
+                            "setFilters": [Function],
+                            "setMaxRows": [Function],
+                            "setOffset": [Function],
+                            "setSchemaQuery": [Function],
+                            "setSelections": [Function],
+                            "setSorts": [Function],
+                            "setView": [Function],
+                          }
+                        }
+                        autoLoad={false}
+                        childNounSingular="Testing"
+                        editing={false}
+                        index={0}
+                        onChangeParentType={[Function]}
+                        onChangeParentValue={[Function]}
+                        onInitialParentValue={[Function]}
+                        onTypeChange={[Function]}
+                        onValueChange={[Function]}
+                        parentDataType={
+                          Object {
+                            "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+                            "deleteHelpLinkTopic": "dataClass",
+                            "dependencyText": "derived sample dependencies",
+                            "descriptionPlural": "parent types",
+                            "descriptionSingular": "parent type",
+                            "inputColumnName": "Inputs/Data/First",
+                            "inputTypeColumnName": "Inputs/Data/First/DataClass",
+                            "inputTypeValueField": "rowId",
+                            "insertColumnNamePrefix": "DataInputs/",
+                            "instanceSchemaName": "exp.data",
+                            "nounAsParentSingular": "Parent",
+                            "nounPlural": "data",
+                            "nounSingular": "data",
+                            "typeListingSchemaQuery": Immutable.Record {
+                              "schemaName": "exp",
+                              "queryName": "DataClasses",
+                              "viewName": undefined,
+                            },
+                            "typeNounSingular": "Data Type",
+                            "uniqueFieldKey": "Name",
+                          }
+                        }
+                        queryModels={Object {}}
+                      >
+                        <div
+                          className="top-spacing"
+                          key="grid-0"
                         >
-                          <td>
-                            Data Type
-                          </td>
-                          <td>
-                            No 
-                            data type
-                             has been set for this 
-                            testing
-                            .
-                          </td>
-                        </tr>
-                        <tr
-                          key="parent-id"
-                        >
-                          <td>
-                            Data ID
-                          </td>
-                          <td>
-                            No 
-                            data
-                             ID has been set for this 
-                            testing
-                            .
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                </SingleParentEntityPanel>
+                          <table
+                            className="table table-responsive table-condensed detail-component--table__fixed"
+                          >
+                            <tbody>
+                              <tr
+                                key="type-name"
+                              >
+                                <td>
+                                  Data Type
+                                </td>
+                                <td>
+                                  No 
+                                  data type
+                                   has been set for this 
+                                  testing
+                                  .
+                                </td>
+                              </tr>
+                              <tr
+                                key="parent-id"
+                              >
+                                <td>
+                                  Data ID
+                                </td>
+                                <td>
+                                  No 
+                                  data
+                                   ID has been set for this 
+                                  testing
+                                  .
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </SingleParentEntity>
+                    </ComponentWithQueryModels>
+                  </withRouter(ComponentWithQueryModels)>
+                </Memo()>
               </div>
             </div>
           </PanelBody>
@@ -691,6 +986,9 @@ exports[`<ParentEntityEditPanel> loading state 1`] = `
             <div
               className="panel-body"
             >
+              <Alert
+                bsStyle="danger"
+              />
               <div
                 className="bottom-spacing"
               >

--- a/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SingleParentEntityPanel> empty state editing 1`] = `
-<SingleParentEntityPanel
+<Memo()
   childNounSingular="Sample"
   editing={true}
   index={0}
@@ -58,23 +58,198 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
     ]
   }
 >
-  <div
-    className="bottom-spacing"
-    key="parent-selections-0"
+  <withRouter(ComponentWithQueryModels)
+    childNounSingular="Sample"
+    editing={true}
+    index={0}
+    onTypeChange={[Function]}
+    onValueChange={[Function]}
+    parentDataType={
+      Object {
+        "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+        "deleteHelpLinkTopic": "dataClass",
+        "dependencyText": "derived sample dependencies",
+        "descriptionPlural": "parent types",
+        "descriptionSingular": "parent type",
+        "inputColumnName": "Inputs/Data/First",
+        "inputTypeColumnName": "Inputs/Data/First/DataClass",
+        "inputTypeValueField": "rowId",
+        "insertColumnNamePrefix": "DataInputs/",
+        "instanceSchemaName": "exp.data",
+        "nounAsParentSingular": "Parent",
+        "nounPlural": "data",
+        "nounSingular": "data",
+        "typeListingSchemaQuery": Immutable.Record {
+          "schemaName": "exp",
+          "queryName": "DataClasses",
+          "viewName": undefined,
+        },
+        "typeNounSingular": "Data Type",
+        "uniqueFieldKey": "Name",
+      }
+    }
+    parentTypeOptions={
+      Immutable.List [
+        Object {
+          "label": "Second Source",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+          "query": "Second Source",
+          "rowId": 322,
+          "schema": "exp.data",
+          "value": "second source",
+        },
+        Object {
+          "label": "Source 1",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+          "query": "Source 1",
+          "rowId": 321,
+          "schema": "exp.data",
+          "value": "source 1",
+        },
+        Object {
+          "label": "Vendor 3",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+          "query": "Vendor 3",
+          "rowId": 323,
+          "schema": "exp.data",
+          "value": "vendor 3",
+        },
+      ]
+    }
+    queryConfigs={Object {}}
   >
-    <div
-      className="form-group row"
+    <ComponentWithQueryModels
+      autoLoad={false}
+      childNounSingular="Sample"
+      editing={true}
+      index={0}
+      modelLoader={
+        Object {
+          "clearSelections": [Function],
+          "loadCharts": [Function],
+          "loadQueryInfo": [Function],
+          "loadRows": [Function],
+          "loadSelections": [Function],
+          "replaceSelections": [Function],
+          "selectAllRows": [Function],
+          "setSelections": [Function],
+        }
+      }
+      onTypeChange={[Function]}
+      onValueChange={[Function]}
+      parentDataType={
+        Object {
+          "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+          "deleteHelpLinkTopic": "dataClass",
+          "dependencyText": "derived sample dependencies",
+          "descriptionPlural": "parent types",
+          "descriptionSingular": "parent type",
+          "inputColumnName": "Inputs/Data/First",
+          "inputTypeColumnName": "Inputs/Data/First/DataClass",
+          "inputTypeValueField": "rowId",
+          "insertColumnNamePrefix": "DataInputs/",
+          "instanceSchemaName": "exp.data",
+          "nounAsParentSingular": "Parent",
+          "nounPlural": "data",
+          "nounSingular": "data",
+          "typeListingSchemaQuery": Immutable.Record {
+            "schemaName": "exp",
+            "queryName": "DataClasses",
+            "viewName": undefined,
+          },
+          "typeNounSingular": "Data Type",
+          "uniqueFieldKey": "Name",
+        }
+      }
+      parentTypeOptions={
+        Immutable.List [
+          Object {
+            "label": "Second Source",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+            "query": "Second Source",
+            "rowId": 322,
+            "schema": "exp.data",
+            "value": "second source",
+          },
+          Object {
+            "label": "Source 1",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+            "query": "Source 1",
+            "rowId": 321,
+            "schema": "exp.data",
+            "value": "source 1",
+          },
+          Object {
+            "label": "Vendor 3",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+            "query": "Vendor 3",
+            "rowId": 323,
+            "schema": "exp.data",
+            "value": "vendor 3",
+          },
+        ]
+      }
+      queryConfigs={Object {}}
     >
-      <SelectInput
-        containerClass=""
-        formsy={false}
-        inputClass="col-sm-6"
-        label="Data Type 1"
-        labelClass="col-sm-3 col-xs-12 entity-insert--parent-label"
-        name="entityType0"
-        onChange={[Function]}
-        options={
-          Array [
+      <SingleParentEntity
+        actions={
+          Object {
+            "addModel": [Function],
+            "clearSelections": [Function],
+            "loadAllModels": [Function],
+            "loadCharts": [Function],
+            "loadFirstPage": [Function],
+            "loadLastPage": [Function],
+            "loadModel": [Function],
+            "loadNextPage": [Function],
+            "loadPreviousPage": [Function],
+            "loadRows": [Function],
+            "replaceSelections": [Function],
+            "selectAllRows": [Function],
+            "selectPage": [Function],
+            "selectReport": [Function],
+            "selectRow": [Function],
+            "setFilters": [Function],
+            "setMaxRows": [Function],
+            "setOffset": [Function],
+            "setSchemaQuery": [Function],
+            "setSelections": [Function],
+            "setSorts": [Function],
+            "setView": [Function],
+          }
+        }
+        autoLoad={false}
+        childNounSingular="Sample"
+        editing={true}
+        index={0}
+        onTypeChange={[Function]}
+        onValueChange={[Function]}
+        parentDataType={
+          Object {
+            "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+            "deleteHelpLinkTopic": "dataClass",
+            "dependencyText": "derived sample dependencies",
+            "descriptionPlural": "parent types",
+            "descriptionSingular": "parent type",
+            "inputColumnName": "Inputs/Data/First",
+            "inputTypeColumnName": "Inputs/Data/First/DataClass",
+            "inputTypeValueField": "rowId",
+            "insertColumnNamePrefix": "DataInputs/",
+            "instanceSchemaName": "exp.data",
+            "nounAsParentSingular": "Parent",
+            "nounPlural": "data",
+            "nounSingular": "data",
+            "typeListingSchemaQuery": Immutable.Record {
+              "schemaName": "exp",
+              "queryName": "DataClasses",
+              "viewName": undefined,
+            },
+            "typeNounSingular": "Data Type",
+            "uniqueFieldKey": "Name",
+          }
+        }
+        parentTypeOptions={
+          Immutable.List [
             Object {
               "label": "Second Source",
               "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
@@ -101,199 +276,70 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
             },
           ]
         }
-        placeholder="Select a Data Type ..."
-        required={true}
+        queryModels={Object {}}
       >
-        <SelectInputImpl
-          allowCreate={false}
-          allowDisable={false}
-          autoValue={true}
-          autoload={true}
-          clearCacheOnChange={true}
-          containerClass=""
-          delimiter=","
-          formsy={false}
-          initiallyDisabled={false}
-          inputClass="col-sm-6"
-          label="Data Type 1"
-          labelClass="col-sm-3 col-xs-12 entity-insert--parent-label"
-          labelKey="label"
-          name="entityType0"
-          onChange={[Function]}
-          options={
-            Array [
-              Object {
-                "label": "Second Source",
-                "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
-                "query": "Second Source",
-                "rowId": 322,
-                "schema": "exp.data",
-                "value": "second source",
-              },
-              Object {
-                "label": "Source 1",
-                "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
-                "query": "Source 1",
-                "rowId": 321,
-                "schema": "exp.data",
-                "value": "source 1",
-              },
-              Object {
-                "label": "Vendor 3",
-                "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
-                "query": "Vendor 3",
-                "rowId": 323,
-                "schema": "exp.data",
-                "value": "vendor 3",
-              },
-            ]
-          }
-          placeholder="Select a Data Type ..."
-          required={true}
-          saveOnBlur={false}
-          showLabel={true}
-          valueKey="value"
+        <div
+          className="bottom-spacing"
+          key="parent-selections-0"
         >
           <div
-            className=""
+            className="form-group row"
           >
-            <FieldLabel
-              fieldName="entityType0"
-              id="selectinput-0"
-              isDisabled={false}
-              labelOverlayProps={
-                Object {
-                  "addLabelAsterisk": undefined,
-                  "description": "Select  a Data Type 1",
-                  "inputId": "entityType0",
-                  "isFormsy": false,
-                  "label": "Data Type 1",
-                  "labelClass": "col-sm-3 col-xs-12 entity-insert--parent-label",
-                  "required": true,
-                }
+            <SelectInput
+              containerClass=""
+              formsy={false}
+              inputClass="col-sm-6"
+              label="Data Type 1"
+              labelClass="col-sm-3 col-xs-12 entity-insert--parent-label"
+              name="entityType0"
+              onChange={[Function]}
+              options={
+                Array [
+                  Object {
+                    "label": "Second Source",
+                    "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+                    "query": "Second Source",
+                    "rowId": 322,
+                    "schema": "exp.data",
+                    "value": "second source",
+                  },
+                  Object {
+                    "label": "Source 1",
+                    "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+                    "query": "Source 1",
+                    "rowId": 321,
+                    "schema": "exp.data",
+                    "value": "source 1",
+                  },
+                  Object {
+                    "label": "Vendor 3",
+                    "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+                    "query": "Vendor 3",
+                    "rowId": 323,
+                    "schema": "exp.data",
+                    "value": "vendor 3",
+                  },
+                ]
               }
-              showLabel={true}
-              showToggle={false}
-              toggleProps={
-                Object {
-                  "onClick": [Function],
-                }
-              }
-              withLabelOverlay={true}
+              placeholder="Select a Data Type ..."
+              required={true}
             >
-              <LabelOverlay
-                addLabelAsterisk={false}
-                canMouseOverTooltip={false}
-                description="Select  a Data Type 1"
-                inputId="entityType0"
-                isFormsy={false}
+              <SelectInputImpl
+                allowCreate={false}
+                allowDisable={false}
+                autoValue={true}
+                autoload={true}
+                clearCacheOnChange={true}
+                containerClass=""
+                delimiter=","
+                formsy={false}
+                initiallyDisabled={false}
+                inputClass="col-sm-6"
                 label="Data Type 1"
                 labelClass="col-sm-3 col-xs-12 entity-insert--parent-label"
-                required={true}
-              >
-                <label
-                  className="col-sm-3 col-xs-12 entity-insert--parent-label text__truncate-and-wrap"
-                  htmlFor="entityType0"
-                >
-                  <span>
-                    Data Type 1
-                  </span>
-                   
-                  <OverlayTrigger
-                    defaultOverlayShown={false}
-                    overlay={
-                      <Popover
-                        bsClass="popover"
-                        id="labkey-app-1"
-                        placement="right"
-                        title="Data Type 1"
-                      >
-                        <React.Fragment>
-                          <p>
-                            <strong>
-                              Description: 
-                            </strong>
-                            Select  a Data Type 1
-                          </p>
-                          <p>
-                            <small>
-                              <i>
-                                This field is required.
-                              </i>
-                            </small>
-                          </p>
-                        </React.Fragment>
-                      </Popover>
-                    }
-                    trigger={
-                      Array [
-                        "hover",
-                        "focus",
-                      ]
-                    }
-                  >
-                    <i
-                      className="fa fa-question-circle"
-                      onBlur={[Function]}
-                      onClick={null}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
-                    />
-                  </OverlayTrigger>
-                  <span
-                    className="required-symbol"
-                  >
-                     *
-                  </span>
-                </label>
-              </LabelOverlay>
-            </FieldLabel>
-            <div
-              className="col-sm-6"
-            >
-              <Select
-                addLabelText="Add \\"{label}\\"?"
-                arrowRenderer={[Function]}
-                autoload={true}
-                autosize={true}
-                backspaceRemoves={true}
-                backspaceToRemoveMessage="Press backspace to remove {label}"
-                clearAllText="Clear all"
-                clearRenderer={[Function]}
-                clearValueText="Clear value"
-                clearable={true}
-                closeOnSelect={true}
-                deleteRemoves={true}
-                delimiter=","
-                disabled={false}
-                escapeClearsValue={true}
-                filterOptions={[Function]}
-                ignoreAccents={true}
-                ignoreCase={true}
-                inputProps={
-                  Object {
-                    "id": "selectinput-0",
-                  }
-                }
-                isLoading={false}
-                joinValues={false}
                 labelKey="label"
-                matchPos="any"
-                matchProp="any"
-                menuBuffer={0}
-                menuRenderer={[Function]}
-                multi={false}
                 name="entityType0"
-                noResultsText="No results found"
-                onBlur={[Function]}
-                onBlurResetsInput={true}
                 onChange={[Function]}
-                onCloseResetsInput={true}
-                onFocus={[Function]}
-                onSelectResetsInput={true}
-                openOnClick={true}
-                optionComponent={[Function]}
                 options={
                   Array [
                     Object {
@@ -322,118 +368,295 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
                     },
                   ]
                 }
-                pageSize={5}
                 placeholder="Select a Data Type ..."
                 required={true}
-                scrollMenuIntoView={true}
-                searchable={true}
-                simpleValue={false}
-                tabSelectsValue={true}
-                valueComponent={[Function]}
+                saveOnBlur={false}
+                showLabel={true}
                 valueKey="value"
               >
                 <div
-                  className="Select Select--single is-clearable is-searchable"
+                  className=""
                 >
-                  <div
-                    className="Select-control"
-                    onKeyDown={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
+                  <FieldLabel
+                    fieldName="entityType0"
+                    id="selectinput-0"
+                    isDisabled={false}
+                    labelOverlayProps={
+                      Object {
+                        "addLabelAsterisk": undefined,
+                        "description": "Select  a Data Type 1",
+                        "inputId": "entityType0",
+                        "isFormsy": false,
+                        "label": "Data Type 1",
+                        "labelClass": "col-sm-3 col-xs-12 entity-insert--parent-label",
+                        "required": true,
+                      }
+                    }
+                    showLabel={true}
+                    showToggle={false}
+                    toggleProps={
+                      Object {
+                        "onClick": [Function],
+                      }
+                    }
+                    withLabelOverlay={true}
                   >
-                    <span
-                      className="Select-multi-value-wrapper"
-                      id="react-select-2--value"
+                    <LabelOverlay
+                      addLabelAsterisk={false}
+                      canMouseOverTooltip={false}
+                      description="Select  a Data Type 1"
+                      inputId="entityType0"
+                      isFormsy={false}
+                      label="Data Type 1"
+                      labelClass="col-sm-3 col-xs-12 entity-insert--parent-label"
+                      required={true}
                     >
-                      <div
-                        className="Select-placeholder"
+                      <label
+                        className="col-sm-3 col-xs-12 entity-insert--parent-label text__truncate-and-wrap"
+                        htmlFor="entityType0"
                       >
-                        Select a Data Type ...
-                      </div>
-                      <AutosizeInput
-                        aria-activedescendant="react-select-2--value"
-                        aria-expanded="false"
-                        aria-haspopup="false"
-                        aria-owns=""
-                        className="Select-input"
-                        id="selectinput-0"
-                        injectStyles={true}
-                        minWidth="5"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={true}
-                        role="combobox"
-                        value=""
-                      >
-                        <div
-                          className="Select-input"
-                          style={
-                            Object {
-                              "display": "inline-block",
-                            }
+                        <span>
+                          Data Type 1
+                        </span>
+                         
+                        <OverlayTrigger
+                          defaultOverlayShown={false}
+                          overlay={
+                            <Popover
+                              bsClass="popover"
+                              id="labkey-app-1"
+                              placement="right"
+                              title="Data Type 1"
+                            >
+                              <React.Fragment>
+                                <p>
+                                  <strong>
+                                    Description: 
+                                  </strong>
+                                  Select  a Data Type 1
+                                </p>
+                                <p>
+                                  <small>
+                                    <i>
+                                      This field is required.
+                                    </i>
+                                  </small>
+                                </p>
+                              </React.Fragment>
+                            </Popover>
+                          }
+                          trigger={
+                            Array [
+                              "hover",
+                              "focus",
+                            ]
                           }
                         >
-                          <input
-                            aria-activedescendant="react-select-2--value"
-                            aria-expanded="false"
-                            aria-haspopup="false"
-                            aria-owns=""
-                            id="selectinput-0"
+                          <i
+                            className="fa fa-question-circle"
                             onBlur={[Function]}
-                            onChange={[Function]}
+                            onClick={null}
                             onFocus={[Function]}
-                            required={true}
-                            role="combobox"
-                            style={
-                              Object {
-                                "boxSizing": "content-box",
-                                "width": "5px",
-                              }
-                            }
-                            value=""
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
                           />
-                          <div
-                            style={
-                              Object {
-                                "height": 0,
-                                "left": 0,
-                                "overflow": "scroll",
-                                "position": "absolute",
-                                "top": 0,
-                                "visibility": "hidden",
-                                "whiteSpace": "pre",
-                              }
-                            }
-                          />
-                        </div>
-                      </AutosizeInput>
-                    </span>
-                    <span
-                      className="Select-arrow-zone"
-                      onMouseDown={[Function]}
+                        </OverlayTrigger>
+                        <span
+                          className="required-symbol"
+                        >
+                           *
+                        </span>
+                      </label>
+                    </LabelOverlay>
+                  </FieldLabel>
+                  <div
+                    className="col-sm-6"
+                  >
+                    <Select
+                      addLabelText="Add \\"{label}\\"?"
+                      arrowRenderer={[Function]}
+                      autoload={true}
+                      autosize={true}
+                      backspaceRemoves={true}
+                      backspaceToRemoveMessage="Press backspace to remove {label}"
+                      clearAllText="Clear all"
+                      clearRenderer={[Function]}
+                      clearValueText="Clear value"
+                      clearable={true}
+                      closeOnSelect={true}
+                      deleteRemoves={true}
+                      delimiter=","
+                      disabled={false}
+                      escapeClearsValue={true}
+                      filterOptions={[Function]}
+                      ignoreAccents={true}
+                      ignoreCase={true}
+                      inputProps={
+                        Object {
+                          "id": "selectinput-0",
+                        }
+                      }
+                      isLoading={false}
+                      joinValues={false}
+                      labelKey="label"
+                      matchPos="any"
+                      matchProp="any"
+                      menuBuffer={0}
+                      menuRenderer={[Function]}
+                      multi={false}
+                      name="entityType0"
+                      noResultsText="No results found"
+                      onBlur={[Function]}
+                      onBlurResetsInput={true}
+                      onChange={[Function]}
+                      onCloseResetsInput={true}
+                      onFocus={[Function]}
+                      onSelectResetsInput={true}
+                      openOnClick={true}
+                      optionComponent={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "Second Source",
+                            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+                            "query": "Second Source",
+                            "rowId": 322,
+                            "schema": "exp.data",
+                            "value": "second source",
+                          },
+                          Object {
+                            "label": "Source 1",
+                            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+                            "query": "Source 1",
+                            "rowId": 321,
+                            "schema": "exp.data",
+                            "value": "source 1",
+                          },
+                          Object {
+                            "label": "Vendor 3",
+                            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+                            "query": "Vendor 3",
+                            "rowId": 323,
+                            "schema": "exp.data",
+                            "value": "vendor 3",
+                          },
+                        ]
+                      }
+                      pageSize={5}
+                      placeholder="Select a Data Type ..."
+                      required={true}
+                      scrollMenuIntoView={true}
+                      searchable={true}
+                      simpleValue={false}
+                      tabSelectsValue={true}
+                      valueComponent={[Function]}
+                      valueKey="value"
                     >
-                      <span
-                        className="Select-arrow"
-                        onMouseDown={[Function]}
-                      />
-                    </span>
+                      <div
+                        className="Select Select--single is-clearable is-searchable"
+                      >
+                        <div
+                          className="Select-control"
+                          onKeyDown={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                        >
+                          <span
+                            className="Select-multi-value-wrapper"
+                            id="react-select-2--value"
+                          >
+                            <div
+                              className="Select-placeholder"
+                            >
+                              Select a Data Type ...
+                            </div>
+                            <AutosizeInput
+                              aria-activedescendant="react-select-2--value"
+                              aria-expanded="false"
+                              aria-haspopup="false"
+                              aria-owns=""
+                              className="Select-input"
+                              id="selectinput-0"
+                              injectStyles={true}
+                              minWidth="5"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              required={true}
+                              role="combobox"
+                              value=""
+                            >
+                              <div
+                                className="Select-input"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                  }
+                                }
+                              >
+                                <input
+                                  aria-activedescendant="react-select-2--value"
+                                  aria-expanded="false"
+                                  aria-haspopup="false"
+                                  aria-owns=""
+                                  id="selectinput-0"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  required={true}
+                                  role="combobox"
+                                  style={
+                                    Object {
+                                      "boxSizing": "content-box",
+                                      "width": "5px",
+                                    }
+                                  }
+                                  value=""
+                                />
+                                <div
+                                  style={
+                                    Object {
+                                      "height": 0,
+                                      "left": 0,
+                                      "overflow": "scroll",
+                                      "position": "absolute",
+                                      "top": 0,
+                                      "visibility": "hidden",
+                                      "whiteSpace": "pre",
+                                    }
+                                  }
+                                />
+                              </div>
+                            </AutosizeInput>
+                          </span>
+                          <span
+                            className="Select-arrow-zone"
+                            onMouseDown={[Function]}
+                          >
+                            <span
+                              className="Select-arrow"
+                              onMouseDown={[Function]}
+                            />
+                          </span>
+                        </div>
+                      </div>
+                    </Select>
                   </div>
                 </div>
-              </Select>
-            </div>
+              </SelectInputImpl>
+            </SelectInput>
           </div>
-        </SelectInputImpl>
-      </SelectInput>
-    </div>
-  </div>
-</SingleParentEntityPanel>
+        </div>
+      </SingleParentEntity>
+    </ComponentWithQueryModels>
+  </withRouter(ComponentWithQueryModels)>
+</Memo()>
 `;
 
 exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
-<SingleParentEntityPanel
+<Memo()
   childNounSingular="Sample"
   editing={false}
   index={0}
@@ -490,50 +713,273 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
     ]
   }
 >
-  <div
-    className="top-spacing"
-    key="grid-0"
+  <withRouter(ComponentWithQueryModels)
+    childNounSingular="Sample"
+    editing={false}
+    index={0}
+    onTypeChange={[Function]}
+    onValueChange={[Function]}
+    parentDataType={
+      Object {
+        "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+        "deleteHelpLinkTopic": "dataClass",
+        "dependencyText": "derived sample dependencies",
+        "descriptionPlural": "parent types",
+        "descriptionSingular": "parent type",
+        "inputColumnName": "Inputs/Data/First",
+        "inputTypeColumnName": "Inputs/Data/First/DataClass",
+        "inputTypeValueField": "rowId",
+        "insertColumnNamePrefix": "DataInputs/",
+        "instanceSchemaName": "exp.data",
+        "nounAsParentSingular": "Parent",
+        "nounPlural": "data",
+        "nounSingular": "data",
+        "typeListingSchemaQuery": Immutable.Record {
+          "schemaName": "exp",
+          "queryName": "DataClasses",
+          "viewName": undefined,
+        },
+        "typeNounSingular": "Data Type",
+        "uniqueFieldKey": "Name",
+      }
+    }
+    parentTypeOptions={
+      Immutable.List [
+        Object {
+          "label": "Second Source",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+          "query": "Second Source",
+          "rowId": 322,
+          "schema": "exp.data",
+          "value": "second source",
+        },
+        Object {
+          "label": "Source 1",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+          "query": "Source 1",
+          "rowId": 321,
+          "schema": "exp.data",
+          "value": "source 1",
+        },
+        Object {
+          "label": "Vendor 3",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+          "query": "Vendor 3",
+          "rowId": 323,
+          "schema": "exp.data",
+          "value": "vendor 3",
+        },
+      ]
+    }
+    queryConfigs={Object {}}
   >
-    <table
-      className="table table-responsive table-condensed detail-component--table__fixed"
+    <ComponentWithQueryModels
+      autoLoad={false}
+      childNounSingular="Sample"
+      editing={false}
+      index={0}
+      modelLoader={
+        Object {
+          "clearSelections": [Function],
+          "loadCharts": [Function],
+          "loadQueryInfo": [Function],
+          "loadRows": [Function],
+          "loadSelections": [Function],
+          "replaceSelections": [Function],
+          "selectAllRows": [Function],
+          "setSelections": [Function],
+        }
+      }
+      onTypeChange={[Function]}
+      onValueChange={[Function]}
+      parentDataType={
+        Object {
+          "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+          "deleteHelpLinkTopic": "dataClass",
+          "dependencyText": "derived sample dependencies",
+          "descriptionPlural": "parent types",
+          "descriptionSingular": "parent type",
+          "inputColumnName": "Inputs/Data/First",
+          "inputTypeColumnName": "Inputs/Data/First/DataClass",
+          "inputTypeValueField": "rowId",
+          "insertColumnNamePrefix": "DataInputs/",
+          "instanceSchemaName": "exp.data",
+          "nounAsParentSingular": "Parent",
+          "nounPlural": "data",
+          "nounSingular": "data",
+          "typeListingSchemaQuery": Immutable.Record {
+            "schemaName": "exp",
+            "queryName": "DataClasses",
+            "viewName": undefined,
+          },
+          "typeNounSingular": "Data Type",
+          "uniqueFieldKey": "Name",
+        }
+      }
+      parentTypeOptions={
+        Immutable.List [
+          Object {
+            "label": "Second Source",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+            "query": "Second Source",
+            "rowId": 322,
+            "schema": "exp.data",
+            "value": "second source",
+          },
+          Object {
+            "label": "Source 1",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+            "query": "Source 1",
+            "rowId": 321,
+            "schema": "exp.data",
+            "value": "source 1",
+          },
+          Object {
+            "label": "Vendor 3",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+            "query": "Vendor 3",
+            "rowId": 323,
+            "schema": "exp.data",
+            "value": "vendor 3",
+          },
+        ]
+      }
+      queryConfigs={Object {}}
     >
-      <tbody>
-        <tr
-          key="type-name"
+      <SingleParentEntity
+        actions={
+          Object {
+            "addModel": [Function],
+            "clearSelections": [Function],
+            "loadAllModels": [Function],
+            "loadCharts": [Function],
+            "loadFirstPage": [Function],
+            "loadLastPage": [Function],
+            "loadModel": [Function],
+            "loadNextPage": [Function],
+            "loadPreviousPage": [Function],
+            "loadRows": [Function],
+            "replaceSelections": [Function],
+            "selectAllRows": [Function],
+            "selectPage": [Function],
+            "selectReport": [Function],
+            "selectRow": [Function],
+            "setFilters": [Function],
+            "setMaxRows": [Function],
+            "setOffset": [Function],
+            "setSchemaQuery": [Function],
+            "setSelections": [Function],
+            "setSorts": [Function],
+            "setView": [Function],
+          }
+        }
+        autoLoad={false}
+        childNounSingular="Sample"
+        editing={false}
+        index={0}
+        onTypeChange={[Function]}
+        onValueChange={[Function]}
+        parentDataType={
+          Object {
+            "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+            "deleteHelpLinkTopic": "dataClass",
+            "dependencyText": "derived sample dependencies",
+            "descriptionPlural": "parent types",
+            "descriptionSingular": "parent type",
+            "inputColumnName": "Inputs/Data/First",
+            "inputTypeColumnName": "Inputs/Data/First/DataClass",
+            "inputTypeValueField": "rowId",
+            "insertColumnNamePrefix": "DataInputs/",
+            "instanceSchemaName": "exp.data",
+            "nounAsParentSingular": "Parent",
+            "nounPlural": "data",
+            "nounSingular": "data",
+            "typeListingSchemaQuery": Immutable.Record {
+              "schemaName": "exp",
+              "queryName": "DataClasses",
+              "viewName": undefined,
+            },
+            "typeNounSingular": "Data Type",
+            "uniqueFieldKey": "Name",
+          }
+        }
+        parentTypeOptions={
+          Immutable.List [
+            Object {
+              "label": "Second Source",
+              "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+              "query": "Second Source",
+              "rowId": 322,
+              "schema": "exp.data",
+              "value": "second source",
+            },
+            Object {
+              "label": "Source 1",
+              "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+              "query": "Source 1",
+              "rowId": 321,
+              "schema": "exp.data",
+              "value": "source 1",
+            },
+            Object {
+              "label": "Vendor 3",
+              "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+              "query": "Vendor 3",
+              "rowId": 323,
+              "schema": "exp.data",
+              "value": "vendor 3",
+            },
+          ]
+        }
+        queryModels={Object {}}
+      >
+        <div
+          className="top-spacing"
+          key="grid-0"
         >
-          <td>
-            Data Type
-          </td>
-          <td>
-            No 
-            data type
-             has been set for this 
-            sample
-            .
-          </td>
-        </tr>
-        <tr
-          key="parent-id"
-        >
-          <td>
-            Data ID
-          </td>
-          <td>
-            No 
-            data
-             ID has been set for this 
-            sample
-            .
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</SingleParentEntityPanel>
+          <table
+            className="table table-responsive table-condensed detail-component--table__fixed"
+          >
+            <tbody>
+              <tr
+                key="type-name"
+              >
+                <td>
+                  Data Type
+                </td>
+                <td>
+                  No 
+                  data type
+                   has been set for this 
+                  sample
+                  .
+                </td>
+              </tr>
+              <tr
+                key="parent-id"
+              >
+                <td>
+                  Data ID
+                </td>
+                <td>
+                  No 
+                  data
+                   ID has been set for this 
+                  sample
+                  .
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </SingleParentEntity>
+    </ComponentWithQueryModels>
+  </withRouter(ComponentWithQueryModels)>
+</Memo()>
 `;
 
 exports[`<SingleParentEntityPanel> with data not editing 1`] = `
-<SingleParentEntityPanel
+<Memo()
   childNounSingular="Sample"
   editing={false}
   index={0}
@@ -600,41 +1046,79 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
   }
   parentTypeQueryName="Second Source"
 >
-  <div
-    className="top-spacing"
-    key="grid-0"
-  >
-    <table
-      className="table table-responsive table-condensed detail-component--table__fixed"
-    >
-      <tbody>
-        <tr
-          key="type-name"
-        >
-          <td>
-            Data Type
-          </td>
-          <td>
-            <a
-              href="#/sources/Second%20Source"
-            >
-              Second Source
-            </a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <QueryGridPanel
-      asPanel={false}
-      initModelOnMount={true}
-      model={
-        Immutable.Record {
-          "id": "dataclasses-parent-data|exp$pdata/second source",
-          "schema": "exp.data",
+  <withRouter(ComponentWithQueryModels)
+    childNounSingular="Sample"
+    chosenType="Second Source"
+    editing={false}
+    index={0}
+    onRemoveParentType={[Function]}
+    onTypeChange={[Function]}
+    onValueChange={[Function]}
+    parentDataType={
+      Object {
+        "appUrlPrefixParts": Array [
+          "sources",
+        ],
+        "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+        "deleteHelpLinkTopic": "dataClass",
+        "dependencyText": "derived sample dependencies",
+        "descriptionPlural": "parent types",
+        "descriptionSingular": "parent type",
+        "inputColumnName": "Inputs/Data/First",
+        "inputTypeColumnName": "Inputs/Data/First/DataClass",
+        "inputTypeValueField": "rowId",
+        "insertColumnNamePrefix": "DataInputs/",
+        "instanceSchemaName": "exp.data",
+        "nounAsParentSingular": "Parent",
+        "nounPlural": "data",
+        "nounSingular": "data",
+        "typeListingSchemaQuery": Immutable.Record {
+          "schemaName": "exp",
+          "queryName": "DataClasses",
+          "viewName": undefined,
+        },
+        "typeNounSingular": "Data Type",
+        "uniqueFieldKey": "Name",
+      }
+    }
+    parentLSIDs={
+      Array [
+        "url:lsid:blah",
+      ]
+    }
+    parentTypeOptions={
+      Immutable.List [
+        Object {
+          "label": "Second Source",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
           "query": "Second Source",
-          "queryParameters": undefined,
-          "allowSelection": false,
-          "baseFilters": Immutable.List [
+          "rowId": 322,
+          "schema": "exp.data",
+          "value": "second source",
+        },
+        Object {
+          "label": "Source 1",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+          "query": "Source 1",
+          "rowId": 321,
+          "schema": "exp.data",
+          "value": "source 1",
+        },
+        Object {
+          "label": "Vendor 3",
+          "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+          "query": "Vendor 3",
+          "rowId": 323,
+          "schema": "exp.data",
+          "value": "vendor 3",
+        },
+      ]
+    }
+    parentTypeQueryName="Second Source"
+    queryConfigs={
+      Object {
+        "model": Object {
+          "baseFilters": Array [
             Filter {
               "columnName": "LSID",
               "filterType": Object {
@@ -661,252 +1145,470 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             },
           ],
           "bindURL": false,
-          "containerPath": undefined,
-          "containerFilter": undefined,
-          "data": Immutable.Map {},
-          "dataIds": Immutable.List [],
-          "displayColumns": undefined,
-          "editable": false,
-          "editing": false,
-          "filterArray": Immutable.List [],
-          "includeDetailsColumn": false,
-          "includeUpdateColumn": false,
-          "isError": false,
-          "isLoaded": false,
-          "isLoading": true,
-          "isPaged": true,
-          "keyValue": undefined,
-          "loader": GridLoader {},
-          "maxRows": 20,
-          "message": undefined,
-          "messages": undefined,
-          "offset": 0,
-          "omittedColumns": Immutable.List [],
-          "pageNumber": 1,
-          "queryInfo": undefined,
-          "requiredColumns": Immutable.List [],
-          "selectedIds": Immutable.List [],
-          "selectedLoaded": false,
-          "selectedState": 2,
-          "selectedQuantity": 0,
-          "showSearchBox": true,
-          "showViewSelector": true,
-          "hideEmptyViewSelector": undefined,
-          "showChartSelector": true,
-          "showExport": true,
-          "hideEmptyChartSelector": undefined,
-          "sortable": true,
-          "sorts": undefined,
-          "title": undefined,
-          "totalRows": 0,
-          "urlParams": Immutable.List [
-            "p",
-            "reportId",
-          ],
-          "urlParamValues": Immutable.Map {},
-          "urlPrefix": undefined,
-          "view": undefined,
+          "schemaQuery": Immutable.Record {
+            "schemaName": "exp.data",
+            "queryName": "Second Source",
+            "viewName": undefined,
+          },
+        },
+      }
+    }
+  >
+    <ComponentWithQueryModels
+      autoLoad={false}
+      childNounSingular="Sample"
+      chosenType="Second Source"
+      editing={false}
+      index={0}
+      modelLoader={
+        Object {
+          "clearSelections": [Function],
+          "loadCharts": [Function],
+          "loadQueryInfo": [Function],
+          "loadRows": [Function],
+          "loadSelections": [Function],
+          "replaceSelections": [Function],
+          "selectAllRows": [Function],
+          "setSelections": [Function],
         }
       }
-      showGridBar={false}
-      showSampleComparisonReports={false}
+      onRemoveParentType={[Function]}
+      onTypeChange={[Function]}
+      onValueChange={[Function]}
+      parentDataType={
+        Object {
+          "appUrlPrefixParts": Array [
+            "sources",
+          ],
+          "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+          "deleteHelpLinkTopic": "dataClass",
+          "dependencyText": "derived sample dependencies",
+          "descriptionPlural": "parent types",
+          "descriptionSingular": "parent type",
+          "inputColumnName": "Inputs/Data/First",
+          "inputTypeColumnName": "Inputs/Data/First/DataClass",
+          "inputTypeValueField": "rowId",
+          "insertColumnNamePrefix": "DataInputs/",
+          "instanceSchemaName": "exp.data",
+          "nounAsParentSingular": "Parent",
+          "nounPlural": "data",
+          "nounSingular": "data",
+          "typeListingSchemaQuery": Immutable.Record {
+            "schemaName": "exp",
+            "queryName": "DataClasses",
+            "viewName": undefined,
+          },
+          "typeNounSingular": "Data Type",
+          "uniqueFieldKey": "Name",
+        }
+      }
+      parentLSIDs={
+        Array [
+          "url:lsid:blah",
+        ]
+      }
+      parentTypeOptions={
+        Immutable.List [
+          Object {
+            "label": "Second Source",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+            "query": "Second Source",
+            "rowId": 322,
+            "schema": "exp.data",
+            "value": "second source",
+          },
+          Object {
+            "label": "Source 1",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+            "query": "Source 1",
+            "rowId": 321,
+            "schema": "exp.data",
+            "value": "source 1",
+          },
+          Object {
+            "label": "Vendor 3",
+            "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+            "query": "Vendor 3",
+            "rowId": 323,
+            "schema": "exp.data",
+            "value": "vendor 3",
+          },
+        ]
+      }
+      parentTypeQueryName="Second Source"
+      queryConfigs={
+        Object {
+          "model": Object {
+            "baseFilters": Array [
+              Filter {
+                "columnName": "LSID",
+                "filterType": Object {
+                  "getDisplaySymbol": [Function],
+                  "getDisplayText": [Function],
+                  "getLongDisplayText": [Function],
+                  "getMultiValueFilter": [Function],
+                  "getMultiValueMaxOccurs": [Function],
+                  "getMultiValueMinOccurs": [Function],
+                  "getMultiValueSeparator": [Function],
+                  "getOpposite": [Function],
+                  "getSingleValueFilter": [Function],
+                  "getURLParameterValue": [Function],
+                  "getURLSuffix": [Function],
+                  "isDataValueRequired": [Function],
+                  "isMultiValued": [Function],
+                  "isTableWise": [Function],
+                  "parseValue": [Function],
+                  "validate": [Function],
+                },
+                "value": Array [
+                  "url:lsid:blah",
+                ],
+              },
+            ],
+            "bindURL": false,
+            "schemaQuery": Immutable.Record {
+              "schemaName": "exp.data",
+              "queryName": "Second Source",
+              "viewName": undefined,
+            },
+          },
+        }
+      }
     >
-      <div
-        className=""
+      <SingleParentEntity
+        actions={
+          Object {
+            "addModel": [Function],
+            "clearSelections": [Function],
+            "loadAllModels": [Function],
+            "loadCharts": [Function],
+            "loadFirstPage": [Function],
+            "loadLastPage": [Function],
+            "loadModel": [Function],
+            "loadNextPage": [Function],
+            "loadPreviousPage": [Function],
+            "loadRows": [Function],
+            "replaceSelections": [Function],
+            "selectAllRows": [Function],
+            "selectPage": [Function],
+            "selectReport": [Function],
+            "selectRow": [Function],
+            "setFilters": [Function],
+            "setMaxRows": [Function],
+            "setOffset": [Function],
+            "setSchemaQuery": [Function],
+            "setSelections": [Function],
+            "setSorts": [Function],
+            "setView": [Function],
+          }
+        }
+        autoLoad={false}
+        childNounSingular="Sample"
+        chosenType="Second Source"
+        editing={false}
+        index={0}
+        onRemoveParentType={[Function]}
+        onTypeChange={[Function]}
+        onValueChange={[Function]}
+        parentDataType={
+          Object {
+            "appUrlPrefixParts": Array [
+              "sources",
+            ],
+            "deleteConfirmationActionName": "getDataDeleteConfirmationData.api",
+            "deleteHelpLinkTopic": "dataClass",
+            "dependencyText": "derived sample dependencies",
+            "descriptionPlural": "parent types",
+            "descriptionSingular": "parent type",
+            "inputColumnName": "Inputs/Data/First",
+            "inputTypeColumnName": "Inputs/Data/First/DataClass",
+            "inputTypeValueField": "rowId",
+            "insertColumnNamePrefix": "DataInputs/",
+            "instanceSchemaName": "exp.data",
+            "nounAsParentSingular": "Parent",
+            "nounPlural": "data",
+            "nounSingular": "data",
+            "typeListingSchemaQuery": Immutable.Record {
+              "schemaName": "exp",
+              "queryName": "DataClasses",
+              "viewName": undefined,
+            },
+            "typeNounSingular": "Data Type",
+            "uniqueFieldKey": "Name",
+          }
+        }
+        parentLSIDs={
+          Array [
+            "url:lsid:blah",
+          ]
+        }
+        parentTypeOptions={
+          Immutable.List [
+            Object {
+              "label": "Second Source",
+              "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Second+Source",
+              "query": "Second Source",
+              "rowId": 322,
+              "schema": "exp.data",
+              "value": "second source",
+            },
+            Object {
+              "label": "Source 1",
+              "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Source+1",
+              "query": "Source 1",
+              "rowId": 321,
+              "schema": "exp.data",
+              "value": "source 1",
+            },
+            Object {
+              "label": "Vendor 3",
+              "lsid": "urn:lsid:labkey.com:DataClass.Folder-252:Vendor+3",
+              "query": "Vendor 3",
+              "rowId": 323,
+              "schema": "exp.data",
+              "value": "vendor 3",
+            },
+          ]
+        }
+        parentTypeQueryName="Second Source"
+        queryModels={
+          Object {
+            "model": QueryModel {
+              "baseFilters": Array [
+                Filter {
+                  "columnName": "LSID",
+                  "filterType": Object {
+                    "getDisplaySymbol": [Function],
+                    "getDisplayText": [Function],
+                    "getLongDisplayText": [Function],
+                    "getMultiValueFilter": [Function],
+                    "getMultiValueMaxOccurs": [Function],
+                    "getMultiValueMinOccurs": [Function],
+                    "getMultiValueSeparator": [Function],
+                    "getOpposite": [Function],
+                    "getSingleValueFilter": [Function],
+                    "getURLParameterValue": [Function],
+                    "getURLSuffix": [Function],
+                    "isDataValueRequired": [Function],
+                    "isMultiValued": [Function],
+                    "isTableWise": [Function],
+                    "parseValue": [Function],
+                    "validate": [Function],
+                  },
+                  "value": Array [
+                    "url:lsid:blah",
+                  ],
+                },
+              ],
+              "bindURL": false,
+              "charts": undefined,
+              "chartsError": undefined,
+              "chartsLoadingState": "INITIALIZED",
+              "containerFilter": undefined,
+              "containerPath": undefined,
+              "filterArray": Array [],
+              "id": "model",
+              "includeDetailsColumn": false,
+              "includeUpdateColumn": false,
+              "keyValue": undefined,
+              "maxRows": 20,
+              "messages": Array [],
+              "offset": 0,
+              "omittedColumns": Array [],
+              "orderedRows": undefined,
+              "queryInfo": undefined,
+              "queryInfoError": undefined,
+              "queryInfoLoadingState": "LOADING",
+              "queryParameters": undefined,
+              "requiredColumns": Array [],
+              "rowCount": undefined,
+              "rows": undefined,
+              "rowsError": undefined,
+              "rowsLoadingState": "INITIALIZED",
+              "schemaQuery": Immutable.Record {
+                "schemaName": "exp.data",
+                "queryName": "Second Source",
+                "viewName": undefined,
+              },
+              "selectedReportId": undefined,
+              "selections": undefined,
+              "selectionsError": undefined,
+              "selectionsLoadingState": "INITIALIZED",
+              "sorts": Array [],
+              "title": undefined,
+              "urlPrefix": "query",
+              Symbol(immer-draftable): true,
+            },
+          }
+        }
       >
         <div
-          className=""
+          className="top-spacing"
+          key="grid-0"
         >
-          <div
-            className="row"
+          <table
+            className="table table-responsive table-condensed detail-component--table__fixed"
+          >
+            <tbody>
+              <tr
+                key="type-name"
+              >
+                <td>
+                  Data Type
+                </td>
+                <td>
+                  <a
+                    href="#/sources/Second%20Source"
+                  >
+                    Second Source
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <GridPanel
+            actions={
+              Object {
+                "addModel": [Function],
+                "clearSelections": [Function],
+                "loadAllModels": [Function],
+                "loadCharts": [Function],
+                "loadFirstPage": [Function],
+                "loadLastPage": [Function],
+                "loadModel": [Function],
+                "loadNextPage": [Function],
+                "loadPreviousPage": [Function],
+                "loadRows": [Function],
+                "replaceSelections": [Function],
+                "selectAllRows": [Function],
+                "selectPage": [Function],
+                "selectReport": [Function],
+                "selectRow": [Function],
+                "setFilters": [Function],
+                "setMaxRows": [Function],
+                "setOffset": [Function],
+                "setSchemaQuery": [Function],
+                "setSelections": [Function],
+                "setSorts": [Function],
+                "setView": [Function],
+              }
+            }
+            allowSelections={false}
+            allowSorting={true}
+            asPanel={false}
+            hideEmptyChartSelector={false}
+            hideEmptyViewMenu={false}
+            model={
+              QueryModel {
+                "baseFilters": Array [
+                  Filter {
+                    "columnName": "LSID",
+                    "filterType": Object {
+                      "getDisplaySymbol": [Function],
+                      "getDisplayText": [Function],
+                      "getLongDisplayText": [Function],
+                      "getMultiValueFilter": [Function],
+                      "getMultiValueMaxOccurs": [Function],
+                      "getMultiValueMinOccurs": [Function],
+                      "getMultiValueSeparator": [Function],
+                      "getOpposite": [Function],
+                      "getSingleValueFilter": [Function],
+                      "getURLParameterValue": [Function],
+                      "getURLSuffix": [Function],
+                      "isDataValueRequired": [Function],
+                      "isMultiValued": [Function],
+                      "isTableWise": [Function],
+                      "parseValue": [Function],
+                      "validate": [Function],
+                    },
+                    "value": Array [
+                      "url:lsid:blah",
+                    ],
+                  },
+                ],
+                "bindURL": false,
+                "charts": undefined,
+                "chartsError": undefined,
+                "chartsLoadingState": "INITIALIZED",
+                "containerFilter": undefined,
+                "containerPath": undefined,
+                "filterArray": Array [],
+                "id": "model",
+                "includeDetailsColumn": false,
+                "includeUpdateColumn": false,
+                "keyValue": undefined,
+                "maxRows": 20,
+                "messages": Array [],
+                "offset": 0,
+                "omittedColumns": Array [],
+                "orderedRows": undefined,
+                "queryInfo": undefined,
+                "queryInfoError": undefined,
+                "queryInfoLoadingState": "LOADING",
+                "queryParameters": undefined,
+                "requiredColumns": Array [],
+                "rowCount": undefined,
+                "rows": undefined,
+                "rowsError": undefined,
+                "rowsLoadingState": "INITIALIZED",
+                "schemaQuery": Immutable.Record {
+                  "schemaName": "exp.data",
+                  "queryName": "Second Source",
+                  "viewName": undefined,
+                },
+                "selectedReportId": undefined,
+                "selections": undefined,
+                "selectionsError": undefined,
+                "selectionsLoadingState": "INITIALIZED",
+                "sorts": Array [],
+                "title": undefined,
+                "urlPrefix": "query",
+                Symbol(immer-draftable): true,
+              }
+            }
+            showButtonBar={false}
+            showChartMenu={false}
+            showExport={false}
+            showHeader={true}
+            showOmniBox={false}
+            showPagination={true}
+            showSampleComparisonReports={false}
+            showViewMenu={true}
           >
             <div
-              className="col-md-12"
+              className="grid-panel"
             >
-              <QueryGrid
-                model={
-                  Immutable.Record {
-                    "id": "dataclasses-parent-data|exp$pdata/second source",
-                    "schema": "exp.data",
-                    "query": "Second Source",
-                    "queryParameters": undefined,
-                    "allowSelection": false,
-                    "baseFilters": Immutable.List [
-                      Filter {
-                        "columnName": "LSID",
-                        "filterType": Object {
-                          "getDisplaySymbol": [Function],
-                          "getDisplayText": [Function],
-                          "getLongDisplayText": [Function],
-                          "getMultiValueFilter": [Function],
-                          "getMultiValueMaxOccurs": [Function],
-                          "getMultiValueMinOccurs": [Function],
-                          "getMultiValueSeparator": [Function],
-                          "getOpposite": [Function],
-                          "getSingleValueFilter": [Function],
-                          "getURLParameterValue": [Function],
-                          "getURLSuffix": [Function],
-                          "isDataValueRequired": [Function],
-                          "isMultiValued": [Function],
-                          "isTableWise": [Function],
-                          "parseValue": [Function],
-                          "validate": [Function],
-                        },
-                        "value": Array [
-                          "url:lsid:blah",
-                        ],
-                      },
-                    ],
-                    "bindURL": false,
-                    "containerPath": undefined,
-                    "containerFilter": undefined,
-                    "data": Immutable.Map {},
-                    "dataIds": Immutable.List [],
-                    "displayColumns": undefined,
-                    "editable": false,
-                    "editing": false,
-                    "filterArray": Immutable.List [],
-                    "includeDetailsColumn": false,
-                    "includeUpdateColumn": false,
-                    "isError": false,
-                    "isLoaded": false,
-                    "isLoading": true,
-                    "isPaged": true,
-                    "keyValue": undefined,
-                    "loader": GridLoader {},
-                    "maxRows": 20,
-                    "message": undefined,
-                    "messages": undefined,
-                    "offset": 0,
-                    "omittedColumns": Immutable.List [],
-                    "pageNumber": 1,
-                    "queryInfo": undefined,
-                    "requiredColumns": Immutable.List [],
-                    "selectedIds": Immutable.List [],
-                    "selectedLoaded": false,
-                    "selectedState": 2,
-                    "selectedQuantity": 0,
-                    "showSearchBox": true,
-                    "showViewSelector": true,
-                    "hideEmptyViewSelector": undefined,
-                    "showChartSelector": true,
-                    "showExport": true,
-                    "hideEmptyChartSelector": undefined,
-                    "sortable": true,
-                    "sorts": undefined,
-                    "title": undefined,
-                    "totalRows": 0,
-                    "urlParams": Immutable.List [
-                      "p",
-                      "reportId",
-                    ],
-                    "urlParamValues": Immutable.Map {},
-                    "urlPrefix": undefined,
-                    "view": undefined,
-                  }
-                }
+              <div
+                className="grid-panel__body"
               >
-                <Grid
-                  bordered={true}
-                  calcWidths={true}
-                  cellular={false}
-                  columns={Immutable.List []}
-                  condensed={true}
-                  data={Immutable.List []}
-                  emptyText="No data available."
-                  gridId="dataclasses-parent-data|exp$pdata/second source"
-                  headerCell={[Function]}
-                  isLoading={true}
-                  loadingText={
-                    <LoadingSpinner
-                      msg="Loading..."
-                      wrapperClassName=""
-                    />
-                  }
-                  messages={Immutable.List []}
-                  responsive={true}
-                  showHeader={true}
-                  striped={true}
-                  transpose={false}
+                <div
+                  className="grid-panel__info"
                 >
-                  <div
-                    className="table-responsive"
-                    data-gridid="dataclasses-parent-data|exp$pdata/second source"
+                  <LoadingSpinner
+                    msg="Loading data..."
+                    wrapperClassName=""
                   >
-                    <GridMessages
-                      messages={Immutable.List []}
+                    <span
+                      className=""
                     >
-                      <div
-                        className="grid-messages"
-                      >
-                        <Component />
-                      </div>
-                    </GridMessages>
-                    <table
-                      className="table table-striped table-bordered table-condensed"
-                    >
-                      <GridHeader
-                        calcWidths={true}
-                        columns={Immutable.List []}
-                        headerCell={[Function]}
-                        showHeader={true}
-                        transpose={false}
-                      >
-                        <thead>
-                          <tr>
-                            <Component />
-                          </tr>
-                        </thead>
-                      </GridHeader>
-                      <GridBody
-                        columns={Immutable.List []}
-                        data={Immutable.List []}
-                        emptyText="No data available."
-                        isLoading={true}
-                        loadingText={
-                          <LoadingSpinner
-                            msg="Loading..."
-                            wrapperClassName=""
-                          />
-                        }
-                        transpose={false}
-                      >
-                        <tbody>
-                          <tr
-                            className="grid-loading"
-                            key="grid-default-row"
-                          >
-                            <td
-                              colSpan={0}
-                            >
-                              <LoadingSpinner
-                                msg="Loading..."
-                                wrapperClassName=""
-                              >
-                                <span
-                                  className=""
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="fa fa-spinner fa-pulse"
-                                  />
-                                   
-                                  Loading...
-                                </span>
-                              </LoadingSpinner>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </GridBody>
-                    </table>
-                  </div>
-                </Grid>
-              </QueryGrid>
+                      <i
+                        aria-hidden="true"
+                        className="fa fa-spinner fa-pulse"
+                      />
+                       
+                      Loading data...
+                    </span>
+                  </LoadingSpinner>
+                </div>
+                <div
+                  className="grid-panel__grid"
+                />
+              </div>
             </div>
-          </div>
+          </GridPanel>
         </div>
-      </div>
-    </QueryGridPanel>
-  </div>
-</SingleParentEntityPanel>
+      </SingleParentEntity>
+    </ComponentWithQueryModels>
+  </withRouter(ComponentWithQueryModels)>
+</Memo()>
 `;

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -7,8 +7,6 @@ import { EntityDataType } from './models';
 export const DATA_DELETE_CONFIRMATION_ACTION = 'getDataDeleteConfirmationData.api';
 export const SAMPLE_DELETE_CONFIRMATION_ACTION = 'getMaterialDeleteConfirmationData.api';
 
-export const PARENT_DATA_GRID_PREFIX = 'parent-data';
-
 export const SampleTypeDataType: EntityDataType = {
     typeListingSchemaQuery: SCHEMAS.EXP_TABLES.SAMPLE_SETS,
     instanceSchemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -3,12 +3,7 @@ import { List, Map, Set } from 'immutable';
 import { naturalSort, QueryGridModel } from '../../..';
 import { DELIMITER } from '../forms/input/SelectInput';
 
-import { PARENT_DATA_GRID_PREFIX } from './constants';
 import { EntityChoice, EntityDataType, IEntityTypeOption } from './models';
-
-export function getParentGridPrefix(parentDataType: EntityDataType): string {
-    return parentDataType.typeListingSchemaQuery.queryName + '-' + PARENT_DATA_GRID_PREFIX;
-}
 
 export function parentValuesDiffer(
     sortedOriginalParents: List<EntityChoice>,
@@ -90,7 +85,7 @@ export function getUpdatedRowForParentChanges(
     originalParents: List<EntityChoice>,
     currentParents: List<EntityChoice>,
     childModel: QueryGridModel
-) {
+): Record<string, any> {
     const queryData = childModel.getRow();
     const queryInfo = childModel.queryInfo;
 


### PR DESCRIPTION
#### Rationale
The current `<SingleParentEntityPanel/>` (SPEP) is backed by `QueryGridModel` and it's associated components. All instances of SPEP's are created via `<ParentEntityEditPanel/>` and is responsible for their configuration. Formerly, this meant the parent would attempt to invalidate the underlying QGMs when either rows were updated or the parent component was unmounted. 

In a product test suite we're seeing failures due to this invalidation because it causes a race condition with grid initialization updates from the underlying `<QueryGrid/>`s created by the SPEPs. Due to the decoupled nature of these updates it is very difficult to catch/prevent this race condition.

With this PR I've updated `<SingleParentEntityPanel/>` to be backed by `QueryModel` and it's associated components. This alleviates the need for invalidation by the parent and reduces these component's complexity.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/514

#### Changes
* Convert `<SingleParentEntityPanel/>` to use `QueryModel`.
* Update `<ParentEntityEditPanel/>` to no longer invalidate `QueryGridModel`s for underlying single parent panels.
* Switch `<ParentEntityEditPanel/>` to be a `React.Component` instead of a `ReactN.Component`.