### PR TITLE
Add queryModel prop to AssayImportSubMenuItem

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.17.0-fb-AssayImportSubMenuItemQM.0",
+  "version": "2.17.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.16.1",
+  "version": "2.17.0-fb-AssayImportSubMenuItemQM.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.17.0
+*Released*: ?? March 2021
+* Add queryModel prop to AssayImportSubMenuItem
+
 ### version 2.16.1
 *Released*: 22 March 2021
 * add lookupStoreInvalidate util

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.17.0
-*Released*: ?? March 2021
+*Released*: 23 March 2021
 * Add queryModel prop to AssayImportSubMenuItem
 
 ### version 2.16.1

--- a/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
@@ -43,7 +43,7 @@ export class AssayImportSubMenuItemImpl extends PureComponent<Props & InjectedAs
             importItems = getImportItemsForAssayDefinitions(assayModel, model, providerType);
         }
 
-        return importItems.map((subItems, href, assay) => ({ text: assay.name, href }));
+        return importItems.map((href, assay) => ({ text: assay.name, href }));
     };
 
     render(): ReactNode {

--- a/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
@@ -8,13 +8,18 @@ import {
     SubMenuItem,
     SubMenuItemProps,
     QueryGridModel,
-    withAssayModels,
+    withAssayModels, QueryModel,
 } from '../../..';
 import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
+import { getImportItemsForAssayDefinitionsQM } from './actions';
 
 interface Props extends SubMenuItemProps {
     isLoaded?: boolean;
+    /**
+     * @deprecated: Use QueryModel instead.
+     */
     model?: QueryGridModel;
+    queryModel?: QueryModel;
     requireSelection: boolean;
     nounPlural?: string;
     providerType?: string;
@@ -29,15 +34,16 @@ export class AssayImportSubMenuItemImpl extends PureComponent<Props & InjectedAs
     };
 
     getItems = (): ISubItem[] => {
-        const { assayModel, model, providerType } = this.props;
+        const { assayModel, model, providerType, queryModel } = this.props;
+        let importItems;
 
-        return getImportItemsForAssayDefinitions(assayModel, model, providerType).reduce((subItems, href, assay) => {
-            subItems.push({
-                text: assay.name,
-                href,
-            });
-            return subItems;
-        }, []);
+        if (queryModel !== undefined) {
+            importItems = getImportItemsForAssayDefinitionsQM(assayModel, queryModel, providerType);
+        } else {
+            importItems = getImportItemsForAssayDefinitions(assayModel, model, providerType);
+        }
+
+        return importItems.map((subItems, href, assay) => ({ text: assay.name, href }));
     };
 
     render(): ReactNode {

--- a/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
@@ -1,14 +1,14 @@
-import React, { PureComponent, ReactNode } from 'react';
+import React, { FC, useMemo } from 'react';
 import { MenuItem, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import {
     getImportItemsForAssayDefinitions,
     InjectedAssayModel,
-    ISubItem,
     SubMenuItem,
     SubMenuItemProps,
     QueryGridModel,
-    withAssayModels, QueryModel,
+    withAssayModels,
+    QueryModel,
 } from '../../..';
 import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
 import { getImportItemsForAssayDefinitionsQM } from './actions';
@@ -26,15 +26,13 @@ interface Props extends SubMenuItemProps {
 }
 
 // exported for jest testing
-export class AssayImportSubMenuItemImpl extends PureComponent<Props & InjectedAssayModel> {
-    static defaultProps = {
-        isLoaded: true,
-        nounPlural: 'items',
-        text: 'Upload Assay Data',
-    };
+export const AssayImportSubMenuItemImpl: FC<Props & InjectedAssayModel> = props => {
+    const { assayModel, isLoaded, model, nounPlural, providerType, queryModel, requireSelection } = props;
+    const items = useMemo(() => {
+        if (!isLoaded) {
+            return [];
+        }
 
-    getItems = (): ISubItem[] => {
-        const { assayModel, model, providerType, queryModel } = this.props;
         let importItems;
 
         if (queryModel !== undefined) {
@@ -43,53 +41,58 @@ export class AssayImportSubMenuItemImpl extends PureComponent<Props & InjectedAs
             importItems = getImportItemsForAssayDefinitions(assayModel, model, providerType);
         }
 
-        return importItems.map((href, assay) => ({ text: assay.name, href }));
-    };
+        // Convert OrderedMap to array.
+        return importItems.reduce((subItems, href, assay) => {
+            subItems.push({ text: assay.name, href });
+            return subItems;
+        }, []);
+    }, [assayModel, isLoaded, model, providerType, queryModel]);
 
-    render(): ReactNode {
-        const { isLoaded, model, requireSelection, nounPlural } = this.props;
+    if (!isLoaded) {
+        return (
+            <MenuItem disabled={true}>
+                <span className="fa fa-spinner fa-pulse" /> Loading assays...
+            </MenuItem>
+        );
+    }
 
-        if (!isLoaded) {
-            return (
-                <MenuItem disabled={true}>
-                    <span className="fa fa-spinner fa-pulse" /> Loading assays...
-                </MenuItem>
-            );
-        }
-
-        const items = this.getItems();
-
-        // only display menu if valid items are available
-        if (items.length) {
-            const selectedCount = model ? model.selectedIds.size : -1;
-            const overlayMessage =
-                requireSelection && selectedCount === 0
-                    ? 'Select one or more ' + nounPlural + '.'
-                    : selectedCount > MAX_EDITABLE_GRID_ROWS
-                    ? 'At most ' + MAX_EDITABLE_GRID_ROWS + ' ' + nounPlural + ' can be selected.'
-                    : '';
-            const menuProps: Props = Object.assign({}, this.props, {
-                disabled: overlayMessage.length > 0,
-                items,
-            });
-
-            delete menuProps.model;
-
-            if (menuProps.disabled) {
-                const overlay = <Popover id="assay-submenu-warning">{overlayMessage}</Popover>;
-
-                return (
-                    <OverlayTrigger overlay={overlay} placement="right">
-                        <MenuItem disabled={true}>{menuProps.text}</MenuItem>
-                    </OverlayTrigger>
-                );
-            }
-
-            return <SubMenuItem {...menuProps} />;
-        }
-
+    // Only display menu if valid items are available
+    if (items.length === 0) {
         return null;
     }
-}
+
+    let selectedCount = -1;
+
+    if (queryModel !== undefined) {
+        selectedCount = queryModel.selections.size;
+    } else if (model) {
+        selectedCount = model.selectedIds.size;
+    }
+
+    const overlayMessage =
+        requireSelection && selectedCount === 0
+            ? 'Select one or more ' + nounPlural + '.'
+            : selectedCount > MAX_EDITABLE_GRID_ROWS
+            ? 'At most ' + MAX_EDITABLE_GRID_ROWS + ' ' + nounPlural + ' can be selected.'
+            : '';
+    const menuProps: Props = Object.assign({}, props, {
+        disabled: overlayMessage.length > 0,
+        items,
+        model: undefined,
+        queryModel: undefined,
+    });
+
+    if (menuProps.disabled) {
+        const overlay = <Popover id="assay-submenu-warning">{overlayMessage}</Popover>;
+
+        return (
+            <OverlayTrigger overlay={overlay} placement="right">
+                <MenuItem disabled={true}>{menuProps.text}</MenuItem>
+            </OverlayTrigger>
+        );
+    }
+
+    return <SubMenuItem {...menuProps} />;
+};
 
 export const AssayImportSubMenuItem = withAssayModels<Props>(AssayImportSubMenuItemImpl);

--- a/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
@@ -27,7 +27,17 @@ interface Props extends SubMenuItemProps {
 
 // exported for jest testing
 export const AssayImportSubMenuItemImpl: FC<Props & InjectedAssayModel> = props => {
-    const { assayModel, isLoaded, model, nounPlural, providerType, queryModel, requireSelection } = props;
+    const {
+        assayModel,
+        isLoaded = true,
+        model,
+        nounPlural = 'items',
+        providerType,
+        queryModel,
+        requireSelection,
+        text = 'Upload Assay Data',
+    } = props;
+
     const items = useMemo(() => {
         if (!isLoaded) {
             return [];
@@ -80,6 +90,7 @@ export const AssayImportSubMenuItemImpl: FC<Props & InjectedAssayModel> = props 
         items,
         model: undefined,
         queryModel: undefined,
+        text,
     });
 
     if (menuProps.disabled) {

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -27,6 +27,7 @@ import {
     QueryGridModel,
     SCHEMAS,
     SchemaQuery,
+    QueryModel,
 } from '../../..';
 
 import { AssayUploadTabs } from '../../constants';
@@ -241,6 +242,32 @@ export function deleteAssayRuns(
             }),
         });
     });
+}
+
+export function getImportItemsForAssayDefinitionsQM(
+    assayStateModel: AssayStateModel,
+    sampleModel?: QueryModel,
+    providerType?: string
+): OrderedMap<AssayDefinitionModel, string> {
+    let targetSQ;
+    const selectionKey = sampleModel ? sampleModel.id : undefined;
+
+    if (sampleModel?.queryInfo) {
+        targetSQ = sampleModel.queryInfo.schemaQuery;
+    }
+
+    return assayStateModel.definitions
+        .filter(assay => providerType === undefined || assay.type === providerType)
+        .filter(assay => !targetSQ || assay.hasLookup(targetSQ))
+        .sort(naturalSortByProperty('name'))
+        .reduce((items, assay) => {
+            const href = assay.getImportUrl(
+                selectionKey ? AssayUploadTabs.Grid : AssayUploadTabs.Files,
+                selectionKey,
+                sampleModel ? List(sampleModel.filters) : undefined
+            );
+            return items.set(assay, href);
+        }, OrderedMap<AssayDefinitionModel, string>());
 }
 
 export function getImportItemsForAssayDefinitions(


### PR DESCRIPTION
#### Rationale
This PR updates AssayImportSubMenuItem to have an optional `queryModel` prop so it can be used with QueryModel backed components. I needed this for a Biologics PR that is getting deferred indefinitely (upgrade Experiments Tabbed Grid Panel to use QueryModel). This will be useful in other areas of Biologics, as well as SM.

#### Related Pull Requests
* n/a

#### Changes
* Add queryModel prop to AssayImportSubMenuItem
* Add getImportItemsForAssayDefinitionsQM to internal/components/assay/actions
