### PR TITLE
Issue 42844: Sample Type designer update to include metricUnit check in "isValid" check

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.26.0-fb-sampleTypeMetricUnit42844.1",
+  "version": "2.26.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.26.0",
+  "version": "2.26.0-fb-sampleTypeMetricUnit42844.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42844: Sample Type designer update to include metricUnit check in "isValid" check
+
 ### version 2.26.0
 *Released*: 28 April 2021
 * Item 8789: Add util function for incrementClientSideMetricCount()

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.26.1
+*Released*: 29 April 2021
 * Issue 42844: Sample Type designer update to include metricUnit check in "isValid" check
 
 ### version 2.26.0

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -139,10 +139,12 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
             });
     }
 
-    updateValidStatus = (newModel?: SampleTypeModel) => {
-        const { model, updateModel } = this.props;
+    updateValidStatus = (newModel?: SampleTypeModel): void => {
+        const { model, updateModel, metricUnitProps } = this.props;
         const updatedModel = newModel || model;
-        const isValid = updatedModel && updatedModel.hasValidProperties();
+        const isValid =
+            updatedModel?.hasValidProperties() && updatedModel?.isMetricUnitValid(metricUnitProps?.metricUnitRequired);
+
         this.setState(
             () => ({ isValid }),
             () => {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42844
In LKSM, the sample type metric unit is a required property in the top properties panel for the sample type field editor. If a user enters a sample type name but not a metric unit value and goes to the fields panel, they are not given any error message about this missing required field until this try to save. This PR adds the metric unit required check to the isValid state for the panel collapse/change.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/515
* https://github.com/LabKey/platform/pull/2225
* https://github.com/LabKey/biologics/pull/875
* https://github.com/LabKey/sampleManagement/pull/559

#### Changes
* SampleTypePropertiesPanel.updateValidStatus change to include metric unit requirement check in isValid state value
