### PR TITLE
42756: Disable bulk update for Submitters+Readers

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.24.0-fb-issue-42756-1.0",
+  "version": "2.24.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.24.0",
+  "version": "2.24.0-fb-issue-42756-1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.24.1
+*Released*: 20 April 2021
 * Issue 42756: Disable bulk update for Submitters+Readers
 
 ### version 2.24.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42756: Disable bulk update for Submitters+Readers
+
 ### version 2.24.0
 *Released*: 19 April 2021
 * Item 8735: Misc updates to support DetailEditing shared component in LKB

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -64,6 +64,8 @@ import {
     SampleCreationTypeModel,
     SchemaQuery,
     SelectInput,
+    useServerContext,
+    User,
     withFormSteps,
     WithFormStepsProps,
     WizardNavButtons,
@@ -144,6 +146,7 @@ interface FromLocationProps {
     selectionKey?: string;
     tab?: number;
     target?: any;
+    user?: User;
 }
 
 type Props = FromLocationProps & OwnProps & WithFormStepsProps;
@@ -1079,6 +1082,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             importOnly,
             nounPlural,
             entityDataType,
+            user,
         } = this.props;
         const { error, file, insertModel, isMerge, isSubmitting, originalQueryInfo } = this.state;
 
@@ -1127,7 +1131,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                                     stepIndex={importOnly ? EntityInsertPanelTabs.First : EntityInsertPanelTabs.Second}
                                 >
                                     {this.renderHeader(false)}
-                                    {!disableMerge && (
+                                    {(!disableMerge && user.hasUpdatePermission()) && (
                                         <div className="margin-bottom">
                                             <input
                                                 type="checkbox"
@@ -1216,6 +1220,8 @@ export const EntityInsertPanelFormSteps = withFormSteps(EntityInsertPanelImpl, {
 export const EntityInsertPanel: FC<{ location?: Location } & OwnProps> = memo(props => {
     const { location, ...entityInsertPanelProps } = props;
 
+    const { user } = useServerContext();
+
     const fromLocationProps = useMemo<FromLocationProps>(() => {
         if (!location) {
             return {};
@@ -1230,6 +1236,7 @@ export const EntityInsertPanel: FC<{ location?: Location } & OwnProps> = memo(pr
             selectionKey,
             tab: parseInt(tab, 10),
             target,
+            user: user,
         };
     }, [location]);
 


### PR DESCRIPTION
#### Rationale
To address this issue : https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42756
We want to ensure the bulk update import option is properly hidden if the user doesn't have update permissions. We also need to ensure the update will fail on the same permission check on execute.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/2193

#### Changes
- check for update permissions in addition to the disableMerge flag in `EntityInsertPanel.tsx`