### PR TITLE
Issue 42598: FileTree component styling fixes for font family, text color, and node display for wide text

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.21.0",
+  "version": "2.21.0-fb-fileTreeStyling42598.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.21.0-fb-fileTreeStyling42598.1",
+  "version": "2.21.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.21.0-fb-fileTreeStyling42598.0",
+  "version": "2.21.0-fb-fileTreeStyling42598.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.21.0
 *Released*: 2 April 2021
 * Issue 42598: FileTree component styling fixes for font family, text color, and node display for wide text
+* Ontology search input - cancel form submit on enter key to prevent page reload
 
 ### version 2.21.0
 *Released*: 2 April 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.21.0
-*Released*: 2 April 2021
+### version 2.21.1
+*Released*: 5 April 2021
 * Issue 42598: FileTree component styling fixes for font family, text color, and node display for wide text
 * Ontology search input - cancel form submit on enter key to prevent page reload
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,6 +3,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.21.0
 *Released*: 2 April 2021
+* Issue 42598: FileTree component styling fixes for font family, text color, and node display for wide text
+
+### version 2.21.0
+*Released*: 2 April 2021
 * Add support for uniqueId (barcode) fields
     * Add Concept URI for unique Id fields.
     * In EntityInsertPanel, add placeholder text for generated Ids and make them read-only

--- a/packages/components/src/internal/components/files/FileTree.tsx
+++ b/packages/components/src/internal/components/files/FileTree.tsx
@@ -8,7 +8,7 @@ import { faFolder, faFileAlt, faFolderOpen } from '@fortawesome/free-solid-svg-i
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
-const fileTree_color = '#777';
+const fileTree_color = '#333'; // $text-color
 const customStyle: TreeTheme = {
     tree: {
         base: {
@@ -17,7 +17,7 @@ const customStyle: TreeTheme = {
             margin: 0,
             padding: 0,
             color: fileTree_color,
-            fontFamily: 'lucida grande ,tahoma,verdana,arial,sans-serif',
+            fontFamily: 'Roboto, Helvetica Neue, Helvetica, Arial, sans-serif', // $font-family-sans-serif
             fontSize: '14px',
         },
         node: {
@@ -29,6 +29,7 @@ const customStyle: TreeTheme = {
                 position: 'relative',
                 padding: '0px 5px',
                 display: 'flex',
+                width: 'fit-content',
             },
             activeLink: {
                 borderRadius: '5px',

--- a/packages/components/src/internal/components/files/__snapshots__/FileTree.spec.tsx.snap
+++ b/packages/components/src/internal/components/files/__snapshots__/FileTree.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`FileTree with data 1`] = `
   className="filetree-container"
 >
   <ul
-    className="css-utoqxu"
+    className="css-1fcb9io"
   >
     <li
       className="css-79elbk"
@@ -19,6 +19,7 @@ exports[`FileTree with data 1`] = `
             "display": "flex",
             "padding": "0px 5px",
             "position": "relative",
+            "width": "fit-content",
           }
         }
       >
@@ -33,7 +34,7 @@ exports[`FileTree with data 1`] = `
               width={10}
             >
               <polygon
-                className="css-l0fi0l"
+                className="css-1gdmwl6"
                 points="0,0 0,10 10,5"
               />
             </svg>
@@ -61,7 +62,7 @@ exports[`FileTree with data 1`] = `
           <div
             style={
               Object {
-                "color": "#777",
+                "color": "#333",
                 "display": "inline-block",
                 "verticalAlign": "top",
               }
@@ -120,6 +121,7 @@ exports[`FileTree with data 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -134,7 +136,7 @@ exports[`FileTree with data 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -162,7 +164,7 @@ exports[`FileTree with data 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }
@@ -219,6 +221,7 @@ exports[`FileTree with data 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -233,7 +236,7 @@ exports[`FileTree with data 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -261,7 +264,7 @@ exports[`FileTree with data 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }
@@ -318,6 +321,7 @@ exports[`FileTree with data 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -332,7 +336,7 @@ exports[`FileTree with data 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -360,7 +364,7 @@ exports[`FileTree with data 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }
@@ -417,6 +421,7 @@ exports[`FileTree with data 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -431,7 +436,7 @@ exports[`FileTree with data 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -459,7 +464,7 @@ exports[`FileTree with data 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }
@@ -517,7 +522,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
   className="filetree-container"
 >
   <ul
-    className="css-utoqxu"
+    className="css-1fcb9io"
   >
     <li
       className="css-79elbk"
@@ -531,6 +536,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
             "display": "flex",
             "padding": "0px 5px",
             "position": "relative",
+            "width": "fit-content",
           }
         }
       >
@@ -545,7 +551,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
               width={10}
             >
               <polygon
-                className="css-l0fi0l"
+                className="css-1gdmwl6"
                 points="0,0 0,10 10,5"
               />
             </svg>
@@ -557,7 +563,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
           <div
             style={
               Object {
-                "color": "#777",
+                "color": "#333",
                 "display": "inline-block",
                 "verticalAlign": "top",
               }
@@ -618,6 +624,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -632,7 +639,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -644,7 +651,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }
@@ -701,6 +708,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -715,7 +723,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -727,7 +735,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }
@@ -784,6 +792,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -798,7 +807,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -810,7 +819,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }
@@ -867,6 +876,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                   "display": "flex",
                   "padding": "0px 5px",
                   "position": "relative",
+                  "width": "fit-content",
                 }
               }
             >
@@ -881,7 +891,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                     width={10}
                   >
                     <polygon
-                      className="css-l0fi0l"
+                      className="css-1gdmwl6"
                       points="0,0 0,10 10,5"
                     />
                   </svg>
@@ -893,7 +903,7 @@ exports[`FileTree with data allowMultiSelect false 1`] = `
                 <div
                   style={
                     Object {
-                      "color": "#777",
+                      "color": "#333",
                       "display": "inline-block",
                       "verticalAlign": "top",
                     }

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -80,9 +80,15 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
         [searchPathClickHandler]
     );
 
+    // cancel form submit since we are just using the input for the search menu display
+    const onSubmit = useCallback((evt) => {
+        evt.preventDefault();
+        return false;
+    }, []);
+
     return (
         <div className="concept-search-container">
-            <form autoComplete="off">
+            <form autoComplete="off" onSubmit={onSubmit}>
                 <input
                     type="text"
                     className="form-control"

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -81,7 +81,7 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
     );
 
     // cancel form submit since we are just using the input for the search menu display
-    const onSubmit = useCallback((evt) => {
+    const onSubmit = useCallback(evt => {
         evt.preventDefault();
         return false;
     }, []);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42598

Matt noticed that the default text font family and color used in the nodes of the FileTree component do not use the standard values used in the ui-components variables. This PR updates those to use Roboto and the #333 text color. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/491
* https://github.com/LabKey/ontology/pull/30
* https://github.com/LabKey/provenance/pull/61
* https://github.com/LabKey/moduleEditor/pull/34

#### Changes
* FileTree styling update to use Roboto font family and the #333 text color to match values from variables.scss
* FileTree fix for node display for wide text so that it isn't scrunched with the expand/collapse icon
