### PR TITLE
Item 8735: Misc updates to support DetailEditing shared component in LKB

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.23.2",
+  "version": "2.23.2-fb-detailEditingFromComponents.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.23.2-fb-detailEditingFromComponents.0",
+  "version": "2.24.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD April 2021
+* Item 8735: Misc updates to support DetailEditing shared component in LKB
+    * DetailEditing.tsx - add optional detailRenderer to be used in view/read mode
+    * Export DetailPanelHeader.tsx to use in LKB
+    * Formsy addValidationRule isNumericWithError in resolveRenderer for DetailEditing.tsx usages
+    * form/details/extractChanges check for date validation of with/without timestamp
+
 ### version 2.23.2
 *Released*: 16 April 2021
 * Issue 42932: FieldEditorOverlay fix to recognize change to props by looking at row's RowId

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD April 2021
+### version 2.24.0
+*Released*: 19 April 2021
 * Item 8735: Misc updates to support DetailEditing shared component in LKB
     * DetailEditing.tsx - add optional detailRenderer to be used in view/read mode
     * Export DetailPanelHeader.tsx to use in LKB

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -227,6 +227,7 @@ import { ColorPickerInput } from './internal/components/forms/input/ColorPickerI
 import { ColorIcon } from './internal/components/base/ColorIcon';
 import { QuerySelect } from './internal/components/forms/QuerySelect';
 import { PageDetailHeader } from './internal/components/forms/PageDetailHeader';
+import { DetailPanelHeader } from './internal/components/forms/detail/DetailPanelHeader';
 import { DetailEditing } from './internal/components/forms/detail/DetailEditing';
 
 import { resolveDetailRenderer } from './internal/components/forms/detail/DetailEditRenderer';
@@ -664,6 +665,7 @@ export {
     FieldEditProps,
     QuerySelect,
     UserSelectInput,
+    DetailPanelHeader,
     DetailEditing,
     handleInputTab,
     handleTabKeyOnTextArea,

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -26,6 +26,7 @@ import { fileInputRenderer } from '../renderers';
 import { Detail } from './Detail';
 import { DetailPanelHeader } from './DetailPanelHeader';
 import { extractChanges } from './utils';
+import { DetailRenderer } from './DetailDisplay';
 
 const EMPTY_FILE_FOR_DELETE = new File([], '');
 
@@ -43,6 +44,7 @@ interface Props {
     submitText?: string;
     title?: string;
     useEditIcon: boolean;
+    detailRenderer?: DetailRenderer;
 }
 
 interface State {
@@ -184,6 +186,7 @@ export class DetailEditing extends Component<Props, State> {
             asSubPanel,
             submitText,
             title,
+            detailRenderer,
         } = this.props;
         const { canSubmit, editing, isSubmitting, warning, error } = this.state;
 
@@ -212,6 +215,7 @@ export class DetailEditing extends Component<Props, State> {
                 editingMode={editingMode}
                 queryColumns={queryColumns}
                 queryModel={queryModel}
+                detailRenderer={editingMode ? undefined : detailRenderer}
                 fileInputRenderer={this.fileInputRenderer}
             />
         );

--- a/packages/components/src/internal/components/forms/detail/utils.ts
+++ b/packages/components/src/internal/components/forms/detail/utils.ts
@@ -19,7 +19,11 @@ function arrayListIsEqual(valueArr: Array<string | number>, nestedModelList: Lis
     return matched === valueArr.length;
 }
 
-export function extractChanges(queryInfo: QueryInfo, currentData: Map<string, any>, formValues: Record<string, any>): Record<string, any> {
+export function extractChanges(
+    queryInfo: QueryInfo,
+    currentData: Map<string, any>,
+    formValues: Record<string, any>
+): Record<string, any> {
     const changedValues = {};
     // Loop through submitted formValues and check against existing currentData from server
     Object.keys(formValues).forEach(field => {

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -16,6 +16,7 @@
 import React, { ReactNode, ReactText } from 'react';
 import { List, Map } from 'immutable';
 import { Input } from 'formsy-react-components';
+import { addValidationRule, validationRules } from 'formsy-react';
 
 import { FileColumnRenderer, FileInput, QueryColumn } from '../../..';
 
@@ -79,6 +80,13 @@ const AppendUnitsInputRenderer: InputRenderer = (
 );
 
 export function resolveRenderer(column: QueryColumn): InputRenderer {
+    // 23462: Global Formsy validation rule for numbers
+    if (!validationRules.isNumericWithError) {
+        addValidationRule('isNumericWithError', (values: any, value: string | number) => {
+            return validationRules.isNumeric(values, value) || 'Please enter a number.';
+        });
+    }
+
     if (column?.inputRenderer) {
         switch (column.inputRenderer.toLowerCase()) {
             case 'experimentalias':


### PR DESCRIPTION
#### Rationale
SM recently completed a dev story to allow for better support for file/attachment field types in the Details panel view and edit mode. As part of that work, I saw that LKB still had its own copy of the DetailEditing.tsx component and DetailPanelHeader.tsx component which were very close to the shared component versions. This PR removes those duplicate implementations and makes the necessary updates in the LKB app to use the shared component versions. Note that this then allows for the file/attachment data types to be supported in the LKB app as well in the Details panel view/edit mode.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/505
* https://github.com/LabKey/biologics/pull/864

#### Changes
* DetailEditing.tsx - add optional detailRenderer to be used in view/read mode
* Export DetailPanelHeader.tsx to use in LKB
* Formsy addValidationRule isNumericWithError in resolveRenderer for DetailEditing.tsx usages
* form/details/extractChanges check for date validation of with/without timestamp
