### PR TITLE
Issue 42932: FieldEditorOverlay fix to recognize change to props by looking at row's RowId

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.23.1-fb-freezerLocationDesc42932.0",
+  "version": "2.23.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.23.1",
+  "version": "2.23.1-fb-freezerLocationDesc42932.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42932: FieldEditorOverlay fix to recognize change to props by looking at row's RowId
+
 ### version 2.23.1
 *Released*: 15 April 2021
 * Issue 42527: Support 'Is Primary Key' column for Summary View

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.23.2
+*Released*: 16 April 2021
 * Issue 42932: FieldEditorOverlay fix to recognize change to props by looking at row's RowId
 
 ### version 2.23.1

--- a/packages/components/src/internal/components/forms/FieldEditorOverlay.spec.tsx
+++ b/packages/components/src/internal/components/forms/FieldEditorOverlay.spec.tsx
@@ -1,37 +1,48 @@
 import React from 'react';
-import { fromJS } from "immutable";
+import { fromJS, List } from 'immutable';
 
-import { FieldEditorOverlay, QueryColumn, QueryInfo } from '../../..';
 import { mount } from 'enzyme';
 
-const queryInfo = QueryInfo.create({columns: fromJS({
-        description: QueryColumn.create({caption: 'Description', fieldKey: 'Description', inputType: 'textarea'}),
-        value: QueryColumn.create({caption: 'Value', fieldKey: 'Value', inputType: 'number'}),
-        units: QueryColumn.create({caption: 'Units', fieldKey: 'Units', inputType: 'text'})
-    })});
+import { FieldEditorOverlay, QueryColumn, QueryInfo } from '../../..';
+
+const queryInfo = QueryInfo.create({
+    pkCols: List(['RowId']),
+    columns: fromJS({
+        rowid: QueryColumn.create({ caption: 'Row Id', fieldKey: 'RowId', inputType: 'number' }),
+        description: QueryColumn.create({ caption: 'Description', fieldKey: 'Description', inputType: 'textarea' }),
+        value: QueryColumn.create({ caption: 'Value', fieldKey: 'Value', inputType: 'number' }),
+        units: QueryColumn.create({ caption: 'Units', fieldKey: 'Units', inputType: 'text' }),
+    }),
+});
 
 const DATA_ROW = {
-    RowId: {value: 1},
-    Description: {value: 'Test description.'},
-    Value: {value: 1, displayValue: 1},
-    Units: {value: 10, displayValue: "meters"}
+    RowId: { value: 1 },
+    Description: { value: 'Test description.' },
+    Value: { value: 1, displayValue: 1 },
+    Units: { value: 10, displayValue: 'meters' },
 };
 
-
 describe('<FieldEditorOverlay/>', () => {
+    test('getRowId', () => {
+        expect(FieldEditorOverlay.getRowId(undefined, undefined)).toBe(undefined);
+        expect(FieldEditorOverlay.getRowId(queryInfo, undefined)).toBe(undefined);
+        expect(FieldEditorOverlay.getRowId(undefined, DATA_ROW)).toBe(undefined);
+        expect(FieldEditorOverlay.getRowId(new QueryInfo(), DATA_ROW)).toBe(undefined);
+        expect(FieldEditorOverlay.getRowId(queryInfo, DATA_ROW)).toBe(1);
+    });
 
-    test("isLoading", () => {
+    test('isLoading', () => {
         const component = (
             <FieldEditorOverlay
                 queryInfo={queryInfo}
-                fieldProps={[{key: 'Description'}]}
+                fieldProps={[{ key: 'Description' }]}
                 isLoading={true}
                 row={undefined}
                 onUpdate={jest.fn}
             />
         );
         const wrapper = mount(component);
-        expect(wrapper.text()).toBe("");
+        expect(wrapper.text()).toBe('');
         wrapper.unmount();
     });
 
@@ -40,14 +51,14 @@ describe('<FieldEditorOverlay/>', () => {
             <FieldEditorOverlay
                 canUpdate={true}
                 queryInfo={queryInfo}
-                fieldProps={[{key: 'Description'}]}
+                fieldProps={[{ key: 'Description' }]}
                 isLoading={false}
                 row={DATA_ROW}
                 onUpdate={jest.fn}
             />
         );
         const wrapper = mount(component);
-        expect(wrapper.text()).toBe("Test description.");
+        expect(wrapper.text()).toBe('Test description.');
         wrapper.unmount();
     });
 
@@ -55,24 +66,24 @@ describe('<FieldEditorOverlay/>', () => {
         const component = (
             <FieldEditorOverlay
                 queryInfo={queryInfo}
-                fieldProps={[{key: 'Description'}, {key: 'Value'}, {key: 'Units'}]}
-                iconField={'Units'}
+                fieldProps={[{ key: 'Description' }, { key: 'Value' }, { key: 'Units' }]}
+                iconField="Units"
                 isLoading={false}
                 row={DATA_ROW}
                 onUpdate={jest.fn}
             />
         );
         const wrapper = mount(component);
-        expect(wrapper.text()).toBe("meters");
+        expect(wrapper.text()).toBe('meters');
         wrapper.unmount();
     });
 
-    test("do not show iconText", () => {
+    test('do not show iconText', () => {
         const component = (
             <FieldEditorOverlay
                 canUpdate={true}
                 queryInfo={queryInfo}
-                fieldProps={[{key: 'Description'}, {key: 'Value'}]}
+                fieldProps={[{ key: 'Description' }, { key: 'Value' }]}
                 showIconText={false}
                 isLoading={false}
                 row={DATA_ROW}
@@ -80,9 +91,9 @@ describe('<FieldEditorOverlay/>', () => {
             />
         );
         const wrapper = mount(component);
-        expect(wrapper.find(".field-edit__icon").prop("title")).toBe("Edit Description");
-        expect(wrapper.find("span")).toHaveLength(3);
-        expect(wrapper.text()).toBe("");
+        expect(wrapper.find('.field-edit__icon').prop('title')).toBe('Edit Description');
+        expect(wrapper.find('span')).toHaveLength(3);
+        expect(wrapper.text()).toBe('');
         wrapper.unmount();
     });
 
@@ -91,58 +102,64 @@ describe('<FieldEditorOverlay/>', () => {
             <FieldEditorOverlay
                 canUpdate={true}
                 queryInfo={queryInfo}
-                fieldProps={[{key: 'Description'}]}
+                fieldProps={[{ key: 'Description' }]}
                 isLoading={false}
                 row={{}}
                 onUpdate={jest.fn}
             />
         );
         const wrapper = mount(component);
-        expect(wrapper.find(".field-edit__icon").prop("title")).toBe("Edit Description");
-        expect(wrapper.find("span").at(3).text()).toBe("Click to add Description");
+        expect(wrapper.find('.field-edit__icon').prop('title')).toBe('Edit Description');
+        expect(wrapper.find('span').at(3).text()).toBe('Click to add Description');
         wrapper.unmount();
     });
 
     test('custom caption', () => {
-        const component = <FieldEditorOverlay
-            canUpdate={true}
-            queryInfo={queryInfo}
-            fieldProps={[{key: 'Description'}]}
-            isLoading={false}
-            row={DATA_ROW}
-            onUpdate={jest.fn}
-            caption={'storage description'}
-        />;
+        const component = (
+            <FieldEditorOverlay
+                canUpdate={true}
+                queryInfo={queryInfo}
+                fieldProps={[{ key: 'Description' }]}
+                isLoading={false}
+                row={DATA_ROW}
+                onUpdate={jest.fn}
+                caption="storage description"
+            />
+        );
         const wrapper = mount(component);
-        expect(wrapper.find(".field-edit__icon").prop("title")).toBe("Edit storage description");
+        expect(wrapper.find('.field-edit__icon').prop('title')).toBe('Edit storage description');
         wrapper.unmount();
     });
 
     test('user without update perm', () => {
-        const component = <FieldEditorOverlay
-            queryInfo={queryInfo}
-            fieldProps={[{key: 'Description'}]}
-            isLoading={false}
-            row={DATA_ROW}
-            onUpdate={jest.fn}
-        />;
+        const component = (
+            <FieldEditorOverlay
+                queryInfo={queryInfo}
+                fieldProps={[{ key: 'Description' }]}
+                isLoading={false}
+                row={DATA_ROW}
+                onUpdate={jest.fn}
+            />
+        );
         const wrapper = mount(component);
         expect(wrapper.text()).toBe('Test description.');
         wrapper.unmount();
     });
 
     test('user cannot see value', () => {
-        const component = <FieldEditorOverlay
-            queryInfo={queryInfo}
-            fieldProps={[{key: 'Description'}]}
-            isLoading={false}
-            row={DATA_ROW}
-            onUpdate={jest.fn}
-            showValueOnNotAllowed={false}
-        />;
+        const component = (
+            <FieldEditorOverlay
+                queryInfo={queryInfo}
+                fieldProps={[{ key: 'Description' }]}
+                isLoading={false}
+                row={DATA_ROW}
+                onUpdate={jest.fn}
+                showValueOnNotAllowed={false}
+            />
+        );
         const wrapper = mount(component);
 
-        expect(wrapper.text()).toBe("");
+        expect(wrapper.text()).toBe('');
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/forms/FieldEditorOverlay.tsx
+++ b/packages/components/src/internal/components/forms/FieldEditorOverlay.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { OverlayTrigger } from 'react-bootstrap';
 import { List } from 'immutable';
 
@@ -51,6 +51,12 @@ type Props = FieldEditorOverlayProps;
 export class FieldEditorOverlay extends React.PureComponent<Props, State> {
     private fieldEditOverlayTrigger: React.RefObject<any>;
 
+    static getRowId(queryInfo: QueryInfo, row: any): string | number {
+        if (!queryInfo || !row) return undefined;
+        const pkCols: List<QueryColumn> = queryInfo.getPkCols();
+        return pkCols.size > 0 ? row[pkCols.get(0).fieldKey]?.value : undefined;
+    }
+
     static defaultProps = {
         iconAlwaysVisible: true,
         showIconText: true,
@@ -67,17 +73,21 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.init();
     }
 
-    componentDidUpdate(prevProps: Props) {
-        if (prevProps.isLoading && !this.props.isLoading) {
+    componentDidUpdate(prevProps: Props): void {
+        const currentRowId = FieldEditorOverlay.getRowId(this.props.queryInfo, this.props.row);
+        const previousRowId = FieldEditorOverlay.getRowId(prevProps.queryInfo, prevProps.row);
+        const rowIdChanged = currentRowId && previousRowId && currentRowId !== previousRowId;
+
+        if (rowIdChanged || (prevProps.isLoading && !this.props.isLoading)) {
             this.init();
         }
     }
 
-    init() {
+    init(): void {
         const { fieldProps, isLoading, queryInfo, row } = this.props;
 
         if (!isLoading && queryInfo) {
@@ -126,7 +136,7 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
         }
     }
 
-    handleOverlayClose = () => {
+    handleOverlayClose = (): void => {
         document.body.click();
         this.setState({
             error: undefined,
@@ -142,12 +152,6 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
         );
     }
 
-    getRowId(): string | number {
-        const { queryInfo, row } = this.props;
-        const pkCols: List<QueryColumn> = queryInfo.getPkCols();
-        return row[pkCols.get(0).fieldKey].value;
-    }
-
     updateFields = submittedValues => {
         const { containerPath, row, queryInfo, onUpdate, handleUpdateRows } = this.props;
 
@@ -160,7 +164,7 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
                 schemaQuery,
                 rows: [
                     {
-                        rowId: this.getRowId(),
+                        rowId: FieldEditorOverlay.getRowId(queryInfo, row),
                         name,
                     },
                 ],
@@ -190,7 +194,7 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
         }
     };
 
-    render() {
+    render(): ReactNode {
         const { canUpdate, showIconText, showValueOnNotAllowed, appendToCurrentNode } = this.props;
         const { error, fields, iconField } = this.state;
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42932
In the FM app, the FieldEditorOverlay is used to allow for the description value to be set/updated for a given freezer location. However, when you use the breadcrumbs to toggle the location, it does not re-init or re-render the FieldEditorOverlay because it was not properly checking for this case in the componentDidUpdate. Also, there was another issue where the location prop changes wasn't property adding the new query model to the state and loading it. These PRs fix both of those issues.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/504
* https://github.com/LabKey/inventory/pull/225

#### Changes
* Make getRowId static on FieldEditorOverlay and add jest tests for it
* Add componentDidUpdate for FieldEditorOverlay to check for change to RowId prop
