### PR TITLE
Item 8546: Ontology concept picker initial concept search implementation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.5",
+  "version": "2.6.3-fb-ontologySearchPart1.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.8",
+  "version": "2.6.3-fb-ontologySearchPart1.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.10",
+  "version": "2.6.3-fb-ontologySearchPart1.11",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.9",
+  "version": "2.6.3-fb-ontologySearchPart1.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.1-fb-ontologySearchPart1.1",
+  "version": "2.6.1-fb-ontologySearchPart1.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.1",
+  "version": "2.6.1-fb-ontologySearchPart1.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.1",
+  "version": "2.6.3-fb-ontologySearchPart1.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.4",
+  "version": "2.6.3-fb-ontologySearchPart1.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.3",
+  "version": "2.6.3-fb-ontologySearchPart1.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.0",
+  "version": "2.6.3-fb-ontologySearchPart1.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.2",
+  "version": "2.6.3-fb-ontologySearchPart1.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.7",
+  "version": "2.6.3-fb-ontologySearchPart1.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.6",
+  "version": "2.6.3-fb-ontologySearchPart1.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3-fb-ontologySearchPart1.11",
+  "version": "2.6.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.6.3",
+  "version": "2.6.3-fb-ontologySearchPart1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 8546: Ontology concept picker panel search
+
 ### version 2.6.1
 *Released*: 2 March 2021
 * Issue 42589: Product Menu attempts to load before application initialized

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.6.4
+*Released*: 16 March 2021
 * Item 8546: Ontology concept picker panel search
     - FileTree component updates show props to `showLoading` and `showAnimations`
     - Concept path display update for hover to get full path info for "current path"

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,12 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Item 8546: Ontology concept picker panel search
+    - FileTree component updates show props to `showLoading` and `showAnimations`
+    - Concept path display update for hover to get full path info for "current path"
+    - Ontology tree panel update for adding search input field and results menu behavior
+    - Ontology tree panel update to allow for loading data into tree and navigating to an alternate path via search or alternate path click in path information tab
+    - Ontology panel header update to show ontology description and concept count in tooltip
+    - search/actions.ts update to allow for a custom category filter array
 
 ### version 2.6.3
 *Released*: 10 March 2021

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -91,6 +91,7 @@ import {
     isFieldDeletable,
 } from './propertiesUtil';
 import { DomainPropertiesGrid } from './DomainPropertiesGrid';
+import { ONTOLOGY_MODULE_NAME } from '../ontology/actions';
 
 interface IDomainFormInput {
     allowImportExport?: boolean;
@@ -222,17 +223,16 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                 const serverModuleNames = data.modules
                     .filter(module => module.enabled)
                     .map(module => module.name.toLowerCase());
+                this.setState({ serverModuleNames });
 
                 // if the Ontology module is available, get the updated set of available data types
-                if (serverModuleNames.indexOf('ontology') > -1) {
+                if (serverModuleNames.indexOf(ONTOLOGY_MODULE_NAME) > -1) {
                     try {
                         const availableTypes = await getAvailableTypesForOntology(domain);
-                        this.setState({ availableTypes, serverModuleNames });
+                        this.setState({ availableTypes });
                     } catch (error) {
                         console.error('Failed to retrieve available types for Ontology.', error);
                     }
-                } else {
-                    this.setState({ serverModuleNames });
                 }
             },
         });
@@ -1311,7 +1311,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                             selectAll={selectAll}
                             actions={actions}
                             appPropertiesOnly={appPropertiesOnly}
-                            hasOntologyModule={serverModuleNames?.indexOf('ontology') > -1}
+                            hasOntologyModule={serverModuleNames?.indexOf(ONTOLOGY_MODULE_NAME) > -1}
                         />
                     ) : (
                         this.renderDetailedFieldView()

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -35,6 +35,8 @@ import { ActionButton } from '../buttons/ActionButton';
 
 import { ToggleWithInputField } from '../forms/input/ToggleWithInputField';
 
+import { ONTOLOGY_MODULE_NAME } from '../ontology/actions';
+
 import {
     DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
     EXPAND_TRANSITION,
@@ -91,7 +93,6 @@ import {
     isFieldDeletable,
 } from './propertiesUtil';
 import { DomainPropertiesGrid } from './DomainPropertiesGrid';
-import { ONTOLOGY_MODULE_NAME } from '../ontology/actions';
 
 interface IDomainFormInput {
     allowImportExport?: boolean;
@@ -219,7 +220,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         // query to get the set of available modules for the given LabKey server
         Security.getModules({
             containerPath: getServerContext().container.path,
-            success: async (data) => {
+            success: async data => {
                 const serverModuleNames = data.modules
                     .filter(module => module.enabled)
                     .map(module => module.name.toLowerCase());
@@ -1232,7 +1233,9 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
 
                                         return (
                                             <DomainRow
-                                                ref={ref => {this.refsArray[i] = ref;}}
+                                                ref={ref => {
+                                                    this.refsArray[i] = ref;
+                                                }}
                                                 domainId={domain.domainId}
                                                 helpNoun={helpNoun}
                                                 key={'domain-row-key-' + i}

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.spec.tsx
@@ -12,7 +12,7 @@ const DOMAIN = DomainDesign.create({
     fields: [
         { name: 'a', rangeURI: INTEGER_TYPE.rangeURI },
         { name: 'b', rangeURI: DATETIME_TYPE.rangeURI },
-        { name: 'c' }
+        { name: 'c' },
     ],
 });
 const ACTIONS = {
@@ -45,7 +45,7 @@ describe('DomainPropertiesGrid', () => {
 
         expect(text).toContain('http://www.w3.org/2001/XMLSchema#int'); // rangeURI of field 'a'
         expect(text).toContain('http://www.w3.org/2001/XMLSchema#dateTime'); // rangeURI of field 'b'
-        expect(text).toContain('http://www.w3.org/2001/XMLSchema#string'); //rangeURI of field 'c' -- string is default
+        expect(text).toContain('http://www.w3.org/2001/XMLSchema#string'); // rangeURI of field 'c' -- string is default
 
         // Removed column, as this information does not surface in UI
         expect(text).not.toContain('Property URI');

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.spec.tsx
@@ -30,6 +30,7 @@ describe('DomainPropertiesGrid', () => {
                 actions={ACTIONS}
                 selectAll={false}
                 appPropertiesOnly={false}
+                hasOntologyModule={false}
             />
         );
         const text = domainPropertiesGrid.text();
@@ -62,6 +63,7 @@ describe('DomainPropertiesGrid', () => {
                 actions={ACTIONS}
                 selectAll={false}
                 appPropertiesOnly={true}
+                hasOntologyModule={false}
             />
         );
         const text = domainPropertiesGrid.text();
@@ -76,6 +78,29 @@ describe('DomainPropertiesGrid', () => {
 
         expect(text).not.toContain('Property URI');
         expect(text).not.toContain('Source Ontology');
+
+        domainPropertiesGrid.unmount();
+    });
+
+    test('with ontology module', () => {
+        const domainPropertiesGrid = mount(
+            <DomainPropertiesGrid
+                domain={DOMAIN}
+                search="searchStr"
+                actions={ACTIONS}
+                selectAll={false}
+                appPropertiesOnly={false}
+                hasOntologyModule={true}
+            />
+        );
+        const text = domainPropertiesGrid.text();
+
+        expect(text).toContain('Source Ontology');
+        expect(text).toContain('Concept Import Column');
+        expect(text).toContain('Concept Label Column');
+        expect(text).toContain('Principal Concept Code');
+
+        expect(text).not.toContain('Property URI');
 
         domainPropertiesGrid.unmount();
     });

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
@@ -44,7 +44,13 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
         // TODO: Maintain hash of fieldIndex : gridIndex on state in order to make delete and filter run in N rather than N^2 time.
         this.state = {
             gridData,
-            gridColumns: domain.getGridColumns(onFieldsChange, scrollFunction, domainKindName, appPropertiesOnly, hasOntologyModule),
+            gridColumns: domain.getGridColumns(
+                onFieldsChange,
+                scrollFunction,
+                domainKindName,
+                appPropertiesOnly,
+                hasOntologyModule
+            ),
             visibleGridData: this.getVisibleGridData(gridData),
             search: this.props.search,
         };
@@ -60,13 +66,13 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
         // When new field added
         if (prevGridData.size < newGridData.size) {
             this.uponRowAdd(newGridData);
-        // When fields are deleted
+            // When fields are deleted
         } else if (prevGridData.size > newGridData.size) {
             this.uponRowDelete();
-        // When search is updated
+            // When search is updated
         } else if (prevSearch !== newSearch) {
             this.uponFilter();
-        // If selection updated
+            // If selection updated
         } else {
             this.uponRowSelection();
         }
@@ -90,7 +96,7 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
         const initGridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
         // Handle bug that occurs if multiple fields have the same name
-        let replaceGridData = (new Set(gridData.map(row => row.get('name')).toJS())).size !== gridData.size;
+        const replaceGridData = new Set(gridData.map(row => row.get('name')).toJS()).size !== gridData.size;
         if (replaceGridData) {
             this.setState({ gridData: initGridData, visibleGridData: this.getVisibleGridData(initGridData) });
             return;
@@ -161,7 +167,9 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
     headerCell = (column: GridColumn, index: number, columnCount?: number): ReactNode => {
         const { selectAll, actions } = this.props;
         if (column.index === GRID_SELECTION_INDEX) {
-            return <Checkbox className="domain-summary-selectAll" checked={selectAll} onChange={actions.toggleSelectAll} />;
+            return (
+                <Checkbox className="domain-summary-selectAll" checked={selectAll} onChange={actions.toggleSelectAll} />
+            );
         }
 
         return headerCell(this.sortColumn, column, index, false, true, columnCount);

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
@@ -23,6 +23,7 @@ interface DomainPropertiesGridProps {
     search: string;
     selectAll: boolean;
     appPropertiesOnly?: boolean;
+    hasOntologyModule: boolean;
 }
 
 interface DomainPropertiesGridState {
@@ -35,26 +36,26 @@ interface DomainPropertiesGridState {
 export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGridProps, DomainPropertiesGridState> {
     constructor(props: DomainPropertiesGridProps) {
         super(props);
-        const { domain, actions, appPropertiesOnly } = this.props;
+        const { domain, actions, appPropertiesOnly, hasOntologyModule } = this.props;
         const { onFieldsChange, scrollFunction } = actions;
         const { domainKindName } = domain;
-        const gridData = domain.getGridData(appPropertiesOnly);
+        const gridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
         // TODO: Maintain hash of fieldIndex : gridIndex on state in order to make delete and filter run in N rather than N^2 time.
         this.state = {
             gridData,
-            gridColumns: domain.getGridColumns(onFieldsChange, scrollFunction, domainKindName, appPropertiesOnly),
+            gridColumns: domain.getGridColumns(onFieldsChange, scrollFunction, domainKindName, appPropertiesOnly, hasOntologyModule),
             visibleGridData: this.getVisibleGridData(gridData),
             search: this.props.search,
         };
     }
 
     componentDidUpdate(prevProps: Readonly<DomainPropertiesGridProps>): void {
-        const { appPropertiesOnly, domain } = this.props;
+        const { appPropertiesOnly, domain, hasOntologyModule } = this.props;
         const prevSearch = prevProps.search;
         const newSearch = this.props.search;
-        const prevGridData = prevProps.domain.getGridData(appPropertiesOnly);
-        const newGridData = domain.getGridData(appPropertiesOnly);
+        const prevGridData = prevProps.domain.getGridData(appPropertiesOnly, hasOntologyModule);
+        const newGridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
         // When new field added
         if (prevGridData.size < newGridData.size) {
@@ -84,9 +85,9 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
     };
 
     uponRowDelete = (): void => {
-        const { appPropertiesOnly, domain } = this.props;
+        const { appPropertiesOnly, domain, hasOntologyModule } = this.props;
         const { gridData } = this.state;
-        const initGridData = domain.getGridData(appPropertiesOnly);
+        const initGridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
         // Handle bug that occurs if multiple fields have the same name
         let replaceGridData = (new Set(gridData.map(row => row.get('name')).toJS())).size !== gridData.size;
@@ -108,9 +109,9 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
     };
 
     uponFilter = (): void => {
-        const { appPropertiesOnly, domain } = this.props;
+        const { appPropertiesOnly, domain, hasOntologyModule } = this.props;
         const { gridData } = this.state;
-        const initGridData = domain.getGridData(appPropertiesOnly);
+        const initGridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
         const updatedGridData = gridData.map(row => {
             const nextRowIndex = initGridData.findIndex(nextRow => nextRow.get('fieldIndex') === row.get('fieldIndex'));
@@ -122,9 +123,9 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
     };
 
     uponRowSelection = (): void => {
-        const { appPropertiesOnly, domain } = this.props;
+        const { appPropertiesOnly, domain, hasOntologyModule } = this.props;
         const { gridData } = this.state;
-        const initGridData = domain.getGridData(appPropertiesOnly);
+        const initGridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
         for (let i = 0; i < gridData.size; i++) {
             const row = gridData.get(i);

--- a/packages/components/src/internal/components/domainproperties/DomainRow.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.spec.tsx
@@ -96,6 +96,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -136,6 +137,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -198,6 +200,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -260,6 +263,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -322,6 +326,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -393,6 +398,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -469,6 +475,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -537,6 +544,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -597,6 +605,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -645,6 +654,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );
@@ -669,6 +679,7 @@ describe('DomainRow', () => {
                     defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
                     defaultValueOptions={DEFAULT_OPTIONS}
                     helpNoun="domain"
+                    serverModuleNames={undefined}
                 />
             )
         );

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -80,6 +80,7 @@ interface IDomainRowProps {
     defaultDefaultValueType: string;
     defaultValueOptions: List<string>;
     appPropertiesOnly?: boolean;
+    serverModuleNames: string[];
     showFilePropertyType?: boolean;
     domainIndex: number;
     successBsStyle?: string;
@@ -452,6 +453,7 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
             defaultDefaultValueType,
             defaultValueOptions,
             appPropertiesOnly,
+            serverModuleNames,
             successBsStyle,
             domainFormDisplayOptions,
             getDomainFields,
@@ -547,6 +549,7 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
                                     onChange={this.onSingleFieldChange}
                                     showingModal={this.showingModal}
                                     appPropertiesOnly={appPropertiesOnly}
+                                    serverModuleNames={serverModuleNames}
                                     successBsStyle={successBsStyle}
                                     domainFormDisplayOptions={domainFormDisplayOptions}
                                 />

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -367,7 +367,7 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
                         componentClass="select"
                         name={createFormInputName(DOMAIN_FIELD_TYPE)}
                         disabled={
-                            !field.isNew() && field.isPrimaryKey ||
+                            (!field.isNew() && field.isPrimaryKey) ||
                             isFieldPartiallyLocked(field.lockType) ||
                             isFieldFullyLocked(field.lockType) ||
                             isPrimaryKeyFieldLocked(field.lockType)

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.spec.tsx
@@ -30,6 +30,7 @@ const DEFAULT_PROPS = {
     index: 1,
     domainIndex: 1,
     domainFormDisplayOptions: DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
+    serverModuleNames: undefined,
     onChange: jest.fn(),
     onMultiChange: jest.fn(),
     showingModal: jest.fn(),

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -39,6 +39,7 @@ interface IDomainRowExpandedOptionsProps {
     onMultiChange: (changes: List<IFieldChange>) => void;
     showingModal: (boolean) => void;
     appPropertiesOnly?: boolean;
+    serverModuleNames: string[];
     domainIndex: number;
     successBsStyle?: string;
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
@@ -202,6 +203,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
             onChange,
             showingModal,
             appPropertiesOnly,
+            serverModuleNames,
             domainIndex,
             successBsStyle,
             domainFormDisplayOptions,
@@ -219,6 +221,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                             field={field}
                             onChange={onChange}
                             appPropertiesOnly={appPropertiesOnly}
+                            serverModuleNames={serverModuleNames}
                         />
                     </Col>
                     {!isFieldFullyLocked(field.lockType) && (

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
@@ -31,7 +31,7 @@ describe('NameAndLinkingOptions', () => {
             propertyURI: 'test',
         });
 
-        const numeric = mount(<NameAndLinkingOptions index={1} domainIndex={1} field={field} onChange={jest.fn()} />);
+        const numeric = mount(<NameAndLinkingOptions index={1} domainIndex={1} field={field} serverModuleNames={undefined} onChange={jest.fn()} />);
 
         // Verify section label
         const sectionLabel = numeric.find({ className: 'domain-field-section-heading domain-field-section-hdr' });

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
@@ -31,7 +31,15 @@ describe('NameAndLinkingOptions', () => {
             propertyURI: 'test',
         });
 
-        const numeric = mount(<NameAndLinkingOptions index={1} domainIndex={1} field={field} serverModuleNames={undefined} onChange={jest.fn()} />);
+        const numeric = mount(
+            <NameAndLinkingOptions
+                index={1}
+                domainIndex={1}
+                field={field}
+                serverModuleNames={undefined}
+                onChange={jest.fn()}
+            />
+        );
 
         // Verify section label
         const sectionLabel = numeric.find({ className: 'domain-field-section-heading domain-field-section-hdr' });

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -17,6 +17,7 @@ import {
 import { DomainField } from './models';
 import { SectionHeading } from './SectionHeading';
 import { DomainFieldLabel } from './DomainFieldLabel';
+import { ONTOLOGY_MODULE_NAME } from '../ontology/actions';
 
 interface NameAndLinkingProps {
     index: number;
@@ -118,7 +119,7 @@ export class NameAndLinkingOptions extends PureComponent<NameAndLinkingProps> {
                             onChange={this.handleChange}
                             disabled={isFieldFullyLocked(field.lockType)}
                         />
-                        {!appPropertiesOnly && serverModuleNames?.indexOf('ontology') > -1 && (
+                        {!appPropertiesOnly && serverModuleNames?.indexOf(ONTOLOGY_MODULE_NAME) > -1 && (
                             <OntologyConceptAnnotation
                                 id={createFormInputId(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT, domainIndex, index)}
                                 field={field}

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -6,7 +6,7 @@ import { helpLinkNode, URL_ENCODING_TOPIC } from '../../util/helpLinks';
 import { OntologyConceptAnnotation } from '../ontology/OntologyConceptAnnotation';
 
 import { isFieldFullyLocked } from './propertiesUtil';
-import { createFormInputId, createFormInputName, hasActiveModule } from './actions';
+import { createFormInputId, createFormInputName } from './actions';
 import {
     DOMAIN_FIELD_DESCRIPTION,
     DOMAIN_FIELD_IMPORTALIASES,
@@ -24,6 +24,7 @@ interface NameAndLinkingProps {
     field: DomainField;
     onChange: (string, any) => void;
     appPropertiesOnly?: boolean;
+    serverModuleNames: string[];
 }
 
 export class NameAndLinkingOptions extends PureComponent<NameAndLinkingProps> {
@@ -60,7 +61,7 @@ export class NameAndLinkingOptions extends PureComponent<NameAndLinkingProps> {
     };
 
     render(): ReactNode {
-        const { index, field, domainIndex, appPropertiesOnly } = this.props;
+        const { index, field, domainIndex, appPropertiesOnly, serverModuleNames } = this.props;
 
         return (
             <div>
@@ -117,7 +118,7 @@ export class NameAndLinkingOptions extends PureComponent<NameAndLinkingProps> {
                             onChange={this.handleChange}
                             disabled={isFieldFullyLocked(field.lockType)}
                         />
-                        {!appPropertiesOnly && hasActiveModule('Ontology') && (
+                        {!appPropertiesOnly && serverModuleNames?.indexOf('ontology') > -1 && (
                             <OntologyConceptAnnotation
                                 id={createFormInputId(DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT, domainIndex, index)}
                                 field={field}

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -5,6 +5,8 @@ import { helpLinkNode, URL_ENCODING_TOPIC } from '../../util/helpLinks';
 
 import { OntologyConceptAnnotation } from '../ontology/OntologyConceptAnnotation';
 
+import { ONTOLOGY_MODULE_NAME } from '../ontology/actions';
+
 import { isFieldFullyLocked } from './propertiesUtil';
 import { createFormInputId, createFormInputName } from './actions';
 import {
@@ -17,7 +19,6 @@ import {
 import { DomainField } from './models';
 import { SectionHeading } from './SectionHeading';
 import { DomainFieldLabel } from './DomainFieldLabel';
-import { ONTOLOGY_MODULE_NAME } from '../ontology/actions';
 
 interface NameAndLinkingProps {
     index: number;

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -568,25 +568,21 @@ describe('DomainDesign', () => {
     });
 
     test('getGridData with ontology', () => {
-        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
-        const gridData = GRID_DATA.getGridData(false);
+        const gridData = GRID_DATA.getGridData(false, true);
         expect(gridData.toJS()).toStrictEqual(gridDataConstWithOntology);
     });
 
     test('getGridData without ontology', () => {
-        LABKEY.container.activeModules = ['Core', 'Query'];
-        const gridData = GRID_DATA.getGridData(false);
+        const gridData = GRID_DATA.getGridData(false, false);
         expect(gridData.toJS()).toStrictEqual(gridDataConst);
     });
 
     test('getGridData appPropertiesOnly', () => {
-        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
-        let gridData = GRID_DATA.getGridData(true);
+        let gridData = GRID_DATA.getGridData(true, true);
         expect(gridData.toJS()).toStrictEqual(gridDataAppPropsOnlyConst);
 
         // should be the same with or without the Ontology module in this case
-        LABKEY.container.activeModules = ['Core', 'Query'];
-        gridData = GRID_DATA.getGridData(true);
+        gridData = GRID_DATA.getGridData(true, false);
         expect(gridData.toJS()).toStrictEqual(gridDataAppPropsOnlyConst);
     });
 
@@ -596,7 +592,7 @@ describe('DomainDesign', () => {
                 { name: 'a', rangeURI: INTEGER_TYPE.rangeURI },
                 { name: 'b', rangeURI: TEXT_TYPE.rangeURI },
             ],
-        }).getGridColumns(jest.fn(), jest.fn(), 'domainKindName', false);
+        }).getGridColumns(jest.fn(), jest.fn(), 'domainKindName', false, false);
 
         expect(gridColumns.toJS().slice(2)).toStrictEqual(gridColumnsConst.slice(2));
 

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -310,12 +310,14 @@ export class DomainDesign
         return mapping;
     }
 
-    getGridData(appPropertiesOnly: boolean): List<any> {
+    getGridData(appPropertiesOnly: boolean, hasOntologyModule: boolean): List<any> {
         return this.fields.map((field, i) => {
             let fieldSerial = DomainField.serialize(field);
             const dataType = field.dataType;
             fieldSerial = removeUnusedProperties(fieldSerial);
-            fieldSerial = removeUnusedOntologyProperties(fieldSerial);
+            if (!hasOntologyModule) {
+                fieldSerial = removeUnusedOntologyProperties(fieldSerial);
+            }
             if (appPropertiesOnly) {
                 fieldSerial = removeNonAppProperties(fieldSerial);
             }
@@ -359,7 +361,8 @@ export class DomainDesign
         onFieldsChange: DomainOnChange,
         scrollFunction: (i: number) => void,
         domainKindName: string,
-        appPropertiesOnly: boolean
+        appPropertiesOnly: boolean,
+        hasOntologyModule: boolean
     ): List<GridColumn | DomainPropertiesGridColumn> {
         const selectionCol = new GridColumn({
             index: GRID_SELECTION_INDEX,
@@ -411,7 +414,9 @@ export class DomainDesign
 
         delete columns.name;
         columns = removeUnusedProperties(columns);
-        columns = removeUnusedOntologyProperties(columns);
+        if (!hasOntologyModule) {
+            columns = removeUnusedOntologyProperties(columns);
+        }
         if (appPropertiesOnly) {
             columns = removeNonAppProperties(columns);
         }

--- a/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
+++ b/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
@@ -175,12 +175,10 @@ export function removeUnusedProperties(obj) {
 }
 
 export function removeUnusedOntologyProperties(obj) {
-    if (!hasActiveModule('Ontology')) {
-        delete obj.sourceOntology;
-        delete obj.conceptImportColumn;
-        delete obj.conceptLabelColumn;
-        delete obj.principalConceptCode;
-    }
+    delete obj.sourceOntology;
+    delete obj.conceptImportColumn;
+    delete obj.conceptLabelColumn;
+    delete obj.principalConceptCode;
     return obj;
 }
 

--- a/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
+++ b/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
@@ -18,7 +18,6 @@ import { List } from 'immutable';
 
 import { DOMAIN_FIELD_FULLY_LOCKED, DOMAIN_FIELD_PARTIALLY_LOCKED, DOMAIN_FIELD_PRIMARY_KEY_LOCKED } from './constants';
 import { DomainDesign, DomainField, DomainPropertiesGridColumn } from './models';
-import { hasActiveModule } from './actions';
 
 // this is similar to what's in PropertiesEditorUtil.java that does the name validation in the old UI
 export function isLegalName(str: string): boolean {

--- a/packages/components/src/internal/components/files/FileTree.spec.tsx
+++ b/packages/components/src/internal/components/files/FileTree.spec.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, ReactWrapper, shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
+import { Treebeard, animations } from 'react-treebeard';
+
+import { LoadingSpinner } from '../../..';
 
 import { FileTree } from './FileTree';
 import { fetchFileTestTree } from './FileTreeTest';
@@ -27,7 +30,9 @@ describe('FileTree', () => {
     });
 
     test('with data allowMultiSelect false', () => {
-        const component = <FileTree allowMultiSelect={false} loadData={fetchFileTestTree} onFileSelect={jest.fn(() => true)} />;
+        const component = (
+            <FileTree allowMultiSelect={false} loadData={fetchFileTestTree} onFileSelect={jest.fn(() => true)} />
+        );
         const tree = shallow(component);
 
         return waitForLoad(tree).then(() => {
@@ -42,5 +47,34 @@ describe('FileTree', () => {
                 tree.unmount();
             });
         });
+    });
+
+    function validate(wrapper: ReactWrapper, loading = false): void {
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(loading ? 1 : 0);
+        expect(wrapper.find(Treebeard)).toHaveLength(!loading ? 1 : 0);
+    }
+
+    test('showLoading', () => {
+        const wrapper = mount(
+            <FileTree loadData={fetchFileTestTree} onFileSelect={jest.fn(() => true)} showLoading={true} />
+        );
+        validate(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('showAnimations', () => {
+        let wrapper = mount(
+            <FileTree loadData={fetchFileTestTree} onFileSelect={jest.fn(() => true)} showAnimations={true} />
+        );
+        validate(wrapper);
+        expect(wrapper.find(Treebeard).prop('animations')).toBe(animations);
+        wrapper.unmount();
+
+        wrapper = mount(
+            <FileTree loadData={fetchFileTestTree} onFileSelect={jest.fn(() => true)} showAnimations={false} />
+        );
+        validate(wrapper);
+        expect(wrapper.find(Treebeard).prop('animations')).toBe(false);
+        wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/files/FileTree.tsx
+++ b/packages/components/src/internal/components/files/FileTree.tsx
@@ -176,7 +176,12 @@ const Header = props => {
                         {showNodeIcon && (
                             <NodeIcon useFileIconCls={useFileIconCls} isDirectory={isDirectory} node={node} />
                         )}
-                        <div className={classNames({'filetree-file-name': !isDirectory, 'filetree-directory-name': isDirectory })}>
+                        <div
+                            className={classNames({
+                                'filetree-file-name': !isDirectory,
+                                'filetree-directory-name': isDirectory,
+                            })}
+                        >
                             {node.name}
                         </div>
                     </div>
@@ -551,19 +556,19 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
 
         return (
             <div className="filetree-container">
-                {showLoading ? <LoadingSpinner />
-                    : error ? (
-                        <Alert bsStyle="danger">{error}</Alert>
-                    ) : (
-                        <Treebeard
-                            animations={showAnimations ? animations : false}
-                            data={data}
-                            onToggle={this.onToggle}
-                            decorators={{ ...decorators, Header: this.headerDecorator }}
-                            style={customStyle}
-                        />
-                    )
-                }
+                {showLoading ? (
+                    <LoadingSpinner />
+                ) : error ? (
+                    <Alert bsStyle="danger">{error}</Alert>
+                ) : (
+                    <Treebeard
+                        animations={showAnimations ? animations : false}
+                        data={data}
+                        onToggle={this.onToggle}
+                        decorators={{ ...decorators, Header: this.headerDecorator }}
+                        style={customStyle}
+                    />
+                )}
             </div>
         );
     }

--- a/packages/components/src/internal/components/files/FileTree.tsx
+++ b/packages/components/src/internal/components/files/FileTree.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Treebeard, decorators, TreeTheme } from 'react-treebeard';
+import { Treebeard, decorators, TreeTheme, animations } from 'react-treebeard';
 import { Checkbox, Alert } from 'react-bootstrap';
 import { List } from 'immutable';
 import classNames from 'classnames';
@@ -195,6 +195,8 @@ interface FileTreeProps {
     getRootPermissions?: (directory?: string) => Promise<any>;
     defaultRootName?: string;
     showNodeIcon?: boolean;
+    showLoading?: boolean;
+    showAnimations?: boolean;
 }
 
 interface FileTreeState {
@@ -213,6 +215,8 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
         useFileIconCls: false,
         emptyDirectoryText: 'No Files Found',
         defaultRootName: 'root',
+        showLoading: false,
+        showAnimations: true,
     };
 
     constructor(props: FileTreeProps) {
@@ -494,7 +498,6 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
 
         if (cursor) {
             cursor.active = false;
-            this.setState(() => ({ cursor, data: { ...data } }));
         }
 
         node.active = active;
@@ -542,20 +545,24 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
     };
 
     render(): React.ReactNode {
+        const { showLoading, showAnimations } = this.props;
         const { data, error } = this.state;
 
         return (
             <div className="filetree-container">
-                {error ? (
-                    <Alert bsStyle="danger">{error}</Alert>
-                ) : (
-                    <Treebeard
-                        data={data}
-                        onToggle={this.onToggle}
-                        decorators={{ ...decorators, Header: this.headerDecorator }}
-                        style={customStyle}
-                    />
-                )}
+                {showLoading ? <LoadingSpinner />
+                    : error ? (
+                        <Alert bsStyle="danger">{error}</Alert>
+                    ) : (
+                        <Treebeard
+                            animations={showAnimations ? animations : false}
+                            data={data}
+                            onToggle={this.onToggle}
+                            decorators={{ ...decorators, Header: this.headerDecorator }}
+                            style={customStyle}
+                        />
+                    )
+                }
             </div>
         );
     }

--- a/packages/components/src/internal/components/files/FileTree.tsx
+++ b/packages/components/src/internal/components/files/FileTree.tsx
@@ -131,7 +131,7 @@ const Header = props => {
         showNodeIcon = true,
     } = props;
     const isDirectory = node.children !== undefined;
-    const activeColor = node.active && !allowMultiSelect ? 'lk-text-theme-dark' : undefined; // $brand-primary and $gray-light
+    const activeColor = node.active && !allowMultiSelect ? 'lk-text-theme-dark filetree-node-active' : undefined; // $brand-primary and $gray-light
 
     if (nodeIsEmpty(node.id)) {
         return <div className="filetree-empty-directory">{emptyDirectoryText}</div>;

--- a/packages/components/src/internal/components/files/FileTree.tsx
+++ b/packages/components/src/internal/components/files/FileTree.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFolder, faFileAlt, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 
-import { LoadingSpinner } from '../../..';
+import { LoadingSpinner } from '../base/LoadingSpinner';
 
 const fileTree_color = '#777';
 const customStyle: TreeTheme = {
@@ -419,6 +419,7 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
 
     // recursively toggle all child files. afterCascade used to check selection box of each subfile
     cascadeToggle = (node, afterCascade: (any) => any): void => {
+        // TODO move this to be defined as a function of the component so it isn't redefined for each recursive call
         const afterToggle = () => {
             afterCascade(node);
             if (node.children) {

--- a/packages/components/src/internal/components/files/FileTree.tsx
+++ b/packages/components/src/internal/components/files/FileTree.tsx
@@ -1,12 +1,10 @@
-import { Treebeard, decorators, TreeTheme } from 'react-treebeard';
-
 import React, { PureComponent } from 'react';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFolder, faFileAlt, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { Treebeard, decorators, TreeTheme } from 'react-treebeard';
 import { Checkbox, Alert } from 'react-bootstrap';
 import { List } from 'immutable';
 import classNames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFolder, faFileAlt, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 
 import { LoadingSpinner } from '../../..';
 
@@ -89,7 +87,7 @@ const customStyle: TreeTheme = {
     },
 };
 
-const DEFAULT_ROOT_PREFIX = '|root';
+export const DEFAULT_ROOT_PREFIX = '|root';
 const CHECK_ID_PREFIX = 'filetree-check-';
 
 // Place holder names for empty or loading display.  Uses asterisk which will never be in a file name.
@@ -97,11 +95,11 @@ const EMPTY_FILE_NAME = '*empty';
 const LOADING_FILE_NAME = '*loading';
 
 const nodeIsLoading = (id: string): boolean => {
-    return id.endsWith('|' + LOADING_FILE_NAME);
+    return id?.endsWith('|' + LOADING_FILE_NAME);
 };
 
 const nodeIsEmpty = (id: string): boolean => {
-    return id.endsWith('|' + EMPTY_FILE_NAME);
+    return id?.endsWith('|' + EMPTY_FILE_NAME);
 };
 
 const NodeIcon = props => {
@@ -426,7 +424,7 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
             }
         };
 
-        this.onToggle(node, true, afterToggle);
+        this.onToggle(node, true, true, afterToggle);
     };
 
     handleCheckbox = (evt): void => {
@@ -490,9 +488,17 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
     // node in this.state.data. This function is updating that node which is directly updating this.state.data, then
     // we make a clone of this.state.data for setState.  Directly manipulating anything in this.state is NOT a recommended React
     // pattern.  This is done in this case to work with the treebeard package, but should not be copied elsewhere.
-    onToggle = (node: any, toggled: boolean, callback?: () => any): void => {
+    onToggle = (node: any, toggled: boolean, active = true, callback?: () => any): void => {
         const { allowMultiSelect } = this.props;
         const { cursor, data } = this.state;
+
+        if (cursor) {
+            cursor.active = false;
+            this.setState(() => ({ cursor, data: { ...data } }));
+        }
+
+        node.active = active;
+        node.toggled = toggled;
 
         if (!allowMultiSelect) {
             if (!this.onFileSelect(node.id, true, !!node.children, node)) {
@@ -500,15 +506,8 @@ export class FileTree extends PureComponent<FileTreeProps, FileTreeState> {
             }
         }
 
-        if (cursor) {
-            cursor.active = false;
-            this.setState(() => ({ cursor, data: { ...data } }));
-        }
-        node.active = true;
-        node.toggled = toggled;
-
         // load data in directory if not already loaded
-        if (node.children && node.children.length === 0) {
+        if (node.children?.length === 0) {
             node.children = [{ id: node.id + '|' + LOADING_FILE_NAME }];
             this.setState(
                 () => ({ cursor: node, data: { ...data } }),

--- a/packages/components/src/internal/components/files/__snapshots__/FileTree.spec.tsx.snap
+++ b/packages/components/src/internal/components/files/__snapshots__/FileTree.spec.tsx.snap
@@ -564,7 +564,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
             }
           >
             <div
-              className="lk-text-theme-dark"
+              className="lk-text-theme-dark filetree-node-active"
             >
               <div
                 className="filetree-resource-row"

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.spec.tsx
@@ -21,7 +21,7 @@ describe('ConceptInformationTabs', () => {
     }
 
     test('no concept', () => {
-        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} />);
+        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} alternatePathClickHandler={jest.fn} />);
         validate(wrapper);
         expect(wrapper.find(ConceptOverviewPanelImpl).prop('concept')).toBe(undefined);
         wrapper.unmount();
@@ -29,14 +29,16 @@ describe('ConceptInformationTabs', () => {
 
     test('with concept', () => {
         const concept = new ConceptModel({ code: 'a', label: 'b' });
-        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} concept={concept} />);
+        const wrapper = mount(
+            <ConceptInformationTabs {...DEFAULT_PROPS} concept={concept} alternatePathClickHandler={jest.fn} />
+        );
         validate(wrapper);
         expect(wrapper.find(ConceptOverviewPanelImpl).prop('concept')).toBe(concept);
         wrapper.unmount();
     });
 
     test('activeTab and defaultActiveKey', () => {
-        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} />);
+        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} alternatePathClickHandler={jest.fn} />);
         validate(wrapper);
         expect(wrapper.find(Tab.Container).prop('defaultActiveKey')).toBe(ConceptInfoTabs.CONCEPT_OVERVIEW_TAB);
         expect(wrapper.find(Tab.Container).prop('activeKey')).toBe(ConceptInfoTabs.CONCEPT_OVERVIEW_TAB);

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
@@ -8,7 +8,7 @@ import { ConceptPathInfo } from './ConceptPathInfo';
 interface ConceptInformationTabsProps {
     concept?: ConceptModel;
     selectedPath?: PathModel;
-    alternatePathClickHandler: (path: PathModel) => void;
+    alternatePathClickHandler: (path: PathModel, isAlternatePath?: boolean) => void;
 }
 
 export const enum ConceptInfoTabs {

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
@@ -8,7 +8,7 @@ import { ConceptPathInfo } from './ConceptPathInfo';
 interface ConceptInformationTabsProps {
     concept?: ConceptModel;
     selectedPath?: PathModel;
-    alternatePathClickHandler?: (path: PathModel) => void;
+    alternatePathClickHandler: (path: PathModel) => void;
 }
 
 export const enum ConceptInfoTabs {

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
@@ -45,7 +45,7 @@ describe('ConceptOverviewPanelImpl', () => {
 
     test('with selected path', () => {
         const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT} selectedPath={TEST_PATH} />);
-        validate(wrapper, false, 5);
+        validate(wrapper, false, 4);
         expect(wrapper.find('.title').text()).toBe(TEST_CONCEPT.label);
         expect(wrapper.find('.code').text()).toBe(TEST_CONCEPT.code);
         expect(wrapper.find(Button)).toHaveLength(1);

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { Modal } from 'react-bootstrap';
+import { Button, Modal } from 'react-bootstrap';
 import { mount, ReactWrapper } from 'enzyme';
 
 import { Alert } from '../../..';
 
 import { ConceptOverviewModal, ConceptOverviewPanelImpl, OntologyConceptOverviewPanel } from './ConceptOverviewPanel';
-import { ConceptModel } from './models';
+import { ConceptModel, PathModel } from './models';
 
 const TEST_CONCEPT = new ConceptModel({ code: 'a', label: 'b', description: 'c' });
+const TEST_PATH = new PathModel({});
 
 describe('OntologyConceptOverviewPanel', () => {
     test('without code prop', () => {
@@ -32,10 +33,23 @@ describe('ConceptOverviewPanelImpl', () => {
     });
 
     test('with concept', () => {
-        const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT} />);
+        const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT}  />);
         validate(wrapper, false, 3);
         expect(wrapper.find('.title').text()).toBe(TEST_CONCEPT.label);
         expect(wrapper.find('.code').text()).toBe(TEST_CONCEPT.code);
+        expect(wrapper.find(Button)).toHaveLength(0);
+        expect(wrapper.find('.description-title').text()).toBe('Description');
+        expect(wrapper.find('.description-text').text()).toBe(TEST_CONCEPT.description);
+        wrapper.unmount();
+    });
+
+    test('with selected path', () => {
+        const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT} selectedPath={TEST_PATH} />);
+        validate(wrapper, false, 5);
+        expect(wrapper.find('.title').text()).toBe(TEST_CONCEPT.label);
+        expect(wrapper.find('.code').text()).toBe(TEST_CONCEPT.code);
+        expect(wrapper.find(Button)).toHaveLength(1);
+        expect(wrapper.find(Button).text()).toBe('Show Path');
         expect(wrapper.find('.description-title').text()).toBe('Description');
         expect(wrapper.find('.description-text').text()).toBe(TEST_CONCEPT.description);
         wrapper.unmount();

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.spec.tsx
@@ -4,7 +4,13 @@ import { mount, ReactWrapper } from 'enzyme';
 
 import { Alert } from '../../..';
 
-import { ConceptOverviewModal, ConceptOverviewPanelImpl, OntologyConceptOverviewPanel } from './ConceptOverviewPanel';
+import {
+    ConceptOverviewModal,
+    ConceptOverviewPanelImpl,
+    ConceptSynonyms,
+    OntologyConceptOverviewPanel,
+} from './ConceptOverviewPanel';
+import { ConceptPathDisplay } from './ConceptPathDisplay';
 import { ConceptModel, PathModel } from './models';
 
 const TEST_CONCEPT = new ConceptModel({ code: 'a', label: 'b', description: 'c' });
@@ -20,38 +26,81 @@ describe('OntologyConceptOverviewPanel', () => {
     });
 });
 
+describe('ConceptSynonyms', () => {
+    test('without synonyms', () => {
+        let wrapper = mount(<ConceptSynonyms synonyms={undefined} />);
+        expect(wrapper.find('.synonyms-title')).toHaveLength(0);
+        expect(wrapper.find('.synonyms-text')).toHaveLength(0);
+        wrapper.unmount();
+
+        wrapper = mount(<ConceptSynonyms synonyms={[]} />);
+        expect(wrapper.find('.synonyms-title')).toHaveLength(0);
+        expect(wrapper.find('.synonyms-text')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('with sorted synonyms', () => {
+        const wrapper = mount(<ConceptSynonyms synonyms={['a', 'c', 'b']} />);
+        expect(wrapper.find('.synonyms-title')).toHaveLength(1);
+        expect(wrapper.find('.synonyms-text')).toHaveLength(1);
+        expect(wrapper.find('li')).toHaveLength(3);
+        expect(wrapper.find('li').at(0).text()).toBe('a');
+        expect(wrapper.find('li').at(1).text()).toBe('b');
+        expect(wrapper.find('li').at(2).text()).toBe('c');
+        wrapper.unmount();
+    });
+});
+
 describe('ConceptOverviewPanelImpl', () => {
-    function validate(wrapper: ReactWrapper, isEmpty: boolean, divCount = 1): void {
-        expect(wrapper.find('.none-selected')).toHaveLength(isEmpty ? 1 : 0);
+    function validate(
+        wrapper: ReactWrapper,
+        concept: ConceptModel,
+        divCount = 1,
+        hasSelectedPath = false,
+        showPath = false
+    ): void {
+        expect(wrapper.find('.none-selected')).toHaveLength(concept === undefined ? 1 : 0);
         expect(wrapper.find('div')).toHaveLength(divCount);
+        expect(wrapper.find(ConceptPathDisplay)).toHaveLength(showPath ? 1 : 0);
+
+        expect(wrapper.find(Button)).toHaveLength(hasSelectedPath ? 1 : 0);
+        if (hasSelectedPath) {
+            expect(wrapper.find(Button).text()).toBe(showPath ? 'Hide Path' : 'Show Path');
+        }
+
+        if (concept) {
+            expect(wrapper.find('.title').first().text()).toBe(concept.label);
+            expect(wrapper.find('.code').first().text()).toBe(concept.code);
+            expect(wrapper.find('.description-title').text()).toBe('Description');
+            expect(wrapper.find('.description-text').text()).toBe(concept.description);
+        }
     }
 
     test('no concept', () => {
         const wrapper = mount(<ConceptOverviewPanelImpl concept={undefined} />);
-        validate(wrapper, true);
+        validate(wrapper, undefined);
         wrapper.unmount();
     });
 
     test('with concept', () => {
-        const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT}  />);
-        validate(wrapper, false, 3);
-        expect(wrapper.find('.title').text()).toBe(TEST_CONCEPT.label);
-        expect(wrapper.find('.code').text()).toBe(TEST_CONCEPT.code);
-        expect(wrapper.find(Button)).toHaveLength(0);
-        expect(wrapper.find('.description-title').text()).toBe('Description');
-        expect(wrapper.find('.description-text').text()).toBe(TEST_CONCEPT.description);
+        const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT} />);
+        validate(wrapper, TEST_CONCEPT, 3);
         wrapper.unmount();
     });
 
-    test('with selected path', () => {
+    test('with selected path, not shown', () => {
         const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT} selectedPath={TEST_PATH} />);
-        validate(wrapper, false, 4);
-        expect(wrapper.find('.title').text()).toBe(TEST_CONCEPT.label);
-        expect(wrapper.find('.code').text()).toBe(TEST_CONCEPT.code);
-        expect(wrapper.find(Button)).toHaveLength(1);
-        expect(wrapper.find(Button).text()).toBe('Show Path');
-        expect(wrapper.find('.description-title').text()).toBe('Description');
-        expect(wrapper.find('.description-text').text()).toBe(TEST_CONCEPT.description);
+        validate(wrapper, TEST_CONCEPT, 4, true);
+        wrapper.unmount();
+    });
+
+    test('with selected path, shown', () => {
+        const wrapper = mount(<ConceptOverviewPanelImpl concept={TEST_CONCEPT} selectedPath={TEST_PATH} />);
+        wrapper.find(Button).simulate('click');
+        validate(wrapper, TEST_CONCEPT, 8, true, true);
+        expect(wrapper.find(ConceptPathDisplay).prop('title')).toBe('Current Path');
+        expect(wrapper.find(ConceptPathDisplay).prop('path')).toBe(TEST_PATH);
+        expect(wrapper.find(ConceptPathDisplay).prop('isSelected')).toBe(true);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -84,9 +84,9 @@ export const ConceptOverviewPanelImpl: FC<ConceptOverviewPanelImplProps> = memo(
     return (
         <>
             {selectedPath && (
-                <div className="button-container">
+                <div className="path-button-container">
                     <Button className={showPath ? 'show-path' : ''} onClick={handleShowPath}>
-                        {showPath ? 'Hide ' : 'Show '} Path
+                        {showPath ? 'Hide' : 'Show'} Path
                     </Button>
                 </div>
             )}

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -1,7 +1,9 @@
-import React, { FC, memo, useEffect, useState } from 'react';
-import { Modal } from 'react-bootstrap';
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
+import { Button, Modal } from 'react-bootstrap';
 
-import { Alert, naturalSort } from '../../..';
+import { Alert } from '../base/Alert';
+
+import { naturalSort } from '../../../public/sort';
 
 import { ConceptModel, PathModel } from './models';
 import { fetchConceptForCode } from './actions';
@@ -67,6 +69,11 @@ const ConceptSynonyms: FC<{ synonyms: string[] }> = memo(props => {
  */
 export const ConceptOverviewPanelImpl: FC<ConceptOverviewPanelImplProps> = memo(props => {
     const { concept, selectedPath = undefined } = props;
+    const [showPath, setShowPath] = useState<boolean>();
+
+    const handleShowPath = useCallback((): void => {
+        setShowPath(!showPath);
+    }, [showPath, setShowPath]);
 
     if (!concept) {
         return <div className="none-selected">No concept selected</div>;
@@ -77,15 +84,23 @@ export const ConceptOverviewPanelImpl: FC<ConceptOverviewPanelImplProps> = memo(
     return (
         <>
             {selectedPath && (
-                <ConceptPathDisplay
-                    title={CURRENT_PATH_TITLE}
-                    path={selectedPath}
-                    isSelected={true}
-                    isCollapsed={true}
-                />
+                <div className="button-container">
+                    <Button className={showPath ? 'show-path' : ''} onClick={handleShowPath}>
+                        {showPath ? 'Hide ' : 'Show '} Path
+                    </Button>
+                </div>
             )}
-            {label && <div className="title margin-bottom">{label}</div>}
-            {code && <span className="code">{code}</span>}
+            {label && <div className="title small-margin-bottom">{label}</div>}
+            {code && <span className="code margin-bottom">{code}</span>}
+            {selectedPath && (
+                <div className="concept-overview-selected-path">
+                    {showPath && (
+                        <>
+                            <ConceptPathDisplay title={CURRENT_PATH_TITLE} path={selectedPath} isSelected={true} />
+                        </>
+                    )}
+                </div>
+            )}
             {description && (
                 <div>
                     <div className="description-title">Description</div>

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -92,13 +92,9 @@ export const ConceptOverviewPanelImpl: FC<ConceptOverviewPanelImplProps> = memo(
             )}
             {label && <div className="title small-margin-bottom">{label}</div>}
             {code && <span className="code margin-bottom">{code}</span>}
-            {selectedPath && (
+            {selectedPath && showPath && (
                 <div className="concept-overview-selected-path">
-                    {showPath && (
-                        <>
-                            <ConceptPathDisplay title={CURRENT_PATH_TITLE} path={selectedPath} isSelected={true} />
-                        </>
-                    )}
+                    <ConceptPathDisplay title={CURRENT_PATH_TITLE} path={selectedPath} isSelected={true} />
                 </div>
             )}
             {description && (

--- a/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptOverviewPanel.tsx
@@ -1,9 +1,7 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Button, Modal } from 'react-bootstrap';
 
-import { Alert } from '../base/Alert';
-
-import { naturalSort } from '../../../public/sort';
+import { Alert, naturalSort } from '../../..';
 
 import { ConceptModel, PathModel } from './models';
 import { fetchConceptForCode } from './actions';
@@ -47,7 +45,8 @@ interface ConceptOverviewPanelImplProps {
     selectedPath?: PathModel;
 }
 
-const ConceptSynonyms: FC<{ synonyms: string[] }> = memo(props => {
+// exported for jest testing
+export const ConceptSynonyms: FC<{ synonyms: string[] }> = memo(props => {
     const { synonyms } = props;
     if (!synonyms || synonyms.length === 0) return undefined;
 

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
@@ -25,13 +25,11 @@ describe('ConceptPathDisplayImpl', () => {
         path: PathModel = undefined,
         parentCount = 0,
         title: string = undefined,
-        isCollapsed = false,
         isSelected = false,
-        isLoading = false,
+        isLoading = false
     ): void {
         expect(wrapper.find('.concept-path-container')).toHaveLength(path ? 1 : 0);
         expect(wrapper.find('.concept-path')).toHaveLength(path ? 1 : 0);
-        expect(wrapper.find('.collapsed')).toHaveLength(isCollapsed ? 1 : 0);
         expect(wrapper.find('.selected')).toHaveLength(isSelected ? 1 : 0);
         expect(wrapper.find('.concept-path-label')).toHaveLength(parentCount);
         expect(wrapper.find('i')).toHaveLength(parentCount === 0 ? (isLoading ? 1 : 0) : parentCount - 1);
@@ -50,7 +48,7 @@ describe('ConceptPathDisplayImpl', () => {
 
     test('Parent path not loaded yet', () => {
         const wrapper = mount(<ConceptPathDisplayImpl path={TEST_CONCEPT_PATH} parentPaths={undefined} />);
-        validate(wrapper, TEST_CONCEPT_PATH, 0, undefined, false, false, true);
+        validate(wrapper, TEST_CONCEPT_PATH, 0, undefined, false, true);
         wrapper.unmount();
     });
 
@@ -107,39 +105,19 @@ describe('ConceptPathDisplayImpl', () => {
         wrapper.unmount();
     });
 
-    test('Collapsed set', () => {
-        const parentPaths = [];
-        const title = 'Long title to show';
-        const collapsed = true;
-        const selected = false;
-        const wrapper = mount(
-            <ConceptPathDisplayImpl
-                path={TEST_CONCEPT_PATH}
-                parentPaths={parentPaths}
-                title={title}
-                isCollapsed={collapsed}
-                isSelected={selected}
-            />
-        );
-        validate(wrapper, TEST_CONCEPT_PATH, parentPaths.length, title, collapsed, selected);
-        wrapper.unmount();
-    });
-
     test('Selected set', () => {
         const parentPaths = [];
         const title = 'Long title to show';
-        const collapsed = false;
         const selected = true;
         const wrapper = mount(
             <ConceptPathDisplayImpl
                 path={TEST_CONCEPT_PATH}
                 parentPaths={parentPaths}
                 title={title}
-                isCollapsed={collapsed}
                 isSelected={selected}
             />
         );
-        validate(wrapper, TEST_CONCEPT_PATH, parentPaths.length, title, collapsed, selected);
+        validate(wrapper, TEST_CONCEPT_PATH, parentPaths.length, title, selected);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
@@ -26,14 +26,15 @@ describe('ConceptPathDisplayImpl', () => {
         parentCount = 0,
         title: string = undefined,
         isCollapsed = false,
-        isSelected = false
+        isSelected = false,
+        isLoading = false,
     ): void {
         expect(wrapper.find('.concept-path-container')).toHaveLength(path ? 1 : 0);
         expect(wrapper.find('.concept-path')).toHaveLength(path ? 1 : 0);
         expect(wrapper.find('.collapsed')).toHaveLength(isCollapsed ? 1 : 0);
         expect(wrapper.find('.selected')).toHaveLength(isSelected ? 1 : 0);
         expect(wrapper.find('.concept-path-label')).toHaveLength(parentCount);
-        expect(wrapper.find('i')).toHaveLength(parentCount === 0 ? 0 : parentCount - 1);
+        expect(wrapper.find('i')).toHaveLength(parentCount === 0 ? (isLoading ? 1 : 0) : parentCount - 1);
         expect(wrapper.find('.title')).toHaveLength(title ? 1 : 0);
 
         if (title) {
@@ -49,7 +50,7 @@ describe('ConceptPathDisplayImpl', () => {
 
     test('Parent path not loaded yet', () => {
         const wrapper = mount(<ConceptPathDisplayImpl path={TEST_CONCEPT_PATH} parentPaths={undefined} />);
-        validate(wrapper, TEST_CONCEPT_PATH);
+        validate(wrapper, TEST_CONCEPT_PATH, 0, undefined, false, false, true);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
@@ -17,6 +17,16 @@ describe('ConceptPathDisplay', () => {
         expect(wrapper.find(ConceptPathDisplayImpl)).toHaveLength(0);
         wrapper.unmount();
     });
+
+    test('Path set', () => {
+        const wrapper = mount(<ConceptPathDisplay path={TEST_CONCEPT_PATH} title={'test title'} isSelected={true} />);
+        expect(wrapper.find(ConceptPathDisplayImpl)).toHaveLength(1);
+        expect(wrapper.find(ConceptPathDisplayImpl).prop('path')).toBe(TEST_CONCEPT_PATH);
+        expect(wrapper.find(ConceptPathDisplayImpl).prop('title')).toBe('test title');
+        expect(wrapper.find(ConceptPathDisplayImpl).prop('isSelected')).toBe(true);
+        expect(wrapper.find(ConceptPathDisplayImpl).prop('parentPaths')).toBe(undefined);
+        wrapper.unmount();
+    });
 });
 
 describe('ConceptPathDisplayImpl', () => {
@@ -33,6 +43,7 @@ describe('ConceptPathDisplayImpl', () => {
         expect(wrapper.find('.selected')).toHaveLength(isSelected ? 1 : 0);
         expect(wrapper.find('.concept-path-label')).toHaveLength(parentCount);
         expect(wrapper.find('i')).toHaveLength(parentCount === 0 ? (isLoading ? 1 : 0) : parentCount - 1);
+        expect(wrapper.find('.concept-path-spacer')).toHaveLength(parentCount > 0 ? parentCount - 1 : 0);
         expect(wrapper.find('.title')).toHaveLength(title ? 1 : 0);
 
         if (title) {

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.spec.tsx
@@ -19,7 +19,7 @@ describe('ConceptPathDisplay', () => {
     });
 
     test('Path set', () => {
-        const wrapper = mount(<ConceptPathDisplay path={TEST_CONCEPT_PATH} title={'test title'} isSelected={true} />);
+        const wrapper = mount(<ConceptPathDisplay path={TEST_CONCEPT_PATH} title="test title" isSelected={true} />);
         expect(wrapper.find(ConceptPathDisplayImpl)).toHaveLength(1);
         expect(wrapper.find(ConceptPathDisplayImpl).prop('path')).toBe(TEST_CONCEPT_PATH);
         expect(wrapper.find(ConceptPathDisplayImpl).prop('title')).toBe('test title');

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -66,7 +66,15 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
         );
     });
 
-    // const icon = ;
+    const pathBody = (
+        <>
+            {title && <div className="title">{title}</div>}
+            <div className="concept-path">
+                {!parentPaths && <LoadingSpinner />}
+                {parentPaths && <>{fullpath}</>}
+            </div>
+        </>
+    );
 
     return (
         <div
@@ -76,21 +84,12 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
             })}
             onClick={updatePath}
         >
-            <LabelHelpTip
-                placement="bottom"
-                iconComponent={
-                    <>
-                        {title && <div className="title">{title}</div>}
-                        <div className="concept-path">
-                            {!parentPaths && <LoadingSpinner />}
-                            {parentPaths && <>{fullpath}</>}
-                        </div>
-                    </>
-                }
-                title="Full Path"
-            >
-                <div unselectable="on">{fullpath}</div>
-            </LabelHelpTip>
+            {isCollapsed && (
+                <LabelHelpTip placement="bottom" iconComponent={pathBody} title="Full Path">
+                    {isCollapsed && <div unselectable="on">{fullpath}</div>}
+                </LabelHelpTip>
+            )}
+            {!isCollapsed && <>{pathBody}</>}
         </div>
     );
 });

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -12,7 +12,7 @@ export interface ConceptPathDisplayProps {
     path: PathModel;
     isSelected?: boolean;
     isCollapsed?: boolean;
-    onClick?: (path: PathModel) => void;
+    onClick?: (path: PathModel, isAlternatePath?: boolean) => void;
 }
 
 export const ConceptPathDisplay: FC<ConceptPathDisplayProps> = memo(props => {
@@ -48,7 +48,7 @@ interface ConceptPathDisplayImplProps extends ConceptPathDisplayProps {
 export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(props => {
     const { isCollapsed = false, isSelected = false, onClick = undefined, parentPaths, path, title } = props;
     const updatePath = useCallback((): void => {
-        onClick?.(path);
+        onClick?.(path, true);
     }, [path, onClick]);
 
     if (!path) return undefined;

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -87,6 +87,7 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
                         </div>
                     </>
                 }
+                title="Full Path"
             >
                 <div unselectable="on">{fullpath}</div>
             </LabelHelpTip>

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -23,6 +23,7 @@ export const ConceptPathDisplay: FC<ConceptPathDisplayProps> = memo(props => {
 
     useEffect(() => {
         if (path) {
+            setParentPaths(undefined);
             fetchParentPaths(path.path)
                 .then(response => {
                     setParentPaths(response);

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -6,6 +6,7 @@ import { PathModel } from './models';
 import { Alert } from '../base/Alert';
 
 import { fetchParentPaths } from './actions';
+import { LoadingSpinner } from '../../..';
 
 export interface ConceptPathDisplayProps {
     title?: string;
@@ -63,6 +64,7 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
         >
             {title && <div className="title">{title}</div>}
             <div className="concept-path">
+                {!parentPaths && <LoadingSpinner />}
                 {parentPaths?.map((parent, idx) => {
                     return (
                         <>

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import { Alert } from '../base/Alert';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
-import { LabelHelpTip } from '../base/LabelHelpTip';
 
 import { PathModel } from './models';
 import { fetchParentPaths } from './actions';
@@ -14,7 +13,6 @@ export interface ConceptPathDisplayProps {
     title?: string;
     path: PathModel;
     isSelected?: boolean;
-    isCollapsed?: boolean;
     onClick?: (path: PathModel, isAlternatePath?: boolean) => void;
 }
 
@@ -50,7 +48,7 @@ interface ConceptPathDisplayImplProps extends ConceptPathDisplayProps {
 }
 
 export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(props => {
-    const { isCollapsed = false, isSelected = false, onClick = undefined, parentPaths, path, title } = props;
+    const { isSelected = false, onClick = undefined, parentPaths, path, title } = props;
     const updatePath = useCallback((): void => {
         onClick?.(path, true);
     }, [path, onClick]);
@@ -66,30 +64,18 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
         );
     });
 
-    const pathBody = (
-        <>
+    return (
+        <div
+            className={classNames('concept-path-container', {
+                selected: isSelected,
+            })}
+            onClick={updatePath}
+        >
             {title && <div className="title">{title}</div>}
             <div className="concept-path">
                 {!parentPaths && <LoadingSpinner />}
                 {parentPaths && <>{fullpath}</>}
             </div>
-        </>
-    );
-
-    return (
-        <div
-            className={classNames('concept-path-container', {
-                selected: isSelected,
-                collapsed: isCollapsed,
-            })}
-            onClick={updatePath}
-        >
-            {isCollapsed && (
-                <LabelHelpTip placement="bottom" iconComponent={pathBody} title="Full Path">
-                    {isCollapsed && <div unselectable="on">{fullpath}</div>}
-                </LabelHelpTip>
-            )}
-            {!isCollapsed && <>{pathBody}</>}
         </div>
     );
 });

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -1,12 +1,14 @@
+/* eslint-disable import/no-cycle */
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 
-import { PathModel } from './models';
-
 import { Alert } from '../base/Alert';
 
+import { LoadingSpinner } from '../base/LoadingSpinner';
+import { LabelHelpTip } from '../base/LabelHelpTip';
+
+import { PathModel } from './models';
 import { fetchParentPaths } from './actions';
-import { LoadingSpinner } from '../../..';
 
 export interface ConceptPathDisplayProps {
     title?: string;
@@ -55,6 +57,17 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
 
     if (!path) return undefined;
 
+    const fullpath = parentPaths?.map((parent, idx) => {
+        return (
+            <>
+                <span className="concept-path-label">{parent.label}</span>
+                {idx !== parentPaths.length - 1 && <i className="fa fa-chevron-right concept-path-spacer" />}
+            </>
+        );
+    });
+
+    // const icon = ;
+
     return (
         <div
             className={classNames('concept-path-container', {
@@ -63,18 +76,20 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
             })}
             onClick={updatePath}
         >
-            {title && <div className="title">{title}</div>}
-            <div className="concept-path">
-                {!parentPaths && <LoadingSpinner />}
-                {parentPaths?.map((parent, idx) => {
-                    return (
-                        <>
-                            <span className="concept-path-label">{parent.label}</span>
-                            {idx !== parentPaths.length - 1 && <i className="fa fa-chevron-right" />}
-                        </>
-                    );
-                })}
-            </div>
+            <LabelHelpTip
+                placement="bottom"
+                iconComponent={
+                    <>
+                        {title && <div className="title">{title}</div>}
+                        <div className="concept-path">
+                            {!parentPaths && <LoadingSpinner />}
+                            {parentPaths && <>{fullpath}</>}
+                        </div>
+                    </>
+                }
+            >
+                <div unselectable="on">{fullpath}</div>
+            </LabelHelpTip>
         </div>
     );
 });

--- a/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathDisplay.tsx
@@ -55,15 +55,6 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
 
     if (!path) return undefined;
 
-    const fullpath = parentPaths?.map((parent, idx) => {
-        return (
-            <>
-                <span className="concept-path-label">{parent.label}</span>
-                {idx !== parentPaths.length - 1 && <i className="fa fa-chevron-right concept-path-spacer" />}
-            </>
-        );
-    });
-
     return (
         <div
             className={classNames('concept-path-container', {
@@ -74,7 +65,16 @@ export const ConceptPathDisplayImpl: FC<ConceptPathDisplayImplProps> = memo(prop
             {title && <div className="title">{title}</div>}
             <div className="concept-path">
                 {!parentPaths && <LoadingSpinner />}
-                {parentPaths && <>{fullpath}</>}
+                {parentPaths?.map((parent, idx) => {
+                    return (
+                        <>
+                            <span className="concept-path-label">{parent.label}</span>
+                            {idx !== parentPaths.length - 1 && (
+                                <i className="fa fa-chevron-right concept-path-spacer" />
+                            )}
+                        </>
+                    );
+                })}
             </div>
         </div>
     );

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
@@ -12,7 +12,7 @@ import { ConceptPathDisplay } from './ConceptPathDisplay';
 
 describe('ConceptPathInfo', () => {
     test('Nothing set', () => {
-        const wrapper = mount(<ConceptPathInfo />);
+        const wrapper = mount(<ConceptPathInfo alternatePathClickHandler={jest.fn} />);
         expect(wrapper.find(Alert)).toHaveLength(1);
         expect(wrapper.find(Alert).text()).toBe('');
         expect(wrapper.find(ConceptPathInfoImpl)).toHaveLength(1);
@@ -48,7 +48,7 @@ describe('ConceptPathInfoImpl', () => {
     }
 
     test('Nothing set', () => {
-        const wrapper = mount(<ConceptPathInfoImpl selectedCode={undefined} />);
+        const wrapper = mount(<ConceptPathInfoImpl selectedCode={undefined} alternatePathClickHandler={jest.fn} />);
         expect(wrapper.find('.none-selected')).toHaveLength(1);
         expect(wrapper.find('.none-selected').text()).toBe('No concept selected');
         expect(wrapper.find('.concept-pathinfo-container')).toHaveLength(0);
@@ -58,7 +58,7 @@ describe('ConceptPathInfoImpl', () => {
 
     test('Code set, aka Loading', () => {
         const code = 'MagicCode';
-        const wrapper = mount(<ConceptPathInfoImpl selectedCode={code} />);
+        const wrapper = mount(<ConceptPathInfoImpl selectedCode={code} alternatePathClickHandler={jest.fn} />);
         validate(wrapper, code, true);
         wrapper.unmount();
     });
@@ -71,7 +71,12 @@ describe('ConceptPathInfoImpl', () => {
         });
         const alternatePaths = undefined;
         const wrapper = mount(
-            <ConceptPathInfoImpl selectedCode={code} selectedPath={path} alternatePaths={alternatePaths} />
+            <ConceptPathInfoImpl
+                selectedCode={code}
+                selectedPath={path}
+                alternatePaths={alternatePaths}
+                alternatePathClickHandler={jest.fn}
+            />
         );
         validate(wrapper, code, true, alternatePaths, path);
         wrapper.unmount();
@@ -88,7 +93,12 @@ describe('ConceptPathInfoImpl', () => {
         });
         const alternatePaths = [];
         const wrapper = mount(
-            <ConceptPathInfoImpl selectedCode={code} selectedPath={path} alternatePaths={alternatePaths} />
+            <ConceptPathInfoImpl
+                selectedCode={code}
+                selectedPath={path}
+                alternatePaths={alternatePaths}
+                alternatePathClickHandler={jest.fn}
+            />
         );
         validate(wrapper, code, false, alternatePaths, path);
         wrapper.unmount();
@@ -102,7 +112,12 @@ describe('ConceptPathInfoImpl', () => {
         });
         const alternatePaths = [path];
         const wrapper = mount(
-            <ConceptPathInfoImpl selectedCode={code} selectedPath={path} alternatePaths={alternatePaths} />
+            <ConceptPathInfoImpl
+                selectedCode={code}
+                selectedPath={path}
+                alternatePaths={alternatePaths}
+                alternatePathClickHandler={jest.fn}
+            />
         );
         validate(wrapper, code, false, alternatePaths, path);
         wrapper.unmount();
@@ -130,7 +145,12 @@ describe('ConceptPathInfoImpl', () => {
         const selected = path3;
         const alternatePaths = [path1, path2, path3, path4];
         const wrapper = mount(
-            <ConceptPathInfoImpl selectedCode={code} selectedPath={selected} alternatePaths={alternatePaths} />
+            <ConceptPathInfoImpl
+                selectedCode={code}
+                selectedPath={selected}
+                alternatePaths={alternatePaths}
+                alternatePathClickHandler={jest.fn}
+            />
         );
         validate(wrapper, code, false, alternatePaths, selected);
         wrapper.unmount();

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
@@ -160,8 +160,8 @@ describe('ConceptPathInfoImpl', () => {
 });
 
 describe('AlternatePathPanel', () => {
-    const TEST_SELECTED_PATH = new PathModel({ code: 'a', label: 'A', path: 'a/a'});
-    const TEST_ALTERNATE_PATH = new PathModel({ code: 'a', label: 'A', path: 'b/a'});
+    const TEST_SELECTED_PATH = new PathModel({ code: 'a', label: 'A', path: 'a/a' });
+    const TEST_ALTERNATE_PATH = new PathModel({ code: 'a', label: 'A', path: 'b/a' });
 
     function validate(wrapper: ReactWrapper, hasSelectedPath = false, alternatePathCount = 0): void {
         expect(wrapper.find('.current-path-container')).toHaveLength(hasSelectedPath ? 1 : 0);

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
@@ -44,7 +44,7 @@ describe('ConceptPathInfoImpl', () => {
         expect(wrapper.find('.alternate-paths-container')?.find(ConceptPathDisplay)).toHaveLength(
             alternatePaths?.length > 0 ? alternatePaths.length - 1 : 0
         );
-        expect(wrapper.find('.no-path-info')).toHaveLength(alternatePaths?.length === 0 ? 1 : 0);
+        expect(wrapper.find('.no-path-info')).toHaveLength(alternatePaths?.length <= 1 ? 1 : 0);
     }
 
     test('Nothing set', () => {

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
@@ -24,12 +24,12 @@ describe('ConceptPathInfoImpl', () => {
     function validate(
         wrapper: ReactWrapper,
         code: string = undefined,
-        isLoading = false,
+        loadingCount = 0,
         alternatePaths: PathModel[] = undefined,
         selectedPath: PathModel = undefined
     ): void {
         expect(wrapper.find('.none-selected')).toHaveLength(code ? 0 : 1);
-        expect(wrapper.find(LoadingSpinner)).toHaveLength(isLoading ? 1 : 0);
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(loadingCount);
         expect(wrapper.find(ConceptPathDisplay)).toHaveLength(alternatePaths?.length ? alternatePaths.length : 0);
         expect(wrapper.find('.current-path-container')).toHaveLength(
             alternatePaths?.length > 0 && selectedPath ? 1 : 0
@@ -59,7 +59,7 @@ describe('ConceptPathInfoImpl', () => {
     test('Code set, aka Loading', () => {
         const code = 'MagicCode';
         const wrapper = mount(<ConceptPathInfoImpl selectedCode={code} alternatePathClickHandler={jest.fn} />);
-        validate(wrapper, code, true);
+        validate(wrapper, code, 1);
         wrapper.unmount();
     });
 
@@ -78,7 +78,7 @@ describe('ConceptPathInfoImpl', () => {
                 alternatePathClickHandler={jest.fn}
             />
         );
-        validate(wrapper, code, true, alternatePaths, path);
+        validate(wrapper, code, 1, alternatePaths, path);
         wrapper.unmount();
     });
 
@@ -100,7 +100,7 @@ describe('ConceptPathInfoImpl', () => {
                 alternatePathClickHandler={jest.fn}
             />
         );
-        validate(wrapper, code, false, alternatePaths, path);
+        validate(wrapper, code, 0, alternatePaths, path);
         wrapper.unmount();
     });
 
@@ -119,7 +119,7 @@ describe('ConceptPathInfoImpl', () => {
                 alternatePathClickHandler={jest.fn}
             />
         );
-        validate(wrapper, code, false, alternatePaths, path);
+        validate(wrapper, code, 1, alternatePaths, path);
         wrapper.unmount();
     });
 
@@ -152,7 +152,7 @@ describe('ConceptPathInfoImpl', () => {
                 alternatePathClickHandler={jest.fn}
             />
         );
-        validate(wrapper, code, false, alternatePaths, selected);
+        validate(wrapper, code, 4, alternatePaths, selected);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.spec.tsx
@@ -6,7 +6,7 @@ import { Alert } from '../base/Alert';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { PathModel } from './models';
-import { ConceptPathInfo, ConceptPathInfoImpl } from './ConceptPathInfo';
+import { AlternatePathPanel, ConceptPathInfo, ConceptPathInfoImpl } from './ConceptPathInfo';
 
 import { ConceptPathDisplay } from './ConceptPathDisplay';
 
@@ -16,6 +16,8 @@ describe('ConceptPathInfo', () => {
         expect(wrapper.find(Alert)).toHaveLength(1);
         expect(wrapper.find(Alert).text()).toBe('');
         expect(wrapper.find(ConceptPathInfoImpl)).toHaveLength(1);
+        expect(wrapper.find(ConceptPathInfoImpl).prop('selectedCode')).toBe(undefined);
+        expect(wrapper.find(ConceptPathInfoImpl).prop('alternatePaths')).toBe(undefined);
         wrapper.unmount();
     });
 });
@@ -153,6 +155,77 @@ describe('ConceptPathInfoImpl', () => {
             />
         );
         validate(wrapper, code, 4, alternatePaths, selected);
+        wrapper.unmount();
+    });
+});
+
+describe('AlternatePathPanel', () => {
+    const TEST_SELECTED_PATH = new PathModel({ code: 'a', label: 'A', path: 'a/a'});
+    const TEST_ALTERNATE_PATH = new PathModel({ code: 'a', label: 'A', path: 'b/a'});
+
+    function validate(wrapper: ReactWrapper, hasSelectedPath = false, alternatePathCount = 0): void {
+        expect(wrapper.find('.current-path-container')).toHaveLength(hasSelectedPath ? 1 : 0);
+        expect(wrapper.find('.alternate-paths-container')).toHaveLength(1);
+        expect(wrapper.find('.no-path-info')).toHaveLength(alternatePathCount === 0 ? 1 : 0);
+        expect(wrapper.find('.title')).toHaveLength(1 + (hasSelectedPath ? 1 : 0));
+        expect(wrapper.find(ConceptPathDisplay)).toHaveLength(alternatePathCount + (hasSelectedPath ? 1 : 0));
+    }
+
+    test('no paths', () => {
+        const wrapper = mount(
+            <AlternatePathPanel selectedPath={undefined} alternatePaths={[]} alternatePathClickHandler={jest.fn} />
+        );
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('with selected path but no alternates', () => {
+        const wrapper = mount(
+            <AlternatePathPanel
+                selectedPath={TEST_SELECTED_PATH}
+                alternatePaths={[TEST_SELECTED_PATH]}
+                alternatePathClickHandler={jest.fn}
+            />
+        );
+        validate(wrapper, true);
+        expect(wrapper.find(ConceptPathDisplay).prop('path')).toBe(TEST_SELECTED_PATH);
+        expect(wrapper.find(ConceptPathDisplay).prop('isSelected')).toBe(true);
+        wrapper.unmount();
+    });
+
+    test('with selected path and alternate', () => {
+        const wrapper = mount(
+            <AlternatePathPanel
+                selectedPath={TEST_SELECTED_PATH}
+                alternatePaths={[TEST_SELECTED_PATH, TEST_ALTERNATE_PATH]}
+                alternatePathClickHandler={jest.fn}
+            />
+        );
+        validate(wrapper, true, 1);
+        expect(wrapper.find(ConceptPathDisplay).first().prop('path')).toBe(TEST_SELECTED_PATH);
+        expect(wrapper.find(ConceptPathDisplay).first().prop('isSelected')).toBe(true);
+        expect(wrapper.find(ConceptPathDisplay).first().prop('onClick')).toBeUndefined();
+        expect(wrapper.find(ConceptPathDisplay).last().prop('path')).toBe(TEST_ALTERNATE_PATH);
+        expect(wrapper.find(ConceptPathDisplay).last().prop('isSelected')).toBeUndefined();
+        expect(wrapper.find(ConceptPathDisplay).last().prop('onClick')).toBeDefined();
+        wrapper.unmount();
+    });
+
+    test('with no selected path and alternates', () => {
+        const wrapper = mount(
+            <AlternatePathPanel
+                selectedPath={undefined}
+                alternatePaths={[TEST_SELECTED_PATH, TEST_ALTERNATE_PATH]}
+                alternatePathClickHandler={jest.fn}
+            />
+        );
+        validate(wrapper, false, 2);
+        expect(wrapper.find(ConceptPathDisplay).first().prop('path')).toBe(TEST_SELECTED_PATH);
+        expect(wrapper.find(ConceptPathDisplay).first().prop('isSelected')).toBeUndefined();
+        expect(wrapper.find(ConceptPathDisplay).first().prop('onClick')).toBeDefined();
+        expect(wrapper.find(ConceptPathDisplay).last().prop('path')).toBe(TEST_ALTERNATE_PATH);
+        expect(wrapper.find(ConceptPathDisplay).last().prop('isSelected')).toBeUndefined();
+        expect(wrapper.find(ConceptPathDisplay).last().prop('onClick')).toBeDefined();
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
@@ -19,6 +19,7 @@ export const ConceptPathInfo: FC<ConceptPathInfoProps> = memo(props => {
 
     useEffect(() => {
         if (selectedCode) {
+            setAlternatePaths(undefined);
             fetchAlternatePaths(selectedCode)
                 .then(response => {
                     setAlternatePaths(response);

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
@@ -9,7 +9,7 @@ import { ConceptPathDisplay } from './ConceptPathDisplay';
 export interface ConceptPathInfoProps {
     selectedCode?: string;
     selectedPath?: PathModel;
-    alternatePathClickHandler?: (path: PathModel) => void;
+    alternatePathClickHandler: (path: PathModel) => void;
 }
 
 export const ConceptPathInfo: FC<ConceptPathInfoProps> = memo(props => {

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
@@ -74,7 +74,7 @@ const AlternatePathPanel: FC<ConceptPathInfoImplProps> = memo(props => {
             )}
             <div className="alternate-paths-container">
                 <div className="title">Alternate Paths</div>
-                {altPaths?.length === 0 && <div>No alternate paths</div>}
+                {altPaths?.length === 0 && <div className="no-path-info">No alternate paths</div>}
                 {altPaths?.map(path => (
                     <ConceptPathDisplay key={path.path} path={path} onClick={alternatePathClickHandler} />
                 ))}

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
@@ -9,7 +9,7 @@ import { ConceptPathDisplay } from './ConceptPathDisplay';
 export interface ConceptPathInfoProps {
     selectedCode?: string;
     selectedPath?: PathModel;
-    alternatePathClickHandler: (path: PathModel) => void;
+    alternatePathClickHandler: (path: PathModel, isAlternatePath?: boolean) => void;
 }
 
 export const ConceptPathInfo: FC<ConceptPathInfoProps> = memo(props => {

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
@@ -43,6 +43,7 @@ interface ConceptPathInfoImplProps extends ConceptPathInfoProps {
     alternatePaths?: PathModel[];
 }
 
+// export for jest testing
 export const ConceptPathInfoImpl: FC<ConceptPathInfoImplProps> = memo(props => {
     const { selectedCode, selectedPath, alternatePaths } = props;
 
@@ -60,7 +61,8 @@ export const ConceptPathInfoImpl: FC<ConceptPathInfoImplProps> = memo(props => {
     );
 });
 
-const AlternatePathPanel: FC<ConceptPathInfoImplProps> = memo(props => {
+// export for jest testing
+export const AlternatePathPanel: FC<ConceptPathInfoImplProps> = memo(props => {
     const { selectedPath, alternatePaths, alternatePathClickHandler } = props;
 
     const altPaths = alternatePaths.filter(path => path.path !== selectedPath?.path);

--- a/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptPathInfo.tsx
@@ -74,7 +74,7 @@ const AlternatePathPanel: FC<ConceptPathInfoImplProps> = memo(props => {
                 </div>
             )}
             <div className="alternate-paths-container">
-                <div className="title">Alternate Paths</div>
+                <div className="title">Alternate Path(s)</div>
                 {altPaths?.length === 0 && <div className="no-path-info">No alternate paths</div>}
                 {altPaths?.map(path => (
                     <ConceptPathDisplay key={path.path} path={path} onClick={alternatePathClickHandler} />

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
@@ -43,6 +43,7 @@ const DEFAULT_PROPS = {
     ontology: undefined,
     selectedConcept: undefined,
     setSelectedConcept: jest.fn,
+    setSelectedPath: jest.fn,
     asPanel: false,
 };
 

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
@@ -57,8 +57,6 @@ const TEST_CONCEPT = new ConceptModel({ code: 'a', label: 'b' });
 describe('OntologyBrowserPanelImpl', () => {
     function validate(wrapper: ReactWrapper, loading: boolean, asPanel = false): void {
         expect(wrapper.find('.ontology-browser-container')).toHaveLength(!loading ? 1 : 0);
-        expect(wrapper.find('.ontology-description')).toHaveLength(!loading ? 1 : 0);
-        expect(wrapper.find('.ontology-concept-count')).toHaveLength(!loading ? 1 : 0);
         expect(wrapper.find('.left-panel')).toHaveLength(!loading ? 2 : 0);
         expect(wrapper.find('.right-panel')).toHaveLength(!loading ? 2 : 0);
         expect(wrapper.find(OntologyTreePanel)).toHaveLength(!loading ? 1 : 0);
@@ -76,8 +74,6 @@ describe('OntologyBrowserPanelImpl', () => {
     test('ontology', () => {
         const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} />);
         validate(wrapper, false);
-        expect(wrapper.find('.ontology-description').text()).toBe(TEST_ONTOLOGY.description);
-        expect(wrapper.find('.ontology-concept-count').text()).toBe(TEST_ONTOLOGY.conceptCount + ' total concepts');
         expect(wrapper.find(OntologyTreePanel).prop('root').label).toBe(TEST_ONTOLOGY.name);
         wrapper.unmount();
     });
@@ -94,7 +90,7 @@ describe('OntologyBrowserPanelImpl', () => {
     test('asPanel', () => {
         const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} asPanel={true} />);
         validate(wrapper, false, true);
-        expect(wrapper.find('.panel-heading').text()).toBe('Browse test name (t)');
+        expect(wrapper.find('.panel-heading').text()).toContain('Browse test name (t)');
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { Alert, LoadingSpinner } from '../../..';
+import { Alert, LabelHelpTip, LoadingSpinner } from '../../..';
 
 import { OntologyBrowserPanel, OntologyBrowserPanelImpl } from './OntologyBrowserPanel';
 import { OntologySelectionPanel } from './OntologySelectionPanel';
+import { OntologyTreeSearchContainer } from './OntologyTreeSearchContainer';
 import { OntologyTreePanel } from './OntologyTreePanel';
 import { ConceptInformationTabs } from './ConceptInformationTabs';
 import { ConceptModel, OntologyModel } from './models';
@@ -60,9 +61,11 @@ describe('OntologyBrowserPanelImpl', () => {
         expect(wrapper.find('.ontology-browser-container')).toHaveLength(!loading ? 1 : 0);
         expect(wrapper.find('.left-panel')).toHaveLength(!loading ? 2 : 0);
         expect(wrapper.find('.right-panel')).toHaveLength(!loading ? 2 : 0);
+        expect(wrapper.find(OntologyTreeSearchContainer)).toHaveLength(!loading ? 1 : 0);
         expect(wrapper.find(OntologyTreePanel)).toHaveLength(!loading ? 1 : 0);
         expect(wrapper.find(ConceptInformationTabs)).toHaveLength(!loading ? 1 : 0);
         expect(wrapper.find('.panel-body')).toHaveLength(asPanel ? 1 : 0);
+        expect(wrapper.find(LabelHelpTip)).toHaveLength(asPanel ? 1 : 0);
     }
 
     test('loading', () => {
@@ -75,6 +78,7 @@ describe('OntologyBrowserPanelImpl', () => {
     test('ontology', () => {
         const wrapper = mount(<OntologyBrowserPanelImpl {...DEFAULT_PROPS} ontology={TEST_ONTOLOGY} />);
         validate(wrapper, false);
+        expect(wrapper.find(OntologyTreeSearchContainer).prop('ontology')).toBe(TEST_ONTOLOGY);
         expect(wrapper.find(OntologyTreePanel).prop('root').label).toBe(TEST_ONTOLOGY.name);
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
@@ -1,13 +1,16 @@
-import React, { FC, memo, useCallback, useEffect, useState } from 'react';
+import React, { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
 
-import { Alert, LoadingSpinner } from '../../..';
+import { Alert, LabelHelpTip, LoadingSpinner, searchUsingIndex } from '../../..';
 
 import { fetchConceptForCode, getOntologyDetails } from './actions';
 import { ConceptModel, OntologyModel, PathModel } from './models';
 import { ConceptInformationTabs } from './ConceptInformationTabs';
 import { OntologyTreePanel } from './OntologyTreePanel';
 import { OntologySelectionPanel } from './OntologySelectionPanel';
+
+const CONCEPT_CATEGORY = 'concept';
+const SEARCH_LIMIT = 10;
 
 export interface OntologyBrowserProps {
     initOntologyId?: string;
@@ -113,18 +116,18 @@ export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(
     const root = ontology.getPathModel();
 
     const body = (
-        <>
-            {description && <p className="ontology-description">{description}</p>}
-            <Row>
-                <Col xs={6} className="left-panel">
-                    <p className="ontology-concept-count">{conceptCount} total concepts</p>
-                    <OntologyTreePanel root={root} onNodeSelection={setSelectedConcept} />
-                </Col>
-                <Col xs={6} className="right-panel">
-                    <ConceptInformationTabs concept={selectedConcept} />
-                </Col>
-            </Row>
-        </>
+        <Row>
+            <Col xs={6} className="left-panel">
+                <OntologyTreeSearchContainer ontology={ontology} />
+                <OntologyTreePanel
+                    root={root}
+                    onNodeSelection={setSelectedConcept}
+                />
+            </Col>
+            <Col xs={6} className="right-panel">
+                <ConceptInformationTabs concept={selectedConcept} />
+            </Col>
+        </Row>
     );
 
     if (!asPanel) {
@@ -133,8 +136,108 @@ export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(
 
     return (
         <div className="panel panel-default ontology-browser-container">
-            <div className="panel-heading">Browse {ontology.getDisplayName()}</div>
+            <div className="panel-heading">
+                Browse {ontology.getDisplayName()}
+                &nbsp;
+                <LabelHelpTip
+                    title="Ontology Details"
+                    placement="bottom"
+                    iconComponent={<i className="fa fa-info-circle" />}
+                >
+                    {description && <p className="ontology-description">{description}</p>}
+                    <p className="ontology-concept-count">{Number(conceptCount).toLocaleString()} total concepts</p>
+                </LabelHelpTip>
+            </div>
             <div className="panel-body">{body}</div>
+        </div>
+    );
+});
+
+// TODO move this to separate file
+interface OntologyTreeSearchContainerProps {
+    ontology: OntologyModel,
+}
+
+export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> = memo(props => {
+    const { ontology } = props;
+    const [isFocused, setIsFocused] = useState<boolean>();
+    const [searchTerm, setSearchTerm] = useState<string>();
+    const [searchHits, setSearchHits] = useState<ConceptModel[]>();
+    const [totalHits, setTotalHits] = useState<number>();
+    const [error, setError] = useState<string>();
+    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [isFocused, searchHits, error]);
+
+    const onSearchChange = useCallback(
+        (evt: ChangeEvent<HTMLInputElement>) => {
+            const { value } = evt.currentTarget;
+            setSearchTerm(value?.length > 2 ? value : undefined);
+        },
+        [setSearchTerm]
+    );
+
+    const onSearchFocus = useCallback(() => { setIsFocused(true); }, [setIsFocused]);
+    const onSearchBlur = useCallback(() => { setIsFocused(false); }, [onSearchFocus]);
+
+    useEffect(() => {
+        setError(undefined);
+        setTotalHits(undefined);
+        if (!searchTerm) {
+            setSearchHits(undefined);
+        } else {
+            const timeOutId = setTimeout(() => {
+                searchUsingIndex({ q: searchTerm, category: CONCEPT_CATEGORY, limit: SEARCH_LIMIT }, undefined, [CONCEPT_CATEGORY])
+                    .then(response => {
+                        setSearchHits(
+                            response.hits.map(hit => {
+                                return new ConceptModel({
+                                    code: hit.identifiers,
+                                    label: hit.title,
+                                    description: hit.summary.split('\n')[1], // format is "<code> <label>\n<description>" see ConceptDocumentProvider
+                                });
+                            })
+                        );
+                        setTotalHits(response.totalHits);
+                    })
+                    .catch(reason => {
+                        setError('Error: unable to get search results. ' + reason?.exception);
+                        setSearchHits(undefined);
+                    });
+            }, 500);
+
+            return () => clearTimeout(timeOutId);
+        }
+    }, [searchTerm, setError, setSearchHits, setTotalHits]);
+
+    return (
+        <div className="concept-search-container">
+            <form autoComplete="off">
+                <input
+                    type="text"
+                    className="form-control"
+                    name="concept-search"
+                    placeholder={'Search ' + ontology.abbreviation}
+                    onChange={onSearchChange}
+                    onFocus={onSearchFocus}
+                    onBlur={onSearchBlur}
+                />
+            </form>
+            {showMenu && (
+                <div>
+                    <ul className="result-menu">
+                        <Alert>{error}</Alert>
+                        {searchHits === undefined && <li key="none">No search results found.</li>}
+                        {searchHits?.map(hit => (
+                            <li key={hit.code}>{hit.label}</li>
+                        ))}
+                        {searchHits?.length < totalHits && (
+                            <div>
+                                More then {SEARCH_LIMIT} results found. Update your search term to further refine your
+                                results.
+                            </div>
+                        )}
+                    </ul>
+                </div>
+            )}
         </div>
     );
 });

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
@@ -1,16 +1,14 @@
-import React, { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
 
-import { Alert, LabelHelpTip, LoadingSpinner, searchUsingIndex } from '../../..';
+import { Alert, LabelHelpTip, LoadingSpinner } from '../../..';
 
 import { fetchConceptForCode, getOntologyDetails } from './actions';
 import { ConceptModel, OntologyModel, PathModel } from './models';
 import { ConceptInformationTabs } from './ConceptInformationTabs';
 import { OntologyTreePanel } from './OntologyTreePanel';
 import { OntologySelectionPanel } from './OntologySelectionPanel';
-
-const CONCEPT_CATEGORY = 'concept';
-const SEARCH_LIMIT = 10;
+import { OntologyTreeSearchContainer } from './OntologyTreeSearchContainer';
 
 export interface OntologyBrowserProps {
     initOntologyId?: string;
@@ -149,95 +147,6 @@ export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(
                 </LabelHelpTip>
             </div>
             <div className="panel-body">{body}</div>
-        </div>
-    );
-});
-
-// TODO move this to separate file
-interface OntologyTreeSearchContainerProps {
-    ontology: OntologyModel,
-}
-
-export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> = memo(props => {
-    const { ontology } = props;
-    const [isFocused, setIsFocused] = useState<boolean>();
-    const [searchTerm, setSearchTerm] = useState<string>();
-    const [searchHits, setSearchHits] = useState<ConceptModel[]>();
-    const [totalHits, setTotalHits] = useState<number>();
-    const [error, setError] = useState<string>();
-    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [isFocused, searchHits, error]);
-
-    const onSearchChange = useCallback(
-        (evt: ChangeEvent<HTMLInputElement>) => {
-            const { value } = evt.currentTarget;
-            setSearchTerm(value?.length > 2 ? value : undefined);
-        },
-        [setSearchTerm]
-    );
-
-    const onSearchFocus = useCallback(() => { setIsFocused(true); }, [setIsFocused]);
-    const onSearchBlur = useCallback(() => { setIsFocused(false); }, [onSearchFocus]);
-
-    useEffect(() => {
-        setError(undefined);
-        setTotalHits(undefined);
-        if (!searchTerm) {
-            setSearchHits(undefined);
-        } else {
-            const timeOutId = setTimeout(() => {
-                searchUsingIndex({ q: searchTerm, category: CONCEPT_CATEGORY, limit: SEARCH_LIMIT }, undefined, [CONCEPT_CATEGORY])
-                    .then(response => {
-                        setSearchHits(
-                            response.hits.map(hit => {
-                                return new ConceptModel({
-                                    code: hit.identifiers,
-                                    label: hit.title,
-                                    description: hit.summary.split('\n')[1], // format is "<code> <label>\n<description>" see ConceptDocumentProvider
-                                });
-                            })
-                        );
-                        setTotalHits(response.totalHits);
-                    })
-                    .catch(reason => {
-                        setError('Error: unable to get search results. ' + reason?.exception);
-                        setSearchHits(undefined);
-                    });
-            }, 500);
-
-            return () => clearTimeout(timeOutId);
-        }
-    }, [searchTerm, setError, setSearchHits, setTotalHits]);
-
-    return (
-        <div className="concept-search-container">
-            <form autoComplete="off">
-                <input
-                    type="text"
-                    className="form-control"
-                    name="concept-search"
-                    placeholder={'Search ' + ontology.abbreviation}
-                    onChange={onSearchChange}
-                    onFocus={onSearchFocus}
-                    onBlur={onSearchBlur}
-                />
-            </form>
-            {showMenu && (
-                <div>
-                    <ul className="result-menu">
-                        <Alert>{error}</Alert>
-                        {searchHits === undefined && <li key="none">No search results found.</li>}
-                        {searchHits?.map(hit => (
-                            <li key={hit.code}>{hit.label}</li>
-                        ))}
-                        {searchHits?.length < totalHits && (
-                            <div>
-                                More then {SEARCH_LIMIT} results found. Update your search term to further refine your
-                                results.
-                            </div>
-                        )}
-                    </ul>
-                </div>
-            )}
         </div>
     );
 });

--- a/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserPanel.tsx
@@ -120,6 +120,7 @@ export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(
                 <OntologyTreePanel
                     root={root}
                     onNodeSelection={setSelectedConcept}
+                    // initSelectedPath={initSelectedPath}
                 />
             </Col>
             <Col xs={6} className="right-panel">

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -3,7 +3,7 @@ import { Button } from 'react-bootstrap';
 
 import { DomainField, DomainFieldLabel } from '../../..';
 
-import { helpLinkNode, ONTOLOGY_TOPIC } from '../../util/helpLinks';
+import { helpLinkNode, ONTOLOGY_CONCEPT_TOPIC } from '../../util/helpLinks';
 import { createFormInputName } from '../domainproperties/actions';
 import { DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT } from '../domainproperties/constants';
 import { isFieldFullyLocked } from '../domainproperties/propertiesUtil';
@@ -137,8 +137,7 @@ function getOntologyConceptAnnotationHelpTipBody(): ReactNode {
             Select an ontology concept to use as an annotation for this field.
             <br />
             <br />
-            {/* TODO update link topic once annotation case is added to docs page*/}
-            Learn more about {helpLinkNode(ONTOLOGY_TOPIC, 'ontology integration')} in LabKey.
+            Learn more about {helpLinkNode(ONTOLOGY_CONCEPT_TOPIC, 'ontology integration')} in LabKey.
         </>
     );
 }

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -15,6 +15,7 @@ import {
 } from '../domainproperties/constants';
 import { ITypeDependentProps } from '../domainproperties/models';
 import { SectionHeading } from '../domainproperties/SectionHeading';
+
 import { OntologyModel } from './models';
 
 interface Props extends ITypeDependentProps {

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -4,7 +4,7 @@ import { List } from 'immutable';
 import { getServerContext } from '@labkey/api';
 
 import { DomainField, LabelHelpTip } from '../../..';
-import { helpLinkNode, ONTOLOGY_TOPIC } from '../../util/helpLinks';
+import { helpLinkNode, ONTOLOGY_LOOKUP_TOPIC } from '../../util/helpLinks';
 
 import { isFieldFullyLocked } from '../domainproperties/propertiesUtil';
 import { createFormInputId, fetchOntologies } from '../domainproperties/actions';
@@ -107,7 +107,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                     </p>
                                     <p>Choose which ontology to use to lookup concept codes and preferred names.</p>
                                     <p>
-                                        Learn more about {helpLinkNode(ONTOLOGY_TOPIC + '#lookup', 'ontology integration')} in
+                                        Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in
                                         LabKey.
                                     </p>
                                 </>
@@ -122,7 +122,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                     Choose which text field to use when looking up a code against the selected ontology.
                                 </p>
                                 <p>
-                                    Learn more about {helpLinkNode(ONTOLOGY_TOPIC + '#lookup', 'ontology integration')} in LabKey.
+                                    Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in LabKey.
                                 </p>
                             </LabelHelpTip>
                         </div>
@@ -133,7 +133,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                             <LabelHelpTip title="Experimental Feature">
                                 <p>Choose which text field to store the preferred name of the concept.</p>
                                 <p>
-                                    Learn more about {helpLinkNode(ONTOLOGY_TOPIC + '#lookup', 'ontology integration')} in LabKey.
+                                    Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in LabKey.
                                 </p>
                             </LabelHelpTip>
                         </div>

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -84,6 +84,9 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
         const sourceId = this.getSourceInputId();
         const labelColId = createFormInputId(DOMAIN_FIELD_ONTOLOGY_LABEL_COL, domainIndex, index);
         const importColId = createFormInputId(DOMAIN_FIELD_ONTOLOGY_IMPORT_COL, domainIndex, index);
+        const learnMore = (
+            <p>Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in LabKey.</p>
+        );
 
         return (
             <div>
@@ -106,10 +109,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                         </i>
                                     </p>
                                     <p>Choose which ontology to use to lookup concept codes and preferred names.</p>
-                                    <p>
-                                        Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in
-                                        LabKey.
-                                    </p>
+                                    {learnMore}
                                 </>
                             </LabelHelpTip>
                         </div>
@@ -121,9 +121,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                 <p>
                                     Choose which text field to use when looking up a code against the selected ontology.
                                 </p>
-                                <p>
-                                    Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in LabKey.
-                                </p>
+                                {learnMore}
                             </LabelHelpTip>
                         </div>
                     </Col>
@@ -132,9 +130,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                             Choose a Label Field
                             <LabelHelpTip title="Experimental Feature">
                                 <p>Choose which text field to store the preferred name of the concept.</p>
-                                <p>
-                                    Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in LabKey.
-                                </p>
+                                {learnMore}
                             </LabelHelpTip>
                         </div>
                     </Col>

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.spec.tsx
@@ -29,7 +29,6 @@ describe('OntologySelectionPanel', () => {
     });
 
     test('no ontologies, non root admin', () => {
-        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
         const ontologies = [];
         const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
         validate(wrapper, 0);
@@ -39,22 +38,11 @@ describe('OntologySelectionPanel', () => {
     });
 
     test('no ontologies, as root admin', () => {
-        LABKEY.container.activeModules = ['Core', 'Query', 'Ontology'];
         LABKEY.user.isRootAdmin = true;
         const ontologies = [];
         const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
         validate(wrapper, 0);
         expect(wrapper.find('.alert-warning').text()).toContain('Click here to get started.');
-        wrapper.unmount();
-    });
-
-    test('no ontologies, as root admin without ontology module', () => {
-        LABKEY.container.activeModules = ['Core', 'Query'];
-        LABKEY.user.isRootAdmin = true;
-        const ontologies = [];
-        const wrapper = mount(<OntologySelectionPanelImpl {...DEFAULT_PROPS} ontologies={ontologies} />);
-        validate(wrapper, 0);
-        expect(wrapper.find('.alert-warning').text()).toBe('No ontologies have been loaded for this server.');
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -3,7 +3,7 @@ import { getServerContext } from '@labkey/api';
 
 import { LoadingSpinner, Alert, SelectInput, buildURL } from '../../..';
 
-import { fetchChildPaths } from './actions';
+import { fetchChildPaths, ONTOLOGY_CONTROLLER } from './actions';
 import { PathModel } from './models';
 
 interface OntologySelectionPanelProps {
@@ -53,7 +53,7 @@ export const OntologySelectionPanelImpl: FC<OntologySelectionPanelImplProps> = m
                     No ontologies have been loaded for this server.
                     {getServerContext().user.isRootAdmin && (
                         <>
-                            &nbsp;Click <a href={buildURL('ontology', 'begin')}>here</a> to get started.
+                            &nbsp;Click <a href={buildURL(ONTOLOGY_CONTROLLER, 'begin')}>here</a> to get started.
                         </>
                     )}
                 </Alert>

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -53,7 +53,7 @@ export const OntologySelectionPanelImpl: FC<OntologySelectionPanelImplProps> = m
             {ontologies?.length === 0 && (
                 <Alert bsStyle="warning">
                     No ontologies have been loaded for this server.
-                    {getServerContext().user.isRootAdmin && hasActiveModule('Ontology') && (
+                    {getServerContext().user.isRootAdmin && (
                         <>
                             &nbsp;Click <a href={buildURL('ontology', 'begin')}>here</a> to get started.
                         </>

--- a/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologySelectionPanel.tsx
@@ -3,8 +3,6 @@ import { getServerContext } from '@labkey/api';
 
 import { LoadingSpinner, Alert, SelectInput, buildURL } from '../../..';
 
-import { hasActiveModule } from '../domainproperties/actions';
-
 import { fetchChildPaths } from './actions';
 import { PathModel } from './models';
 

--- a/packages/components/src/internal/components/ontology/OntologyTreePanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreePanel.spec.tsx
@@ -18,6 +18,8 @@ describe('OntologyTreePanel', () => {
         expect(fileTree.prop('allowMultiSelect')).toBe(false);
         expect(fileTree.prop('showNodeIcon')).toBe(false);
         expect(fileTree.prop('defaultRootName')).toBe(DEFAULT_PROPS.root.label);
+        expect(fileTree.prop('showLoading')).toBe(false);
+        expect(fileTree.prop('showAnimations')).toBe(false);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
@@ -1,10 +1,11 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, RefObject, useRef, useEffect } from 'react';
 import { TreeNode } from 'react-treebeard';
 
 import { naturalSortByProperty, FileTree } from '../../..';
 
 import { PathModel } from './models';
-import { fetchChildPaths } from './actions';
+import { fetchChildPaths, fetchParentPaths } from './actions';
+import { DEFAULT_ROOT_PREFIX } from '../files/FileTree';
 
 export class OntologyPath {
     id: string;
@@ -18,11 +19,23 @@ type PathNode = OntologyPath & TreeNode;
 
 interface OntologyTreeProps {
     root: PathModel;
-    onNodeSelection: (conceptCode: PathModel) => void;
+    onNodeSelection: (path: PathModel) => void;
+    alternatePath?: PathModel;
 }
 
 export const OntologyTreePanel: FC<OntologyTreeProps> = props => {
-    const { root, onNodeSelection } = props;
+    const { root, onNodeSelection, alternatePath } = props;
+    const fileTreeRef: RefObject<FileTree> = useRef();
+
+    // watch for changes to alternatePath so that we can make sure the tree data down to that node is loaded
+    useEffect(() => {
+        if (alternatePath?.path) {
+            fetchParentPaths(alternatePath.path).then(parentPaths => {
+                toggleParentPaths(fileTreeRef.current, alternatePath, parentPaths, true);
+            });
+        }
+    }, [alternatePath]);
+
     const loadData = useCallback(
         async (ontologyPath: string = root.path): Promise<PathNode[]> => {
             const ontPath = await fetchChildPaths(ontologyPath);
@@ -41,8 +54,8 @@ export const OntologyTreePanel: FC<OntologyTreeProps> = props => {
         [root]
     );
 
-    const onSelect = (a: string, b: string, c: boolean, d: boolean, node: PathNode): boolean => {
-        onNodeSelection(node?.data);
+    const onSelect = (name: string, path: string, checked: boolean, isDirectory: boolean, node: PathNode): boolean => {
+        if (node.active) onNodeSelection(node?.data);
         return true;
     };
 
@@ -53,6 +66,25 @@ export const OntologyTreePanel: FC<OntologyTreeProps> = props => {
             allowMultiSelect={false}
             showNodeIcon={false}
             defaultRootName={root.label}
+            ref={fileTreeRef}
         />
     );
+};
+
+const getTreeNodeForPath = function (fileTree, path: string): any {
+    return fileTree.getDataNode(path, fileTree.state.data);
+};
+
+const toggleParentPaths = function (fileTree, alternatePath: PathModel, parentPaths: PathModel[], isRoot = false): void {
+    const parentPath = isRoot ? DEFAULT_ROOT_PREFIX : parentPaths[0].path;
+    parentPaths.shift();
+
+    const node = getTreeNodeForPath(fileTree, parentPath);
+    if (node) {
+        fileTree.onToggle(node, true, alternatePath.path === node.id, () => {
+            if (parentPaths.length > 0) toggleParentPaths(fileTree, alternatePath, parentPaths);
+        });
+    } else if (parentPaths.length > 0) {
+        toggleParentPaths(fileTree, alternatePath, parentPaths);
+    }
 };

--- a/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
@@ -3,9 +3,10 @@ import { TreeNode } from 'react-treebeard';
 
 import { naturalSortByProperty, FileTree } from '../../..';
 
+import { DEFAULT_ROOT_PREFIX } from '../files/FileTree';
+
 import { PathModel } from './models';
 import { fetchChildPaths, fetchParentPaths } from './actions';
-import { DEFAULT_ROOT_PREFIX } from '../files/FileTree';
 
 export class OntologyPath {
     id: string;
@@ -85,7 +86,13 @@ const getTreeNodeForPath = function (fileTree, path: string): any {
     return fileTree.getDataNode(path, fileTree.state.data);
 };
 
-const toggleParentPaths = function (fileTree, alternatePath: PathModel, parentPaths: PathModel[], isRoot: boolean, callback: () => void): void {
+const toggleParentPaths = function (
+    fileTree,
+    alternatePath: PathModel,
+    parentPaths: PathModel[],
+    isRoot: boolean,
+    callback: () => void
+): void {
     const parentPath = isRoot ? DEFAULT_ROOT_PREFIX : parentPaths[0].path;
     parentPaths.shift();
 

--- a/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
@@ -37,6 +37,7 @@ export const OntologyTreePanel: FC<OntologyTreeProps> = props => {
 
                 toggleParentPaths(fileTreeRef.current, alternatePath, parentPaths, true, () => {
                     setShowLoading(false);
+                    scrollToActive();
                 });
             });
         }
@@ -100,5 +101,14 @@ const toggleParentPaths = function (fileTree, alternatePath: PathModel, parentPa
         toggleParentPaths(fileTree, alternatePath, parentPaths, false, callback);
     } else {
         callback();
+    }
+};
+
+const scrollToActive = function (): void {
+    const activeEl = document.getElementsByClassName('filetree-node-active');
+    if (activeEl.length > 0) {
+        activeEl[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } else {
+        setTimeout(scrollToActive, 500);
     }
 };

--- a/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreePanel.tsx
@@ -31,6 +31,7 @@ export const OntologyTreePanel: FC<OntologyTreeProps> = props => {
     // watch for changes to alternatePath so that we can make sure the tree data down to that node is loaded
     useEffect(() => {
         if (alternatePath?.path) {
+            // Get the predecessors for the path, this provides the depth and nodes to potentially load
             fetchParentPaths(alternatePath.path).then(parentPaths => {
                 // if this is a deeply nested path, let's mask the tree with a loading message while we toggle parents
                 if (parentPaths.length > 5) setShowLoading(true);

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
+import { Alert } from '../../..';
+
 import { OntologySearchResultsMenu, OntologyTreeSearchContainer } from './OntologyTreeSearchContainer';
 import { ConceptModel, OntologyModel } from './models';
-
-import { Alert } from '../../..';
 
 const TEST_ONTOLOGY = new OntologyModel({
     abbreviation: 't',
@@ -68,13 +68,13 @@ describe('OntologySearchResultsMenu', () => {
         validate(wrapper, true, 1);
         wrapper.unmount();
 
-        wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} isFocused={true} error={'test error'} />);
+        wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} isFocused={true} error="test error" />);
         validate(wrapper, true);
         wrapper.unmount();
     });
 
     test('error', () => {
-        const wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} error={'test error'} />);
+        const wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} error="test error" />);
         validate(wrapper, true);
         expect(wrapper.find(Alert).text()).toBe('test error');
         wrapper.unmount();
@@ -116,7 +116,7 @@ describe('OntologySearchResultsMenu', () => {
     });
 
     test('with searchHits, without descriptions', () => {
-        const searchHits = [new ConceptModel({code: 'a', label: 'A'})];
+        const searchHits = [new ConceptModel({ code: 'a', label: 'A' })];
 
         const wrapper = mount(
             <OntologySearchResultsMenu {...DEFAULT_PROPS} searchHits={searchHits} totalHits={searchHits.length} />

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { OntologySearchResultsMenu, OntologyTreeSearchContainer } from './OntologyTreeSearchContainer';
+import { ConceptModel, OntologyModel } from './models';
+
+import { Alert } from '../../..';
+
+const TEST_ONTOLOGY = new OntologyModel({
+    abbreviation: 't',
+    name: 'test name',
+    conceptCount: 100,
+    description: 'test desc',
+});
+
+const TEST_SEARCH_HITS = [
+    new ConceptModel({
+        code: 'a',
+        label: 'A',
+        description: 'Description for a',
+    }),
+    new ConceptModel({
+        code: 'b',
+        label: 'B',
+        description: 'Description for b',
+    }),
+];
+
+describe('OntologyTreeSearchContainer', () => {
+    test('default props', () => {
+        const wrapper = mount(
+            <OntologyTreeSearchContainer ontology={TEST_ONTOLOGY} searchPathClickHandler={jest.fn} />
+        );
+        expect(wrapper.find('.concept-search-container')).toHaveLength(1);
+        expect(wrapper.find('input')).toHaveLength(1);
+        expect(wrapper.find('input').prop('placeholder')).toBe('Search t');
+        expect(wrapper.find(OntologySearchResultsMenu)).toHaveLength(1);
+        wrapper.unmount();
+    });
+});
+
+const DEFAULT_PROPS = {
+    searchHits: undefined,
+    totalHits: undefined,
+    isFocused: true,
+    error: undefined,
+    onItemClick: jest.fn,
+};
+
+describe('OntologySearchResultsMenu', () => {
+    function validate(wrapper: ReactWrapper, showMenu = false, itemCount = 0, showFooter = false): void {
+        expect(wrapper.find('ul.result-menu')).toHaveLength(showMenu ? 1 : 0);
+        expect(wrapper.find(Alert)).toHaveLength(showMenu ? 1 : 0);
+        expect(wrapper.find('li')).toHaveLength(itemCount);
+        expect(wrapper.find('.result-footer')).toHaveLength(showFooter ? 1 : 0);
+    }
+
+    test('showMenu', () => {
+        let wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} isFocused={false} />);
+        validate(wrapper);
+        wrapper.unmount();
+
+        wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} isFocused={true} />);
+        validate(wrapper);
+        wrapper.unmount();
+
+        wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} isFocused={true} searchHits={[]} />);
+        validate(wrapper, true, 1);
+        wrapper.unmount();
+
+        wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} isFocused={true} error={'test error'} />);
+        validate(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('error', () => {
+        const wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} error={'test error'} />);
+        validate(wrapper, true);
+        expect(wrapper.find(Alert).text()).toBe('test error');
+        wrapper.unmount();
+    });
+
+    test('no search results found', () => {
+        const wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} searchHits={[]} />);
+        validate(wrapper, true, 1);
+        expect(wrapper.find('li').text()).toBe('No search results found.');
+        wrapper.unmount();
+    });
+
+    test('totalHits footer', () => {
+        const wrapper = mount(<OntologySearchResultsMenu {...DEFAULT_PROPS} searchHits={[]} totalHits={2} />);
+        validate(wrapper, true, 1, true);
+        expect(wrapper.find('.result-footer').text()).toContain('2 results found.');
+        wrapper.unmount();
+    });
+
+    test('with searchHits, with descriptions', () => {
+        const wrapper = mount(
+            <OntologySearchResultsMenu
+                {...DEFAULT_PROPS}
+                searchHits={TEST_SEARCH_HITS}
+                totalHits={TEST_SEARCH_HITS.length}
+            />
+        );
+        validate(wrapper, true, TEST_SEARCH_HITS.length);
+        expect(wrapper.find('.selectable-item')).toHaveLength(TEST_SEARCH_HITS.length);
+        expect(wrapper.find('.bold')).toHaveLength(TEST_SEARCH_HITS.length);
+        expect(wrapper.find('.bold').at(0).text()).toBe(TEST_SEARCH_HITS[0].label);
+        expect(wrapper.find('.bold').at(1).text()).toBe(TEST_SEARCH_HITS[1].label);
+        expect(wrapper.find('.col-xs-2').at(0).text()).toBe(TEST_SEARCH_HITS[0].code);
+        expect(wrapper.find('.col-xs-2').at(1).text()).toBe(TEST_SEARCH_HITS[1].code);
+        expect(wrapper.find('.col-xs-10')).toHaveLength(0);
+        expect(wrapper.find('.col-xs-5')).toHaveLength(TEST_SEARCH_HITS.length * 2);
+        expect(wrapper.find('.col-xs-5').last().text()).toBe(TEST_SEARCH_HITS[1].description);
+        wrapper.unmount();
+    });
+
+    test('with searchHits, without descriptions', () => {
+        const searchHits = [new ConceptModel({code: 'a', label: 'A'})];
+
+        const wrapper = mount(
+            <OntologySearchResultsMenu {...DEFAULT_PROPS} searchHits={searchHits} totalHits={searchHits.length} />
+        );
+        validate(wrapper, true, searchHits.length);
+        expect(wrapper.find('.col-xs-5')).toHaveLength(0);
+        expect(wrapper.find('.col-xs-10')).toHaveLength(searchHits.length);
+        expect(wrapper.find('.col-xs-10').text()).toBe(searchHits[0].label);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -1,0 +1,158 @@
+import React, { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { Col, Row } from 'react-bootstrap';
+
+import { Alert, LabelHelpTip, LoadingSpinner, searchUsingIndex } from '../../..';
+
+import { ConceptModel, OntologyModel } from './models';
+import { ConceptInformationTabs } from './ConceptInformationTabs';
+import { OntologyTreePanel } from './OntologyTreePanel';
+
+const CONCEPT_CATEGORY = 'concept';
+const SEARCH_LIMIT = 10;
+
+interface OntologyBrowserPanelImplProps {
+    ontology: OntologyModel;
+    setSelectedConcept: (conceptCode: string) => void;
+    asPanel: boolean;
+    selectedConcept?: ConceptModel;
+    initSelectedPath?: string;
+}
+
+// exported for jest testing
+export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(props => {
+    const { ontology, selectedConcept, setSelectedConcept, asPanel, initSelectedPath } = props;
+
+    if (!ontology) {
+        return <LoadingSpinner />;
+    }
+
+    const { conceptCount, description } = ontology;
+    const root = ontology.getPathModel();
+
+    const body = (
+        <Row>
+            <Col xs={6} className="left-panel">
+                <OntologyTreeSearchContainer ontology={ontology} />
+                <OntologyTreePanel
+                    root={root}
+                    onNodeSelection={setSelectedConcept}
+                    initSelectedPath={initSelectedPath}
+                />
+            </Col>
+            <Col xs={6} className="right-panel">
+                <ConceptInformationTabs concept={selectedConcept} />
+            </Col>
+        </Row>
+    );
+
+    if (!asPanel) {
+        return <div className="ontology-browser-container">{body}</div>;
+    }
+
+    return (
+        <div className="panel panel-default ontology-browser-container">
+            <div className="panel-heading">
+                Browse {ontology.getDisplayName()}
+                &nbsp;
+                <LabelHelpTip
+                    title="Ontology Details"
+                    placement="bottom"
+                    iconComponent={<i className="fa fa-info-circle" />}
+                >
+                    {description && <p className="ontology-description">{description}</p>}
+                    <p className="ontology-concept-count">{Number(conceptCount).toLocaleString()} total concepts</p>
+                </LabelHelpTip>
+            </div>
+            <div className="panel-body">{body}</div>
+        </div>
+    );
+});
+
+// TODO move this to separate file
+interface OntologyTreeSearchContainerProps {
+    ontology: OntologyModel,
+}
+
+export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> = memo(props => {
+    const { ontology } = props;
+    const [isFocused, setIsFocused] = useState<boolean>();
+    const [searchTerm, setSearchTerm] = useState<string>();
+    const [searchHits, setSearchHits] = useState<ConceptModel[]>();
+    const [totalHits, setTotalHits] = useState<number>();
+    const [error, setError] = useState<string>();
+    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [isFocused, searchHits, error]);
+
+    const onSearchChange = useCallback(
+        (evt: ChangeEvent<HTMLInputElement>) => {
+            const { value } = evt.currentTarget;
+            setSearchTerm(value?.length > 2 ? value : undefined);
+        },
+        [setSearchTerm]
+    );
+
+    const onSearchFocus = useCallback(() => { setIsFocused(true); }, [setIsFocused]);
+    const onSearchBlur = useCallback(() => { setIsFocused(false); }, [onSearchFocus]);
+
+    useEffect(() => {
+        setError(undefined);
+        setTotalHits(undefined);
+        if (!searchTerm) {
+            setSearchHits(undefined);
+        } else {
+            const timeOutId = setTimeout(() => {
+                searchUsingIndex({ q: searchTerm, category: CONCEPT_CATEGORY, limit: SEARCH_LIMIT }, undefined, [CONCEPT_CATEGORY])
+                    .then(response => {
+                        setSearchHits(
+                            response.hits.map(hit => {
+                                return new ConceptModel({
+                                    code: hit.identifiers,
+                                    label: hit.title,
+                                    description: hit.summary.split('\n')[1], // format is "<code> <label>\n<description>" see ConceptDocumentProvider
+                                });
+                            })
+                        );
+                        setTotalHits(response.totalHits);
+                    })
+                    .catch(reason => {
+                        setError('Error: unable to get search results. ' + reason?.exception);
+                        setSearchHits(undefined);
+                    });
+            }, 500);
+
+            return () => clearTimeout(timeOutId);
+        }
+    }, [searchTerm, setError, setSearchHits, setTotalHits]);
+
+    return (
+        <div className="concept-search-container">
+            <form autoComplete="off">
+                <input
+                    type="text"
+                    className="form-control"
+                    name="concept-search"
+                    placeholder={'Search ' + ontology.abbreviation}
+                    onChange={onSearchChange}
+                    onFocus={onSearchFocus}
+                    onBlur={onSearchBlur}
+                />
+            </form>
+            {showMenu && (
+                <div>
+                    <ul className="result-menu">
+                        <Alert>{error}</Alert>
+                        {searchHits === undefined && <li key="none">No search results found.</li>}
+                        {searchHits?.map(hit => (
+                            <li key={hit.code}>{hit.label}</li>
+                        ))}
+                        {searchHits?.length < totalHits && (
+                            <div>
+                                More then {SEARCH_LIMIT} results found. Update your search term to further refine your
+                                results.
+                            </div>
+                        )}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+});

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -1,76 +1,13 @@
 import React, { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Col, Row } from 'react-bootstrap';
 
-import { Alert, LabelHelpTip, LoadingSpinner, searchUsingIndex } from '../../..';
+import { Alert, searchUsingIndex } from '../../..';
 
 import { ConceptModel, OntologyModel } from './models';
-import { ConceptInformationTabs } from './ConceptInformationTabs';
-import { OntologyTreePanel } from './OntologyTreePanel';
 
 const CONCEPT_CATEGORY = 'concept';
 const SEARCH_LIMIT = 10;
-
-interface OntologyBrowserPanelImplProps {
-    ontology: OntologyModel;
-    setSelectedConcept: (conceptCode: string) => void;
-    asPanel: boolean;
-    selectedConcept?: ConceptModel;
-    // initSelectedPath?: string;
-}
-
-// exported for jest testing
-export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(props => {
-    const { ontology, selectedConcept, setSelectedConcept, asPanel } = props;
-
-    if (!ontology) {
-        return <LoadingSpinner />;
-    }
-
-    const { conceptCount, description } = ontology;
-    const root = ontology.getPathModel();
-
-    const body = (
-        <Row>
-            <Col xs={6} className="left-panel">
-                <OntologyTreeSearchContainer ontology={ontology} />
-                <OntologyTreePanel
-                    root={root}
-                    onNodeSelection={setSelectedConcept}
-                    // initSelectedPath={initSelectedPath}
-                />
-            </Col>
-            <Col xs={6} className="right-panel">
-                <ConceptInformationTabs concept={selectedConcept} />
-            </Col>
-        </Row>
-    );
-
-    if (!asPanel) {
-        return <div className="ontology-browser-container">{body}</div>;
-    }
-
-    return (
-        <div className="panel panel-default ontology-browser-container">
-            <div className="panel-heading">
-                Browse {ontology.getDisplayName()}
-                &nbsp;
-                <LabelHelpTip
-                    title="Ontology Details"
-                    placement="bottom"
-                    iconComponent={<i className="fa fa-info-circle" />}
-                >
-                    {description && <p className="ontology-description">{description}</p>}
-                    <p className="ontology-concept-count">{Number(conceptCount).toLocaleString()} total concepts</p>
-                </LabelHelpTip>
-            </div>
-            <div className="panel-body">{body}</div>
-        </div>
-    );
-});
-
-// TODO move this to separate file
 interface OntologyTreeSearchContainerProps {
-    ontology: OntologyModel,
+    ontology: OntologyModel;
 }
 
 export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> = memo(props => {

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -5,7 +5,7 @@ import { Alert, searchUsingIndex } from '../../..';
 import { ConceptModel, OntologyModel } from './models';
 
 const CONCEPT_CATEGORY = 'concept';
-const SEARCH_LIMIT = 10;
+const SEARCH_LIMIT = 20;
 interface OntologyTreeSearchContainerProps {
     ontology: OntologyModel;
 }

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -20,8 +20,6 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
     const [searchHits, setSearchHits] = useState<ConceptModel[]>();
     const [totalHits, setTotalHits] = useState<number>();
     const [error, setError] = useState<string>();
-    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [isFocused, searchHits, error]);
-    const hitsHaveDescriptions = useMemo(() => searchHits?.findIndex(hit => hit.description !== undefined) > -1, [searchHits]);
 
     const onSearchChange = useCallback(
         (evt: ChangeEvent<HTMLInputElement>) => {
@@ -89,37 +87,69 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
                     onBlur={onSearchBlur}
                 />
             </form>
-            {showMenu && (
-                <div>
-                    <ul className="result-menu container">
-                        <Alert>{error}</Alert>
-                        {searchHits?.length === 0 && (
-                            <li key="none">
-                                <div className="row">
-                                    <div className="col col-xs-12">No search results found.</div>
-                                </div>
-                            </li>
-                        )}
-                        {searchHits?.map(hit => (
-                            <li key={hit.code} className="selectable-item" role="option" onMouseDown={evt => onItemClick(evt, hit.code)}>
-                                <div className="row">
-                                    <div className={'col bold ' + (hitsHaveDescriptions ? 'col-xs-5' : 'col-xs-10')}>
-                                        {hit.label}
-                                    </div>
-                                    <div className="col col-xs-2">{hit.code}</div>
-                                    {hitsHaveDescriptions && <div className="col col-xs-5">{hit.description}</div>}
-                                </div>
-                            </li>
-                        ))}
-                        {searchHits?.length < totalHits && (
-                            <div className="result-footer">
-                                {Number(totalHits).toLocaleString()} results found. Update your search term to further
-                                refine your results.
+            <OntologySearchResultsMenu
+                searchHits={searchHits}
+                totalHits={totalHits}
+                isFocused={isFocused}
+                error={error}
+                onItemClick={onItemClick}
+            />
+        </div>
+    );
+});
+
+interface OntologySearchResultsMenuProps {
+    searchHits: ConceptModel[];
+    totalHits: number;
+    isFocused: boolean;
+    error: string;
+    onItemClick: (evt: MouseEvent<HTMLLIElement>, code: string) => void;
+}
+
+// exported for jest testing
+export const OntologySearchResultsMenu: FC<OntologySearchResultsMenuProps> = memo(props => {
+    const { searchHits, isFocused, totalHits, error, onItemClick } = props;
+    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [isFocused, searchHits, error]);
+    const hitsHaveDescriptions = useMemo(() => searchHits?.findIndex(hit => hit.description !== undefined) > -1, [searchHits]);
+
+    if (!showMenu) {
+        return null;
+    }
+
+    return (
+        <div>
+            <ul className="result-menu container">
+                <Alert>{error}</Alert>
+                {searchHits?.length === 0 && (
+                    <li key="none">
+                        <div className="row">
+                            <div className="col col-xs-12">No search results found.</div>
+                        </div>
+                    </li>
+                )}
+                {searchHits?.map(hit => (
+                    <li
+                        key={hit.code}
+                        className="selectable-item"
+                        role="option"
+                        onMouseDown={evt => onItemClick(evt, hit.code)}
+                    >
+                        <div className="row">
+                            <div className={'col bold ' + (hitsHaveDescriptions ? 'col-xs-5' : 'col-xs-10')}>
+                                {hit.label}
                             </div>
-                        )}
-                    </ul>
-                </div>
-            )}
+                            <div className="col col-xs-2">{hit.code}</div>
+                            {hitsHaveDescriptions && <div className="col col-xs-5">{hit.description}</div>}
+                        </div>
+                    </li>
+                ))}
+                {searchHits?.length < totalHits && (
+                    <div className="result-footer">
+                        {Number(totalHits).toLocaleString()} results found. Update your search term to further refine
+                        your results.
+                    </div>
+                )}
+            </ul>
         </div>
     );
 });

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -15,12 +15,12 @@ interface OntologyBrowserPanelImplProps {
     setSelectedConcept: (conceptCode: string) => void;
     asPanel: boolean;
     selectedConcept?: ConceptModel;
-    initSelectedPath?: string;
+    // initSelectedPath?: string;
 }
 
 // exported for jest testing
 export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(props => {
-    const { ontology, selectedConcept, setSelectedConcept, asPanel, initSelectedPath } = props;
+    const { ontology, selectedConcept, setSelectedConcept, asPanel } = props;
 
     if (!ontology) {
         return <LoadingSpinner />;
@@ -36,7 +36,7 @@ export const OntologyBrowserPanelImpl: FC<OntologyBrowserPanelImplProps> = memo(
                 <OntologyTreePanel
                     root={root}
                     onNodeSelection={setSelectedConcept}
-                    initSelectedPath={initSelectedPath}
+                    // initSelectedPath={initSelectedPath}
                 />
             </Col>
             <Col xs={6} className="right-panel">

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -29,8 +29,12 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
         [setSearchTerm]
     );
 
-    const onSearchFocus = useCallback(() => { setIsFocused(true); }, [setIsFocused]);
-    const onSearchBlur = useCallback(() => { setIsFocused(false); }, [onSearchFocus]);
+    const onSearchFocus = useCallback(() => {
+        setIsFocused(true);
+    }, [setIsFocused]);
+    const onSearchBlur = useCallback(() => {
+        setIsFocused(false);
+    }, [onSearchFocus]);
 
     useEffect(() => {
         setError(undefined);
@@ -39,7 +43,9 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
 
         if (searchTerm) {
             const timeOutId = setTimeout(() => {
-                searchUsingIndex({ q: searchTerm, category: CONCEPT_CATEGORY, limit: SEARCH_LIMIT }, undefined, [CONCEPT_CATEGORY])
+                searchUsingIndex({ q: searchTerm, category: CONCEPT_CATEGORY, limit: SEARCH_LIMIT }, undefined, [
+                    CONCEPT_CATEGORY,
+                ])
                     .then(response => {
                         setSearchHits(
                             response.hits.map(hit => {
@@ -109,8 +115,14 @@ interface OntologySearchResultsMenuProps {
 // exported for jest testing
 export const OntologySearchResultsMenu: FC<OntologySearchResultsMenuProps> = memo(props => {
     const { searchHits, isFocused, totalHits, error, onItemClick } = props;
-    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [isFocused, searchHits, error]);
-    const hitsHaveDescriptions = useMemo(() => searchHits?.findIndex(hit => hit.description !== undefined) > -1, [searchHits]);
+    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [
+        isFocused,
+        searchHits,
+        error,
+    ]);
+    const hitsHaveDescriptions = useMemo(() => searchHits?.findIndex(hit => hit.description !== undefined) > -1, [
+        searchHits,
+    ]);
 
     if (!showMenu) {
         return null;

--- a/packages/components/src/internal/components/ontology/actions.ts
+++ b/packages/components/src/internal/components/ontology/actions.ts
@@ -2,7 +2,8 @@ import { ActionURL, Ajax, getServerContext, Utils } from '@labkey/api';
 
 import { ConceptModel, OntologyModel, PathModel } from './models';
 
-const ONTOLOGY_CONTROLLER = 'ontology';
+export const ONTOLOGY_MODULE_NAME = 'ontology';
+export const ONTOLOGY_CONTROLLER = 'ontology';
 const GET_CHILD_PATHS_ACTION = 'getChildPaths.api';
 const GET_ONTOLOGY_ACTION = 'getOntology.api';
 const GET_CONCEPT_ACTION = 'getConcept.api';

--- a/packages/components/src/internal/components/ontology/actions.ts
+++ b/packages/components/src/internal/components/ontology/actions.ts
@@ -63,7 +63,10 @@ export function getOntologyDetails(ontologyId: string): Promise<OntologyModel> {
     return Ontology.getOntology(ontologyId);
 }
 
-export function getOntologyChildPathsAndConcepts(ontologyPath: string, container: string = SHARED_CONTAINER): Promise<PathModel> {
+export function getOntologyChildPathsAndConcepts(
+    ontologyPath: string,
+    container: string = SHARED_CONTAINER
+): Promise<PathModel> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
             url: ActionURL.buildURL(ONTOLOGY_CONTROLLER, GET_CHILD_PATHS_ACTION, container, {

--- a/packages/components/src/internal/components/search/actions.spec.ts
+++ b/packages/components/src/internal/components/search/actions.spec.ts
@@ -1,6 +1,4 @@
-import { fromJS } from 'immutable';
-
-import { getSearchResultCardData } from './actions';
+import { getProcessedSearchHits, getSearchResultCardData } from './actions';
 
 describe('getSearchResultCardData', () => {
     test('data class object', () => {
@@ -105,5 +103,62 @@ describe('getSearchResultCardData', () => {
             iconSrc: 'samples',
             typeName: undefined,
         });
+    });
+});
+
+describe('getProcessedSearchHits', () => {
+    const SEARCH_RESULTS = [
+        {
+            id: 1,
+            title: 'Test data',
+            category: 'data',
+        },
+        {
+            id: 2,
+            title: 'Test material',
+            category: 'material',
+        },
+        {
+            id: 3,
+            title: 'Test workflowJob',
+            category: 'workflowJob',
+        },
+        {
+            id: 4,
+            title: 'Test file workflowJob',
+            category: 'file workflowJob',
+        },
+        {
+            id: 5,
+            title: 'Test other',
+            category: 'other',
+        },
+        {
+            id: 6,
+            title: 'Test has data',
+            category: 'always included',
+            data: { test: 123 },
+        },
+    ];
+
+    test('default category filters', () => {
+        const filteredHits = getProcessedSearchHits(SEARCH_RESULTS);
+        expect(filteredHits).toHaveLength(5);
+        expect(filteredHits[0].title).toBe(SEARCH_RESULTS[0].title);
+        expect(filteredHits[1].title).toBe(SEARCH_RESULTS[1].title);
+        expect(filteredHits[2].title).toBe(SEARCH_RESULTS[2].title);
+        expect(filteredHits[3].title).toBe(SEARCH_RESULTS[3].title);
+        expect(filteredHits[4].title).toBe(SEARCH_RESULTS[5].title);
+    });
+
+    test('custom category filters', () => {
+        let filteredHits = getProcessedSearchHits(SEARCH_RESULTS, undefined, ['other']);
+        expect(filteredHits).toHaveLength(2);
+        expect(filteredHits[0].title).toBe(SEARCH_RESULTS[4].title);
+        expect(filteredHits[1].title).toBe(SEARCH_RESULTS[5].title);
+
+        filteredHits = getProcessedSearchHits(SEARCH_RESULTS, undefined, []);
+        expect(filteredHits).toHaveLength(1);
+        expect(filteredHits[0].title).toBe(SEARCH_RESULTS[5].title);
     });
 });

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -135,10 +135,7 @@ export function getProcessedSearchHits(
         ? results
               .filter(result => {
                   const category = result['category'];
-                  return (
-                      filterCategories?.indexOf(category) > -1 ||
-                      result['data']
-                  );
+                  return filterCategories?.indexOf(category) > -1 || result['data'];
               })
               .map(result => {
                   return {

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -8,8 +8,9 @@ import { SearchIdData, SearchResultCardData } from './models';
 
 export function searchUsingIndex(
     userConfig,
-    getCardDataFn?: (data: Map<any, any>, category?: string) => SearchResultCardData
-): Promise<{}> {
+    getCardDataFn?: (data: Map<any, any>, category?: string) => SearchResultCardData,
+    filterCategories?: string[]
+): Promise<Record<string, any>> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL('search', 'json.api'),
@@ -19,7 +20,10 @@ export function searchUsingIndex(
                 addDataObjects(json);
                 const urlResolver = new URLResolver();
                 urlResolver.resolveSearchUsingIndex(json).then(results => {
-                    resolve({ ...results, hits: getProcessedSearchHits(results['hits'], getCardDataFn) });
+                    resolve({
+                        ...results,
+                        hits: getProcessedSearchHits(results['hits'], getCardDataFn, filterCategories),
+                    });
                 });
             }),
             failure: Utils.getCallbackWrapper(
@@ -124,17 +128,15 @@ function getCardData(
 // TODO: add categories for other search results so the result['data'] check could be removed.
 export function getProcessedSearchHits(
     results: any,
-    getCardDataFn?: (data: Map<any, any>, category?: string) => SearchResultCardData
+    getCardDataFn?: (data: Map<any, any>, category?: string) => SearchResultCardData,
+    filterCategories = ['data', 'material', 'workflowJob', 'file workflowJob']
 ): {} {
     return results
         ? results
               .filter(result => {
                   const category = result['category'];
                   return (
-                      category == 'data' ||
-                      category == 'material' ||
-                      category == 'workflowJob' ||
-                      category == 'file workflowJob' ||
+                      filterCategories?.indexOf(category) > -1 ||
                       result['data']
                   );
               })

--- a/packages/components/src/internal/util/helpLinks.tsx
+++ b/packages/components/src/internal/util/helpLinks.tsx
@@ -13,7 +13,8 @@ export const FIELD_EDITOR_CONDITIONAL_FORMAT_TOPIC = FIELD_EDITOR_TOPIC + '#cond
 export const FIELD_EDITOR_SAMPLE_TYPES_TOPIC = FIELD_EDITOR_TOPIC + '#samp';
 export const DATE_FORMATS_TOPIC = 'dateFormats#date';
 export const NUMBER_FORMATS_TOPIC = 'dateFormats#number';
-export const ONTOLOGY_TOPIC = 'ontology';
+export const ONTOLOGY_LOOKUP_TOPIC = 'ontologyLookup';
+export const ONTOLOGY_CONCEPT_TOPIC = 'ontologyConcept';
 
 export const ASSAY_EDIT_PLATE_TEMPLATE_TOPIC = 'editPlateTemplate';
 export const CONFIGURE_SCRIPTING_TOPIC = 'configureScripting';

--- a/packages/components/src/stories/OntologyConceptPathDisplay.stories.tsx
+++ b/packages/components/src/stories/OntologyConceptPathDisplay.stories.tsx
@@ -11,15 +11,14 @@ export default {
     component: ConceptPathDisplay,
 } as Meta;
 
-export const OntologyConceptPathDisplay: Story<ConceptPathDisplayProps> = props => (
-    <ConceptPathDisplay {...props} />
-);
+export const OntologyConceptPathDisplay: Story<ConceptPathDisplayProps> = props => <ConceptPathDisplay {...props} />;
 
 OntologyConceptPathDisplay.storyName = 'OntologyPathBreadcrumb';
 OntologyConceptPathDisplay.args = {
     isSelected: true,
     path: new PathModel({
-        path: '/NCIT/ST1000023/C7057/C3367/C36278/C36289/C35877/C35880/C35883/C157653/C157287/C162512/C167155/C136411/C142112/C136648/C36214/C140330/C150453/C138065/C163008/C154097/',
+        path:
+            '/NCIT/ST1000023/C7057/C3367/C36278/C36289/C35877/C35880/C35883/C157653/C157287/C162512/C167155/C136411/C142112/C136648/C36214/C140330/C150453/C138065/C163008/C154097/',
         code: 'NCIT:C154097',
         hasChildren: false,
         label: 'Blasts More than 60 Percent of Bone Marrow Nucleated Cells',

--- a/packages/components/src/stories/mock.tsx
+++ b/packages/components/src/stories/mock.tsx
@@ -116,6 +116,8 @@ import getFolderTabsInfo from '../test/data/admin-getFolderTabs.json';
 import getOntologyChildPathsInfo from '../test/data/ontologies-getChildPaths.json';
 import getOntologiesChildPathsInfo from '../test/data/ontologies-getRootChildPaths.json';
 import getOntologyInfo from '../test/data/ontologies-getOntology.json';
+import getOntologyConceptSearchInfo from '../test/data/ontologies-searchConcepts.json';
+import getSearchEmptyInfo from '../test/data/search-jsonEmpty.json';
 
 export const ICON_URL = 'http://labkey.wpengine.com/wp-content/uploads/2015/12/cropped-LK-icon.png';
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
@@ -712,5 +714,15 @@ export function initOnotologyMocks(): void {
                 url : null
             }
         }, res);
+    });
+
+    mock.get(/.*\/search\/?.*\/json.*/, (req, res) => {
+        const queryParams = req.url().query;
+
+        if (queryParams.category === 'concept') {
+            return jsonResponse(getOntologyConceptSearchInfo, res);
+        }
+
+        return jsonResponse(getSearchEmptyInfo, res);
     });
 }

--- a/packages/components/src/test/data/ontologies-searchConcepts.json
+++ b/packages/components/src/test/data/ontologies-searchConcepts.json
@@ -1,0 +1,101 @@
+{
+  "hits" : [ {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C2866 Alzheimer's Disease\nThis is the description for the Alzheimer's Disease concept in the OWL ontology.",
+    "score" : 35.357669830322266,
+    "identifiers" : "owl:C2866",
+    "id" : "concept:owl:C2866",
+    "title" : "Alzheimer's Disease",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC2866&_docid=concept%3Aowl%3AC2866"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C169104 Alzheimer's Disease 17",
+    "score" : 31.31378936767578,
+    "identifiers" : "owl:C169104",
+    "id" : "concept:owl:C169104",
+    "title" : "Alzheimer's Disease 17",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC169104&_docid=concept%3Aowl%3AC169104"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C38778 Alzheimer's Disease Pathway KEGG",
+    "score" : 28.10464096069336,
+    "identifiers" : "owl:C38778",
+    "id" : "concept:owl:C38778",
+    "title" : "Alzheimer's Disease Pathway KEGG",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC38778&_docid=concept%3Aowl%3AC38778"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C39177 Alzheimer's Disease Pathway BioCarta",
+    "score" : 28.10464096069336,
+    "identifiers" : "owl:C39177",
+    "id" : "concept:owl:C39177",
+    "title" : "Alzheimer's Disease Pathway BioCarta",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC39177&_docid=concept%3Aowl%3AC39177"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C120911 Alzheimer Type II Astrocyte",
+    "score" : 28.10464096069336,
+    "identifiers" : "owl:C120911",
+    "id" : "concept:owl:C120911",
+    "title" : "Alzheimer Type II Astrocyte",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC120911&_docid=concept%3Aowl%3AC120911"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C86983 NINCDS-ADRDA Criteria for Alzheimer's Disease",
+    "score" : 25.49503517150879,
+    "identifiers" : "owl:C86983",
+    "id" : "concept:owl:C86983",
+    "title" : "NINCDS-ADRDA Criteria for Alzheimer's Disease",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC86983&_docid=concept%3Aowl%3AC86983"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C146894 Familial Alzheimer's Disease, Type 1",
+    "score" : 25.49503517150879,
+    "identifiers" : "owl:C146894",
+    "id" : "concept:owl:C146894",
+    "title" : "Familial Alzheimer's Disease, Type 1",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC146894&_docid=concept%3Aowl%3AC146894"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C123412 Familial Alzheimer's Disease, Type 3",
+    "score" : 25.49503517150879,
+    "identifiers" : "owl:C123412",
+    "id" : "concept:owl:C123412",
+    "title" : "Familial Alzheimer's Disease, Type 3",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC123412&_docid=concept%3Aowl%3AC123412"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C123413 Familial Alzheimer's Disease, Type 4",
+    "score" : 25.49503517150879,
+    "identifiers" : "owl:C123413",
+    "id" : "concept:owl:C123413",
+    "title" : "Familial Alzheimer's Disease, Type 4",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC123413&_docid=concept%3Aowl%3AC123413"
+  }, {
+    "container" : "7aacb1ca-040d-1037-88ec-f467162bb89c",
+    "summary" : "owl:C21010 Discomfort Scale for Patients with Dementia of the Alzheimer's Type",
+    "score" : 23.330781936645508,
+    "identifiers" : "owl:C21010",
+    "id" : "concept:owl:C21010",
+    "title" : "Discomfort Scale for Patients with Dementia of the Alzheimer's Type",
+    "category" : "concept",
+    "url" : "/labkey/7aacb1ca-040d-1037-88ec-f467162bb89c/ontology-concept.view?code=owl%3AC21010&_docid=concept%3Aowl%3AC21010"
+  } ],
+  "metaData" : {
+    "successProperty" : "success",
+    "idProperty" : "id",
+    "root" : "hits"
+  },
+  "q" : "Alzheimer's",
+  "totalHits" : 19,
+  "success" : true
+}

--- a/packages/components/src/test/data/search-jsonEmpty.json
+++ b/packages/components/src/test/data/search-jsonEmpty.json
@@ -1,0 +1,11 @@
+{
+  "hits" : [ ],
+  "metaData" : {
+    "successProperty" : "success",
+    "idProperty" : "id",
+    "root" : "hits"
+  },
+  "q" : "Alzheimer's",
+  "totalHits" : 0,
+  "success" : true
+}

--- a/packages/components/src/test/setupUtils.ts
+++ b/packages/components/src/test/setupUtils.ts
@@ -51,7 +51,6 @@ export function notificationInit() {
             'API',
             'Announcements',
             'Core',
-            'Ontology',
         ],
     };
     LABKEY.project = {

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -136,7 +136,8 @@
 
 .concept-pathinfo-container {
     min-height: 315px;
-    height: 67vh;
+    height: 65vh;
+    overflow-y: scroll;
 
     .title {
         font-size: 20px;

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -86,6 +86,9 @@
 /* CONCEPT OVERVIEW */
 .ontology-concept-overview-container {
     padding-top: 10px;
+    min-height: 315px;
+    height: 67vh;
+    overflow-y: scroll;
 
     .none-selected {
         font-size: 20px;

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -1,14 +1,58 @@
 .ontology-browser-container {
-    .right-panel {
-        padding-left: 15px;
+    .left-panel {
+        border-right: 1px solid $gray-border;
     }
 
     .concept-information-tabs {
-        padding-right: 15px;
+        padding: 0 15px 0 25px;
     }
 
     .filetree-directory-name {
         max-width: unset;
+        width: max-content;
+    }
+
+    .filetree-container {
+        min-height: 300px;
+        height: 65vh;
+    }
+
+    .concept-search-container {
+        padding-bottom: 30px;
+
+        input {
+            max-width: 450px;
+        }
+
+        .result-menu {
+            background-color: #fff;
+            min-width: 450px;
+            margin: 0;
+            z-index: 1000;
+            position: absolute;
+            list-style: none;
+            border: 1px solid #e6e6e6;
+            padding: 0;
+            box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.05);
+
+            //& > li {
+            //    height: 38px;
+            //    min-height: 38px;
+            //    max-height: 38px;
+            //    padding: 0 12px 0 20px;
+            //    display: flex;
+            //    align-items: center;
+            //    flex-direction: row;
+            //
+            //    cursor: pointer;
+            //    line-height: 1.4;
+            //    margin: 0;
+            //    border: 0;
+            //    outline: 0;
+            //    vertical-align: baseline;
+            //    list-style: none;
+            //}
+        }
     }
 }
 

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -128,7 +128,7 @@
         }
     }
 
-    .button-container {
+    .path-button-container {
         float: right;
         margin-right: 5px;
 

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -39,7 +39,7 @@
             min-width: 450px;
             width: 65vw;
 
-            li {
+            li.selectable-item {
                 cursor: pointer;
                 &:hover {
                     background-color: $gray-lighter;

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -186,26 +186,13 @@
             width: 60ch; //TODO figure out what this should actually be
             text-overflow: ellipsis;
         }
-
-        &:hover {
-            .concept-path {
-                overflow: visible;
-                white-space: normal;
-                width: auto;
-                //position: absolute;
-                direction: ltr;
-                padding-left: 5px;
-            }
-        }
-    }
-
-    .concept-path {
-        i {
-            padding: 0 5px 0;
-        }
     }
 
     .title {
         font-size: 14px;
     }
+}
+
+.concept-path-spacer {
+    padding: 0 5px 0;
 }

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -37,6 +37,7 @@
             max-height: 500px;
             overflow-y: scroll;
             min-width: 450px;
+            max-width: 800px;
             width: 65vw;
 
             li.selectable-item {

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -130,31 +130,8 @@
 
     .path-button-container {
         float: right;
-        margin-right: 5px;
-
-        .btn {
-            position: relative;
-
-            &.show-path {
-                &:after {
-                    position: absolute;
-                    content: "";
-                    height: 0;
-                    width: 0;
-                    font-size: 0;
-                    line-height: 0;
-                    margin-top: 28px;
-                    margin-left: -110px;
-                    border-left: 85px solid transparent;
-                    border-right: 40px solid transparent;
-                    border-bottom: 47px solid $gray-lighter;
-                }
-            }
-        }
-
-        .triangle {
-
-        }
+        width: 80px;
+        margin-left: 5px;
     }
 
     .concept-overview-selected-path {
@@ -163,6 +140,17 @@
         .concept-path-container {
             width: 100%;
             border: $gray-lighter;
+        }
+
+        &:before {
+            content: "";
+            float: right;
+            line-height: 0;
+            margin-top: -20px;
+            margin-right: 26px;
+            border-left: 20px solid transparent;
+            border-right: 20px solid transparent;
+            border-bottom: 20px solid $gray-lighter;
         }
     }
 }
@@ -216,9 +204,14 @@
 
     .title {
         font-size: 14px;
+        padding-bottom: 5px;
     }
-}
 
-.concept-path-spacer {
-    padding: 0 5px 0;
+    .concept-path-spacer {
+        padding: 0 5px 0;
+    }
+
+    .concept-path-label {
+        line-height: 23px;
+    }
 }

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -87,6 +87,7 @@
 /* CONCEPT OVERVIEW */
 .ontology-concept-overview-container {
     padding-top: 10px;
+    padding-right: 5px;
     min-height: 315px;
     height: 67vh;
     overflow-y: scroll;
@@ -124,6 +125,44 @@
 
         li {
             padding-top: 5px;
+        }
+    }
+
+    .button-container {
+        float: right;
+        margin-right: 5px;
+
+        .btn {
+            position: relative;
+
+            &.show-path {
+                &:after {
+                    position: absolute;
+                    content: "";
+                    height: 0;
+                    width: 0;
+                    font-size: 0;
+                    line-height: 0;
+                    margin-top: 28px;
+                    margin-left: -110px;
+                    border-left: 85px solid transparent;
+                    border-right: 40px solid transparent;
+                    border-bottom: 47px solid $gray-lighter;
+                }
+            }
+        }
+
+        .triangle {
+
+        }
+    }
+
+    .concept-overview-selected-path {
+        width: 100%;
+
+        .concept-path-container {
+            width: 100%;
+            border: $gray-lighter;
         }
     }
 }
@@ -173,19 +212,6 @@
 
     &.selected {
         background-color: $gray-lighter;
-    }
-
-    &.collapsed {
-        direction: rtl;
-        float: right;
-
-        .concept-path {
-            overflow: hidden;
-            white-space: nowrap;
-            //width: auto;
-            width: 60ch; //TODO figure out what this should actually be
-            text-overflow: ellipsis;
-        }
     }
 
     .title {

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -25,33 +25,56 @@
         }
 
         .result-menu {
-            background-color: #fff;
-            min-width: 450px;
             margin: 0;
+            padding: 0;
             z-index: 1000;
             position: absolute;
             list-style: none;
-            border: 1px solid #e6e6e6;
-            padding: 0;
-            box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.05);
+            background-color: $white;
+            border: 1px solid $gray-border;
+            box-shadow: 0 2px 2px 0 rgba(0,0,0,0.12);
 
-            //& > li {
-            //    height: 38px;
-            //    min-height: 38px;
-            //    max-height: 38px;
-            //    padding: 0 12px 0 20px;
-            //    display: flex;
-            //    align-items: center;
-            //    flex-direction: row;
-            //
-            //    cursor: pointer;
-            //    line-height: 1.4;
-            //    margin: 0;
-            //    border: 0;
-            //    outline: 0;
-            //    vertical-align: baseline;
-            //    list-style: none;
-            //}
+            max-height: 500px;
+            overflow-y: scroll;
+            min-width: 450px;
+            width: 65vw;
+
+            li {
+                cursor: pointer;
+                &:hover {
+                    background-color: $gray-lighter;
+                }
+            }
+
+            li .row {
+                margin: 0;
+                border-bottom: 1px solid $gray-border;
+                display: flex;
+
+                .col {
+                    color: $gray-light;
+                    padding: 10px;
+                    border-right: 1px solid $gray-border;
+                    display: flex;
+                }
+
+                .bold {
+                    font-weight: bold;
+                }
+            }
+
+            li:last-child .row {
+                border-bottom: none;
+            }
+            li .row .col:last-child {
+                border-right: none;
+            }
+
+            .result-footer {
+                color: $gray-light;
+                font-size: 12px;
+                padding: 10px;
+            }
         }
     }
 }

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -114,33 +114,19 @@
         background-color: $light-gray;
         font-size: 14px;
     }
+
+    .synonyms-text {
+        padding-left: 15px;
+
+        li {
+            padding-top: 5px;
+        }
+    }
 }
 
 /* PATH INFORMATION */
-.concept-pathinfo-container {
+.ontology-concept-pathinfo-container {
     padding-top: 10px;
-    font-size: 14px;
-
-    .title {
-        font-size: 20px;
-    }
-
-    .current-path-container, .alternate-paths-container {
-        margin-top: 15px;
-
-        .concept-path-container{
-            margin-top: 5px;
-
-            &:hover {
-                background-color: $btn-info-bg;
-                cursor: pointer;
-            }
-        }
-
-        .title {
-            font-size: 14px;
-        }
-    }
 
     .none-selected, .no-path-info {
         font-size: 20px;
@@ -148,16 +134,40 @@
     }
 }
 
+.concept-pathinfo-container {
+    min-height: 315px;
+    height: 67vh;
+
+    .title {
+        font-size: 20px;
+    }
+
+    .current-path-container, .alternate-paths-container {
+        padding-top: 15px;
+
+        .title {
+            font-size: 14px;
+        }
+
+        .no-path-info {
+            font-size: 14px;
+            padding: 15px;
+        }
+    }
+
+    .alternate-paths-container .concept-path-container:hover {
+        background-color: $gray-lighter;
+        cursor: pointer;
+    }
+}
+
 .concept-path-container {
     color: $text-color;
     display: inline-block;
-    padding: 2px 5px 2px;
-    border: solid $gray-no-highlight 1px;
-    border-radius: 2px;
-    font-size: 14px;
+    padding: 15px;
 
     &.selected {
-        background-color: $light-gray;
+        background-color: $gray-lighter;
     }
 
     &.collapsed {
@@ -179,7 +189,6 @@
                 width: auto;
                 //position: absolute;
                 direction: ltr;
-                background: $light-gray;
                 padding-left: 5px;
             }
         }


### PR DESCRIPTION
#### Rationale
The ontology concept picker is often used with an ontology that will have thousands of concepts / paths. This makes it difficult for the user to use the tree node expand/collapse navigation exclusively to find what they are looking for. This PR adds in a search input above the tree so that a user can type a search term and click on a resulting / matching concept to load and navigate the tree to the first path related to the selected concept.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/476
* https://github.com/LabKey/ontology/pull/25
* https://github.com/LabKey/platform/pull/2087

#### Changes
* FileTree component updates show props to `showLoading` and `showAnimations`
* Concept path display update for hover to get full path info for "current path"
* Ontology tree panel update for adding search input field and results menu behavior
* Ontology tree panel update to allow for loading data into tree and navigating to an alternate path via search or alternate path click in path information tab
* Ontology panel header update to show ontology description and concept count in tooltip
* search/actions.ts update to allow for a custom category filter array
