### PR TITLE
Issue 42383: FM: When adding samples to storage, the Sample ID dropdown in the editable grid often has a sampleId that is already in storage

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.15.2",
+  "version": "2.15.3-fb-fmBugFix21.4X.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* add lookupStoreInvalidate function
+
 ### version 2.15.2
 *Released*: 18 March 2021
 * Merge release21.3-SNAPSHOT to master.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -154,6 +154,7 @@ import {
     getQueryGridModelsForGridId,
     initQueryGridState,
     invalidateUsers,
+    lookupStoreInvalidate,
     removeQueryGridModel,
     updateEditorModel,
 } from './internal/global';
@@ -431,6 +432,7 @@ export {
     getQueryGridModel,
     getQueryGridModelsForGridId,
     getEditorModel,
+    lookupStoreInvalidate,
     removeQueryGridModel,
     invalidateUsers,
     clearSelected,

--- a/packages/components/src/internal/global.ts
+++ b/packages/components/src/internal/global.ts
@@ -176,6 +176,12 @@ export function removeQueryGridModel(model: QueryGridModel, connectedComponent?:
     );
 }
 
+export function lookupStoreInvalidate(col: QueryColumn): void {
+    setGlobal({
+        QueryGrid_lookups: getGlobalState('lookups').delete(LookupStore.key(col))
+    });
+}
+
 /**
  * Get the query metadata object from the global state.
  */


### PR DESCRIPTION
#### Rationale
QueryColumn lookup is fetched on first access and then stored in global state. For the scenario of adding samples to storage using editable grid, the lookup should be re-queried after each add action to get rid of those that are recently added to storage. 

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/209
* 
#### Changes
* added lookupStoreInvalidate util