### PR TITLE
43051: LookupCell menu appears detached from table cell

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.26.2",
+  "version": "2.26.3-fb-fix-43028.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.26.3-fb-fix-43028.0",
+  "version": "2.26.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.##.#
-*Released*: # April 2021
+### version 2.26.3
+*Released*: 30 April 2021
 * Issue 43028: QuerySelect - fallback to "valueColumn" as option label
 * Issue 43051: LookupCell menu appears detached from table cell
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.##.#
+*Released*: # April 2021
+* Issue 43028: QuerySelect - fallback to "valueColumn" as option label
+* Issue 43051: LookupCell menu appears detached from table cell
+
 ### version 2.26.2
 *Released*: 29 April 2021
 * Issue 42527: Handle edge case in List Designer Summary View. Summary View mode now hides Field Editor HeaderRenderer content

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -48,6 +48,7 @@ import { BulkAddUpdateForm } from '../forms/BulkAddUpdateForm';
 
 import { AddRowsControl, AddRowsControlProps, PlacementType } from './Controls';
 import { Cell } from './Cell';
+import { EDITABLE_GRID_CONTAINER_CLS } from './constants';
 
 const COUNT_COL = new GridColumn({
     index: GRID_EDIT_INDEX,
@@ -856,7 +857,7 @@ export class EditableGrid extends ReactN.PureComponent<EditableGridProps, Editab
                 <div>
                     {this.renderTopControls()}
                     <div
-                        className="editable-grid__container"
+                        className={EDITABLE_GRID_CONTAINER_CLS}
                         onKeyDown={this.onKeyDown}
                         onMouseDown={this.onMouseDown}
                         onMouseUp={this.onMouseUp}

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -25,6 +25,8 @@ import { KEYS, LOOKUP_DEFAULT_SIZE, MODIFICATION_TYPES, SELECTION_TYPES } from '
 import { QueryColumn } from '../../..';
 import { GlobalAppState } from '../../global';
 
+import { EDITABLE_GRID_CONTAINER_CLS } from './constants';
+
 const emptyList = List<ValueDescriptor>();
 
 export interface LookupCellProps {
@@ -49,12 +51,16 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
     private blurTO: number;
     private changeTO: number;
     private inputEl: RefObject<HTMLInputElement>;
+    private menuEl: RefObject<HTMLDivElement>;
+    private wrapperEl: RefObject<HTMLDivElement>;
 
     constructor(props: LookupCellProps) {
         // @ts-ignore // see https://github.com/CharlesStover/reactn/issues/126
         super(props);
 
         this.inputEl = createRef<HTMLInputElement>();
+        this.menuEl = createRef<HTMLInputElement>();
+        this.wrapperEl = createRef<HTMLInputElement>();
 
         this.state = {
             activeOptionIdx: -1,
@@ -65,6 +71,14 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
     componentDidMount(): void {
         const { col, filteredLookupValues, filteredLookupKeys } = this.props;
         initLookup(col, LOOKUP_DEFAULT_SIZE, filteredLookupValues, filteredLookupKeys);
+
+        try {
+            this.getContainerElement()?.addEventListener('scroll', this.onContainerScroll);
+            document.addEventListener('scroll', this.onContainerScroll);
+            this.onContainerScroll();
+        } catch (e) {
+            console.error('Failed to attach listeners for LookupCell scrolling.', e);
+        }
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: LookupCellProps): void {
@@ -72,6 +86,15 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
             this.setState({
                 activeOptionIdx: 0,
             });
+        }
+    }
+
+    componentWillUnmount(): void {
+        try {
+            this.getContainerElement()?.removeEventListener('scroll', this.onContainerScroll);
+            document.removeEventListener('scroll', this.onContainerScroll);
+        } catch (e) {
+            console.error('Failed to detach listeners for LookupCell scrolling.', e);
         }
     }
 
@@ -84,18 +107,21 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
             this.inputEl.current.value = '';
         }
 
-        searchLookup(
-            this.props.col,
-            LOOKUP_DEFAULT_SIZE,
-            undefined,
-            this.props.filteredLookupValues,
-            this.props.filteredLookupKeys
-        );
+        this.resetLookup();
 
         this.setState({
             activeOptionIdx: -1,
             token: undefined,
         });
+    };
+
+    // As a part of the fix for #43051 the LookupCell needs to be able to attach scroll event listeners
+    // to the grid container which is declared in EditableGrid. Handing down a React.RefObject would be preferred,
+    // however, this caused sluggish performance for the grid as this "container ref" was constantly updating and needs
+    // to be passed in as a prop to all Cells. In lieu of the ref approach this uses a DOM selector to located the
+    // nearest container element as designated by a CSS class.
+    getContainerElement = (): Element => {
+        return this.wrapperEl.current?.closest(`.${EDITABLE_GRID_CONTAINER_CLS}`);
     };
 
     focusInput = (): void => {
@@ -122,17 +148,20 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
         return this.props.col.isJunctionLookup();
     };
 
+    onContainerScroll = (): void => {
+        // Issue 43051: LookupCell menu manually updated to account for scrolled grid container
+        if (this.menuEl.current && this.wrapperEl.current) {
+            const rect = this.wrapperEl.current.getBoundingClientRect();
+            this.menuEl.current.style.left = `${rect.left + window.scrollX}px`;
+            this.menuEl.current.style.top = `${rect.bottom}px`;
+        }
+    };
+
     onInputBlur = (): void => {
         this.blurTO = window.setTimeout(() => {
             const { colIdx, modelId, rowIdx } = this.props;
             this.props.select(modelId, colIdx, rowIdx);
-            searchLookup(
-                this.props.col,
-                LOOKUP_DEFAULT_SIZE,
-                null,
-                this.props.filteredLookupValues,
-                this.props.filteredLookupKeys
-            );
+            this.resetLookup();
         }, 200);
     };
 
@@ -145,13 +174,7 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
                 token = this.inputEl.current.value;
             }
 
-            searchLookup(
-                this.props.col,
-                LOOKUP_DEFAULT_SIZE,
-                token,
-                this.props.filteredLookupValues,
-                this.props.filteredLookupKeys
-            );
+            this.searchLookup(token);
 
             this.setState({
                 activeOptionIdx: -1,
@@ -222,6 +245,20 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
         if (onCellModify) onCellModify();
 
         this.focusInput();
+    };
+
+    resetLookup = (): void => {
+        this.searchLookup(undefined);
+    };
+
+    searchLookup = (token: string): void => {
+        searchLookup(
+            this.props.col,
+            LOOKUP_DEFAULT_SIZE,
+            token,
+            this.props.filteredLookupValues,
+            this.props.filteredLookupKeys
+        );
     };
 
     renderOptions(): ReactNode {
@@ -308,7 +345,7 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
 
     render(): ReactNode {
         return (
-            <div className="cell-lookup">
+            <div className="cell-lookup" ref={this.wrapperEl}>
                 {this.renderValue()}
                 <input
                     autoFocus
@@ -320,7 +357,7 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
                     ref={this.inputEl}
                     type="text"
                 />
-                <div className="cell-lookup-menu">{this.renderOptions()}</div>
+                <div className="cell-lookup-menu" ref={this.menuEl}>{this.renderOptions()}</div>
             </div>
         );
     }

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -357,7 +357,9 @@ export class LookupCell extends ReactN.Component<LookupCellProps, LookupCellStat
                     ref={this.inputEl}
                     type="text"
                 />
-                <div className="cell-lookup-menu" ref={this.menuEl}>{this.renderOptions()}</div>
+                <div className="cell-lookup-menu" ref={this.menuEl}>
+                    {this.renderOptions()}
+                </div>
             </div>
         );
     }

--- a/packages/components/src/internal/components/editable/constants.ts
+++ b/packages/components/src/internal/components/editable/constants.ts
@@ -1,0 +1,1 @@
+export const EDITABLE_GRID_CONTAINER_CLS = 'editable-grid__container';

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -254,7 +254,7 @@ export function formatResults(model: QuerySelectModel, results: Map<string, any>
 
     return results
         .map(result => ({
-            label: result.getIn([model.displayColumn, 'value']),
+            label: result.getIn([model.displayColumn, 'value']) ?? result.getIn([model.valueColumn, 'value']),
             value: result.getIn([model.valueColumn, 'value']),
         }))
         .sortBy(item => item.label, similaritySortFactory(token))

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -293,7 +293,7 @@ $table-cell-selection-bg-color: #EDF3FF;
         box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.05);
         border-radius: 3px;
 
-        position: absolute;
+        position: fixed;
 
         & > li {
           height: 38px;


### PR DESCRIPTION
#### Rationale
This PR addresses:

* [43028](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43028): Mixture Wizard Expects Ingredient "Scientific Name" Value
* [43051](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43051): Editable Grid: LookupCell menu appears detached from table cell

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/876

#### Changes
* Add scroll event listeners to `LookupCell` to adjust position of lookup menu upon container scroll.
* Fallback to "valueColumn"s value as the label for option's created by `QuerySelect`.