### PR TITLE
Issue42527: Summary View 'isPrimaryKey' column 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.23.0-fb-issue42527-1.0",
+  "version": "2.23.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.22.5",
+  "version": "2.22.5-fb-issue42527-1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.23.1
+*Released*: 15 April 2021
 * Issue 42527: Support 'Is Primary Key' column for Summary View
 
 ### version 2.23.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42527: Support 'Is Primary Key' column for Summary View
+
 ### version 2.22.5
 *Released*: 12 April 2021
 * Issue 42475: Add file image to data class details page

--- a/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
@@ -959,5 +959,20 @@ describe('DomainForm', () => {
         expect(form.find('.domain-field-row').length).toEqual(0);
         expect(form.find('.table-responsive').length).toEqual(1);
         expect(form.find('.domain-field-toolbar').length).toEqual(2);
+        expect(form.text()).not.toContain("Is Primary Key");
+    });
+
+    test('with summaryViewMode isPrimaryKey column', () => {
+        const fields = [];
+        fields.push({ name: 'Field0' });
+        fields.push({ name: 'Field1' });
+        fields.push({ name: 'Field2' });
+
+        // 'Is Primary Key' column should only render on List domains
+        const domain = DomainDesign.create({ fields, domainKindName:'VarList' });
+        const form = mount(<DomainFormImpl domain={domain} onChange={jest.fn()} testMode={true} />);
+        form.setState({ summaryViewMode: true });
+
+        expect(form.text()).toContain("Is Primary Key");
     });
 });

--- a/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
@@ -45,6 +45,7 @@ import {
 import { clearFieldDetails, createFormInputId, updateDomainField } from './actions';
 
 import { DomainRow } from './DomainRow';
+import { INT_LIST } from './list/constants';
 
 beforeAll(() => {
     initUnitTestMocks();
@@ -959,20 +960,33 @@ describe('DomainForm', () => {
         expect(form.find('.domain-field-row').length).toEqual(0);
         expect(form.find('.table-responsive').length).toEqual(1);
         expect(form.find('.domain-field-toolbar').length).toEqual(2);
-        expect(form.text()).not.toContain("Is Primary Key");
+        expect(form.text()).not.toContain('Is Primary Key');
     });
 
-    test('with summaryViewMode isPrimaryKey column', () => {
+    // 'Is Primary Key' column should only render on List domains
+    test('with summaryViewMode isPrimaryKey column, VarList', () => {
         const fields = [];
         fields.push({ name: 'Field0' });
         fields.push({ name: 'Field1' });
         fields.push({ name: 'Field2' });
 
-        // 'Is Primary Key' column should only render on List domains
-        const domain = DomainDesign.create({ fields, domainKindName:'VarList' });
+        const domain = DomainDesign.create({ fields, domainKindName: 'VarList' });
         const form = mount(<DomainFormImpl domain={domain} onChange={jest.fn()} testMode={true} />);
         form.setState({ summaryViewMode: true });
 
-        expect(form.text()).toContain("Is Primary Key");
+        expect(form.text()).toContain('Is Primary Key');
+    });
+
+    test('with summaryViewMode isPrimaryKey column, IntList', () => {
+        const fields = [];
+        fields.push({ name: 'Field0' });
+        fields.push({ name: 'Field1' });
+        fields.push({ name: 'Field2' });
+
+        const domain = DomainDesign.create({ fields, domainKindName: INT_LIST });
+        const form = mount(<DomainFormImpl domain={domain} onChange={jest.fn()} testMode={true} />);
+        form.setState({ summaryViewMode: true });
+
+        expect(form.text()).toContain('Is Primary Key');
     });
 });

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
@@ -41,8 +41,6 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
         const { domainKindName } = domain;
         const gridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
-        console.log(domain.toJS());
-
         // TODO: Maintain hash of fieldIndex : gridIndex on state in order to make delete and filter run in N rather than N^2 time.
         this.state = {
             gridData,

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesGrid.tsx
@@ -41,6 +41,8 @@ export class DomainPropertiesGrid extends React.PureComponent<DomainPropertiesGr
         const { domainKindName } = domain;
         const gridData = domain.getGridData(appPropertiesOnly, hasOntologyModule);
 
+        console.log(domain.toJS());
+
         // TODO: Maintain hash of fieldIndex : gridIndex on state in order to make delete and filter run in N rather than N^2 time.
         this.state = {
             gridData,

--- a/packages/components/src/internal/components/domainproperties/list/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/list/actions.ts
@@ -16,7 +16,7 @@
 import { ActionURL, Ajax, Utils, Domain, getServerContext } from '@labkey/api';
 
 import { ListModel } from './models';
-import {INT_LIST} from "./constants";
+import { INT_LIST } from './constants';
 
 function getListProperties(listId?: number): Promise<ListModel> {
     return new Promise((resolve, reject) => {

--- a/packages/components/src/internal/components/domainproperties/list/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/list/actions.ts
@@ -16,6 +16,7 @@
 import { ActionURL, Ajax, Utils, Domain, getServerContext } from '@labkey/api';
 
 import { ListModel } from './models';
+import {INT_LIST} from "./constants";
 
 function getListProperties(listId?: number): Promise<ListModel> {
     return new Promise((resolve, reject) => {
@@ -43,7 +44,7 @@ export function fetchListDesign(listId?: number): Promise<ListModel> {
                 Domain.getDomainDetails({
                     containerPath: getServerContext().container.path,
                     domainId: model.domainId,
-                    domainKind: listId === undefined ? 'IntList' : undefined, // NOTE there is also a VarList domain kind but for this purpose either will work
+                    domainKind: listId === undefined ? INT_LIST : undefined, // NOTE there is also a VarList domain kind but for this purpose either will work
                     success: data => {
                         resolve(ListModel.create(data));
                     },

--- a/packages/components/src/internal/components/domainproperties/list/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/list/constants.ts
@@ -8,5 +8,5 @@ export const DISCUSSION_LINKS_TIP =
     'Optionally allow one or more discussion links to be shown on the details view of each list item.';
 export const SEARCH_INDEXING_TIP = 'Controls how this list is indexed for search within LabKey Server.';
 
-export const VAR_LIST = "VarList";
-export const INT_LIST = "IntList";
+export const VAR_LIST = 'VarList';
+export const INT_LIST = 'IntList';

--- a/packages/components/src/internal/components/domainproperties/list/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/list/constants.ts
@@ -7,3 +7,6 @@ export const CUSTOM_TEMPLATE_TIP = 'Example: ${Key} ${value}';
 export const DISCUSSION_LINKS_TIP =
     'Optionally allow one or more discussion links to be shown on the details view of each list item.';
 export const SEARCH_INDEXING_TIP = 'Controls how this list is indexed for search within LabKey Server.';
+
+export const VAR_LIST = "VarList";
+export const INT_LIST = "IntList";

--- a/packages/components/src/internal/components/domainproperties/list/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/list/models.spec.ts
@@ -4,7 +4,7 @@ import getDomainDetailsJSON from '../../../../test/data/list-getDomainDetails.js
 import { DomainField } from '../models';
 
 import { ListModel } from './models';
-import {INT_LIST, VAR_LIST} from "./constants";
+import { INT_LIST, VAR_LIST } from './constants';
 
 // Minimal domain object mock
 const domainDesign = { fields: [{ name: 'PK', isPrimaryKey: true }] };

--- a/packages/components/src/internal/components/domainproperties/list/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/list/models.spec.ts
@@ -4,6 +4,7 @@ import getDomainDetailsJSON from '../../../../test/data/list-getDomainDetails.js
 import { DomainField } from '../models';
 
 import { ListModel } from './models';
+import {INT_LIST, VAR_LIST} from "./constants";
 
 // Minimal domain object mock
 const domainDesign = { fields: [{ name: 'PK', isPrimaryKey: true }] };
@@ -60,11 +61,11 @@ describe('ListModel', () => {
     });
 
     test('getDomainKind', () => {
-        expect(ListModel.create({ options: { keyType: 'Varchar' }, domainDesign }).getDomainKind()).toEqual('VarList');
-        expect(ListModel.create({ options: { keyType: 'Integer' }, domainDesign }).getDomainKind()).toEqual('IntList');
+        expect(ListModel.create({ options: { keyType: 'Varchar' }, domainDesign }).getDomainKind()).toEqual(VAR_LIST);
+        expect(ListModel.create({ options: { keyType: 'Integer' }, domainDesign }).getDomainKind()).toEqual(INT_LIST);
         expect(
             ListModel.create({ options: { keyType: 'AutoIncrementInteger' }, domainDesign }).getDomainKind()
-        ).toEqual('IntList');
+        ).toEqual(INT_LIST);
         expect(ListModel.create({ options: { keyType: undefined }, domainDesign }).getDomainKind()).toBeFalsy();
     });
 

--- a/packages/components/src/internal/components/domainproperties/list/models.ts
+++ b/packages/components/src/internal/components/domainproperties/list/models.ts
@@ -17,6 +17,7 @@ import { Record } from 'immutable';
 
 import { DomainDesign, DomainField } from '../models';
 import { DOMAIN_FIELD_PRIMARY_KEY_LOCKED } from '../constants';
+import {INT_LIST, VAR_LIST} from "./constants";
 
 export interface AdvancedSettingsForm {
     titleColumn?: string;
@@ -120,9 +121,9 @@ export class ListModel extends Record({
 
     getDomainKind(): string {
         if (this.keyType === 'Varchar') {
-            return 'VarList';
+            return VAR_LIST;
         } else if (this.keyType === 'Integer' || this.keyType === 'AutoIncrementInteger') {
-            return 'IntList';
+            return INT_LIST;
         }
 
         return undefined;

--- a/packages/components/src/internal/components/domainproperties/list/models.ts
+++ b/packages/components/src/internal/components/domainproperties/list/models.ts
@@ -17,7 +17,8 @@ import { Record } from 'immutable';
 
 import { DomainDesign, DomainField } from '../models';
 import { DOMAIN_FIELD_PRIMARY_KEY_LOCKED } from '../constants';
-import {INT_LIST, VAR_LIST} from "./constants";
+
+import { INT_LIST, VAR_LIST } from './constants';
 
 export interface AdvancedSettingsForm {
     titleColumn?: string;

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -425,7 +425,7 @@ export class DomainDesign
         if (appPropertiesOnly) {
             columns = removeNonAppProperties(columns);
         }
-        if (domainKindName !== 'List') {
+        if (domainKindName !== 'VarList' && domainKindName !== 'IntList') {
             delete columns.isPrimaryKey;
         }
 

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -71,6 +71,7 @@ import {
     removeUnusedProperties,
     reorderSummaryColumns,
 } from './propertiesUtil';
+import { INT_LIST, VAR_LIST } from './list/constants';
 
 export interface IFieldChange {
     id: string;
@@ -425,7 +426,7 @@ export class DomainDesign
         if (appPropertiesOnly) {
             columns = removeNonAppProperties(columns);
         }
-        if (domainKindName !== 'VarList' && domainKindName !== 'IntList') {
+        if (domainKindName !== VAR_LIST && domainKindName !== INT_LIST) {
             delete columns.isPrimaryKey;
         }
 


### PR DESCRIPTION
#### Rationale
Display the 'Is Primary Key' column only for List Domain Designers within Summary View.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2177
* https://github.com/LabKey/sampleManagement/pull/547
* https://github.com/LabKey/biologics/pull/855

#### Changes
* Update test
* Check for domainKindName indicating domain is a list
