### PR TITLE
Issue 42635: Fix problem with undefined references in getDisambiguatedSelectInputOptions

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.15.1-jobSamplesQueryModel.0",
+  "version": "2.15.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.15.0",
+  "version": "2.15.1-jobSamplesQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Fix problem with undefined references in `getDisambiguatedSelectInputOptions`
+
 ### version 2.15.0
 *Released*: 16 March 2021
 * Add `<DisabledMenuItem/>`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.15.1
+*Released*: 18 March 2021
 * Fix problem with undefined references in `getDisambiguatedSelectInputOptions`
 
 ### version 2.15.0

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -424,9 +424,9 @@ export function getDisambiguatedSelectInputOptions(
         Object.keys(rows).forEach(row => {
             const data = rows[row];
             rawOptions.push({
-                value: data[keyField].value,
-                label: data[valueField].value,
-                type: data[typeField].value,
+                value: data[keyField]?.value,
+                label: data[valueField]?.value,
+                type: data[typeField]?.value,
             });
         });
     }


### PR DESCRIPTION
#### Rationale
When the data passed in to `getDisambiguatedSelectInputOptions` is an object instead of an immutable map, we need to properly handle the case that one or more of the keys may be undefined or not available.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/519
* https://github.com/LabKey/biologics/pull/830

#### Changes
* Fix problem with undefined references in `getDisambiguatedSelectInputOptions`
