### PR TITLE
QueryColumn: expose dimension, measure properties

### DIFF
--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -27,6 +27,10 @@ Components, models, actions, and utility functions for LabKey applications and p
     * Don't show file inputType columns in editable grid or add/update bulk forms
     * Better handling for error messages from virus file detection response
 
+### version 2.22.6
+*Released*: 12 April 2021
+* QueryColumn: expose dimension, measure properties
+
 ### version 2.22.5
 *Released*: 12 April 2021
 * Issue 42475: Add file image to data class details page

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -38,7 +38,7 @@ export class QueryColumn extends Record({
     // defaultScale: undefined,
     defaultValue: null,
     description: undefined,
-    // dimension: undefined,
+    dimension: undefined,
     displayAsLookup: undefined,
     // excludeFromShifting: undefined,
     // ext: undefined,
@@ -62,7 +62,7 @@ export class QueryColumn extends Record({
     jsonType: undefined,
     // keyField: undefined,
     lookup: undefined,
-    // measure: undefined,
+    measure: undefined,
     multiValue: false,
     // mvEnabled: undefined,
     name: undefined,
@@ -102,7 +102,7 @@ export class QueryColumn extends Record({
     // declare defaultScale: string;
     declare defaultValue: any;
     declare description: string;
-    // declare dimension: boolean;
+    declare dimension: boolean;
     declare displayAsLookup: boolean;
     // declare excludeFromShifting: boolean;
     // declare ext: any;
@@ -126,7 +126,7 @@ export class QueryColumn extends Record({
     declare jsonType: string;
     // declare keyField: boolean;
     declare lookup: QueryLookup;
-    // declare measure: boolean;
+    declare measure: boolean;
     declare multiValue: boolean;
     // declare mvEnabled: boolean;
     declare name: string;


### PR DESCRIPTION
#### Rationale
Expose `dimension` and `measure` properties on `QueryColumn`. These are already being passed from the server to just commenting them in on the client to allow access.

#### Related Pull Requests
* https://github.com/LabKey/hjfSampleRequests/pull/4

#### Changes
* Comment in `dimension` and `measure` properties on `QueryColumn`.
