### PR TITLE
Fix selectedState for QueryModel when the total number of rows is less than the page size

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.15.3-selectionState.0",
+  "version": "2.15.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.15.2",
+  "version": "2.15.3-selectionState.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.15.3
+*Released*: 21 March 2021
 * Fix for `selectedState` in `QueryModel` when total rows is less than page size
 
 ### version 2.15.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Fix for `selectedState` in `QueryModel` when total rows is less than page size
+
 ### version 2.15.2
 *Released*: 18 March 2021
 * Merge release21.3-SNAPSHOT to master.

--- a/packages/components/src/public/QueryModel/QueryModel.spec.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.spec.ts
@@ -1,4 +1,4 @@
-import { LoadingState, QueryInfo, SchemaQuery, QuerySort } from '../..';
+import { GRID_CHECKBOX_OPTIONS, LoadingState, QueryInfo, QuerySort, SchemaQuery } from '../..';
 import { initUnitTests, makeQueryInfo } from '../../internal/testHelpers';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 
@@ -143,4 +143,57 @@ describe('QueryModel', () => {
         expect(model.displayColumns).toEqual(expectedDisplayCols);
         expect(model.columnString).toEqual('Name,RowId,Flag,mixtureTypeId,expirationTime');
     });
+
+    test('SelectedState', () => {
+        let model = new QueryModel({schemaQuery: SCHEMA_QUERY });
+        // not loaded, no data
+        expect(model.selectedState).toBe(GRID_CHECKBOX_OPTIONS.NONE);
+
+        // loaded, no selections
+        model = model.mutate({
+            rows: {'1': {test: 1}, '2': {test: 2}, '3': {test: 3}},
+            orderedRows: ['1', '3', '2'],
+            rowCount: 3,
+            maxRows: 20,
+            queryInfoLoadingState: LoadingState.LOADED,
+            rowsLoadingState: LoadingState.LOADED
+        });
+        expect(model.selectedState).toBe(GRID_CHECKBOX_OPTIONS.NONE);
+
+        // loaded, all selected on page but more data
+        model = model.mutate({
+            selections: new Set(['1', '2', '3']),
+            rowCount: 30,
+            maxRows: 3,
+        });
+        expect(model.selectedState).toBe(GRID_CHECKBOX_OPTIONS.ALL);
+
+        // some selected on page
+        model = model.mutate({
+            selections: new Set(['2', '3'])
+        });
+        expect(model.selectedState).toBe(GRID_CHECKBOX_OPTIONS.SOME);
+
+        // none selected on page
+        model = model.mutate({
+            selections: new Set()
+        });
+        expect(model.selectedState).toBe(GRID_CHECKBOX_OPTIONS.NONE);
+
+        // all selected, total rows less than a page
+        model = model.mutate({
+            selections: new Set(['1', '2', '3']),
+            rowCount: 3,
+            maxRows: 20,
+        });
+        expect(model.selectedState).toBe(GRID_CHECKBOX_OPTIONS.ALL);
+
+        // some selected from total less than a page
+        model = model.mutate({
+            selections: new Set(['3']),
+            rowCount: 3,
+            maxRows: 33,
+        });
+        expect(model.selectedState).toBe(GRID_CHECKBOX_OPTIONS.SOME);
+    })
 });

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -703,7 +703,7 @@ export class QueryModel {
         if (!isLoading && hasData && selections) {
             const selectedOnPage = orderedRows.filter(rowId => selections.has(rowId)).length;
 
-            if (selectedOnPage === maxRows && rowCount > 0) {
+            if ((selectedOnPage === rowCount || selectedOnPage === maxRows) && rowCount > 0) {
                 return GRID_CHECKBOX_OPTIONS.ALL;
             } else if (selectedOnPage > 0) {
                 // if model has any selected on the page show checkbox as indeterminate


### PR DESCRIPTION
#### Rationale
We are currently showing the "Some selected" state when all rows are selected in a grid that has less than a page of data.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/525

#### Changes
* update `selectedState` method and add tests
