### PR TITLE
Issue 42872: Better import and export handling for field names with special characters

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.22.5",
+  "version": "2.22.6-importExportFields.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.23.3-importExportFields.2",
+  "version": "2.23.3-importExportFields.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.23.3-importExportFields.1",
+  "version": "2.23.3-importExportFields.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.24.4-importExportFields.6",
+  "version": "2.24.4-importExportFields.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.24.4-importExportFields.5",
+  "version": "2.24.4-importExportFields.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42872: Handle field names with special characters in grids and forms better.
+
 ### version 2.22.5
 *Released*: 12 April 2021
 * Issue 42475: Add file image to data class details page

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -39,7 +39,7 @@ export const DEFAULT_SAMPLE_FIELD_CONFIG = {
     lookupSchema: 'exp',
     lookupQuery: 'Materials',
     lookupType: { ...SAMPLE_TYPE },
-    name: 'SampleId',
+    name: 'SampleID',
 } as Partial<IDomainField>;
 
 const NEW_SAMPLE_SET_OPTION: IParentOption = {

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -1085,7 +1085,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
             "conceptURI": "http://www.labkey.org/exp/xml#sample",
           },
         },
-        "name": "SampleId",
+        "name": "SampleID",
         "rangeURI": "http://www.w3.org/2001/XMLSchema#int",
         "required": true,
       }

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -256,7 +256,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                         loadOnFocus
                                         maxRows={10}
                                         multiple={multiple}
-                                        name={col.name}
+                                        name={col.fieldKey}
                                         onQSChange={this.onQSChange}
                                         placeholder="Select or type to search..."
                                         preLoad

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -140,7 +140,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
                                             <tr key={key}>
                                                 <td>{field.titleRenderer}</td>
                                                 <td data-caption={field.title} data-fieldkey={field.fieldKey}>
-                                                    {field.renderer(newRow.get(decodePart(key)), row)}
+                                                    {field.renderer(newRow.get(decodePart(key)) ?? newRow.get(key), row)}
                                                 </td>
                                             </tr>
                                         );

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -11,6 +11,7 @@ import {
     resolveDetailRenderer,
     titleRenderer as defaultTitleRenderer,
 } from './DetailEditRenderer';
+import { decodePart } from '../../../../public/SchemaQuery';
 
 export type Renderer = (data: any, row?: any) => ReactNode;
 
@@ -139,7 +140,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
                                             <tr key={key}>
                                                 <td>{field.titleRenderer}</td>
                                                 <td data-caption={field.title} data-fieldkey={field.fieldKey}>
-                                                    {field.renderer(newRow.get(key), row)}
+                                                    {field.renderer(newRow.get(decodePart(key)), row)}
                                                 </td>
                                             </tr>
                                         );

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.spec.tsx
@@ -58,6 +58,7 @@ describe('resolveDetailEditRenderer', () => {
 
     const default_props = {
         name: 'test',
+        fieldKey: 'test',
         caption: 'test',
         readOnly: false,
         userEditable: true,

--- a/packages/components/src/internal/components/forms/input/AliasInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.tsx
@@ -49,7 +49,7 @@ export class AliasInput extends Component<AliasInputProps> {
                 label={col.caption}
                 required={col.required}
                 multiple={true}
-                name={col.name}
+                name={col.fieldKey}
                 noResultsText="Enter alias name(s)"
                 placeholder="Enter alias name(s)"
                 promptTextCreator={(text: string) => `Create alias "${text}"`}

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -103,7 +103,7 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
                         label={label}
                         labelOverlayProps={{
                             isFormsy: false,
-                            inputId: queryColumn.name,
+                            inputId: queryColumn.fieldKey,
                             addLabelAsterisk,
                         }}
                         showLabel={showLabel}
@@ -118,7 +118,7 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
                 <div className="col-sm-9 col-xs-12">
                     <input
                         disabled={this.state.isDisabled}
-                        name={name ?? queryColumn.name}
+                        name={name ?? queryColumn.fieldKey}
                         required={queryColumn.required}
                         type="checkbox"
                         value={this.props.formsy ? this.props.getValue() : this.state.checked}

--- a/packages/components/src/internal/components/forms/input/DateInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DateInput.tsx
@@ -74,7 +74,7 @@ export class DateInput extends DisableableInput<DateInputProps, any> {
             changeDebounceInterval,
             elementWrapperClassName,
             labelClassName,
-            name: name ? name : queryColumn.name,
+            name: name ? name : queryColumn.fieldKey,
             onChange,
             placeholder: datePlaceholder(queryColumn),
             queryColumn,

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -175,8 +175,8 @@ class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, DatePic
                         wrapperClassName={inputWrapperClassName}
                         className={inputClassName}
                         isClearable={isClearable}
-                        name={name ? name : queryColumn.name}
-                        id={queryColumn.name}
+                        name={name ? name : queryColumn.fieldKey}
+                        id={queryColumn.fieldKey}
                         disabled={isDisabled}
                         selected={selectedDate}
                         onChange={this.onChange}

--- a/packages/components/src/internal/components/forms/input/LookupSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/LookupSelectInput.tsx
@@ -166,7 +166,7 @@ export class LookupSelectInput extends React.PureComponent<OwnProps, StateProps>
                 id,
                 label: <LabelOverlay column={queryColumn} inputId={id} isFormsy={false} />,
                 multiple,
-                name: queryColumn.name,
+                name: queryColumn.fieldKey,
                 required: queryColumn.required,
             },
             this.props,

--- a/packages/components/src/internal/components/forms/input/RadioGroupInput.tsx
+++ b/packages/components/src/internal/components/forms/input/RadioGroupInput.tsx
@@ -57,7 +57,7 @@ class RadioGroupInputImpl extends PureComponent<Props, State> {
     }
 
     render() : ReactNode {
-        const { options } = this.props;
+        const { options, name } = this.props;
         const { selectedValue } = this.state;
         let inputs = [];
 
@@ -69,7 +69,7 @@ class RadioGroupInputImpl extends PureComponent<Props, State> {
                             hidden={true}
                             checked={true}
                             type="radio"
-                            name="creationType"
+                            name={name}
                             value={options[0].value}
                             onChange={this.onValueChange}
                         />
@@ -85,7 +85,7 @@ class RadioGroupInputImpl extends PureComponent<Props, State> {
                                 checked={selected && !option.disabled}
                                 className={""}
                                 type="radio"
-                                name="creationType"
+                                name={name}
                                 value={option.value}
                                 onChange={this.onValueChange}
                                 disabled={option.disabled}

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -103,11 +103,11 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
                 onChange={this.onChange}
                 cols={cols}
                 elementWrapperClassName={elementWrapperClassName}
-                id={queryColumn.name}
+                id={queryColumn.fieldKey}
                 label={this.renderLabel()}
                 labelClassName={labelClassName}
                 placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
-                name={name ? name : queryColumn.name}
+                name={name ? name : queryColumn.fieldKey}
                 rowClassName={rowClassName}
                 rows={rows}
                 required={queryColumn.required}

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -148,10 +148,10 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
                 disabled={this.state.isDisabled}
                 changeDebounceInterval={changeDebounceInterval}
                 elementWrapperClassName={elementWrapperClassName}
-                id={queryColumn.name}
+                id={queryColumn.fieldKey}
                 label={this.renderLabel()}
                 labelClassName={labelClassName}
-                name={name ? name : queryColumn.name}
+                name={name ? name : queryColumn.fieldKey}
                 onChange={this.onChange}
                 placeholder={placeholder || `Enter ${queryColumn.caption.toLowerCase()}`}
                 required={queryColumn.required}

--- a/packages/components/src/internal/components/omnibox/actions/Filter.spec.tsx
+++ b/packages/components/src/internal/components/omnibox/actions/Filter.spec.tsx
@@ -26,7 +26,7 @@ import mixturesQuery from '../../../../test/data/mixtures-getQuery.json';
 import { initUnitTests, makeQueryInfo, makeTestData } from '../../../testHelpers';
 
 import { FilterAction, getURLSuffix } from './Filter';
-import { ActionOption, Value } from './Action';
+import { ActionOption, ActionValue, Value } from './Action';
 
 let queryInfo: QueryInfo;
 let getColumns: () => List<QueryColumn>;
@@ -163,6 +163,38 @@ describe('FilterAction::completeAction', () => {
                 expectFilter(expectedFilter, value.param);
             }),
         ]);
+    });
+});
+
+describe("FilterAction::actionValueFromFilter", () => {
+    let action;
+    const urlPrefix = undefined;
+
+    beforeEach(() => {
+        // needs to be in beforeEach so it gets instantiated after beforeAll
+        action = new FilterAction(urlPrefix, getColumns);
+    });
+
+    // TODO add tests for various value options
+    test("no label, unencoded column", () => {
+        const filter = Filter.create('colName', '10', Filter.Types.EQUAL);
+        const value: ActionValue = action.actionValueFromFilter(filter);
+        expect(value.displayValue).toBe('colName = 10');
+        expect(value.value).toBe('\"colName\" = 10');
+    });
+
+    test("no label, encoded column", () => {
+        const filter = Filter.create('U mg$SL', '10', Filter.Types.EQUAL);
+        const value: ActionValue = action.actionValueFromFilter(filter);
+        expect(value.displayValue).toBe('U mg/L = 10');
+        expect(value.value).toBe('\"U mg$SL\" = 10');
+    });
+
+    test("with label", () => {
+        const filter = Filter.create('U mgS$L', 'x', Filter.Types.EQUAL);
+        const value: ActionValue = action.actionValueFromFilter(filter, "otherLabel");
+        expect(value.displayValue).toBe('otherLabel = x');
+        expect(value.value).toBe('\"otherLabel\" = x');
     });
 });
 

--- a/packages/components/src/internal/components/omnibox/actions/Filter.ts
+++ b/packages/components/src/internal/components/omnibox/actions/Filter.ts
@@ -21,6 +21,7 @@ import { QueryColumn, QueryInfo } from '../../../..';
 import { parseColumns, resolveFieldKey } from '../utils';
 
 import { Action, ActionOption, ActionValue, Value } from './Action';
+import { decodePart } from '../../../../public/SchemaQuery';
 
 /**
  * The following section prepares the SYMBOL_MAP and SUFFIX_MAP to allow any Filter Action instances
@@ -446,7 +447,7 @@ export class FilterAction implements Action {
         let isReadOnly = false;
 
         let value: string, inputValue: string;
-        const displayParts = [columnName, resolveSymbol(filterType)];
+        const displayParts = [decodePart(columnName), resolveSymbol(filterType)];
         const inputDisplayParts = [`"${displayParts[0]}"`, displayParts[1]]; // need to quote column name for input display
 
         if (!filterType.isDataValueRequired()) {

--- a/packages/components/src/internal/components/omnibox/actions/Sort.spec.tsx
+++ b/packages/components/src/internal/components/omnibox/actions/Sort.spec.tsx
@@ -45,7 +45,6 @@ describe("SortAction::parseParam", () => {
             param: '-name',
             value: 'name desc'
         });
-        // verify(values[0], 'Name', '-name', 'name desc');
     });
 
     test("unencoded value, ASC", () => {

--- a/packages/components/src/internal/components/omnibox/actions/Sort.spec.tsx
+++ b/packages/components/src/internal/components/omnibox/actions/Sort.spec.tsx
@@ -1,0 +1,125 @@
+import { FilterAction } from './Filter';
+import { Filter } from '@labkey/api';
+import { ActionValue, Value } from './Action';
+import { QueryInfo } from '../../../../public/QueryInfo';
+import { fromJS, List } from 'immutable';
+import { QueryColumn } from '../../../../public/QueryColumn';
+import { initUnitTests, makeQueryInfo, makeTestData } from '../../../testHelpers';
+import mixturesQuery from '../../../../test/data/mixtures-getQuery.json';
+import mixturesQueryInfo from '../../../../test/data/mixtures-getQueryDetails.json';
+import { QueryGridModel } from '../../../QueryGridModel';
+import { SortAction } from './Sort';
+import { QuerySort } from '../../../../public/QuerySort';
+
+
+let queryInfo: QueryInfo;
+let getColumns: () => List<QueryColumn>;
+
+beforeAll(() => {
+    initUnitTests();
+    const mockData = makeTestData(mixturesQuery);
+    queryInfo = makeQueryInfo(mixturesQueryInfo);
+    const model = new QueryGridModel({
+        queryInfo,
+        messages: fromJS(mockData.messages),
+        data: fromJS(mockData.rows),
+        dataIds: fromJS(mockData.orderedRows),
+        totalRows: mockData.rowCount,
+    });
+    getColumns = (all?) => (all ? model.getAllColumns() : model.getDisplayColumns());
+});
+
+describe("SortAction::parseParam", () => {
+    let action;
+
+    beforeEach(() => {
+        // needs to be in beforeEach so it gets instantiated after beforeAll
+        action = new SortAction(undefined, getColumns);
+    });
+
+    test("unencoded value, DESC", () => {
+        const values = action.parseParam("ignored", "-name", getColumns());
+        expect(values).toHaveLength(1);
+        expect(values[0]).toMatchObject({
+            displayValue: 'Name',
+            param: '-name',
+            value: 'name desc'
+        });
+        // verify(values[0], 'Name', '-name', 'name desc');
+    });
+
+    test("unencoded value, ASC", () => {
+        const values = action.parseParam("ignored", "Name", getColumns());
+        expect(values).toHaveLength(1);
+        expect(values[0]).toMatchObject({
+            displayValue: 'Name',
+            param: 'Name',
+            value: 'Name asc'
+        });
+    });
+
+    test("encoded value, DESC", () => {
+        const values = action.parseParam("ignored", "-Measure u$SL", getColumns());
+        expect(values).toHaveLength(1);
+        expect(values[0]).toMatchObject({
+            displayValue: 'Measure u/L',
+            param: '-Measure u/L',
+            value: 'Measure u/L desc'
+        })
+    });
+
+    test("encoded value, ASC", () => {
+        const values = action.parseParam("ignored", "Name u$SL", getColumns());
+        expect(values).toHaveLength(1);
+        expect(values[0]).toMatchObject( {
+            displayValue: 'Name u/L',
+            param: 'Name u/L',
+            value: 'Name u/L asc'
+        })
+    });
+});
+
+describe("SortAction::actionValueFromSort", () => {
+    let action;
+
+    beforeEach(() => {
+        // needs to be in beforeEach so it gets instantiated after beforeAll
+        action = new SortAction(undefined, getColumns);
+    });
+
+    test("no label, encoded column", () => {
+        const value: ActionValue = action.actionValueFromSort(
+            {
+                dir: '-',
+                fieldKey: "U m$SLB"
+            }
+        );
+        expect(value).toMatchObject({
+            value: 'U m$SLB DESC',
+            displayValue: 'U m/LB',
+        });
+    });
+
+    test("no label, unencoded column", () => {
+        const value: ActionValue = action.actionValueFromSort(
+            {
+                fieldKey: "Units"
+            }
+        );
+        expect(value).toMatchObject({
+            value: 'Units ASC',
+            displayValue: 'Units',
+        });
+    });
+
+    test("with label", () => {
+        const value: ActionValue = action.actionValueFromSort({
+            fieldKey: "Units"
+        }, 'Labeling'
+        );
+        expect(value).toMatchObject({
+            value: 'Units ASC',
+            displayValue: 'Labeling',
+        });
+    });
+});

--- a/packages/components/src/internal/components/omnibox/actions/Sort.ts
+++ b/packages/components/src/internal/components/omnibox/actions/Sort.ts
@@ -19,6 +19,7 @@ import { parseColumns, resolveFieldKey } from '../utils';
 import { QueryColumn, QuerySort } from '../../../..';
 
 import { Action, ActionOption, ActionValue, Value } from './Action';
+import { decodePart } from '../../../../public/SchemaQuery';
 
 export class SortAction implements Action {
     iconCls = 'sort';
@@ -163,7 +164,7 @@ export class SortAction implements Action {
             raw;
 
         return params.map(param => {
-            raw = param.trim();
+            raw = decodePart(param).trim();
 
             if (raw.length > 0) {
                 dir = raw.indexOf('-') === 0 ? 'DESC' : 'ASC';
@@ -184,7 +185,7 @@ export class SortAction implements Action {
         const { dir, fieldKey } = sort;
         return {
             value: `${fieldKey} ${dir === '-' ? 'DESC' : 'ASC'}`,
-            displayValue: label ?? fieldKey,
+            displayValue: label ?? decodePart(fieldKey),
             valueObject: sort,
             action: this,
         };

--- a/packages/components/src/internal/models.spec.ts
+++ b/packages/components/src/internal/models.spec.ts
@@ -569,7 +569,7 @@ describe('EditorModel', () => {
                         value: 'orange',
                         ignoreMe: 'nothing to see',
                     },
-                    withDisplayValue: {
+                    'withDisplay/Value': {
                         value: 'b',
                         displayValue: 'blue',
                         otherField: 'irrelevant',
@@ -587,7 +587,7 @@ describe('EditorModel', () => {
                         value: 'orangish',
                         ignoreMe: 'nothing to see',
                     },
-                    withDisplayValue: {
+                    'withDisplay/Value': {
                         value: 'b',
                         displayValue: 'black',
                         otherField: 'irrelevant',
@@ -599,18 +599,18 @@ describe('EditorModel', () => {
             });
             const updates = Map<any, any>({
                 withValue: 'purple',
-                withDisplayValue: 'teal',
+                'withDisplay$SValue': 'teal',
             });
             expect(EditorModel.convertQueryDataToEditorData(queryData, updates)).toStrictEqual(
                 Map<string, any>({
                     1: Map<string, any>({
                         withValue: 'purple',
-                        withDisplayValue: 'teal',
+                        withDisplay$SValue: 'teal',
                         doNotChangeMe: 'fred',
                     }),
                     2: Map<string, any>({
                         withValue: 'purple',
-                        withDisplayValue: 'teal',
+                        withDisplay$SValue: 'teal',
                         doNotChangeMe: 'maroon',
                     }),
                 })

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -32,6 +32,7 @@ import { DefaultGridLoader } from './components/GridLoader';
 import { GRID_EDIT_INDEX } from './constants';
 import { IQueryGridModel } from './QueryGridModel';
 import { getDateTimeFormat, parseDate } from './util/Date';
+import { encodePart } from '../public/SchemaQuery';
 
 export function getStateModelId(gridId: string, schemaQuery: SchemaQuery, keyValue?: any): string {
     const parts = [gridId, resolveSchemaQuery(schemaQuery)];
@@ -677,7 +678,9 @@ export class EditorModel
         return data.map(valueMap => {
             const returnMap = valueMap.reduce((m, valueMap, key) => {
                 const editorData = EditorModel.getEditorDataFromQueryValueMap(valueMap);
-                if (editorData !== undefined) return m.set(key, editorData);
+                // data maps have keys that are display names/captions. We need to convert to the
+                // encoded keys used in our filters to match up with values from the forms.
+                if (editorData !== undefined) return m.set(encodePart(key), editorData);
                 else return m;
             }, Map<any, any>());
             return updates ? returnMap.merge(updates) : returnMap;

--- a/packages/components/src/internal/util/utils.spec.ts
+++ b/packages/components/src/internal/util/utils.spec.ts
@@ -332,7 +332,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            AndAgain: {
+            'And/Again': {
                 value: 'again',
             },
             Name: {
@@ -354,7 +354,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            AndAgain: {
+            'And/Again': {
                 value: 'again',
             },
             Name: {
@@ -376,7 +376,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            AndAgain: {
+            'And/Again': {
                 value: 'again',
             },
             Name: {
@@ -398,7 +398,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            AndAgain: {
+            'And/Again': {
                 value: 'again',
             },
             Name: {
@@ -425,7 +425,7 @@ describe('getUpdatedData', () => {
             originalData,
             {
                 Data: 'data1',
-                AndAgain: 'again',
+                'And$SAgain': 'again',
             },
             List<string>(['RowId'])
         );
@@ -438,7 +438,7 @@ describe('getUpdatedData', () => {
             {
                 Value: 'val',
                 Data: 'data1',
-                AndAgain: 'again',
+                'And$SAgain': 'again',
                 Other: 'other3',
             },
             List<string>(['RowId'])
@@ -466,7 +466,7 @@ describe('getUpdatedData', () => {
             {
                 Value: 'val2',
                 Data: 'data2',
-                AndAgain: 'again2',
+                'And$SAgain': 'again2',
                 Other: 'not another',
             },
             List<string>(['RowId'])
@@ -476,28 +476,28 @@ describe('getUpdatedData', () => {
             RowId: 445,
             Value: 'val2',
             Data: 'data2',
-            AndAgain: 'again2',
+            'And/Again': 'again2',
             Other: 'not another',
         });
         expect(updatedData[1]).toStrictEqual({
             RowId: 446,
             Value: 'val2',
             Data: 'data2',
-            AndAgain: 'again2',
+            'And/Again': 'again2',
             Other: 'not another',
         });
         expect(updatedData[2]).toStrictEqual({
             RowId: 447,
             Value: 'val2',
             Data: 'data2',
-            AndAgain: 'again2',
+            'And/Again': 'again2',
             Other: 'not another',
         });
         expect(updatedData[3]).toStrictEqual({
             RowId: 448,
             Value: 'val2',
             Data: 'data2',
-            AndAgain: 'again2',
+            'And/Again': 'again2',
             Other: 'not another',
         });
     });
@@ -507,7 +507,7 @@ describe('getUpdatedData', () => {
             originalData,
             {
                 Value: null,
-                AndAgain: undefined,
+                'And$SAgain': undefined,
                 Other: 'not another',
             },
             List<string>(['RowId'])
@@ -516,23 +516,23 @@ describe('getUpdatedData', () => {
         expect(updatedData[0]).toStrictEqual({
             RowId: 445,
             Value: null,
-            AndAgain: null,
+            'And/Again': null,
             Other: 'not another',
         });
         expect(updatedData[1]).toStrictEqual({
             RowId: 446,
             Value: null,
-            AndAgain: null,
+            'And/Again': null,
             Other: 'not another',
         });
         expect(updatedData[2]).toStrictEqual({
             RowId: 447,
-            AndAgain: null,
+            'And/Again': null,
             Other: 'not another',
         });
         expect(updatedData[3]).toStrictEqual({
             RowId: 448,
-            AndAgain: null,
+            'And/Again': null,
             Other: 'not another',
         });
     });

--- a/packages/components/src/public/QueryColumn.spec.ts
+++ b/packages/components/src/public/QueryColumn.spec.ts
@@ -325,16 +325,28 @@ describe('QueryColumn: Sample Lookup', () => {
 
     test('resolveFieldKey', () => {
         expect(new QueryColumn({}).resolveFieldKey()).toBe(undefined);
-        expect(new QueryColumn({ name: 'name' }).resolveFieldKey()).toBe('name');
-        expect(new QueryColumn({ name: 'name', lookup: { displayColumn: 'displayColumn' } }).resolveFieldKey()).toBe(
+        expect(new QueryColumn({ fieldKey: 'name', name: 'name' }).resolveFieldKey()).toBe('name');
+        expect(new QueryColumn({ fieldKey: 'name$Sslash', name: 'name/slash' }).resolveFieldKey()).toBe('name$Sslash');
+        expect(new QueryColumn({ fieldKey: 'name', name: 'name', lookup: { displayColumn: 'displayColumn' } }).resolveFieldKey()).toBe(
             'name/displayColumn'
+        );
+        expect(new QueryColumn({ fieldKey: 'name$Sslash', name: 'name/slash', lookup: { displayColumn: 'displayColumn' } }).resolveFieldKey()).toBe(
+            'name$Sslash/displayColumn'
         );
         expect(
             new QueryColumn({
+                fieldKey: 'name',
                 name: 'name',
                 lookup: { displayColumn: 'displayColumn1/displayColumn2' },
             }).resolveFieldKey()
         ).toBe('name/displayColumn1$SdisplayColumn2');
+        expect(
+            new QueryColumn({
+                fieldKey: 'name$Sslash',
+                name: 'name/slash',
+                lookup: { displayColumn: 'displayColumn1/displayColumn2' },
+            }).resolveFieldKey()
+        ).toBe('name$Sslash/displayColumn1$SdisplayColumn2');
     });
 });
 

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -253,9 +253,9 @@ export class QueryColumn extends Record({
         let fieldKey: string;
 
         if (this.isLookup()) {
-            fieldKey = [this.name, this.lookup.displayColumn.replace(/\//g, '$S')].join('/');
+            fieldKey = [this.fieldKey, this.lookup.displayColumn.replace(/\//g, '$S')].join('/');
         } else {
-            fieldKey = this.name;
+            fieldKey = this.fieldKey;
         }
 
         return fieldKey;


### PR DESCRIPTION
#### Rationale
Field names may contain slashes and other special characters that require encoding in order for filters and updates to work properly.  In several places we had been using the name of the field, which does not have this encoding applied rather than the fieldKey, which does. 

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/862
* https://github.com/LabKey/sampleManagement/pull/552

#### Changes
* Use fieldKey as the name for various input field types 
* Update OmniBox Actions to properly decode fields for display purposes
* Update EditableGrid handling to account for encoded field keys
