### PR TITLE
Item 8789: Add util function for incrementClientSideMetricCount()

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.25.0",
+  "version": "2.25.0-fb-fmCloneFreezers.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.25.0-fb-fmCloneFreezers.1",
+  "version": "2.25.0-fb-fmCloneFreezers.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.25.0-fb-fmCloneFreezers.2",
+  "version": "2.26.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.25.0-fb-fmCloneFreezers.0",
+  "version": "2.25.0-fb-fmCloneFreezers.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.24.4",
+  "version": "2.24.4-fb-fmCloneFreezers.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 8789: Add util function for incrementClientSideMetricCount()
+
 ### version 2.24.4
 *Released*: 23 April 2021
 * Issue 42872: Handle field names with special characters in grids and forms better.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.26.0
+*Released*: 28 April 2021
 * Item 8789: Add util function for incrementClientSideMetricCount()
 
 ### version 2.25.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -148,6 +148,7 @@ import {
     setSelected,
     setSnapshotSelections,
     unselectAll,
+    incrementClientSideMetricCount,
 } from './internal/actions';
 import { cancelEvent } from './internal/events';
 import {
@@ -908,6 +909,7 @@ export {
     resolveErrorMessage,
     getHelpLink,
     helpLinkNode,
+    incrementClientSideMetricCount,
     SAMPLE_ALIQUOT_TOPIC,
     // devTools functions
     applyDevTools,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -3098,8 +3098,8 @@ interface IClientSideMetricCountResponse {
 }
 
 export function incrementClientSideMetricCount(
-    applicationName: string,
-    metricName: string
+    metricName: string,
+    applicationName?: string
 ): Promise<IClientSideMetricCountResponse> {
     return new Promise((resolve, reject) => {
         return Ajax.request({

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -3098,15 +3098,15 @@ interface IClientSideMetricCountResponse {
 }
 
 export function incrementClientSideMetricCount(
-    metricName: string,
-    applicationName?: string
+    featureArea: string,
+    metricName: string
 ): Promise<IClientSideMetricCountResponse> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
             url: buildURL('core', 'incrementClientSideMetricCount.api'),
             method: 'POST',
             jsonData: {
-                applicationName,
+                featureArea,
                 metricName,
             },
             success: Utils.getCallbackWrapper(response => {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -3092,3 +3092,34 @@ export function createQueryGridModelFilteredBySample(
         };
     });
 }
+
+interface IClientSideMetricCountResponse {
+    count: number;
+}
+
+export function incrementClientSideMetricCount(
+    applicationName: string,
+    metricName: string
+): Promise<IClientSideMetricCountResponse> {
+    return new Promise((resolve, reject) => {
+        return Ajax.request({
+            url: buildURL('core', 'incrementClientSideMetricCount.api'),
+            method: 'POST',
+            jsonData: {
+                applicationName,
+                metricName,
+            },
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response);
+            }),
+            failure: Utils.getCallbackWrapper(
+                response => {
+                    console.error(response);
+                    reject(response);
+                },
+                this,
+                true
+            ),
+        });
+    });
+}

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -1219,7 +1219,6 @@ export const EntityInsertPanelFormSteps = withFormSteps(EntityInsertPanelImpl, {
 
 export const EntityInsertPanel: FC<{ location?: Location } & OwnProps> = memo(props => {
     const { location, ...entityInsertPanelProps } = props;
-
     const { user } = useServerContext();
 
     const fromLocationProps = useMemo<FromLocationProps>(() => {
@@ -1236,11 +1235,10 @@ export const EntityInsertPanel: FC<{ location?: Location } & OwnProps> = memo(pr
             selectionKey,
             tab: parseInt(tab, 10),
             target,
-            user: user,
         };
     }, [location]);
 
-    return <EntityInsertPanelFormSteps {...entityInsertPanelProps} {...fromLocationProps} />;
+    return <EntityInsertPanelFormSteps {...entityInsertPanelProps} {...fromLocationProps} user={user} />;
 });
 
 EntityInsertPanel.displayName = 'EntityInsertPanel';


### PR DESCRIPTION
#### Rationale
As part of the story for FM freezer cloning, we are adding in the initial light weight implementation for the client side metrics tracking. This PR provides a ui-components helper function to hit the metric tracking API and pass along the application name (optional) and the metric name to be incremented.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/514
* https://github.com/LabKey/platform/pull/2209
* https://github.com/LabKey/inventory/pull/229

#### Changes
* Add util function for incrementClientSideMetricCount()
* Minor fix for EntityInsertPanel.tsx to not include user with fromLocationProps
