### PR TITLE
Dataclass PHI Support

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.2",
     "@fortawesome/free-solid-svg-icons": "5.15.2",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.2.0",
+    "@labkey/api": "1.2.1",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.18.0-fb-dataclass-phi.0",
+  "version": "2.18.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.18.0",
+  "version": "2.18.0-fb-dataclass-phi.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.2",
     "@fortawesome/free-solid-svg-icons": "5.15.2",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.1.9",
+    "@labkey/api": "1.2.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.18.0
+### version 2.19.0
 *Released*: 30 March 2021
 * Add maxAllowedPhi attribute to User
 * Add styling to Grids for PHI protected columns

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.19.0
+*Released*: ?? March 2021
+* Add maxAllowedPhi attribute to User
+
 ### version 2.18.0
 *Released*: 30 March 2021
 * Issue 42741: EntityInsertPanel fix to use selected sample type name instead of value (which is lowercase) for navigation

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,9 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.19.0
-*Released*: ?? March 2021
+### version 2.18.0
+*Released*: 30 March 2021
 * Add maxAllowedPhi attribute to User
+* Add styling to Grids for PHI protected columns
+* Convert GridMessages to FC
 
 ### version 2.18.0
 *Released*: 30 March 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.19.0
 *Released*: 30 March 2021
 * Add maxAllowedPhi attribute to User
+* Add phiProtected attribute to QueryColumn
 * Add styling to Grids for PHI protected columns
 * Convert GridMessages to FC
 

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -171,28 +171,38 @@ class GridHeader extends React.PureComponent<GridHeaderProps, any> {
             <thead>
                 <tr>
                     {columns.map((column: GridColumn, i: number) => {
-                        let minWidth = column.width;
+                        const { headerCls, index, raw, title, width } = column;
+                        let minWidth = width;
+
                         if (minWidth === undefined) {
-                            minWidth = calcWidths && column.title ? 30 + column.title.length * 8 : undefined;
+                            minWidth = calcWidths && title ? 30 + title.length * 8 : undefined;
                         }
+
                         if (minWidth !== undefined) {
                             minWidth += 'px';
                         }
 
                         if (column.showHeader) {
-                            const headerCls = column.headerCls ? column.headerCls : 'grid-header-cell';
+                            // const className = headerCls ? headerCls : 'grid-header-cell';
+                            const className = classNames(headerCls, {
+                                'grid-header-cell': headerCls === undefined,
+                                'phi-protected': raw?.phiProtected === true,
+                            });
+                            const _title = raw?.phiProtected === true ? '(PHI protected data removed)' : undefined;
+
                             return (
                                 <th
-                                    className={headerCls}
-                                    key={i}
+                                    className={className}
+                                    key={index}
                                     onClick={this._handleClick.bind(this, column)}
                                     style={{ minWidth }}
+                                    title={_title}
                                 >
-                                    {headerCell ? headerCell(column, i, columns.size) : column.title}
+                                    {headerCell ? headerCell(column, i, columns.size) : title}
                                 </th>
                             );
                         }
-                        return <th key={i} style={{ minWidth }} />;
+                        return <th key={index} style={{ minWidth }} />;
                     }, this)}
                 </tr>
             </thead>

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { FC, memo, PureComponent, ReactNode, RefObject } from 'react';
 import classNames from 'classnames';
 import { fromJS, List, Map } from 'immutable';
 
@@ -151,7 +151,7 @@ interface GridHeaderProps {
     transpose?: boolean;
 }
 
-class GridHeader extends React.PureComponent<GridHeaderProps, any> {
+class GridHeader extends PureComponent<GridHeaderProps, any> {
     _handleClick(column: GridColumn, evt) {
         evt.stopPropagation();
         if (this.props.onCellClick) {
@@ -214,23 +214,17 @@ interface GridMessagesProps {
     messages: List<Map<string, string>>;
 }
 
-class GridMessages extends React.PureComponent<GridMessagesProps, any> {
-    render() {
-        const { messages } = this.props;
-
-        return (
-            <div className="grid-messages">
-                {messages.map((message: Map<string, string>, i) => {
-                    return (
-                        <div className="grid-message" key={i}>
-                            {message.get('content')}
-                        </div>
-                    );
-                })}
-            </div>
-        );
-    }
-}
+const GridMessages: FC<GridMessagesProps> = memo(({ messages }) => (
+    <div className="grid-messages">
+        {messages.map((message: Map<string, string>, i) => {
+            return (
+                <div className="grid-message" key={i}>
+                    {message.get('content')}
+                </div>
+            );
+        })}
+    </div>
+));
 
 interface GridBodyProps {
     data: List<Map<string, any>>;
@@ -238,12 +232,12 @@ interface GridBodyProps {
     columns: List<GridColumn>;
     emptyText: string;
     isLoading: boolean;
-    loadingText: React.ReactNode;
+    loadingText: ReactNode;
     rowKey: any;
     transpose: boolean;
 }
 
-class GridBody extends React.PureComponent<GridBodyProps> {
+class GridBody extends PureComponent<GridBodyProps> {
     constructor(props: GridBodyProps) {
         super(props);
 
@@ -329,22 +323,22 @@ export interface GridProps {
     gridId?: string;
     headerCell?: any;
     isLoading?: boolean;
-    loadingText?: React.ReactNode;
+    loadingText?: ReactNode;
     messages?: List<Map<string, string>>;
     responsive?: boolean;
 
     /**
      * If a rowKey is specified the <Grid> will use it as a lookup key into each row. The associated value
-     * will be used as the React.Key for the row.
+     * will be used as the Key for the row.
      */
     rowKey?: any; // a valid React key
     showHeader?: boolean;
     striped?: boolean;
-    tableRef?: React.RefObject<HTMLTableElement>;
+    tableRef?: RefObject<HTMLTableElement>;
     transpose?: boolean;
 }
 
-export class Grid extends React.PureComponent<GridProps> {
+export class Grid extends PureComponent<GridProps> {
     static defaultProps = {
         bordered: true,
         calcWidths: false,

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -183,7 +183,6 @@ class GridHeader extends PureComponent<GridHeaderProps, any> {
                         }
 
                         if (column.showHeader) {
-                            // const className = headerCls ? headerCls : 'grid-header-cell';
                             const className = classNames(headerCls, {
                                 'grid-header-cell': headerCls === undefined,
                                 'phi-protected': raw?.phiProtected === true,

--- a/packages/components/src/internal/components/base/models/User.ts
+++ b/packages/components/src/internal/components/base/models/User.ts
@@ -47,6 +47,7 @@ export class User extends Record(defaultUser) implements IUserProps {
     declare email: string;
     declare phone: string;
     declare avatar: string;
+    declare maxAllowedPhi: string;
 
     declare isAdmin: boolean;
     declare isAnalyst: boolean;

--- a/packages/components/src/internal/components/base/models/User.ts
+++ b/packages/components/src/internal/components/base/models/User.ts
@@ -28,6 +28,7 @@ const defaultUser: IUserProps = {
     isSystemAdmin: false,
     isTrusted: false,
 
+    maxAllowedPhi: undefined,
     permissionsList: List(),
 };
 
@@ -47,7 +48,6 @@ export class User extends Record(defaultUser) implements IUserProps {
     declare email: string;
     declare phone: string;
     declare avatar: string;
-    declare maxAllowedPhi: string;
 
     declare isAdmin: boolean;
     declare isAnalyst: boolean;
@@ -58,6 +58,7 @@ export class User extends Record(defaultUser) implements IUserProps {
     declare isSystemAdmin: boolean;
     declare isTrusted: boolean;
 
+    declare maxAllowedPhi: string;
     declare permissionsList: List<string>;
 
     static getDefaultUser(): User {

--- a/packages/components/src/internal/components/notifications/__snapshots__/Notification.spec.tsx.snap
+++ b/packages/components/src/internal/components/notifications/__snapshots__/Notification.spec.tsx.snap
@@ -43,6 +43,7 @@ Array [
               "isSignedIn": false,
               "isSystemAdmin": false,
               "isTrusted": false,
+              "maxAllowedPhi": undefined,
               "permissionsList": Immutable.List [],
             }
           }
@@ -84,6 +85,7 @@ Array [
               "isSignedIn": false,
               "isSystemAdmin": false,
               "isTrusted": false,
+              "maxAllowedPhi": undefined,
               "permissionsList": Immutable.List [],
             }
           }
@@ -129,6 +131,7 @@ Array [
           "isSignedIn": false,
           "isSystemAdmin": false,
           "isTrusted": false,
+          "maxAllowedPhi": undefined,
           "permissionsList": Immutable.List [],
         }
       }
@@ -172,6 +175,7 @@ Array [
           "isSignedIn": false,
           "isSystemAdmin": false,
           "isTrusted": false,
+          "maxAllowedPhi": undefined,
           "permissionsList": Immutable.List [],
         }
       }
@@ -223,6 +227,7 @@ exports[`<Notification/> one notification 1`] = `
         "isSignedIn": false,
         "isSystemAdmin": false,
         "isTrusted": false,
+        "maxAllowedPhi": undefined,
         "permissionsList": Immutable.List [],
       }
     }
@@ -252,6 +257,7 @@ exports[`<Notification/> with trial notification for admin 1`] = `
       "isSignedIn": false,
       "isSystemAdmin": false,
       "isTrusted": false,
+      "maxAllowedPhi": undefined,
       "permissionsList": Immutable.List [],
     }
   }
@@ -294,6 +300,7 @@ exports[`<Notification/> with trial notification for admin 1`] = `
           "isSignedIn": false,
           "isSystemAdmin": false,
           "isTrusted": false,
+          "maxAllowedPhi": undefined,
           "permissionsList": Immutable.List [],
         }
       }
@@ -346,6 +353,7 @@ exports[`<Notification/> with trial notification for non-admin 1`] = `
       "isSignedIn": false,
       "isSystemAdmin": false,
       "isTrusted": false,
+      "maxAllowedPhi": undefined,
       "permissionsList": Immutable.List [],
     }
   }
@@ -388,6 +396,7 @@ exports[`<Notification/> with trial notification for non-admin 1`] = `
           "isSignedIn": false,
           "isSystemAdmin": false,
           "isTrusted": false,
+          "maxAllowedPhi": undefined,
           "permissionsList": Immutable.List [],
         }
       }

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -65,6 +65,7 @@ export class QueryColumn extends Record({
     // mvEnabled: undefined,
     name: undefined,
     // nullable: undefined,
+    phiProtected: undefined,
     protected: undefined,
     rangeURI: undefined,
     readOnly: undefined,
@@ -128,6 +129,7 @@ export class QueryColumn extends Record({
     // declare mvEnabled: boolean;
     declare name: string;
     // declare nullable: boolean;
+    declare phiProtected: boolean;
     declare 'protected': boolean;
     declare rangeURI: string;
     declare readOnly: boolean;

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -68,7 +68,7 @@
 }
 
 .phi-protected {
-    background-color: #fcf8e3;
+    background: repeating-linear-gradient(-45deg, #fcf8e3, #fcf8e3 10px, #ffffff 10px, #ffffff 20px);
 }
 
 .grid-header-sort {

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -67,6 +67,10 @@
   font-weight: bold;
 }
 
+.phi-protected {
+    background-color: #fcf8e3;
+}
+
 .grid-header-sort {
   position: absolute;
   right: 0;

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1403,10 +1403,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.1.9":
-  version "1.1.9"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.9.tgz#df684a77847cc7c416e77a8c83d2f0eb3182d618"
-  integrity sha1-32hKd4R8x8QW53qMg9Lw6zGC1hg=
+"@labkey/api@1.2.0":
+  version "1.2.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.2.0.tgz#7476277e62e2fe6c4c6a2cc635fb03bef1247c87"
+  integrity sha1-dHYnfmLi/mxMaizGNfsDvvEkfIc=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1403,10 +1403,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.2.0":
-  version "1.2.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.2.0.tgz#7476277e62e2fe6c4c6a2cc635fb03bef1247c87"
-  integrity sha1-dHYnfmLi/mxMaizGNfsDvvEkfIc=
+"@labkey/api@1.2.1":
+  version "1.2.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.2.1.tgz#132a9c5c5140b980f24ae6cd13e9e055e5bd499a"
+  integrity sha1-EyqcXFFAuYDySubNE+ngVeW9SZo=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.1.0-fb-dataclass-phi.0",
+  "version": "1.1.0",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.0.2",
+  "version": "1.1.0-fb-dataclass-phi.0",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/releaseNotes/themes.md
+++ b/packages/themes/releaseNotes/themes.md
@@ -1,6 +1,10 @@
 # @labkey/themes
 UI themes for LabKey Server.
 
+### version 1.1.0
+*Released*: ??
+* Add styling for PHI protected columns in data regions
+
 ### version 1.0.2
 *Released*: 22 December 2020
 * Dependabot package updates

--- a/packages/themes/releaseNotes/themes.md
+++ b/packages/themes/releaseNotes/themes.md
@@ -2,7 +2,7 @@
 UI themes for LabKey Server.
 
 ### version 1.1.0
-*Released*: ??
+*Released*: 30 March 2021
 * Add styling for PHI protected columns in data regions
 
 ### version 1.0.2

--- a/packages/themes/styles/scss/labkey/components/_dataRegion.scss
+++ b/packages/themes/styles/scss/labkey/components/_dataRegion.scss
@@ -87,6 +87,10 @@
     }
   }
 
+  .labkey-phi-protected {
+    background: repeating-linear-gradient(-45deg, #fcf8e3, #fcf8e3 10px, #ffffff 10px, #ffffff 20px);
+  }
+
   .labkey-group-column-header {
     border-bottom: solid 1px $lk-grid-border-color;
     text-align: center;


### PR DESCRIPTION
#### Rationale
This PR affects our Components and Theme packages.

In the theme package I've added styling for DataRegion columns that are PHI protected.

In the components package I've added the maxAllowedPhi attribute to the User class, and adding styling to Grid columns that are PHI protected.

This PR should not be merged until Kevin's platform PR is merged

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2109

#### Changes
* theme: Add styling for PHI protected columns in data regions
* components: Add styling for PHI protected columns in Grid
* components: Convert GridMessages to FC
* components: Add maxAllowedPhi attribute to User
* components: Add phiProtected to QueryColumn
