### PR TITLE
QuerySelect: pass containerPath to getQueryDetails

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.22.3-fb-hjf-sample-request.0",
+  "version": "2.22.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.22.2",
+  "version": "2.22.3-fb-hjf-sample-request.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.##.#
-*Released*: # April 2021
+### version 2.22.3
+*Released*: 9 April 2021
 * Pass already supplied `containerPath` to `getQueryDetails()` for fetching underlying metadata for `<QuerySelect />`.
 
 ### version 2.22.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.##.#
+*Released*: # April 2021
+* Pass already supplied `containerPath` to `getQueryDetails()` for fetching underlying metadata for `<QuerySelect />`.
+
 ### version 2.22.2
 *Released*: 9 April 2021
 * Add showImportDataButton, showInsertNewButton and isFiltered to QueryModel

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -61,7 +61,9 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
         const { componentId, schemaQuery, containerPath } = props;
 
         if (schemaQuery) {
-            getQueryDetails(schemaQuery)
+            const { queryName, schemaName } = schemaQuery;
+
+            getQueryDetails({ schemaName, queryName, containerPath })
                 .then(queryInfo => {
                     const valueColumn = initValueColumn(queryInfo, props.valueColumn);
                     const displayColumn = initDisplayColumn(queryInfo, props.displayColumn);
@@ -89,8 +91,8 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
 
                         selectRows({
                             containerPath,
-                            schemaName: schemaQuery.schemaName,
-                            queryName: schemaQuery.queryName,
+                            schemaName,
+                            queryName,
                             filterArray: [filter],
                         }).then(data => {
                             const { componentId } = props;


### PR DESCRIPTION
#### Rationale
`<QuerySelect />` fetches the underlying `QueryInfo` for the query it is associated with. It already supported a `containerPath` argument but was only passing this through to the underlying `selectRows` call. This aligns the request for the `QueryInfo` with the request for underlying data to the same container path.

#### Related Pull Requests
* https://github.com/LabKey/hjfSampleRequests/pull/1

#### Changes
* Pass already supplied `containerPath` to `getQueryDetails()` for fetching underlying metadata for `<QuerySelect />`.
