### PR TITLE
Misc SM and workflow fixes for 21.4

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.17.0-fb-smFixes213Cory.0",
+  "version": "2.17.0-fb-smFixes213Cory.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.16.1",
+  "version": "2.16.1-fb-smFixes213Cory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.17.0",
+  "version": "2.17.0-fb-smFixes213Cory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.16.1-fb-smFixes213Cory.0",
+  "version": "2.16.1-fb-smFixes213Cory.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.17.0-fb-smFixes213Cory.1",
+  "version": "2.17.0-fb-smFixes213Cory.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.16.1-fb-smFixes213Cory.1",
+  "version": "2.16.1-fb-smFixes213Cory.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.17.0-fb-smFixes213Cory.2",
+  "version": "2.18.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 42741: EntityInsertPanel fix to use selected sample type name instead of value (which is lowercase) for navigation
 * Add EntityDataType.editTypeAppUrlPrefix to use for linking to the edit design app URL on the create/import page
 * EntityInsertPanel fix to handle case where parent param is a schema/query but without specific values to add to grid
+* Add createEntityParentKey helper util function
 
 ### version 2.17.0
 *Released*: 23 March 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42741: EntityInsertPanel fix to use selected sample type name instead of value (which is lowercase) for navigation
+
 ### version 2.16.1
 *Released*: 22 March 2021
 * add lookupStoreInvalidate util

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Add EntityDataType.editTypeAppUrlPrefix to use for linking to the edit design app URL on the create/import page
 * EntityInsertPanel fix to handle case where parent param is a schema/query but without specific values to add to grid
 * Add createEntityParentKey helper util function
+* SubMenuItem fix for expanded menu with filter issue with item disabled state change
 
 ### version 2.17.0
 *Released*: 23 March 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.18.0
+*Released*: 30 March 2021
 * Issue 42741: EntityInsertPanel fix to use selected sample type name instead of value (which is lowercase) for navigation
 * Add EntityDataType.editTypeAppUrlPrefix to use for linking to the edit design app URL on the create/import page
 * EntityInsertPanel fix to handle case where parent param is a schema/query but without specific values to add to grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Issue 42741: EntityInsertPanel fix to use selected sample type name instead of value (which is lowercase) for navigation
 * Add EntityDataType.editTypeAppUrlPrefix to use for linking to the edit design app URL on the create/import page
+* EntityInsertPanel fix to handle case where parent param is a schema/query but without specific values to add to grid
 
 ### version 2.16.1
 *Released*: 22 March 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 42741: EntityInsertPanel fix to use selected sample type name instead of value (which is lowercase) for navigation
+* Add EntityDataType.editTypeAppUrlPrefix to use for linking to the edit design app URL on the create/import page
 
 ### version 2.16.1
 *Released*: 22 March 2021

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -344,6 +344,7 @@ import {
     getSampleDeleteConfirmationData,
 } from './internal/components/entities/actions';
 import { DataClassDataType, SampleTypeDataType } from './internal/components/entities/constants';
+import { createEntityParentKey } from './internal/components/entities/utils';
 import { SampleTypeModel } from './internal/components/domainproperties/samples/models';
 
 import { EditableDetailPanel } from './public/QueryModel/EditableDetailPanel';
@@ -592,6 +593,7 @@ export {
     RemoveEntityButton,
     getSampleDeleteConfirmationData,
     getDataDeleteConfirmationData,
+    createEntityParentKey,
     // search related items
     SearchResultsModel,
     SearchResultCard,

--- a/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportSubMenuItem.tsx
@@ -11,6 +11,7 @@ import {
     QueryModel,
 } from '../../..';
 import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
+
 import { getImportItemsForAssayDefinitionsQM } from './actions';
 
 interface Props extends SubMenuItemProps {

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -240,7 +240,7 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
         if (
             insertModel &&
-            insertModel.getTargetEntityTypeName() === target &&
+            insertModel.getTargetEntityTypeValue() === target &&
             insertModel.selectionKey === selectionKey &&
             (insertModel.originalParents === parents || !allowParents)
         ) {
@@ -303,7 +303,7 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
                                 'Problem retrieving data for ' +
                                 this.typeTextSingular +
                                 " '" +
-                                insertModel.getTargetEntityTypeName() +
+                                insertModel.getTargetEntityTypeLabel() +
                                 "'.",
                         }) as EntityIdCreationModel,
                     });
@@ -322,7 +322,7 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
         const { insertModel } = this.state;
 
         if (insertModel) {
-            const entityTypeName = insertModel ? insertModel.getTargetEntityTypeName() : undefined;
+            const entityTypeName = insertModel ? insertModel.getTargetEntityTypeValue() : undefined;
             if (entityTypeName) {
                 const model = getStateQueryGridModel(
                     'insert-entities',
@@ -670,7 +670,7 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
             if (response?.rows) {
                 this.props.onDataChange?.(false);
                 this.props.afterEntityCreation?.(
-                    insertModel.getTargetEntityTypeName(),
+                    insertModel.getTargetEntityTypeLabel(),
                     response.getFilter(),
                     response.rows.length,
                     'created',
@@ -887,10 +887,10 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
             this.setSubmitting(false);
             this.props.onDataChange?.(false);
             if (useAsync) {
-                this.props.onBackgroundJobStart?.(insertModel.getTargetEntityTypeName(), file.name, response.jobId);
+                this.props.onBackgroundJobStart?.(insertModel.getTargetEntityTypeLabel(), file.name, response.jobId);
             } else {
                 this.props.afterEntityCreation?.(
-                    insertModel.getTargetEntityTypeName(),
+                    insertModel.getTargetEntityTypeLabel(),
                     null,
                     response.rowCount,
                     'imported',
@@ -954,7 +954,7 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
         }
 
         const isGridStep = this.isGridStep();
-        const entityTypeName = insertModel.getTargetEntityTypeName();
+        const entityTypeName = insertModel.getTargetEntityTypeLabel();
         const editEntityTypeDetailsLink = entityTypeName
             ? AppURL.create(nounPlural, entityTypeName, 'update')
             : undefined;

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -942,7 +942,14 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
     };
 
     render() {
-        const { canEditEntityTypeDetails, disableMerge, fileSizeLimits, importOnly, nounPlural } = this.props;
+        const {
+            canEditEntityTypeDetails,
+            disableMerge,
+            fileSizeLimits,
+            importOnly,
+            nounPlural,
+            entityDataType,
+        } = this.props;
         const { error, file, insertModel, isMerge, isSubmitting, originalQueryInfo } = this.state;
 
         if (!insertModel) {
@@ -955,9 +962,10 @@ class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
         const isGridStep = this.isGridStep();
         const entityTypeName = insertModel.getTargetEntityTypeLabel();
-        const editEntityTypeDetailsLink = entityTypeName
-            ? AppURL.create(nounPlural, entityTypeName, 'update')
-            : undefined;
+        const editEntityTypeDetailsLink =
+            entityTypeName && entityDataType?.editTypeAppUrlPrefix
+                ? AppURL.create(entityDataType.editTypeAppUrlPrefix, entityTypeName)
+                : undefined;
 
         return (
             <>

--- a/packages/components/src/internal/components/entities/actions.spec.ts
+++ b/packages/components/src/internal/components/entities/actions.spec.ts
@@ -1,8 +1,8 @@
-import { fromJS, Map } from "immutable";
+import { fromJS, Map } from 'immutable';
 
-import { extractEntityTypeOptionFromRow, getChosenParentData } from "./actions";
-import { EntityDataType, EntityIdCreationModel } from "./models";
-import { DataClassDataType, SampleTypeDataType } from "./constants";
+import { extractEntityTypeOptionFromRow, getChosenParentData } from './actions';
+import { EntityDataType, EntityIdCreationModel } from './models';
+import { DataClassDataType, SampleTypeDataType } from './constants';
 
 describe('extractEntityTypeOptionFromRow', () => {
     const NAME = 'Test Name';

--- a/packages/components/src/internal/components/entities/actions.spec.ts
+++ b/packages/components/src/internal/components/entities/actions.spec.ts
@@ -1,0 +1,82 @@
+import { fromJS, Map } from "immutable";
+
+import { extractEntityTypeOptionFromRow, getChosenParentData } from "./actions";
+import { EntityDataType, EntityIdCreationModel } from "./models";
+import { DataClassDataType, SampleTypeDataType } from "./constants";
+
+describe('extractEntityTypeOptionFromRow', () => {
+    const NAME = 'Test Name';
+    const ROW = fromJS({
+        RowId: { value: 1 },
+        Name: { value: NAME },
+        LSID: { value: 'ABC123' },
+    });
+
+    test('lowerCaseValue = true', () => {
+        const options = extractEntityTypeOptionFromRow(ROW);
+        expect(options.label).toBe(NAME);
+        expect(options.lsid).toBe('ABC123');
+        expect(options.rowId).toBe(1);
+        expect(options.value).toBe(NAME.toLowerCase());
+        expect(options.query).toBe(NAME);
+    });
+
+    test('lowerCaseValue = false', () => {
+        const options = extractEntityTypeOptionFromRow(ROW, false);
+        expect(options.label).toBe(NAME);
+        expect(options.lsid).toBe('ABC123');
+        expect(options.rowId).toBe(1);
+        expect(options.value).toBe(NAME);
+        expect(options.query).toBe(NAME);
+    });
+});
+
+describe('getChosenParentData', () => {
+    let PARENT_ENTITY_DATA_TYPES = Map<string, EntityDataType>();
+    PARENT_ENTITY_DATA_TYPES = PARENT_ENTITY_DATA_TYPES.set(SampleTypeDataType.instanceSchemaName, SampleTypeDataType);
+    PARENT_ENTITY_DATA_TYPES = PARENT_ENTITY_DATA_TYPES.set(DataClassDataType.instanceSchemaName, DataClassDataType);
+
+    test('allowParents = false', async () => {
+        const result = await getChosenParentData(new EntityIdCreationModel(), PARENT_ENTITY_DATA_TYPES, false);
+        expect(result.originalParents).toBe(undefined);
+        expect(result.selectionKey).toBe(undefined);
+        expect(result.entityParents.size).toBe(2);
+        expect(result.entityParents.get(SampleTypeDataType.typeListingSchemaQuery.queryName).size).toBe(0);
+        expect(result.entityParents.get(DataClassDataType.typeListingSchemaQuery.queryName).size).toBe(0);
+        expect(result.entityCount).toBe(0);
+    });
+
+    test('allowParents, initialParents without value', async () => {
+        const result = await getChosenParentData(
+            new EntityIdCreationModel({
+                originalParents: ['samples:TEST'],
+                selectionKey: undefined,
+            }),
+            PARENT_ENTITY_DATA_TYPES,
+            true
+        );
+        expect(result.originalParents).toBe(undefined);
+        expect(result.selectionKey).toBe(undefined);
+        expect(result.entityParents.size).toBe(2);
+        expect(result.entityParents.get(SampleTypeDataType.typeListingSchemaQuery.queryName).size).toBe(1);
+        expect(result.entityParents.get(DataClassDataType.typeListingSchemaQuery.queryName).size).toBe(0);
+        expect(result.entityCount).toBe(0);
+    });
+
+    test('allowParents, without initialParents or selectionKey', async () => {
+        const result = await getChosenParentData(
+            new EntityIdCreationModel({
+                originalParents: undefined,
+                selectionKey: undefined,
+            }),
+            PARENT_ENTITY_DATA_TYPES,
+            true
+        );
+        expect(result.originalParents).toBe(undefined);
+        expect(result.selectionKey).toBe(undefined);
+        expect(result.entityParents.size).toBe(2);
+        expect(result.entityParents.get(SampleTypeDataType.typeListingSchemaQuery.queryName).size).toBe(0);
+        expect(result.entityParents.get(DataClassDataType.typeListingSchemaQuery.queryName).size).toBe(0);
+        expect(result.entityCount).toBe(0);
+    });
+});

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -189,7 +189,8 @@ export function extractEntityTypeOptionFromRow(row: Map<string, any>, lowerCaseV
     };
 }
 
-function getChosenParentData(
+// exported for jest testing
+export function getChosenParentData(
     model: EntityIdCreationModel,
     parentEntityDataTypes: Map<string, EntityDataType>,
     allowParents: boolean

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -8,7 +8,7 @@ import {
     naturalSort,
     SampleCreationType,
     SchemaQuery,
-    selectRows
+    selectRows,
 } from '../../..';
 
 import {

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -2,8 +2,9 @@ import { SCHEMAS } from '../../schemas';
 
 import { DELETE_SAMPLES_TOPIC } from '../../util/helpLinks';
 
-import { EntityDataType } from './models';
 import { SAMPLE_TYPE_KEY } from '../../app/constants';
+
+import { EntityDataType } from './models';
 
 export const DATA_DELETE_CONFIRMATION_ACTION = 'getDataDeleteConfirmationData.api';
 export const SAMPLE_DELETE_CONFIRMATION_ACTION = 'getMaterialDeleteConfirmationData.api';

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -3,6 +3,7 @@ import { SCHEMAS } from '../../schemas';
 import { DELETE_SAMPLES_TOPIC } from '../../util/helpLinks';
 
 import { EntityDataType } from './models';
+import { SAMPLE_TYPE_KEY } from '../../app/constants';
 
 export const DATA_DELETE_CONFIRMATION_ACTION = 'getDataDeleteConfirmationData.api';
 export const SAMPLE_DELETE_CONFIRMATION_ACTION = 'getMaterialDeleteConfirmationData.api';
@@ -24,6 +25,7 @@ export const SampleTypeDataType: EntityDataType = {
     inputTypeColumnName: 'Inputs/Materials/First/SampleSet',
     inputTypeValueField: 'lsid',
     insertColumnNamePrefix: 'MaterialInputs/',
+    editTypeAppUrlPrefix: SAMPLE_TYPE_KEY,
 };
 
 export const DataClassDataType: EntityDataType = {

--- a/packages/components/src/internal/components/entities/models.spec.ts
+++ b/packages/components/src/internal/components/entities/models.spec.ts
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SCHEMAS } from '../../..';
+import { List } from 'immutable';
 
-import { EntityParentType } from './models';
+import { QueryColumn, SampleTypeDataType, SCHEMAS } from '../../..';
+
+import { EntityIdCreationModel, EntityParentType, EntityTypeOption } from './models';
 
 describe('EntityParentType', () => {
     test('generateColumn captionSuffix', () => {
@@ -34,5 +36,60 @@ describe('EntityParentType', () => {
             'Display Column'
         );
         expect(col.caption).toBe('Sampletype Parents');
+    });
+
+    test('getInputType', () => {
+        expect(EntityParentType.create({
+            schema: SCHEMAS.DATA_CLASSES.SCHEMA
+        }).getInputType()).toBe(QueryColumn.DATA_INPUTS);
+        expect(EntityParentType.create({
+            schema: SCHEMAS.SAMPLE_SETS.SCHEMA
+        }).getInputType()).toBe(QueryColumn.MATERIAL_INPUTS);
+    });
+
+    test('createColumnName', () => {
+        expect(EntityParentType.create({
+            schema: SCHEMAS.DATA_CLASSES.SCHEMA,
+            query: 'TEST',
+        }).createColumnName()).toBe('DataInputs/TEST');
+        expect(EntityParentType.create({
+            schema: SCHEMAS.SAMPLE_SETS.SCHEMA,
+            query: 'TEST',
+        }).createColumnName()).toBe('MaterialInputs/TEST');
+    });
+});
+
+describe('EntityIdCreationModel', () => {
+    test('getEmptyEntityParents', () => {
+        const map = EntityIdCreationModel.getEmptyEntityParents(List<string>(['a','b']));
+        expect(map.size).toBe(2);
+        expect(map.get('a').size).toBe(0);
+        expect(map.get('b').size).toBe(0);
+    });
+
+    test('hasTargetEntityType', () => {
+        expect(new EntityIdCreationModel({ targetEntityType: undefined }).hasTargetEntityType()).toBeFalsy();
+        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption() }).hasTargetEntityType()).toBeFalsy();
+        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: undefined }) }).hasTargetEntityType()).toBeFalsy();
+        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }) }).hasTargetEntityType()).toBeTruthy();
+    });
+
+    test('getTargetEntityTypeValue', () => {
+        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: undefined }) }).getTargetEntityTypeValue()).toBe(undefined);
+        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }) }).getTargetEntityTypeValue()).toBe('a');
+    });
+
+    test('getTargetEntityTypeLabel', () => {
+        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: undefined }) }).getTargetEntityTypeLabel()).toBe(undefined);
+        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }) }).getTargetEntityTypeLabel()).toBe('A');
+    });
+
+    test('getSchemaQuery', () => {
+        const sq = new EntityIdCreationModel({
+            entityDataType: SampleTypeDataType,
+            targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }),
+        });
+        expect(sq.getSchemaQuery().schemaName).toBe('samples');
+        expect(sq.getSchemaQuery().queryName).toBe('a');
     });
 });

--- a/packages/components/src/internal/components/entities/models.spec.ts
+++ b/packages/components/src/internal/components/entities/models.spec.ts
@@ -39,29 +39,39 @@ describe('EntityParentType', () => {
     });
 
     test('getInputType', () => {
-        expect(EntityParentType.create({
-            schema: SCHEMAS.DATA_CLASSES.SCHEMA
-        }).getInputType()).toBe(QueryColumn.DATA_INPUTS);
-        expect(EntityParentType.create({
-            schema: SCHEMAS.SAMPLE_SETS.SCHEMA
-        }).getInputType()).toBe(QueryColumn.MATERIAL_INPUTS);
+        expect(
+            EntityParentType.create({
+                schema: SCHEMAS.DATA_CLASSES.SCHEMA,
+            }).getInputType()
+        ).toBe(QueryColumn.DATA_INPUTS);
+        expect(
+            EntityParentType.create({
+                schema: SCHEMAS.SAMPLE_SETS.SCHEMA,
+            }).getInputType()
+        ).toBe(QueryColumn.MATERIAL_INPUTS);
     });
 
     test('createColumnName', () => {
-        expect(EntityParentType.create({
-            schema: SCHEMAS.DATA_CLASSES.SCHEMA,
-            query: 'TEST',
-        }).createColumnName()).toBe('DataInputs/TEST');
-        expect(EntityParentType.create({
-            schema: SCHEMAS.SAMPLE_SETS.SCHEMA,
-            query: 'TEST',
-        }).createColumnName()).toBe('MaterialInputs/TEST');
+        expect(
+            EntityParentType.create({
+                schema: SCHEMAS.DATA_CLASSES.SCHEMA,
+                query: 'TEST',
+            }).createColumnName()
+        ).toBe('DataInputs/TEST');
+        expect(
+            EntityParentType.create({
+                schema: SCHEMAS.SAMPLE_SETS.SCHEMA,
+                query: 'TEST',
+            }).createColumnName()
+        ).toBe('MaterialInputs/TEST');
     });
 });
 
 describe('EntityIdCreationModel', () => {
     test('getEmptyEntityParents', () => {
-        const map = EntityIdCreationModel.getEmptyEntityParents(List<string>(['a','b']));
+        const map = EntityIdCreationModel.getEmptyEntityParents(
+            List<string>(['a', 'b'])
+        );
         expect(map.size).toBe(2);
         expect(map.get('a').size).toBe(0);
         expect(map.get('b').size).toBe(0);
@@ -69,19 +79,45 @@ describe('EntityIdCreationModel', () => {
 
     test('hasTargetEntityType', () => {
         expect(new EntityIdCreationModel({ targetEntityType: undefined }).hasTargetEntityType()).toBeFalsy();
-        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption() }).hasTargetEntityType()).toBeFalsy();
-        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: undefined }) }).hasTargetEntityType()).toBeFalsy();
-        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }) }).hasTargetEntityType()).toBeTruthy();
+        expect(
+            new EntityIdCreationModel({ targetEntityType: new EntityTypeOption() }).hasTargetEntityType()
+        ).toBeFalsy();
+        expect(
+            new EntityIdCreationModel({
+                targetEntityType: new EntityTypeOption({ value: undefined }),
+            }).hasTargetEntityType()
+        ).toBeFalsy();
+        expect(
+            new EntityIdCreationModel({
+                targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }),
+            }).hasTargetEntityType()
+        ).toBeTruthy();
     });
 
     test('getTargetEntityTypeValue', () => {
-        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: undefined }) }).getTargetEntityTypeValue()).toBe(undefined);
-        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }) }).getTargetEntityTypeValue()).toBe('a');
+        expect(
+            new EntityIdCreationModel({
+                targetEntityType: new EntityTypeOption({ value: undefined }),
+            }).getTargetEntityTypeValue()
+        ).toBe(undefined);
+        expect(
+            new EntityIdCreationModel({
+                targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }),
+            }).getTargetEntityTypeValue()
+        ).toBe('a');
     });
 
     test('getTargetEntityTypeLabel', () => {
-        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: undefined }) }).getTargetEntityTypeLabel()).toBe(undefined);
-        expect(new EntityIdCreationModel({ targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }) }).getTargetEntityTypeLabel()).toBe('A');
+        expect(
+            new EntityIdCreationModel({
+                targetEntityType: new EntityTypeOption({ value: undefined }),
+            }).getTargetEntityTypeLabel()
+        ).toBe(undefined);
+        expect(
+            new EntityIdCreationModel({
+                targetEntityType: new EntityTypeOption({ value: 'a', label: 'A' }),
+            }).getTargetEntityTypeLabel()
+        ).toBe('A');
     });
 
     test('getSchemaQuery', () => {

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -76,12 +76,14 @@ export class EntityParentType extends Record({
     query: undefined,
     schema: undefined,
     value: undefined,
+    isParentTypeOnly: false,
 }) {
     declare index: number;
     declare key: string;
     declare query: string;
     declare schema: string;
     declare value: List<DisplayObject>;
+    declare isParentTypeOnly: boolean;
 
     static create(values: any): EntityParentType {
         if (!values.key) values.key = generateId('parent-type-');

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -371,8 +371,12 @@ export class EntityIdCreationModel extends Record({
         return this.targetEntityType && this.targetEntityType.value;
     }
 
-    getTargetEntityTypeName(): string {
+    getTargetEntityTypeValue(): string {
         return this.hasTargetEntityType() ? this.targetEntityType.value : undefined;
+    }
+
+    getTargetEntityTypeLabel(): string {
+        return this.hasTargetEntityType() ? this.targetEntityType.label : undefined;
     }
 
     getParentCount(): number {
@@ -469,7 +473,7 @@ export class EntityIdCreationModel extends Record({
     }
 
     getSchemaQuery(): SchemaQuery {
-        const entityTypeName = this.getTargetEntityTypeName();
+        const entityTypeName = this.getTargetEntityTypeValue();
         return entityTypeName ? SchemaQuery.create(this.entityDataType.instanceSchemaName, entityTypeName) : undefined;
     }
 

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -370,7 +370,7 @@ export class EntityIdCreationModel extends Record({
     }
 
     hasTargetEntityType(): boolean {
-        return this.targetEntityType && this.targetEntityType.value;
+        return this.targetEntityType && this.targetEntityType.value !== undefined;
     }
 
     getTargetEntityTypeValue(): string {

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -578,4 +578,5 @@ export interface EntityDataType {
     appUrlPrefixParts?: string[]; // the prefix used for creating links to this type in the application
     insertColumnNamePrefix: string; // when updating this value as an input, the name of that column (e.g, MaterialInputs)
     filterArray?: Filter.IFilter[]; // A list of filters to use when selecting the set of values
+    editTypeAppUrlPrefix?: string; // the app url route prefix for the edit design page for the given data type
 }

--- a/packages/components/src/internal/components/entities/utils.spec.ts
+++ b/packages/components/src/internal/components/entities/utils.spec.ts
@@ -532,6 +532,10 @@ describe('parentValuesDiffer', () => {
 });
 
 describe('createEntityParentKey', () => {
-    expect(createEntityParentKey(SchemaQuery.create('schema', 'query'))).toBe('schema:query');
-    expect(createEntityParentKey(SchemaQuery.create('schema', 'query'), 'id')).toBe('schema:query:id');
+    test('without id', () => {
+        expect(createEntityParentKey(SchemaQuery.create('schema', 'query'))).toBe('schema:query');
+    });
+    test('with id', () => {
+        expect(createEntityParentKey(SchemaQuery.create('schema', 'query'), 'id')).toBe('schema:query:id');
+    });
 });

--- a/packages/components/src/internal/components/entities/utils.spec.ts
+++ b/packages/components/src/internal/components/entities/utils.spec.ts
@@ -1,6 +1,6 @@
 import { fromJS, List, Map } from 'immutable';
 
-import { DataClassDataType, QueryGridModel, SchemaQuery } from '../../..';
+import { createEntityParentKey, DataClassDataType, QueryGridModel, SchemaQuery } from '../../..';
 
 import { EntityChoice, IEntityTypeOption } from './models';
 import { getInitialParentChoices, parentValuesDiffer } from './utils';
@@ -529,4 +529,9 @@ describe('parentValuesDiffer', () => {
         ]);
         expect(parentValuesDiffer(original, current)).toBe(false);
     });
+});
+
+describe('createEntityParentKey', () => {
+    expect(createEntityParentKey(SchemaQuery.create('schema', 'query'))).toBe('schema:query');
+    expect(createEntityParentKey(SchemaQuery.create('schema', 'query'), 'id')).toBe('schema:query:id');
 });

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -1,6 +1,6 @@
 import { List, Map, Set } from 'immutable';
 
-import { naturalSort, QueryGridModel } from '../../..';
+import { naturalSort, QueryGridModel, SchemaQuery } from '../../..';
 import { DELIMITER } from '../forms/input/SelectInput';
 
 import { EntityChoice, EntityDataType, IEntityTypeOption } from './models';
@@ -124,4 +124,12 @@ export function getUpdatedRowForParentChanges(
         }
     });
     return updatedValues;
+}
+
+export function createEntityParentKey(schemaQuery: SchemaQuery, id?: string): string {
+    const keys = [schemaQuery.schemaName, schemaQuery.queryName];
+    if (id) {
+        keys.push(id);
+    }
+    return keys.join(':').toLowerCase();
 }

--- a/packages/components/src/internal/components/menus/SubMenuItem.tsx
+++ b/packages/components/src/internal/components/menus/SubMenuItem.tsx
@@ -43,7 +43,6 @@ interface SubMenuItemState {
     activeIdx?: number;
     expanded?: boolean;
     filterInput?: string;
-    filterItems?: ISubItem[];
 }
 
 export class SubMenuItem extends React.Component<SubMenuItemProps, SubMenuItemState> {
@@ -71,7 +70,6 @@ export class SubMenuItem extends React.Component<SubMenuItemProps, SubMenuItemSt
         this.state = {
             activeIdx: 0,
             expanded: false,
-            filterItems: this.props.items,
         };
     }
 
@@ -115,24 +113,23 @@ export class SubMenuItem extends React.Component<SubMenuItemProps, SubMenuItemSt
     onFilterChange(evt: React.ChangeEvent<HTMLInputElement>) {
         const filterInput = evt.target.value ? evt.target.value.toLowerCase() : undefined;
 
-        const filterItems = [];
-        this.props.items.forEach(item => {
-            if (!filterInput || (item && item.text && item.text.toLowerCase().indexOf(filterInput) > -1)) {
-                filterItems.push(item);
-            }
-        });
-
         this.setState(() => ({
             activeIdx: 0,
             filterInput,
-            filterItems,
         }));
     }
 
-    select() {
-        const { activeIdx, filterItems } = this.state;
+    getFilteredItems(): ISubItem[] {
+        const { items } = this.props;
+        const { filterInput } = this.state;
+        return items.filter(item => !filterInput || item?.text.toLowerCase().indexOf(filterInput) > -1);
+    }
 
-        if (filterItems && filterItems.length > activeIdx) {
+    select() {
+        const { activeIdx } = this.state;
+        const filterItems = this.getFilteredItems();
+
+        if (filterItems?.length > activeIdx) {
             const item: ISubItem = filterItems[activeIdx];
 
             // TODO: support rest of MenuItemProps interface
@@ -153,19 +150,18 @@ export class SubMenuItem extends React.Component<SubMenuItemProps, SubMenuItemSt
                 activeIdx: 0,
                 expanded,
                 filterInput: undefined,
-                filterItems: this.props.items,
             };
         });
 
         if (expanded) {
             window.setTimeout(() => {
-                this.refs.filter && this.refs.filter.focus();
+                this.refs.filter?.focus();
             }, 25);
         }
     }
 
     renderItems(filter?: boolean) {
-        const itemSet = filter ? this.state.filterItems : this.props.items;
+        const itemSet = filter ? this.getFilteredItems() : this.props.items;
 
         if (itemSet && itemSet.length) {
             const activeIdx = this.state.activeIdx;


### PR DESCRIPTION
#### Rationale
The related app PRs address a few LKSM and LKB issues for 21.4 related to sample creation scenarios. This PR makes a couple of related changes in the EntityInsertPanel component and models to handle these cases.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/527
* https://github.com/LabKey/biologics/pull/840
* https://github.com/LabKey/labkey-ui-components/pull/483
* https://github.com/LabKey/testAutomation/pull/681

#### Changes
* EntityInsertPanel initParents handling of parent key without value to still add the parent type but not any default rows to the grid
* EntityDataType update to add editTypeAppUrlPrefix to fix links for editing type design
* EntityParentType update to add isParentTypeOnly for case mentioned above without parent key value
