### PR TITLE
Issue42527: Handle edge case in List Designer Summary View

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.26.0",
+  "version": "2.26.0-fb-issue42527-2-0.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.26.2
+*Released*: 29 April 2021
 * Issue 42527: Handle edge case in List Designer Summary View. Summary View mode now hides Field Editor HeaderRenderer content
 
 ### version 2.26.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 42527: Handle edge case in List Designer Summary View
+
 ### version 2.26.0
 *Released*: 28 April 2021
 * Item 8789: Add util function for incrementClientSideMetricCount()

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1349,7 +1349,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             <>
                 {(hasFields || !(this.shouldShowInferFromFile() || allowImportExport)) && this.renderToolbar()}
                 {this.renderPanelHeaderContent()}
-                {appDomainHeaderRenderer && this.renderAppDomainHeader()}
+                {appDomainHeaderRenderer && !summaryViewMode && this.renderAppDomainHeader()}
 
                 {hasFields ? (
                     summaryViewMode ? (


### PR DESCRIPTION
#### Rationale
Previously, there was strange behavior when selecting a new List Key while within the Summary View. This update removes the `appDomainHeaderRenderer` when `summaryViewMode` is on.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2226

#### Changes
* Remove `appDomainHeaderRenderer` when `summaryViewMode` is on
