### PR TITLE
FormSchema, AutoForm, HelpIcon

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-fb-form-schema.0",
+  "version": "2.28.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.27.0",
+  "version": "2.28.0-fb-form-schema.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.28.0
+*Released*: ?? May 2021
+* Add FormSchema, Field, Option interfaces
+  * These interfaces are used in conjunction with LabKey server classes of the same name to auto-generate forms with
+    AutoForm (see below)
+* Add AutoForm - A component that generates a form for a given FormSchema
+* Add HelpIcon - A component useful for rendering help text
+
 ### version 2.27.0
 *Released*: 01 May 2021
 * Changes to allow data region filtration based on ontology concepts

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.28.0
-*Released*: ?? May 2021
+*Released*: 6 May 2021
 * Add FormSchema, Field, Option interfaces
   * These interfaces are used in conjunction with LabKey server classes of the same name to auto-generate forms with
     AutoForm (see below)

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -58,6 +58,8 @@ import {
     toggleDevTools,
     valueIsEmpty,
 } from './internal/util/utils';
+import { AutoForm } from './internal/components/AutoForm';
+import { HelpIcon } from './internal/components/HelpIcon';
 import { getUserProperties, getUserRoleDisplay } from './internal/components/user/actions';
 import { BeforeUnload } from './internal/util/BeforeUnload';
 import { getActionErrorMessage, resolveErrorMessage } from './internal/util/messaging';
@@ -1031,6 +1033,8 @@ export {
     OntologyBrowserPanel,
     OntologyConceptOverviewPanel,
     OntologyBrowserFilterPanel,
+    AutoForm,
+    HelpIcon,
 };
 
 //  Due to babel-loader & typescript babel plugins we need to export/import types separately. The babel plugins require
@@ -1102,3 +1106,4 @@ export type {
     AppReducerState,
 } from './internal/app/reducers';
 export type { IAttachment } from './internal/renderers/AttachmentCard';
+export type { Field, FormSchema, Option } from './internal/components/AutoForm';

--- a/packages/components/src/internal/components/AutoForm.spec.tsx
+++ b/packages/components/src/internal/components/AutoForm.spec.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { AutoForm, FormSchema } from './AutoForm';
+
+describe('AutoForm', () => {
+    const expectField = (wrapper, field, index): void => {
+        const fieldEl = wrapper.find('.auto-form-field').at(index);
+
+        const label = fieldEl.find('label').at(0);
+        expect(label.text()).toContain(field.label + (field.required ? '*' : ''));
+
+        if (field.helpText) {
+            // Can't assert text content of help icon at the moment, so just assert it exists.
+            expect(label.find('.help-icon').exists()).toEqual(true);
+        }
+
+        if (field.type === 'textarea') {
+            expect(fieldEl.find('textarea').length).toEqual(1);
+        } else if (field.type === 'radio') {
+            const radios = fieldEl.find('label.radio-inline');
+            expect(radios.length).toEqual(field.options.length);
+            field.options.forEach((option, idx) => {
+                const radio = radios.at(idx);
+                expect(radio.find('input').props().name).toEqual(field.name);
+                expect(radio.find('input').props().value).toEqual(option.value);
+                expect(radio.text()).toEqual(option.label);
+            });
+        } else if (field.type === 'checkbox') {
+            expect(fieldEl.find('input[type="checkbox"]').length).toEqual(1);
+        } else if (field.type === 'select') {
+            expect(fieldEl.find('select').length).toEqual(1);
+            const expectedOptions = field.placeholder ? field.options.length + 1 : field.options.length;
+            const optionEls = fieldEl.find('select > option');
+            expect(optionEls.length).toEqual(expectedOptions);
+            optionEls.forEach((optionEl, idx) => {
+                if (field.placeholder && idx === 0) {
+                    expect(optionEl.props().value).toEqual('');
+                    expect(optionEl.text()).toEqual(field.placeholder);
+                } else {
+                    const option = field.options[field.placeholder ? idx - 1 : idx];
+                    expect(optionEl.props().value).toEqual(option.value);
+                    expect(optionEl.text()).toEqual(option.label);
+                }
+            });
+        } else {
+            expect(fieldEl.find('input[type="text"]').length).toEqual(1);
+        }
+    };
+    test('render', () => {
+        const formSchema: FormSchema = {
+            fields: [
+                {
+                    label: 'text field',
+                    name: 'textField',
+                    type: 'text',
+                },
+                {
+                    label: 'text field, required',
+                    name: 'textFieldRequired',
+                    type: 'text',
+                },
+                {
+                    label: 'text field, help text',
+                    name: 'textFieldHelpText',
+                    helpText: 'this is help text',
+                    type: 'text',
+                },
+                {
+                    label: 'text field, help text and href',
+                    name: 'textFieldHelpTextHref',
+                    helpText: 'this is help text',
+                    helpTextHref: '',
+                    type: 'text',
+                },
+                {
+                    label: 'textarea field',
+                    name: 'textareaField',
+                    type: 'textarea',
+                },
+                {
+                    label: 'number field',
+                    name: 'numberField',
+                    type: 'number',
+                },
+                {
+                    label: 'checkbox field',
+                    name: 'checkboxField',
+                    type: 'checkbox',
+                },
+                {
+                    label: 'select field w/ placeholder',
+                    name: 'selectFieldPlaceholder',
+                    placeholder: 'select placeholder',
+                    options: [
+                        { label: 'option 1', value: 'option1' },
+                        { label: 'option 2', value: 'option2' },
+                    ],
+                    type: 'select',
+                },
+                {
+                    label: 'select field w/o placeholder',
+                    name: 'selectFieldNoPlaceholder',
+                    options: [
+                        { label: 'option 1', value: 'option1' },
+                        { label: 'option 2', value: 'option2' },
+                    ],
+                    type: 'select',
+                },
+                {
+                    label: 'radio field',
+                    name: 'radioField',
+                    options: [
+                        { label: 'option 1', value: 'option1' },
+                        { label: 'option 2', value: 'option2' },
+                    ],
+                    type: 'radio',
+                },
+            ],
+        };
+        const wrapper = mount(<AutoForm formSchema={formSchema} onChange={jest.fn()} values={{}} />);
+
+        formSchema.fields.forEach((field, index) => expectField(wrapper, field, index));
+    });
+
+    test('interaction', () => {
+        const formSchema: FormSchema = {
+            fields: [
+                {
+                    label: 'text field',
+                    name: 'textField',
+                    type: 'text',
+                },
+                {
+                    label: 'radio field',
+                    name: 'radioField',
+                    options: [
+                        { label: 'option 1', value: 'option1' },
+                        { label: 'option 2', value: 'option2' },
+                    ],
+                    type: 'radio',
+                },
+                {
+                    label: 'select field w/o placeholder',
+                    name: 'selectField',
+                    options: [
+                        { label: 'option 1', value: 'option1' },
+                        { label: 'option 2', value: 'option2' },
+                    ],
+                    type: 'select',
+                },
+                {
+                    label: 'checkbox field',
+                    name: 'checkboxField',
+                    type: 'checkbox',
+                },
+            ],
+        };
+
+        const onChange = jest.fn();
+        const wrapper = mount(<AutoForm formSchema={formSchema} onChange={onChange} values={{}} />);
+        const text = 'I am text';
+        wrapper.find('input[type="text"]').simulate('change', { target: { value: text } });
+        expect(onChange).toHaveBeenCalledWith('textField', text);
+        wrapper
+            .find('input[type="radio"]')
+            .at(1)
+            .simulate('change', { target: { value: 'option2' } });
+        expect(onChange).toHaveBeenCalledWith('radioField', 'option2');
+        wrapper.find('select').simulate('change', { target: { value: 'option2' } });
+        expect(onChange).toHaveBeenCalledWith('selectField', 'option2');
+        wrapper.find('input[type="checkbox"]').simulate('change', { target: { checked: false } });
+        expect(onChange).toHaveBeenCalledWith('checkboxField', false);
+    });
+});

--- a/packages/components/src/internal/components/AutoForm.tsx
+++ b/packages/components/src/internal/components/AutoForm.tsx
@@ -1,0 +1,278 @@
+import React, { FC, useCallback } from 'react';
+
+import { HelpIcon } from './HelpIcon';
+
+const INPUT_CLASSES = {
+    checkbox: 'form-check',
+    number: 'form-control',
+    radio: 'radio-inline',
+    select: 'form-control',
+    text: 'form-control',
+    textarea: 'form-control',
+};
+
+/**
+ * See Option in platform/api/org/labkey/api/formSchema
+ */
+export interface Option<T> {
+    label: string;
+    value: T;
+}
+
+/**
+ * See Field in platform/api/org/labkey/api/formSchema
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Field<T = any> {
+    defaultValue: T;
+    helpText: string;
+    helpTextHref: string;
+    label: string;
+    name: string;
+    // Options are used in Select and Radio fields.
+    options?: Array<Option<T>>;
+    placeholder: string;
+    required: boolean;
+    type: string;
+}
+
+/**
+ * See FormSchema in platform/api/org/labkey/api/formSchema
+ */
+export interface FormSchema {
+    fields: Field[];
+}
+
+export interface FieldClassProps {
+    // A map of input types to classNames (see INPUT_CLASSES for the default values)
+    inputClasses?: Record<string, string>;
+    // className for the div that wraps each input element
+    inputWrapperCls?: string;
+    // className for the the label element
+    labelCls?: string;
+    // className for the div that wraps the label element
+    labelWrapperCls?: string;
+    // className for the div that wraps each field component
+    fieldWrapperCls?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface AutoFormFieldProps<T = any> extends FieldClassProps {
+    field: Field<T>;
+    id: string;
+    onChange: (name: string, value: T) => void;
+    value: T;
+}
+
+export interface LabelProps {
+    cls?: string;
+    field: Field;
+    id: string;
+    wrapperCls?: string;
+}
+
+const Label: FC<LabelProps> = ({ cls, field, id, wrapperCls }) => {
+    const { helpText, helpTextHref, label, required } = field;
+    const text = `${label}${required ? '*' : ''}`;
+    let helpEl;
+
+    if (helpText) {
+        let helpLink;
+        if (helpTextHref) {
+            helpLink = (
+                <p>
+                    <a href={helpTextHref} target="_blank" rel="noopener noreferrer">
+                        More info
+                    </a>
+                </p>
+            );
+        }
+        helpEl = (
+            <HelpIcon>
+                <p>{helpText}</p>
+                {helpLink}
+            </HelpIcon>
+        );
+    }
+
+    return (
+        <div className={wrapperCls}>
+            <label className={cls} htmlFor={id}>
+                {text} {helpEl}
+            </label>
+        </div>
+    );
+};
+
+const TextInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
+    const { name, placeholder } = field;
+    const _onChange = useCallback(event => onChange(name, event.target.value), [name]);
+    const className = inputClasses.text ?? '';
+    const _value = value === null || value === undefined ? '' : value;
+    return (
+        <input
+            className={className}
+            id={id}
+            name={name}
+            placeholder={placeholder}
+            type="text"
+            value={_value}
+            onChange={_onChange}
+        />
+    );
+};
+
+const NumberInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
+    const { name, placeholder } = field;
+    const _onChange = useCallback(event => onChange(name, event.target.value), [name]);
+    const className = inputClasses.number ?? '';
+    const _value = value === null || value === undefined ? '' : value;
+    return (
+        <input
+            className={className}
+            id={id}
+            inputMode="numeric"
+            name={name}
+            pattern="[0-9]*"
+            placeholder={placeholder}
+            type="text"
+            value={_value}
+            onChange={_onChange}
+        />
+    );
+};
+
+const TextareaInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
+    const _onChange = useCallback(event => onChange(field.name, event.target.value), [field.name]);
+    const className = inputClasses.textarea ?? '';
+    const _value = value === null || value === undefined ? '' : value;
+    return <textarea className={className} id={id} name={field.name} value={_value} onChange={_onChange} />;
+};
+
+const CheckboxInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
+    const _onChange = useCallback(event => onChange(field.name, event.target.checked === true), [field.name]);
+    const className = inputClasses.checkbox ?? '';
+    return (
+        <input
+            className={className}
+            id={id}
+            name={field.name}
+            type="checkbox"
+            onChange={_onChange}
+            checked={value === true}
+        />
+    );
+};
+
+const SelectInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
+    const { name, options, placeholder } = field;
+    const _onChange = useCallback(
+        event => {
+            const value_ = event.target.value;
+            onChange(name, value_ === '' ? null : value_);
+        },
+        [name]
+    );
+    const _value = value === null || value === undefined ? '' : value;
+    const className = inputClasses.select ?? '';
+    return (
+        <select className={className} id={id} name={name} value={_value} onChange={_onChange}>
+            {placeholder !== null && <option value="">{placeholder}</option>}
+            {options.map(option => (
+                <option key={option.value} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </select>
+    );
+};
+
+const RadioInput: FC<AutoFormFieldProps> = ({ field, inputClasses, onChange, value }) => {
+    const { name, options } = field;
+    const _onChange = useCallback(event => onChange(name, event.target.value), [name]);
+    const className = inputClasses.radio ?? '';
+    return (
+        <div>
+            {options.map(option => (
+                <label className={className} key={option.value}>
+                    <input
+                        name={name}
+                        type="radio"
+                        onChange={_onChange}
+                        value={option.value}
+                        checked={value === option.value}
+                    />
+                    {option.label}
+                </label>
+            ))}
+        </div>
+    );
+};
+
+const AutoFormField: FC<AutoFormFieldProps> = props => {
+    const { field, id, inputWrapperCls, labelCls, labelWrapperCls, fieldWrapperCls } = props;
+    const { type } = field;
+    return (
+        <div className={'auto-form-field ' + fieldWrapperCls}>
+            <Label cls={labelCls} wrapperCls={labelWrapperCls} field={field} id={id} />
+            <div className={inputWrapperCls}>
+                {type === 'text' && <TextInput {...props} />}
+                {type === 'textarea' && <TextareaInput {...props} />}
+                {type === 'number' && <NumberInput {...props} />}
+                {type === 'checkbox' && <CheckboxInput {...props} />}
+                {type === 'select' && <SelectInput {...props} />}
+                {type === 'radio' && <RadioInput {...props} />}
+            </div>
+        </div>
+    );
+};
+
+export interface Props extends FieldClassProps {
+    formSchema: FormSchema;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onChange: (name: string, value: any) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    values: Record<string, any>;
+    wrapperCls?: string;
+}
+
+/**
+ * Generates a form given a FormSchema. FormSchemas are typically generated by LabKey Server, but can be constructed on
+ * the client as well.
+ * @param props
+ * @constructor
+ */
+export const AutoForm: FC<Props> = props => {
+    const {
+        formSchema,
+        inputClasses = INPUT_CLASSES,
+        inputWrapperCls = 'col-sm-8',
+        labelCls = 'control-label col-sm-4',
+        labelWrapperCls,
+        onChange,
+        fieldWrapperCls = 'form-group',
+        values,
+        wrapperCls = 'form-horizontal',
+    } = props;
+
+    // Intentionally not wrapping the component in a <form> despite the name. This is because you may use multiple
+    // FormSchemas to generate a single form, so it is up to the consumer to wrap in a <form> as appropriate.
+    return (
+        <div className={'auto-form ' + wrapperCls}>
+            {formSchema.fields.map(field => (
+                <AutoFormField
+                    key={field.name}
+                    field={field}
+                    id={`auto-form-${field.name}`}
+                    inputClasses={inputClasses}
+                    inputWrapperCls={inputWrapperCls}
+                    labelCls={labelCls}
+                    labelWrapperCls={labelWrapperCls}
+                    onChange={onChange}
+                    fieldWrapperCls={fieldWrapperCls}
+                    value={values[field.name]}
+                />
+            ))}
+        </div>
+    );
+};

--- a/packages/components/src/internal/components/AutoForm.tsx
+++ b/packages/components/src/internal/components/AutoForm.tsx
@@ -24,15 +24,15 @@ export interface Option<T> {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Field<T = any> {
-    defaultValue: T;
-    helpText: string;
-    helpTextHref: string;
+    defaultValue?: T;
+    helpText?: string;
+    helpTextHref?: string;
     label: string;
     name: string;
     // Options are used in Select and Radio fields.
     options?: Array<Option<T>>;
-    placeholder: string;
-    required: boolean;
+    placeholder?: string;
+    required?: boolean;
     type: string;
 }
 

--- a/packages/components/src/internal/components/AutoForm.tsx
+++ b/packages/components/src/internal/components/AutoForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { ChangeEvent, FC, useCallback } from 'react';
 
 import { HelpIcon } from './HelpIcon';
 
@@ -106,7 +106,7 @@ const Label: FC<LabelProps> = ({ cls, field, id, wrapperCls }) => {
 
 const TextInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
     const { name, placeholder } = field;
-    const _onChange = useCallback(event => onChange(name, event.target.value), [name]);
+    const _onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => onChange(name, event.target.value), [name]);
     const className = inputClasses.text ?? '';
     const _value = value === null || value === undefined ? '' : value;
     return (
@@ -124,7 +124,7 @@ const TextInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, 
 
 const NumberInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
     const { name, placeholder } = field;
-    const _onChange = useCallback(event => onChange(name, event.target.value), [name]);
+    const _onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => onChange(name, event.target.value), [name]);
     const className = inputClasses.number ?? '';
     const _value = value === null || value === undefined ? '' : value;
     return (
@@ -143,14 +143,20 @@ const NumberInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange
 };
 
 const TextareaInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
-    const _onChange = useCallback(event => onChange(field.name, event.target.value), [field.name]);
+    const _onChange = useCallback(
+        (event: ChangeEvent<HTMLTextAreaElement>) => onChange(field.name, event.target.value),
+        [field.name]
+    );
     const className = inputClasses.textarea ?? '';
     const _value = value === null || value === undefined ? '' : value;
     return <textarea className={className} id={id} name={field.name} value={_value} onChange={_onChange} />;
 };
 
 const CheckboxInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
-    const _onChange = useCallback(event => onChange(field.name, event.target.checked === true), [field.name]);
+    const _onChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => onChange(field.name, event.target.checked === true),
+        [field.name]
+    );
     const className = inputClasses.checkbox ?? '';
     return (
         <input
@@ -167,7 +173,7 @@ const CheckboxInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChan
 const SelectInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange, value }) => {
     const { name, options, placeholder } = field;
     const _onChange = useCallback(
-        event => {
+        (event: ChangeEvent<HTMLSelectElement>) => {
             const value_ = event.target.value;
             onChange(name, value_ === '' ? null : value_);
         },
@@ -189,7 +195,7 @@ const SelectInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange
 
 const RadioInput: FC<AutoFormFieldProps> = ({ field, inputClasses, onChange, value }) => {
     const { name, options } = field;
-    const _onChange = useCallback(event => onChange(name, event.target.value), [name]);
+    const _onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => onChange(name, event.target.value), [name]);
     const className = inputClasses.radio ?? '';
     return (
         <div>

--- a/packages/components/src/internal/components/AutoForm.tsx
+++ b/packages/components/src/internal/components/AutoForm.tsx
@@ -181,9 +181,10 @@ const SelectInput: FC<AutoFormFieldProps> = ({ field, id, inputClasses, onChange
     );
     const _value = value === null || value === undefined ? '' : value;
     const className = inputClasses.select ?? '';
+    const hasPlaceholder = placeholder !== null && placeholder !== undefined;
     return (
         <select className={className} id={id} name={name} value={_value} onChange={_onChange}>
-            {placeholder !== null && <option value="">{placeholder}</option>}
+            {hasPlaceholder && <option value="">{placeholder}</option>}
             {options.map(option => (
                 <option key={option.value} value={option.value}>
                     {option.label}

--- a/packages/components/src/internal/components/HelpIcon.tsx
+++ b/packages/components/src/internal/components/HelpIcon.tsx
@@ -1,0 +1,20 @@
+import React, { FC, memo, useMemo } from 'react';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+
+import { generateId } from '../..';
+
+interface Props {
+    placement?: 'top' | 'right' | 'bottom' | 'left';
+}
+
+export const HelpIcon: FC<Props> = memo(({ children, placement = 'bottom' }) => {
+    const id = useMemo(() => generateId(), []);
+    const overlayContent = <Popover id={id}>{children}</Popover>;
+    return (
+        <span className="help-icon">
+            <OverlayTrigger overlay={overlayContent} placement={placement}>
+                <i className="fa fa-question-circle" />
+            </OverlayTrigger>
+        </span>
+    );
+});

--- a/packages/components/src/internal/components/HelpIcon.tsx
+++ b/packages/components/src/internal/components/HelpIcon.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useMemo } from 'react';
+import React, { FC, memo, MouseEvent, useCallback, useMemo } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 
 import { generateId } from '../..';
@@ -10,9 +10,15 @@ interface Props {
 export const HelpIcon: FC<Props> = memo(({ children, placement = 'bottom' }) => {
     const id = useMemo(() => generateId(), []);
     const overlayContent = <Popover id={id}>{children}</Popover>;
+    const onClick = useCallback((event: MouseEvent<HTMLSpanElement>) => {
+        // We need to preventDefault and stopPropagation here so we can use HelpIcon inside of <label> elements. If we
+        // cancel the event the popover will not render.
+        event.preventDefault();
+        event.stopPropagation();
+    }, []);
     return (
-        <span className="help-icon">
-            <OverlayTrigger overlay={overlayContent} placement={placement}>
+        <span className="help-icon" onClick={onClick}>
+            <OverlayTrigger overlay={overlayContent} placement={placement} rootClose trigger="click">
                 <i className="fa fa-question-circle" />
             </OverlayTrigger>
         </span>


### PR DESCRIPTION
#### Rationale
I have added server side code to generate FormSchema objects for the File Watcher story I am working on, and need a component to render forms based on a FormSchema. This PR introduces the necessary components. HelpIcon can also be used in ELN, where we have a nearly identical component.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2234

#### Changes
* Add FormSchema Interface
* Add AutoForm and HelpIcon components
