### PR TITLE
Item 8709: Add support for Sample Picklists

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.27.0-smPicklists.3",
+  "version": "2.27.0-smPicklists.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.25.0",
+  "version": "2.26.0-smPicklists.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.30.0-smPicklists.14",
+  "version": "2.30.0-smPicklists.15",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-smPicklists.7",
+  "version": "2.28.0-smPicklists.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.30.0-smPicklists.17",
+  "version": "2.30.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.2",
     "@fortawesome/free-solid-svg-icons": "5.15.2",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.5.0-smPicklists.0",
+    "@labkey/api": "1.5.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-smPicklists.5",
+  "version": "2.28.0-smPicklists.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-smPicklists.4",
+  "version": "2.28.0-smPicklists.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-smPicklists.9",
+  "version": "2.28.0-smPicklists.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.26.0-smPicklists.0",
+  "version": "2.26.0-smPicklists.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.27.0-smPicklists.2",
+  "version": "2.27.0-smPicklists.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.29.0-smPicklists.12",
+  "version": "2.29.0-smPicklists.13",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.30.0-smPicklists.16",
+  "version": "2.30.0-smPicklists.17",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-smPicklists.6",
+  "version": "2.28.0-smPicklists.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.29.0-smPicklists.11",
+  "version": "2.29.0-smPicklists.12",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -44,7 +44,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.2",
     "@fortawesome/free-solid-svg-icons": "5.15.2",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.4.0",
+    "@labkey/api": "1.5.0-smPicklists.0",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.30.0-smPicklists.13",
+  "version": "2.30.0-smPicklists.14",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.30.0-smPicklists.15",
+  "version": "2.30.0-smPicklists.16",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.29.0-smPicklists.10",
+  "version": "2.29.0-smPicklists.11",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-smPicklists.8",
+  "version": "2.28.0-smPicklists.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -8,6 +8,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     * PicklistEditModal
     * PicklistDeleteConfirm
 * Updated domain designer Lookup/Fields to allow for certain tables (e.g., picklists) being excluded from the choice for lookups
+* Add new `getListIdFromDomainId` method
 
 ### version 2.29.0
 *Released*: 11 May 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.30.0
+*Released*: 13 May 2021
 * Add picklist-related components, models, and actions including:
     * PicklistCreationMenuItem
     * PicklistEditModal

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,9 +3,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* Add picklist-related components
+* Add picklist-related components, models, and actions including:
     * PicklistCreationMenuItem
-    * PicklistCreationModal
+    * PicklistEditModal
+    * PicklistDeleteConfirm
 
 ### version 2.28.0
 *Released*: 6 May 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add picklist-related components
+    * PicklistCreationMenuItem
+    * PicklistCreationModal
+
 ### version 2.25.0
 *Released*: 23 April 2021
 * EditableGrid:

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,9 @@ Components, models, actions, and utility functions for LabKey applications and p
     * PicklistCreationMenuItem
     * PicklistEditModal
     * PicklistDeleteConfirm
+* Updated domain designer Lookup/Fields to allow for certain tables (e.g., picklists) being excluded from the choice for lookups
+
+
 
 ### version 2.28.0
 *Released*: 6 May 2021

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -388,7 +388,7 @@ import { IssuesListDefModel } from './internal/components/domainproperties/issue
 import { IssuesListDefDesignerPanels } from './internal/components/domainproperties/issues/IssuesListDefDesignerPanels';
 import { DatasetDesignerPanels } from './internal/components/domainproperties/dataset/DatasetDesignerPanels';
 import { DatasetModel } from './internal/components/domainproperties/dataset/models';
-import { fetchListDesign } from './internal/components/domainproperties/list/actions';
+import { fetchListDesign, getListIdFromDomainId, getListProperties } from './internal/components/domainproperties/list/actions';
 import { fetchIssuesListDefDesign } from './internal/components/domainproperties/issues/actions';
 import { fetchDatasetDesign } from './internal/components/domainproperties/dataset/actions';
 import {
@@ -897,6 +897,8 @@ export {
     ListDesignerPanels,
     ListModel,
     fetchListDesign,
+    getListIdFromDomainId,
+    getListProperties,
     DatasetDesignerPanels,
     DatasetModel,
     fetchDatasetDesign,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -426,8 +426,10 @@ import {
     PRIVATE_PICKLIST_CATEGORY,
     PUBLIC_PICKLIST_CATEGORY
 } from './internal/components/domainproperties/list/constants';
-import { PicklistCreationModal } from './internal/components/picklist/PicklistCreationModal';
+import { PicklistEditModal } from './internal/components/picklist/PicklistEditModal';
+import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
+import { PicklistModel } from './internal/components/picklist/models';
 import {
     AppReducers,
     ProductMenuReducers,
@@ -719,9 +721,11 @@ export {
     UserProvider,
     // data class and sample type related items
     PicklistCreationMenuItem,
-    PicklistCreationModal,
+    PicklistEditModal,
+    PicklistDeleteConfirm,
     PUBLIC_PICKLIST_CATEGORY,
     PRIVATE_PICKLIST_CATEGORY,
+    PicklistModel,
     DataClassModel,
     deleteDataClass,
     fetchDataClass,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -15,7 +15,7 @@
  */
 import { enableMapSet, enablePatches } from 'immer';
 
-import { buildURL, createProductUrl, createProductUrlFromParts, AppURL, spliceURL } from './internal/url/AppURL';
+import { AppURL, buildURL, createProductUrl, createProductUrlFromParts, spliceURL } from './internal/url/AppURL';
 import { hasParameter, imageURL, toggleParameter } from './internal/url/ActionURL';
 import { Container } from './internal/components/base/models/Container';
 import { hasAllPermissions, User } from './internal/components/base/models/User';
@@ -24,7 +24,7 @@ import { insertColumnFilter, QueryColumn, QueryLookup } from './public/QueryColu
 import { QuerySort } from './public/QuerySort';
 import { LastActionStatus, MessageLevel } from './internal/LastActionStatus';
 import { InferDomainResponse } from './public/InferDomainResponse';
-import { inferDomainFromFile, getServerFilePreview } from './internal/components/assay/utils';
+import { getServerFilePreview, inferDomainFromFile } from './internal/components/assay/utils';
 import { ViewInfo } from './internal/ViewInfo';
 import { QueryInfo, QueryInfoStatus } from './public/QueryInfo';
 import { SchemaDetails } from './internal/SchemaDetails';
@@ -32,8 +32,8 @@ import { SCHEMAS } from './internal/schemas';
 import { isLoading, LoadingState } from './public/LoadingState';
 
 import {
-    ServerContextProvider,
     ServerContextConsumer,
+    ServerContextProvider,
     useServerContext,
     useServerContextDispatch,
     withAppUser,
@@ -51,8 +51,8 @@ import {
     downloadAttachment,
     generateId,
     getDisambiguatedSelectInputOptions,
-    isIntegerInRange,
     isImage,
+    isIntegerInRange,
     isNonNegativeFloat,
     isNonNegativeInteger,
     toggleDevTools,
@@ -102,9 +102,9 @@ import { FileTree } from './internal/components/files/FileTree';
 import { Notification } from './internal/components/notifications/Notification';
 import {
     createNotification,
-    withTimeout,
     getPipelineActivityData,
     markAllNotificationsAsRead,
+    withTimeout,
 } from './internal/components/notifications/actions';
 import {
     addNotification,
@@ -118,8 +118,8 @@ import { CreatedModified } from './internal/components/base/CreatedModified';
 import {
     NotificationItemModel,
     Persistence,
-    ServerNotificationModel,
     ServerActivityData,
+    ServerNotificationModel,
 } from './internal/components/notifications/model';
 import { RequiresPermission } from './internal/components/base/Permissions';
 import { PaginationButtons } from './internal/components/buttons/PaginationButtons';
@@ -142,13 +142,13 @@ import {
     gridInit,
     gridInvalidate,
     gridShowError,
+    incrementClientSideMetricCount,
     queryGridInvalidate,
     replaceSelected,
     schemaGridInvalidate,
     setSelected,
     setSnapshotSelections,
     unselectAll,
-    incrementClientSideMetricCount,
 } from './internal/actions';
 import { cancelEvent } from './internal/events';
 import {
@@ -177,15 +177,15 @@ import {
 import { flattenBrowseDataTreeResponse, loadReports } from './internal/query/reports';
 import {
     DataViewInfoTypes,
+    EXPORT_TYPES,
     GRID_CHECKBOX_OPTIONS,
     IMPORT_DATA_FORM_TYPES,
     MAX_EDITABLE_GRID_ROWS,
     NO_UPDATES_MESSAGE,
-    EXPORT_TYPES,
     SM_PIPELINE_JOB_NOTIFICATION_EVENT,
+    SM_PIPELINE_JOB_NOTIFICATION_EVENT_ERROR,
     SM_PIPELINE_JOB_NOTIFICATION_EVENT_START,
     SM_PIPELINE_JOB_NOTIFICATION_EVENT_SUCCESS,
-    SM_PIPELINE_JOB_NOTIFICATION_EVENT_ERROR,
 } from './internal/constants';
 import { getLocation, replaceParameter, replaceParameters, resetParameters } from './internal/util/URL';
 import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
@@ -288,6 +288,7 @@ import {
     deleteAssayDesign,
     deleteAssayRuns,
     fetchAllAssays,
+    GENERAL_ASSAY_PROVIDER_NAME,
     getBatchPropertiesModel,
     getBatchPropertiesRow,
     getImportItemsForAssayDefinitions,
@@ -297,12 +298,11 @@ import {
     importAssayRun,
     RUN_PROPERTIES_GRID_ID,
     RUN_PROPERTIES_REQUIRED_COLUMNS,
-    GENERAL_ASSAY_PROVIDER_NAME,
 } from './internal/components/assay/actions';
 import { BaseBarChart } from './internal/components/chart/BaseBarChart';
 import { processChartData } from './internal/components/chart/utils';
 import { ReportItemModal, ReportList, ReportListItem } from './internal/components/report-list/ReportList';
-import { invalidateLineageResults, getImmediateChildLineageFilterValue } from './internal/components/lineage/actions';
+import { getImmediateChildLineageFilterValue, invalidateLineageResults } from './internal/components/lineage/actions';
 import {
     LINEAGE_DIRECTIONS,
     LINEAGE_GROUPING_GENERATIONS,
@@ -331,11 +331,11 @@ import { SiteUsersGridPanel } from './internal/components/user/SiteUsersGridPane
 import { UserProvider } from './internal/components/user/UserProvider';
 import { FieldEditorOverlay } from './internal/components/forms/FieldEditorOverlay';
 import {
+    DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
     DOMAIN_FIELD_REQUIRED,
     DOMAIN_FIELD_TYPE,
     RANGE_URIS,
     SAMPLE_TYPE_CONCEPT_URI,
-    DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
 } from './internal/components/domainproperties/constants';
 import { ExpandableContainer } from './internal/components/ExpandableContainer';
 import { PermissionAssignments } from './internal/components/permissions/PermissionAssignments';
@@ -354,9 +354,9 @@ import { SampleTypeModel } from './internal/components/domainproperties/samples/
 import { EditableDetailPanel } from './public/QueryModel/EditableDetailPanel';
 import { Pagination } from './internal/components/pagination/Pagination';
 import {
+    flattenValuesFromRow,
     getQueryModelExportParams,
     runDetailsColumnsForQueryModel,
-    flattenValuesFromRow,
 } from './public/QueryModel/utils';
 import { useRouteLeave, withRouteLeave } from './internal/util/RouteLeave';
 import { BarChartViewer } from './internal/components/chart/BarChartViewer';
@@ -390,8 +390,8 @@ import { fetchListDesign, getListProperties } from './internal/components/domain
 import { fetchIssuesListDefDesign } from './internal/components/domainproperties/issues/actions';
 import { fetchDatasetDesign } from './internal/components/domainproperties/dataset/actions';
 import {
-    SampleTypeDesigner,
     DEFAULT_SAMPLE_FIELD_CONFIG,
+    SampleTypeDesigner,
 } from './internal/components/domainproperties/samples/SampleTypeDesigner';
 import { ListDesignerPanels } from './internal/components/domainproperties/list/ListDesignerPanels';
 import { DataClassDesigner } from './internal/components/domainproperties/dataclasses/DataClassDesigner';
@@ -399,7 +399,7 @@ import { DataClassModel } from './internal/components/domainproperties/dataclass
 import { deleteDataClass, fetchDataClass } from './internal/components/domainproperties/dataclasses/actions';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { AssayImportPanels } from './internal/components/assay/AssayImportPanels';
-import { mountWithServerContext, sleep, waitForLifecycle, makeQueryInfo } from './internal/testHelpers';
+import { makeQueryInfo, mountWithServerContext, sleep, waitForLifecycle } from './internal/testHelpers';
 import { QueryModel } from './public/QueryModel/QueryModel';
 import { withQueryModels } from './public/QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './public/QueryModel/GridPanel';
@@ -422,9 +422,12 @@ import { OntologyBrowserPanel } from './internal/components/ontology/OntologyBro
 import { OntologyConceptOverviewPanel } from './internal/components/ontology/ConceptOverviewPanel';
 import { OntologyBrowserFilterPanel } from './internal/components/ontology/OntologyBrowserFilterPanel';
 import { AppModel, LogoutReason } from './internal/app/models';
-import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY} from './internal/components/domainproperties/list/constants';
-import { PicklistCreationModal} from './internal/components/picklist/PicklistCreationModal';
-import { PicklistCreationMenuItem} from './internal/components/picklist/PicklistCreationMenuItem';
+import {
+    PRIVATE_PICKLIST_CATEGORY,
+    PUBLIC_PICKLIST_CATEGORY
+} from './internal/components/domainproperties/list/constants';
+import { PicklistCreationModal } from './internal/components/picklist/PicklistCreationModal';
+import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
 import {
     AppReducers,
     ProductMenuReducers,
@@ -441,6 +444,7 @@ import {
     isSampleAliquotEnabled,
     isSampleManagerEnabled,
     isSamplePicklistEnabled,
+    userCanDeletePublicPicklists,
     userCanDesignLocations,
     userCanDesignSourceTypes,
     userCanManagePicklists,
@@ -479,7 +483,8 @@ import {
     NEW_SAMPLE_TYPE_HREF,
     NEW_SAMPLES_HREF,
     NEW_SOURCE_TYPE_HREF,
-    NOTIFICATION_TIMEOUT, PICKLIST_HOME_HREF,
+    NOTIFICATION_TIMEOUT,
+    PICKLIST_HOME_HREF,
     PICKLIST_KEY,
     SAMPLE_MANAGER_PRODUCT_ID,
     SAMPLE_TYPE_KEY,
@@ -530,6 +535,7 @@ const App = {
     userCanDesignLocations,
     userCanDesignSourceTypes,
     userCanManagePicklists,
+    userCanDeletePublicPicklists,
     SECURITY_LOGOUT,
     SECURITY_SERVER_UNAVAILABLE,
     SECURITY_SESSION_TIMEOUT,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -420,6 +420,8 @@ import { createMockWithRouterProps } from './test/mockUtils';
 import { OntologyBrowserPanel } from './internal/components/ontology/OntologyBrowserPanel';
 import { OntologyConceptOverviewPanel } from './internal/components/ontology/ConceptOverviewPanel';
 import { AppModel, LogoutReason } from './internal/app/models';
+import { PicklistCreationModal} from './internal/components/picklist/PicklistCreationModal';
+import { PicklistCreationMenuItem} from './internal/components/picklist/PicklistCreationMenuItem';
 import {
     AppReducers,
     ProductMenuReducers,
@@ -435,8 +437,10 @@ import {
     isFreezerManagementEnabled,
     isSampleAliquotEnabled,
     isSampleManagerEnabled,
+    isSamplePicklistEnabled,
     userCanDesignLocations,
     userCanDesignSourceTypes,
+    userCanManagePicklists,
 } from './internal/app/utils';
 import {
     doResetQueryGridState,
@@ -473,6 +477,7 @@ import {
     NEW_SAMPLES_HREF,
     NEW_SOURCE_TYPE_HREF,
     NOTIFICATION_TIMEOUT,
+    PICKLIST_KEY,
     SAMPLE_MANAGER_PRODUCT_ID,
     SAMPLE_TYPE_KEY,
     SAMPLES_KEY,
@@ -506,6 +511,7 @@ const App = {
     isFreezerManagementEnabled,
     isSampleManagerEnabled,
     isSampleAliquotEnabled,
+    isSamplePicklistEnabled,
     hasPremiumModule,
     getDateFormat: getAppDateFormat,
     getMenuSectionConfigs,
@@ -520,6 +526,7 @@ const App = {
     updateUserDisplayName,
     userCanDesignLocations,
     userCanDesignSourceTypes,
+    userCanManagePicklists,
     SECURITY_LOGOUT,
     SECURITY_SERVER_UNAVAILABLE,
     SECURITY_SESSION_TIMEOUT,
@@ -532,6 +539,7 @@ const App = {
     FREEZER_MANAGER_PRODUCT_ID,
     ASSAYS_KEY,
     ASSAY_DESIGN_KEY,
+    PICKLIST_KEY,
     SAMPLES_KEY,
     SAMPLE_TYPE_KEY,
     SOURCES_KEY,
@@ -700,6 +708,8 @@ export {
     Principal,
     UserProvider,
     // data class and sample type related items
+    PicklistCreationMenuItem,
+    PicklistCreationModal,
     DataClassModel,
     deleteDataClass,
     fetchDataClass,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -386,7 +386,7 @@ import { IssuesListDefModel } from './internal/components/domainproperties/issue
 import { IssuesListDefDesignerPanels } from './internal/components/domainproperties/issues/IssuesListDefDesignerPanels';
 import { DatasetDesignerPanels } from './internal/components/domainproperties/dataset/DatasetDesignerPanels';
 import { DatasetModel } from './internal/components/domainproperties/dataset/models';
-import { fetchListDesign } from './internal/components/domainproperties/list/actions';
+import { fetchListDesign, getListProperties } from './internal/components/domainproperties/list/actions';
 import { fetchIssuesListDefDesign } from './internal/components/domainproperties/issues/actions';
 import { fetchDatasetDesign } from './internal/components/domainproperties/dataset/actions';
 import {
@@ -421,6 +421,7 @@ import { createMockWithRouterProps } from './test/mockUtils';
 import { OntologyBrowserPanel } from './internal/components/ontology/OntologyBrowserPanel';
 import { OntologyConceptOverviewPanel } from './internal/components/ontology/ConceptOverviewPanel';
 import { AppModel, LogoutReason } from './internal/app/models';
+import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY} from './internal/components/domainproperties/list/constants';
 import { PicklistCreationModal} from './internal/components/picklist/PicklistCreationModal';
 import { PicklistCreationMenuItem} from './internal/components/picklist/PicklistCreationMenuItem';
 import {
@@ -477,7 +478,7 @@ import {
     NEW_SAMPLE_TYPE_HREF,
     NEW_SAMPLES_HREF,
     NEW_SOURCE_TYPE_HREF,
-    NOTIFICATION_TIMEOUT,
+    NOTIFICATION_TIMEOUT, PICKLIST_HOME_HREF,
     PICKLIST_KEY,
     SAMPLE_MANAGER_PRODUCT_ID,
     SAMPLE_TYPE_KEY,
@@ -554,6 +555,7 @@ const App = {
     NEW_SOURCE_TYPE_HREF,
     NEW_SAMPLE_TYPE_HREF,
     NEW_ASSAY_DESIGN_HREF,
+    PICKLIST_HOME_HREF,
     WORKFLOW_HOME_HREF,
     NEW_FREEZER_DESIGN_HREF,
     MANAGE_STORAGE_UNITS_HREF,
@@ -711,6 +713,8 @@ export {
     // data class and sample type related items
     PicklistCreationMenuItem,
     PicklistCreationModal,
+    PUBLIC_PICKLIST_CATEGORY,
+    PRIVATE_PICKLIST_CATEGORY,
     DataClassModel,
     deleteDataClass,
     fetchDataClass,
@@ -876,6 +880,7 @@ export {
     ListDesignerPanels,
     ListModel,
     fetchListDesign,
+    getListProperties,
     DatasetDesignerPanels,
     DatasetModel,
     fetchDatasetDesign,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -430,6 +430,7 @@ import { PicklistEditModal } from './internal/components/picklist/PicklistEditMo
 import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
 import { PicklistModel } from './internal/components/picklist/models';
+import { deletePicklists, updatePicklist } from './internal/components/picklist/actions';
 import {
     AppReducers,
     ProductMenuReducers,
@@ -719,13 +720,16 @@ export {
     SecurityRole,
     Principal,
     UserProvider,
-    // data class and sample type related items
+    // sample picklist items
     PicklistCreationMenuItem,
     PicklistEditModal,
     PicklistDeleteConfirm,
     PUBLIC_PICKLIST_CATEGORY,
     PRIVATE_PICKLIST_CATEGORY,
     PicklistModel,
+    deletePicklists,
+    updatePicklist,
+    // data class and sample type related items
     DataClassModel,
     deleteDataClass,
     fetchDataClass,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -388,7 +388,7 @@ import { IssuesListDefModel } from './internal/components/domainproperties/issue
 import { IssuesListDefDesignerPanels } from './internal/components/domainproperties/issues/IssuesListDefDesignerPanels';
 import { DatasetDesignerPanels } from './internal/components/domainproperties/dataset/DatasetDesignerPanels';
 import { DatasetModel } from './internal/components/domainproperties/dataset/models';
-import { fetchListDesign, getListProperties } from './internal/components/domainproperties/list/actions';
+import { fetchListDesign } from './internal/components/domainproperties/list/actions';
 import { fetchIssuesListDefDesign } from './internal/components/domainproperties/issues/actions';
 import { fetchDatasetDesign } from './internal/components/domainproperties/dataset/actions';
 import {
@@ -897,7 +897,6 @@ export {
     ListDesignerPanels,
     ListModel,
     fetchListDesign,
-    getListProperties,
     DatasetDesignerPanels,
     DatasetModel,
     fetchDatasetDesign,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -388,7 +388,11 @@ import { IssuesListDefModel } from './internal/components/domainproperties/issue
 import { IssuesListDefDesignerPanels } from './internal/components/domainproperties/issues/IssuesListDefDesignerPanels';
 import { DatasetDesignerPanels } from './internal/components/domainproperties/dataset/DatasetDesignerPanels';
 import { DatasetModel } from './internal/components/domainproperties/dataset/models';
-import { fetchListDesign, getListIdFromDomainId, getListProperties } from './internal/components/domainproperties/list/actions';
+import {
+    fetchListDesign,
+    getListIdFromDomainId,
+    getListProperties,
+} from './internal/components/domainproperties/list/actions';
 import { fetchIssuesListDefDesign } from './internal/components/domainproperties/issues/actions';
 import { fetchDatasetDesign } from './internal/components/domainproperties/dataset/actions';
 import {
@@ -426,7 +430,7 @@ import { OntologyBrowserFilterPanel } from './internal/components/ontology/Ontol
 import { AppModel, LogoutReason } from './internal/app/models';
 import {
     PRIVATE_PICKLIST_CATEGORY,
-    PUBLIC_PICKLIST_CATEGORY
+    PUBLIC_PICKLIST_CATEGORY,
 } from './internal/components/domainproperties/list/constants';
 import { PicklistEditModal } from './internal/components/picklist/PicklistEditModal';
 import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1321,7 +1321,7 @@ export function getSelectedData(
     columns?: string,
     sorts?: string,
     queryParameters?: { [key: string]: any },
-    keyColumn: string = 'RowId'
+    keyColumn = 'RowId'
 ): Promise<IGridResponse> {
     const filterArray = [];
     filterArray.push(Filter.create(keyColumn, selections, Filter.Types.IN));

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1319,10 +1319,11 @@ export function getSelectedData(
     selections?: string[],
     columns?: string,
     sorts?: string,
-    queryParameters?: { [key: string]: any }
+    queryParameters?: { [key: string]: any },
+    keyColumn: string = 'RowId'
 ): Promise<IGridResponse> {
     const filterArray = [];
-    filterArray.push(Filter.create('RowId', selections, Filter.Types.IN));
+    filterArray.push(Filter.create(keyColumn, selections, Filter.Types.IN));
 
     return new Promise((resolve, reject) =>
         selectRows({

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -24,6 +24,7 @@ export const FREEZERS_KEY = 'freezers';
 export const BOXES_KEY = 'boxes';
 export const HOME_KEY = 'home';
 export const USER_KEY = 'user';
+export const PICKLIST_KEY = 'samplePicklists';
 
 export const NEW_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new');
 export const NEW_SOURCE_TYPE_HREF = AppURL.create(SOURCE_TYPE_KEY, 'new');

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -24,7 +24,7 @@ export const FREEZERS_KEY = 'freezers';
 export const BOXES_KEY = 'boxes';
 export const HOME_KEY = 'home';
 export const USER_KEY = 'user';
-export const PICKLIST_KEY = 'samplePicklists';
+export const PICKLIST_KEY = 'picklist';
 
 export const NEW_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new');
 export const NEW_SOURCE_TYPE_HREF = AppURL.create(SOURCE_TYPE_KEY, 'new');
@@ -35,6 +35,7 @@ export const WORKFLOW_HOME_HREF = AppURL.create(WORKFLOW_KEY)
     .addParam('active.sort', 'DueDate');
 export const NEW_FREEZER_DESIGN_HREF = AppURL.create(FREEZERS_KEY, 'new');
 export const MANAGE_STORAGE_UNITS_HREF = AppURL.create(BOXES_KEY, 'types', 'update');
+export const PICKLIST_HOME_HREF = AppURL.create(PICKLIST_KEY);
 
 export const USER_PERMISSIONS_REQUEST = '/app/USER_PERMISSIONS_REQUEST';
 export const USER_PERMISSIONS_SUCCESS = '/app/USER_PERMISSIONS_SUCCESS';

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -115,6 +115,10 @@ export function initWebSocketListeners(
     }
 }
 
+export function userCanManagePicklists(user: User): boolean {
+    return hasAllPermissions(user, ['org.labkey.api.lists.permissions.ManagePicklistsPermission']);
+}
+
 export function userCanDesignSourceTypes(user: User): boolean {
     return hasAllPermissions(user, [PermissionTypes.DesignDataClass]);
 }
@@ -144,6 +148,10 @@ function isFreezerManagerEnabledInBiologics(): boolean {
 
 export function isSampleAliquotEnabled(): boolean {
     return getServerContext().experimental && getServerContext().experimental['sampleAliquot'] === true;
+}
+
+export function isSamplePicklistEnabled(): boolean {
+    return getServerContext().experimental && getServerContext().experimental['samplePicklist'] === true;
 }
 
 export function hasModule(moduleName: string) {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -119,6 +119,10 @@ export function userCanManagePicklists(user: User): boolean {
     return hasAllPermissions(user, ['org.labkey.api.lists.permissions.ManagePicklistsPermission']);
 }
 
+export function userCanDeletePublicPicklists(user: User): boolean {
+    return hasAllPermissions(user, [PermissionTypes.ApplicationAdmin]);
+}
+
 export function userCanDesignSourceTypes(user: User): boolean {
     return hasAllPermissions(user, [PermissionTypes.DesignDataClass]);
 }

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -116,11 +116,11 @@ export function initWebSocketListeners(
 }
 
 export function userCanManagePicklists(user: User): boolean {
-    return hasAllPermissions(user, ['org.labkey.api.lists.permissions.ManagePicklistsPermission']);
+    return hasAllPermissions(user, [PermissionTypes.ManagePicklists]);
 }
 
 export function userCanDeletePublicPicklists(user: User): boolean {
-    return hasAllPermissions(user, [PermissionTypes.ApplicationAdmin]);
+    return user.isAdmin;
 }
 
 export function userCanDesignSourceTypes(user: User): boolean {

--- a/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
@@ -192,7 +192,8 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
             let infos = List<{ name: string; type: PropDescType }>();
 
             queries.forEach(q => {
-                infos = infos.concat(q.getLookupInfo(this.props.lookupURI)).toList();
+                if (q.isIncludedForLookups)
+                    infos = infos.concat(q.getLookupInfo(this.props.lookupURI)).toList();
             });
 
             this.setState({

--- a/packages/components/src/internal/components/domainproperties/list/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/list/actions.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Ajax, Utils, Domain } from '@labkey/api';
+import { ActionURL, Ajax, Utils, Domain, getServerContext } from '@labkey/api';
 
 import { ListModel } from './models';
 import { INT_LIST } from './constants';
 
-function getListProperties(listId?: number): Promise<ListModel> {
+export function getListProperties(listId?: number): Promise<ListModel> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('list', 'getListProperties.api'),
@@ -57,5 +57,22 @@ export function fetchListDesign(listId?: number): Promise<ListModel> {
                 console.error(error);
                 reject(error);
             });
+    });
+}
+
+export function getListIdFromDomainId(domainId: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+        Domain.getDomainDetails({
+            containerPath: getServerContext().container.path,
+            domainId,
+            success: (data) => {
+                const newModel = ListModel.create(data);
+                resolve(newModel.listId);
+            },
+            failure: (error) => {
+                console.error("Unable to retrieve list id for domainId: " + domainId, error);
+                reject(undefined);
+            }
+        });
     });
 }

--- a/packages/components/src/internal/components/domainproperties/list/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/list/actions.ts
@@ -18,7 +18,7 @@ import { ActionURL, Ajax, Utils, Domain, getServerContext } from '@labkey/api';
 import { ListModel } from './models';
 import { INT_LIST } from './constants';
 
-function getListProperties(listId?: number): Promise<ListModel> {
+export function getListProperties(listId?: number): Promise<ListModel> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('list', 'getListProperties.api'),

--- a/packages/components/src/internal/components/domainproperties/list/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/list/actions.ts
@@ -65,14 +65,14 @@ export function getListIdFromDomainId(domainId: number): Promise<number> {
         Domain.getDomainDetails({
             containerPath: getServerContext().container.path,
             domainId,
-            success: (data) => {
+            success: data => {
                 const newModel = ListModel.create(data);
                 resolve(newModel.listId);
             },
-            failure: (error) => {
-                console.error("Unable to retrieve list id for domainId: " + domainId, error);
+            failure: error => {
+                console.error('Unable to retrieve list id for domainId: ' + domainId, error);
                 reject(undefined);
-            }
+            },
         });
     });
 }

--- a/packages/components/src/internal/components/domainproperties/list/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/list/actions.ts
@@ -18,7 +18,7 @@ import { ActionURL, Ajax, Utils, Domain, getServerContext } from '@labkey/api';
 import { ListModel } from './models';
 import { INT_LIST } from './constants';
 
-export function getListProperties(listId?: number): Promise<ListModel> {
+function getListProperties(listId?: number): Promise<ListModel> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('list', 'getListProperties.api'),

--- a/packages/components/src/internal/components/domainproperties/list/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/list/constants.ts
@@ -10,3 +10,7 @@ export const SEARCH_INDEXING_TIP = 'Controls how this list is indexed for search
 
 export const VAR_LIST = 'VarList';
 export const INT_LIST = 'IntList';
+export const PICKLIST = 'Picklist';
+
+export const PRIVATE_PICKLIST_CATEGORY = "PrivatePicklist";
+export const PUBLIC_PICKLIST_CATEGORY = "PublicPicklist";

--- a/packages/components/src/internal/components/domainproperties/list/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/list/constants.ts
@@ -12,5 +12,5 @@ export const VAR_LIST = 'VarList';
 export const INT_LIST = 'IntList';
 export const PICKLIST = 'Picklist';
 
-export const PRIVATE_PICKLIST_CATEGORY = "PrivatePicklist";
-export const PUBLIC_PICKLIST_CATEGORY = "PublicPicklist";
+export const PRIVATE_PICKLIST_CATEGORY = 'PrivatePicklist';
+export const PUBLIC_PICKLIST_CATEGORY = 'PublicPicklist';

--- a/packages/components/src/internal/components/domainproperties/list/models.ts
+++ b/packages/components/src/internal/components/domainproperties/list/models.ts
@@ -18,7 +18,7 @@ import { Record } from 'immutable';
 import { DomainDesign, DomainField } from '../models';
 import { DOMAIN_FIELD_PRIMARY_KEY_LOCKED } from '../constants';
 
-import { INT_LIST, VAR_LIST } from './constants';
+import { INT_LIST, PICKLIST, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY, VAR_LIST } from './constants';
 
 export interface AdvancedSettingsForm {
     titleColumn?: string;
@@ -69,6 +69,7 @@ export class ListModel extends Record({
     listId: undefined,
     discussionSettingEnum: undefined,
     containerPath: undefined,
+    category: undefined,
 }) {
     declare exception: string;
     declare domain: DomainDesign;
@@ -97,6 +98,7 @@ export class ListModel extends Record({
     declare listId: number;
     declare discussionSettingEnum: string;
     declare containerPath: string;
+    declare category: string;
 
     static create(raw: any, defaultSettings = null): ListModel {
         if (defaultSettings) {
@@ -121,7 +123,10 @@ export class ListModel extends Record({
     }
 
     getDomainKind(): string {
-        if (this.keyType === 'Varchar') {
+        if (this.category === PUBLIC_PICKLIST_CATEGORY || this.category === PRIVATE_PICKLIST_CATEGORY) {
+            return PICKLIST;
+        }
+        else if (this.keyType === 'Varchar') {
             return VAR_LIST;
         } else if (this.keyType === 'Integer' || this.keyType === 'AutoIncrementInteger') {
             return INT_LIST;

--- a/packages/components/src/internal/components/domainproperties/list/models.ts
+++ b/packages/components/src/internal/components/domainproperties/list/models.ts
@@ -125,8 +125,7 @@ export class ListModel extends Record({
     getDomainKind(): string {
         if (this.category === PUBLIC_PICKLIST_CATEGORY || this.category === PRIVATE_PICKLIST_CATEGORY) {
             return PICKLIST;
-        }
-        else if (this.keyType === 'Varchar') {
+        } else if (this.keyType === 'Varchar') {
             return VAR_LIST;
         } else if (this.keyType === 'Integer' || this.keyType === 'AutoIncrementInteger') {
             return INT_LIST;

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1317,6 +1317,7 @@ interface IQueryInfoLite {
     description?: string;
     hidden?: boolean;
     inherit?: boolean;
+    isIncludedForLookups?: boolean;
     isInherited?: boolean;
     isMetadataOverrideable?: boolean;
     isUserDefined?: boolean;
@@ -1335,6 +1336,7 @@ export class QueryInfoLite
         description: undefined,
         hidden: false,
         inherit: false,
+        isIncludedForLookups: true,
         isInherited: false,
         isMetadataOverrideable: false,
         isUserDefined: false,
@@ -1351,6 +1353,7 @@ export class QueryInfoLite
     declare description?: string;
     declare hidden?: boolean;
     declare inherit?: boolean;
+    declare isIncludedForLookups?: boolean;
     declare isInherited?: boolean;
     declare isMetadataOverrideable?: boolean;
     declare isUserDefined?: boolean;

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
@@ -1,38 +1,53 @@
 import React from 'react';
-import { PicklistCreationMenuItem } from './PicklistCreationMenuItem';
+
 import { mount } from 'enzyme';
 import { MenuItem, Modal } from 'react-bootstrap';
 
-describe("PicklistCreationMenuItem", () => {
+import { PicklistCreationMenuItem } from './PicklistCreationMenuItem';
+
+describe('PicklistCreationMenuItem', () => {
     const key = 'picklists';
-    const selectionKey='test-selection';
-    const selectedQuantity=4;
-    const text= 'Picklist';
+    const selectionKey = 'test-selection';
+    const selectedQuantity = 4;
+    const text = 'Picklist';
 
-    test("modal hidden", () => {
-
-        const wrapper = mount(<PicklistCreationMenuItem itemText={text} selectionKey={selectionKey} selectedQuantity={selectedQuantity} key={key}/>);
+    test('modal hidden', () => {
+        const wrapper = mount(
+            <PicklistCreationMenuItem
+                itemText={text}
+                selectionKey={selectionKey}
+                selectedQuantity={selectedQuantity}
+                key={key}
+            />
+        );
         const menuItem = wrapper.find(MenuItem);
         expect(menuItem).toHaveLength(1);
         expect(menuItem.text()).toBe(text);
-        const memoWrapper = wrapper.find("Memo()");
+        const memoWrapper = wrapper.find('Memo()');
         expect(memoWrapper).toHaveLength(1);
-        expect(memoWrapper.prop("selectionKey")).toBe(selectionKey);
-        expect(memoWrapper.prop("selectedQuantity")).toBe(selectedQuantity);
+        expect(memoWrapper.prop('selectionKey')).toBe(selectionKey);
+        expect(memoWrapper.prop('selectedQuantity')).toBe(selectedQuantity);
         const modal = memoWrapper.find(Modal);
         expect(modal).toHaveLength(1);
-        expect(modal.prop("show")).toBe(false);
+        expect(modal.prop('show')).toBe(false);
         wrapper.unmount();
-   });
+    });
 
-    test("modal shown", () => {
-        const wrapper = mount(<PicklistCreationMenuItem itemText={text} selectionKey={selectionKey} selectedQuantity={selectedQuantity} key={key}/>);
+    test('modal shown', () => {
+        const wrapper = mount(
+            <PicklistCreationMenuItem
+                itemText={text}
+                selectionKey={selectionKey}
+                selectedQuantity={selectedQuantity}
+                key={key}
+            />
+        );
         const menuItem = wrapper.find('MenuItem a');
         expect(menuItem).toHaveLength(1);
         menuItem.simulate('click');
         const modal = wrapper.find(Modal);
         expect(modal).toHaveLength(1);
-        expect(modal.prop("show")).toBe(true);
+        expect(modal.prop('show')).toBe(true);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { PicklistCreationMenuItem } from './PicklistCreationMenuItem';
+import { mount } from 'enzyme';
+import { MenuItem, Modal } from 'react-bootstrap';
+
+describe("PicklistCreationMenuItem", () => {
+    const key = 'picklists';
+    const selectionKey='test-selection';
+    const selectedQuantity=4;
+    const text= 'Picklist';
+
+    test("modal hidden", () => {
+
+        const wrapper = mount(<PicklistCreationMenuItem itemText={text} selectionKey={selectionKey} selectedQuantity={selectedQuantity} key={key}/>);
+        const menuItem = wrapper.find(MenuItem);
+        expect(menuItem).toHaveLength(1);
+        expect(menuItem.text()).toBe(text);
+        const memoWrapper = wrapper.find("Memo()");
+        expect(memoWrapper).toHaveLength(1);
+        expect(memoWrapper.prop("selectionKey")).toBe(selectionKey);
+        expect(memoWrapper.prop("selectedQuantity")).toBe(selectedQuantity);
+        const modal = memoWrapper.find(Modal);
+        expect(modal).toHaveLength(1);
+        expect(modal.prop("show")).toBe(false);
+        wrapper.unmount();
+   });
+
+    test("modal shown", () => {
+        const wrapper = mount(<PicklistCreationMenuItem itemText={text} selectionKey={selectionKey} selectedQuantity={selectedQuantity} key={key}/>);
+        const menuItem = wrapper.find('MenuItem a');
+        expect(menuItem).toHaveLength(1);
+        menuItem.simulate('click');
+        const modal = wrapper.find(Modal);
+        expect(modal).toHaveLength(1);
+        expect(modal.prop("show")).toBe(true);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -1,10 +1,10 @@
 import React, { FC, useState } from 'react';
-import { PicklistCreationModal } from './PicklistCreationModal';
+import { PicklistEditModal } from './PicklistEditModal';
 import { createNotification } from '../notifications/actions';
 import { MenuItem } from 'react-bootstrap';
 import { AppURL } from '../../url/AppURL';
 import { QueryGridModel } from '../../QueryGridModel';
-import { resolveErrorMessage } from '../../util/messaging';
+import { PicklistModel } from './models';
 
 interface Props {
     selectionModel: QueryGridModel
@@ -15,13 +15,13 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     const { selectionModel, key } = props;
     const [ showModal, setShowModal ] = useState<boolean>(false);
 
-    const onFinish = (name: string) => {
+    const onFinish = (picklist: PicklistModel) => {
         createNotification({
             message: () => {
                return (
                    <>
-                       Successfully created "{name}" with {selectionModel.selectedQuantity} sample{selectionModel.selectedQuantity === 1 ? '': 's'}.&nbsp;
-                       <a href={AppURL.create("picklist", name).toHref()}>View picklist.</a>
+                       Successfully created "{picklist.name}" with {selectionModel.selectedQuantity} sample{selectionModel.selectedQuantity === 1 ? '': 's'}.&nbsp;
+                       <a href={AppURL.create("picklist", picklist.name).toHref()}>View picklist.</a>
                    </>
                )
             },
@@ -41,10 +41,10 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     return (
         <>
             <MenuItem onClick={onClick} key={key}>Picklist</MenuItem>
-            <PicklistCreationModal
+            <PicklistEditModal
                 useSelection={true}
                 show={showModal}
-                model={selectionModel}
+                samplesModel={selectionModel}
                 onFinish={onFinish}
                 onCancel={onCancel}
             />

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -25,7 +25,7 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
                    </>
                )
             },
-            alertClass: 'info'
+            alertClass: 'success'
         });
         setShowModal(false);
     }
@@ -48,7 +48,7 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     return (
         <>
             <MenuItem onClick={onClick} key={key}>Picklist</MenuItem>
-            <PicklistCreationModal show={showModal} selectionModel={selectionModel} onFinish={onFinish} onCancel={onCancel}/>
+            <PicklistCreationModal useSelection={true} show={showModal} model={selectionModel} onFinish={onFinish} onCancel={onCancel}/>
         </>
     )
 }

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -15,26 +15,19 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     const { selectionModel, key } = props;
     const [ showModal, setShowModal ] = useState<boolean>(false);
 
-    const onFinish = (name: string, id: number) => {
+    const onFinish = (name: string) => {
         createNotification({
             message: () => {
                return (
                    <>
                        Successfully created "{name}" with {selectionModel.selectedQuantity} sample{selectionModel.selectedQuantity === 1 ? '': 's'}.&nbsp;
-                       <a href={AppURL.create("picklist", id).toHref()}>View picklist.</a>
+                       <a href={AppURL.create("picklist", name).toHref()}>View picklist.</a>
                    </>
                )
             },
             alertClass: 'success'
         });
         setShowModal(false);
-    }
-
-    const onError = (reason: string) => {
-        createNotification({
-            message: resolveErrorMessage(reason),
-            alertClass: 'danger'
-        })
     }
 
     const onCancel = () => {
@@ -48,7 +41,13 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     return (
         <>
             <MenuItem onClick={onClick} key={key}>Picklist</MenuItem>
-            <PicklistCreationModal useSelection={true} show={showModal} model={selectionModel} onFinish={onFinish} onCancel={onCancel}/>
+            <PicklistCreationModal
+                useSelection={true}
+                show={showModal}
+                model={selectionModel}
+                onFinish={onFinish}
+                onCancel={onCancel}
+            />
         </>
     )
 }

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -26,7 +26,7 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
                return (
                    <>
                        Successfully created "{picklist.name}" with {Utils.pluralize(count, 'sample', 'samples')}.&nbsp;
-                       <a href={AppURL.create(PICKLIST_KEY, picklist.name).toHref()}>View picklist</a>.
+                       <a href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>View picklist</a>.
                    </>
                );
             },

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -1,0 +1,54 @@
+import React, { FC, useState } from 'react';
+import { PicklistCreationModal } from './PicklistCreationModal';
+import { createNotification } from '../notifications/actions';
+import { MenuItem } from 'react-bootstrap';
+import { AppURL } from '../../url/AppURL';
+import { QueryGridModel } from '../../QueryGridModel';
+import { resolveErrorMessage } from '../../util/messaging';
+
+interface Props {
+    selectionModel: QueryGridModel
+    key: string
+}
+
+export const PicklistCreationMenuItem: FC<Props> = props => {
+    const { selectionModel, key } = props;
+    const [ showModal, setShowModal ] = useState<boolean>(false);
+
+    const onFinish = (name: string, id: number) => {
+        createNotification({
+            message: () => {
+               return (
+                   <>
+                       Successfully created "{name}" with {selectionModel.selectedQuantity} sample{selectionModel.selectedQuantity === 1 ? '': 's'}.&nbsp;
+                       <a href={AppURL.create("picklist", id).toHref()}>View picklist.</a>
+                   </>
+               )
+            },
+            alertClass: 'info'
+        });
+        setShowModal(false);
+    }
+
+    const onError = (reason: string) => {
+        createNotification({
+            message: resolveErrorMessage(reason),
+            alertClass: 'danger'
+        })
+    }
+
+    const onCancel = () => {
+        setShowModal(false);
+    }
+
+    const onClick = () => {
+        setShowModal(true);
+    }
+
+    return (
+        <>
+            <MenuItem onClick={onClick} key={key}>Picklist</MenuItem>
+            <PicklistCreationModal show={showModal} selectionModel={selectionModel} onFinish={onFinish} onCancel={onCancel}/>
+        </>
+    )
+}

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -3,27 +3,32 @@ import { PicklistEditModal } from './PicklistEditModal';
 import { createNotification } from '../notifications/actions';
 import { MenuItem } from 'react-bootstrap';
 import { AppURL } from '../../url/AppURL';
-import { QueryGridModel } from '../../QueryGridModel';
 import { PicklistModel } from './models';
+import { PICKLIST_KEY } from '../../app/constants';
+import { Utils } from '@labkey/api';
 
 interface Props {
-    selectionModel: QueryGridModel
-    key: string
+    selectionKey?: string,
+    selectedQuantity?: number,
+    sampleIds?: string[],
+    key: string,
+    itemText: string,
 }
 
 export const PicklistCreationMenuItem: FC<Props> = props => {
-    const { selectionModel, key } = props;
+    const { sampleIds, selectionKey, selectedQuantity, key, itemText } = props;
     const [ showModal, setShowModal ] = useState<boolean>(false);
 
     const onFinish = (picklist: PicklistModel) => {
+        const count = sampleIds ? sampleIds.length : selectedQuantity;
         createNotification({
             message: () => {
                return (
                    <>
-                       Successfully created "{picklist.name}" with {selectionModel.selectedQuantity} sample{selectionModel.selectedQuantity === 1 ? '': 's'}.&nbsp;
-                       <a href={AppURL.create("picklist", picklist.name).toHref()}>View picklist.</a>
+                       Successfully created "{picklist.name}" with {Utils.pluralize(count, 'sample', 'samples')}.&nbsp;
+                       <a href={AppURL.create(PICKLIST_KEY, picklist.name).toHref()}>View picklist</a>.
                    </>
-               )
+               );
             },
             alertClass: 'success'
         });
@@ -40,11 +45,12 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
 
     return (
         <>
-            <MenuItem onClick={onClick} key={key}>Picklist</MenuItem>
+            <MenuItem onClick={onClick} key={key}>{itemText}</MenuItem>
             <PicklistEditModal
-                useSelection={true}
+                selectionKey={selectionKey}
+                selectedQuantity={selectedQuantity}
+                sampleIds={sampleIds}
                 show={showModal}
-                samplesModel={selectionModel}
                 onFinish={onFinish}
                 onCancel={onCancel}
             />

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -1,51 +1,60 @@
 import React, { FC, useState } from 'react';
-import { PicklistEditModal } from './PicklistEditModal';
-import { createNotification } from '../notifications/actions';
+
 import { MenuItem } from 'react-bootstrap';
-import { AppURL } from '../../url/AppURL';
-import { PicklistModel } from './models';
-import { PICKLIST_KEY } from '../../app/constants';
+
 import { Utils } from '@labkey/api';
 
+import { createNotification } from '../notifications/actions';
+
+import { AppURL } from '../../url/AppURL';
+
+import { PICKLIST_KEY } from '../../app/constants';
+
+import { PicklistEditModal } from './PicklistEditModal';
+
+import { PicklistModel } from './models';
+
 interface Props {
-    selectionKey?: string,
-    selectedQuantity?: number,
-    sampleIds?: string[],
-    key: string,
-    itemText: string,
+    selectionKey?: string;
+    selectedQuantity?: number;
+    sampleIds?: string[];
+    key: string;
+    itemText: string;
 }
 
 export const PicklistCreationMenuItem: FC<Props> = props => {
     const { sampleIds, selectionKey, selectedQuantity, key, itemText } = props;
-    const [ showModal, setShowModal ] = useState<boolean>(false);
+    const [showModal, setShowModal] = useState<boolean>(false);
 
     const onFinish = (picklist: PicklistModel) => {
         const count = sampleIds ? sampleIds.length : selectedQuantity;
         createNotification({
             message: () => {
-               return (
-                   <>
-                       Successfully created "{picklist.name}" with {Utils.pluralize(count, 'sample', 'samples')}.&nbsp;
-                       <a href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>View picklist</a>.
-                   </>
-               );
+                return (
+                    <>
+                        Successfully created "{picklist.name}" with {Utils.pluralize(count, 'sample', 'samples')}.&nbsp;
+                        <a href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>View picklist</a>.
+                    </>
+                );
             },
-            alertClass: 'success'
+            alertClass: 'success',
         });
         setShowModal(false);
-    }
+    };
 
     const onCancel = () => {
         setShowModal(false);
-    }
+    };
 
     const onClick = () => {
         setShowModal(true);
-    }
+    };
 
     return (
         <>
-            <MenuItem onClick={onClick} key={key}>{itemText}</MenuItem>
+            <MenuItem onClick={onClick} key={key}>
+                {itemText}
+            </MenuItem>
             <PicklistEditModal
                 selectionKey={selectionKey}
                 selectedQuantity={selectedQuantity}
@@ -55,5 +64,5 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
                 onCancel={onCancel}
             />
         </>
-    )
-}
+    );
+};

--- a/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
@@ -53,7 +53,7 @@ export const PicklistCreationModal: FC<Props> = memo(props => {
         finally {
             setIsSubmitting(false);
         }
-    }, [name, description, onFinish]);
+    }, [name, description, onFinish, shared]);
 
     let title;
     if (useSelection) {

--- a/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, FC, FormEvent, memo, useCallback, useState } from '
 import { Checkbox, Modal } from 'react-bootstrap';
 import { WizardNavButtons } from '../buttons/WizardNavButtons';
 import { QueryGridModel } from '../../QueryGridModel';
-import { createPicklist } from './actions';
+import { addSamplesToPicklist, createPicklist } from './actions';
 import { Alert } from '../base/Alert';
 import { resolveErrorMessage } from '../../util/messaging';
 
@@ -32,10 +32,20 @@ export const PicklistCreationModal: FC<Props> = memo(props => {
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ picklistError, setPicklistError ] = useState<string>(undefined);
 
+    const onHide = useCallback((data: any) => {
+        setPicklistError(undefined);
+        setIsSubmitting(false);
+        onCancel(data);
+    }, []);
+
     const onCreatePicklist = useCallback(async () => {
         setIsSubmitting(true);
         try {
             const picklist = await createPicklist(name, description, shared, model, useSelection);
+            await addSamplesToPicklist(
+                name,
+                useSelection ? model.selectionKey : undefined,
+                useSelection ? undefined : [model.getRow().get("RowId")]);
             onFinish(picklist.name, picklist.listId)
         } catch (e) {
             setPicklistError(resolveErrorMessage(e));
@@ -87,7 +97,7 @@ export const PicklistCreationModal: FC<Props> = memo(props => {
 
             <Modal.Footer>
                 <WizardNavButtons
-                    cancel={onCancel}
+                    cancel={onHide}
                     cancelText={'Cancel'}
                     canFinish={true}
                     containerClassName=""

--- a/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
@@ -41,7 +41,7 @@ export const PicklistCreationModal: FC<Props> = memo(props => {
     const onCreatePicklist = useCallback(async () => {
         setIsSubmitting(true);
         try {
-            const picklist = await createPicklist(name, description, shared, model, useSelection);
+            const picklist = await createPicklist(name, description, shared);
             await addSamplesToPicklist(
                 name,
                 useSelection ? model.selectionKey : undefined,

--- a/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
@@ -1,0 +1,90 @@
+import React, { ChangeEvent, FC, FormEvent, memo, useCallback, useState } from 'react';
+import { Checkbox, Modal } from 'react-bootstrap';
+import { WizardNavButtons } from '../buttons/WizardNavButtons';
+import { QueryGridModel } from '../../QueryGridModel';
+import { createPicklist } from './actions';
+import { Alert } from '../base/Alert';
+import { resolveErrorMessage } from '../../util/messaging';
+
+interface Props {
+    show: boolean,
+    selectionModel: QueryGridModel,
+    onCancel: (any) => void,
+    onFinish: (name: string, id: number) => void,
+}
+
+export const PicklistCreationModal: FC<Props> = memo(props => {
+    const { show, onCancel, onFinish, selectionModel } = props;
+    const [ name, setName ] = useState<string>('');
+    const onNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setName(evt.target.value), []);
+
+    const [ description, setDescription ] = useState<string>(undefined);
+    const onDescriptionChange = useCallback((evt: ChangeEvent<HTMLTextAreaElement>) => setDescription(evt.target.value), []);
+
+    const [ shared, setShared ] = useState<boolean>(false);
+    // Using a type for evt here causes difficulties.  It wants a FormEvent<Checkbox> but
+    // then it doesn't recognize checked as a valid field on current target.
+    const onSharedChanged = useCallback((evt) => {
+        setShared(evt.currentTarget.checked);
+    }, []);
+
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ picklistError, setPicklistError ] = useState<string>(undefined);
+
+
+    const onCreatePicklist = useCallback(async () => {
+        setIsSubmitting(true);
+        try {
+            const picklist = await createPicklist(name, description, shared, selectionModel);
+            onFinish(picklist.name, picklist.listId)
+        } catch (e) {
+            setPicklistError(resolveErrorMessage(e));
+        }
+        finally {
+            setIsSubmitting(false);
+        }
+    }, [name, description, onFinish]);
+
+    return (
+        <Modal show={show} onHide={onCancel}>
+            <Modal.Header closeButton>
+                <Modal.Title>Create a New Picklist from {selectionModel.selectedQuantity} Selected Sample{selectionModel.selectedQuantity === 1 ? '' : 's'}</Modal.Title>
+            </Modal.Header>
+
+            <Modal.Body>
+                <Alert>{picklistError}</Alert>
+
+                <form>
+                    <div className="form-group">
+                        <label className="control-label">Name</label>
+
+                        <input className="form-control" value={name} onChange={onNameChange} type="text"/>
+                    </div>
+                    <div className="form-group">
+                        <label className="control-label">Description</label>
+
+                        <textarea className="form-control" value={description} onChange={onDescriptionChange}/>
+
+                        <Checkbox checked={shared} onChange={onSharedChanged} >
+                            <span>Share this picklist publicly with team members</span>
+                        </Checkbox>
+                    </div>
+                </form>
+            </Modal.Body>
+
+            <Modal.Footer>
+                <WizardNavButtons
+                    cancel={onCancel}
+                    cancelText={'Cancel'}
+                    canFinish={true}
+                    containerClassName=""
+                    isFinishing={isSubmitting}
+                    isFinishingText="Creating Picklist..."
+                    finish
+                    finishText="Create Picklist"
+                    nextStep={onCreatePicklist}
+                />
+            </Modal.Footer>
+        </Modal>
+    )
+});

--- a/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationModal.tsx
@@ -11,7 +11,7 @@ interface Props {
     model: QueryGridModel,
     useSelection?: boolean, // if false, will use the single row from the model
     onCancel: (any) => void,
-    onFinish: (name: string, id: number) => void,
+    onFinish: (name: string) => void,
 }
 
 export const PicklistCreationModal: FC<Props> = memo(props => {
@@ -45,8 +45,8 @@ export const PicklistCreationModal: FC<Props> = memo(props => {
             await addSamplesToPicklist(
                 name,
                 useSelection ? model.selectionKey : undefined,
-                useSelection ? undefined : [model.getRow().get("RowId")]);
-            onFinish(picklist.name, picklist.listId)
+                useSelection ? undefined : [model.getRow().getIn(['RowId', 'value'])]);
+            onFinish(picklist.name)
         } catch (e) {
             setPicklistError(resolveErrorMessage(e));
         }

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.spec.tsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import { PicklistDeleteConfirmMessage } from './PicklistDeleteConfirm';
+import { mount, ReactWrapper } from 'enzyme';
+import { Alert } from '../base/Alert';
+import { PicklistModel } from './models';
+
+describe("PicklistDeleteConfirmMessage", () => {
+
+    function validateText(wrapper: ReactWrapper, expectedAlerts: string[], unexpectedAlerts: string[] = [], expectedMsg: string[] = []) {
+        const alert = wrapper.find(Alert);
+        if (expectedAlerts?.length > 0) {
+            expect(alert).toHaveLength(1);
+            const alertText = alert.text();
+            expectedAlerts.forEach(txt => {
+                expect(alertText).toContain(txt);
+            });
+            unexpectedAlerts.forEach(txt => {
+                expect(alertText.indexOf(txt)).toBe(-1);
+            })
+        }
+        else {
+            expect(alert).toHaveLength(0);
+        }
+        const msgSpan = wrapper.find("span");
+        expect(msgSpan).toHaveLength(1);
+        const msgText = msgSpan.text();
+        if (expectedMsg == undefined) {
+            expect(msgText.trim()).toHaveLength(0)
+        }
+        else {
+            expectedMsg?.forEach(msg => {
+                expect(msgText).toContain(msg);
+            });
+        }
+
+    }
+
+    test("no data", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={undefined}
+                numSelected={undefined}
+                noun={undefined}
+            />);
+        expect(wrapper.find("span")).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test("many deletable, none public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 3,
+                    numNotDeletable: 0,
+                    numShared: 0,
+                    deletableLists: [],
+                }}
+                numSelected={3}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper,
+            undefined,
+            undefined,
+            ['Are you sure you want to delete the selected lists?',
+            'Deletion cannot be undone',
+            'Do you want to proceed?'
+        ]);
+        wrapper.unmount();
+    });
+
+    test("all deletable, all public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 3,
+                    numNotDeletable: 0,
+                    numShared: 3,
+                    deletableLists: [],
+                }}
+                numSelected={3}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            'These are public picklists that are shared with your team members.'
+        ], [
+            'cannot be deleted'
+        ], [
+            'Are you sure you want to delete the selected lists?'
+        ]);
+        wrapper.unmount();
+    });
+
+    test("all deletable, one public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 3,
+                    numNotDeletable: 0,
+                    numShared: 1,
+                    deletableLists: [],
+                }}
+                numSelected={3}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            '1 of the 3 lists is a public picklist shared with your team members.'
+        ], [
+            'cannot be deleted'
+        ]);
+        wrapper.unmount();
+    });
+
+
+    test("all deletable, some public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 3,
+                    numNotDeletable: 0,
+                    numShared: 2,
+                    deletableLists: [],
+                }}
+                numSelected={3}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            '2 of the 3 lists are public picklists shared with your team members.'
+        ], [
+            'cannot be deleted'
+        ]);
+        wrapper.unmount();
+    });
+
+    test("none deletable, one public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 0,
+                    numNotDeletable: 3,
+                    numShared: 1,
+                    deletableLists: [],
+                }}
+                numSelected={3}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            'All of the selected picklists were created by other users and cannot be deleted.',
+        ], [
+            'shared with your team members'
+        ], undefined);
+        wrapper.unmount();
+    });
+
+    test ("one deletable, one public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 1,
+                    numNotDeletable: 3,
+                    numShared: 1,
+                    deletableLists: [new PicklistModel({name: 'Public Deletable', listId: 1})],
+                }}
+                numSelected={4}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            'This is a public picklist that is shared with your team members.',
+            '3 of the 4 selected picklists were created by other users'
+        ], [], [
+            'Are you sure you want to delete "Public Deletable"?'
+        ]);
+        wrapper.unmount();
+    });
+
+    test("one deletable, not public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 1,
+                    numNotDeletable: 3,
+                    numShared: 0,
+                    deletableLists: [],
+                }}
+                numSelected={4}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            '3 of the 4 selected picklists were created by other users'
+        ], [
+            'This is a public picklist that is shared with your team members.',
+        ]);
+        wrapper.unmount();
+    });
+
+    test("one not deletable, not public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 1,
+                    numNotDeletable: 1,
+                    numShared: 0,
+                    deletableLists: [new PicklistModel({name: 'Public Deletable', listId: 1})],
+                }}
+                numSelected={2}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            '1 of the 2 selected picklists was created by another user'
+        ], [
+            'shared with your team members.',
+        ], [
+            'Are you sure you want to delete "Public Deletable"?'
+        ]);
+        wrapper.unmount();
+    });
+
+    test("one not deletable, public", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 0,
+                    numNotDeletable: 1,
+                    numShared: 1,
+                    deletableLists: [],
+                }}
+                numSelected={1}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            'The selected picklist was created by another user',
+        ], [
+            'shared with your team members.',
+        ], undefined);
+        wrapper.unmount();
+    });
+
+    test("one private and one public selected, some deletable", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 1,
+                    numNotDeletable: 3,
+                    numShared: 1,
+                    deletableLists: [],
+                }}
+                numSelected={4}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            '3 of the 4 selected picklists were created by other users',
+            'This is a public picklist'
+        ], [
+        ], [
+            'delete the selected lists'
+        ]);
+        wrapper.unmount();
+    });
+
+    test("some private and one public selected, some deletable", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 5,
+                    numNotDeletable: 3,
+                    numShared: 1,
+                    deletableLists: [],
+                }}
+                numSelected={8}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            '3 of the 8 selected picklists were created by other users',
+            '1 of the 5 lists is a public picklist'
+        ], [
+        ], [
+            'delete the selected lists'
+        ]);
+        wrapper.unmount();
+    });
+
+
+    test("some private and some public selected, some deletable", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 5,
+                    numNotDeletable: 3,
+                    numShared: 3,
+                    deletableLists: [],
+                }}
+                numSelected={8}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            '3 of the 8 selected picklists were created by other users',
+            '3 of the 5 lists are public picklists'
+        ], [
+
+        ], [
+            'delete the selected lists'
+        ]);
+        wrapper.unmount();
+    });
+
+    test("some private and some public selected, not deletable", () => {
+        const wrapper = mount(
+            <PicklistDeleteConfirmMessage
+                deletionData={{
+                    numDeletable: 0,
+                    numNotDeletable: 3,
+                    numShared: 3,
+                    deletableLists: [],
+                }}
+                numSelected={3}
+                noun={"Picklist"}
+            />);
+        validateText(wrapper, [
+            'All of the selected picklists were created by other users',
+        ], [
+            'shared with your team members'
+        ], undefined);
+        wrapper.unmount();
+    });
+});
+

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.spec.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
-import { PicklistDeleteConfirmMessage } from './PicklistDeleteConfirm';
+
 import { mount, ReactWrapper } from 'enzyme';
+
 import { Alert } from '../base/Alert';
+
+import { PicklistDeleteConfirmMessage } from './PicklistDeleteConfirm';
 import { PicklistModel } from './models';
 
-describe("PicklistDeleteConfirmMessage", () => {
-
-    function validateText(wrapper: ReactWrapper, expectedAlerts: string[], unexpectedAlerts: string[] = [], expectedMsg: string[] = []) {
+describe('PicklistDeleteConfirmMessage', () => {
+    function validateText(
+        wrapper: ReactWrapper,
+        expectedAlerts: string[],
+        unexpectedAlerts: string[] = [],
+        expectedMsg: string[] = []
+    ) {
         const alert = wrapper.find(Alert);
         if (expectedAlerts?.length > 0) {
             expect(alert).toHaveLength(1);
@@ -16,37 +23,31 @@ describe("PicklistDeleteConfirmMessage", () => {
             });
             unexpectedAlerts.forEach(txt => {
                 expect(alertText.indexOf(txt)).toBe(-1);
-            })
-        }
-        else {
+            });
+        } else {
             expect(alert).toHaveLength(0);
         }
-        const msgSpan = wrapper.find("span");
+        const msgSpan = wrapper.find('span');
         expect(msgSpan).toHaveLength(1);
         const msgText = msgSpan.text();
         if (expectedMsg == undefined) {
-            expect(msgText.trim()).toHaveLength(0)
-        }
-        else {
+            expect(msgText.trim()).toHaveLength(0);
+        } else {
             expectedMsg?.forEach(msg => {
                 expect(msgText).toContain(msg);
             });
         }
-
     }
 
-    test("no data", () => {
+    test('no data', () => {
         const wrapper = mount(
-            <PicklistDeleteConfirmMessage
-                deletionData={undefined}
-                numSelected={undefined}
-                noun={undefined}
-            />);
-        expect(wrapper.find("span")).toHaveLength(0);
+            <PicklistDeleteConfirmMessage deletionData={undefined} numSelected={undefined} noun={undefined} />
+        );
+        expect(wrapper.find('span')).toHaveLength(0);
         wrapper.unmount();
     });
 
-    test("many deletable, none public", () => {
+    test('many deletable, none public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -56,19 +57,18 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={3}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper,
-            undefined,
-            undefined,
-            ['Are you sure you want to delete the selected lists?',
+                noun="Picklist"
+            />
+        );
+        validateText(wrapper, undefined, undefined, [
+            'Are you sure you want to delete the selected lists?',
             'Deletion cannot be undone',
-            'Do you want to proceed?'
+            'Do you want to proceed?',
         ]);
         wrapper.unmount();
     });
 
-    test("all deletable, all public", () => {
+    test('all deletable, all public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -78,19 +78,19 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={3}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            'These are public picklists that are shared with your team members.'
-        ], [
-            'cannot be deleted'
-        ], [
-            'Are you sure you want to delete the selected lists?'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['These are public picklists that are shared with your team members.'],
+            ['cannot be deleted'],
+            ['Are you sure you want to delete the selected lists?']
+        );
         wrapper.unmount();
     });
 
-    test("all deletable, one public", () => {
+    test('all deletable, one public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -100,18 +100,18 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={3}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            '1 of the 3 lists is a public picklist shared with your team members.'
-        ], [
-            'cannot be deleted'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['1 of the 3 lists is a public picklist shared with your team members.'],
+            ['cannot be deleted']
+        );
         wrapper.unmount();
     });
 
-
-    test("all deletable, some public", () => {
+    test('all deletable, some public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -121,17 +121,18 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={3}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            '2 of the 3 lists are public picklists shared with your team members.'
-        ], [
-            'cannot be deleted'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['2 of the 3 lists are public picklists shared with your team members.'],
+            ['cannot be deleted']
+        );
         wrapper.unmount();
     });
 
-    test("none deletable, one public", () => {
+    test('none deletable, one public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -141,38 +142,44 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={3}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            'All of the selected picklists were created by other users and cannot be deleted.',
-        ], [
-            'shared with your team members'
-        ], undefined);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['All of the selected picklists were created by other users and cannot be deleted.'],
+            ['shared with your team members'],
+            undefined
+        );
         wrapper.unmount();
     });
 
-    test ("one deletable, one public", () => {
+    test('one deletable, one public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
                     numDeletable: 1,
                     numNotDeletable: 3,
                     numShared: 1,
-                    deletableLists: [new PicklistModel({name: 'Public Deletable', listId: 1})],
+                    deletableLists: [new PicklistModel({ name: 'Public Deletable', listId: 1 })],
                 }}
                 numSelected={4}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            'This is a public picklist that is shared with your team members.',
-            '3 of the 4 selected picklists were created by other users'
-        ], [], [
-            'Are you sure you want to delete "Public Deletable"?'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            [
+                'This is a public picklist that is shared with your team members.',
+                '3 of the 4 selected picklists were created by other users',
+            ],
+            [],
+            ['Are you sure you want to delete "Public Deletable"?']
+        );
         wrapper.unmount();
     });
 
-    test("one deletable, not public", () => {
+    test('one deletable, not public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -182,39 +189,40 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={4}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            '3 of the 4 selected picklists were created by other users'
-        ], [
-            'This is a public picklist that is shared with your team members.',
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['3 of the 4 selected picklists were created by other users'],
+            ['This is a public picklist that is shared with your team members.']
+        );
         wrapper.unmount();
     });
 
-    test("one not deletable, not public", () => {
+    test('one not deletable, not public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
                     numDeletable: 1,
                     numNotDeletable: 1,
                     numShared: 0,
-                    deletableLists: [new PicklistModel({name: 'Public Deletable', listId: 1})],
+                    deletableLists: [new PicklistModel({ name: 'Public Deletable', listId: 1 })],
                 }}
                 numSelected={2}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            '1 of the 2 selected picklists was created by another user'
-        ], [
-            'shared with your team members.',
-        ], [
-            'Are you sure you want to delete "Public Deletable"?'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['1 of the 2 selected picklists was created by another user'],
+            ['shared with your team members.'],
+            ['Are you sure you want to delete "Public Deletable"?']
+        );
         wrapper.unmount();
     });
 
-    test("one not deletable, public", () => {
+    test('one not deletable, public', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -224,17 +232,19 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={1}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            'The selected picklist was created by another user',
-        ], [
-            'shared with your team members.',
-        ], undefined);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['The selected picklist was created by another user'],
+            ['shared with your team members.'],
+            undefined
+        );
         wrapper.unmount();
     });
 
-    test("one private and one public selected, some deletable", () => {
+    test('one private and one public selected, some deletable', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -244,19 +254,19 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={4}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            '3 of the 4 selected picklists were created by other users',
-            'This is a public picklist'
-        ], [
-        ], [
-            'delete the selected lists'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['3 of the 4 selected picklists were created by other users', 'This is a public picklist'],
+            [],
+            ['delete the selected lists']
+        );
         wrapper.unmount();
     });
 
-    test("some private and one public selected, some deletable", () => {
+    test('some private and one public selected, some deletable', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -266,20 +276,19 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={8}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            '3 of the 8 selected picklists were created by other users',
-            '1 of the 5 lists is a public picklist'
-        ], [
-        ], [
-            'delete the selected lists'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['3 of the 8 selected picklists were created by other users', '1 of the 5 lists is a public picklist'],
+            [],
+            ['delete the selected lists']
+        );
         wrapper.unmount();
     });
 
-
-    test("some private and some public selected, some deletable", () => {
+    test('some private and some public selected, some deletable', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -289,20 +298,19 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={8}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            '3 of the 8 selected picklists were created by other users',
-            '3 of the 5 lists are public picklists'
-        ], [
-
-        ], [
-            'delete the selected lists'
-        ]);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['3 of the 8 selected picklists were created by other users', '3 of the 5 lists are public picklists'],
+            [],
+            ['delete the selected lists']
+        );
         wrapper.unmount();
     });
 
-    test("some private and some public selected, not deletable", () => {
+    test('some private and some public selected, not deletable', () => {
         const wrapper = mount(
             <PicklistDeleteConfirmMessage
                 deletionData={{
@@ -312,14 +320,15 @@ describe("PicklistDeleteConfirmMessage", () => {
                     deletableLists: [],
                 }}
                 numSelected={3}
-                noun={"Picklist"}
-            />);
-        validateText(wrapper, [
-            'All of the selected picklists were created by other users',
-        ], [
-            'shared with your team members'
-        ], undefined);
+                noun="Picklist"
+            />
+        );
+        validateText(
+            wrapper,
+            ['All of the selected picklists were created by other users'],
+            ['shared with your team members'],
+            undefined
+        );
         wrapper.unmount();
     });
 });
-

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -11,7 +11,6 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 interface Props {
     model: QueryModel,
-    actions: Actions,
     user: User,
     useSelection: boolean,
     onConfirm: (listsToDelete: any[]) => void,
@@ -20,7 +19,7 @@ interface Props {
 
 export const PicklistDeleteConfirm: FC<Props> = memo(props => {
 
-    const { model, actions, onConfirm, onCancel, useSelection, user } = props;
+    const { model, onConfirm, onCancel, useSelection, user } = props;
     const [ errorMessage, setErrorMessage ] = useState(undefined);
     const [ nounAndNumber, setNounAndNumber ] = useState('Picklist');
     const [ deletionData, setDeletionData ]  = useState<PicklistDeletionData>(undefined);
@@ -31,7 +30,7 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
 
     useEffect(() =>  {
         if (useSelection) {
-            getPicklistDeleteData(model, actions, user)
+            getPicklistDeleteData(model, user)
                 .then(data => {
                     setNounAndNumber(data.numDeletable === 1 ? '1 Picklist' : data.numDeletable + ' Picklists');
                     setDeletionData(data);
@@ -53,7 +52,7 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
                 deletableLists: [picklist]
             });
         }
-    }, [model, actions, user]);
+    }, [model, user]);
 
     const onConfirmDelete = useCallback(() => {
         onConfirm(deletionData.deletableLists);
@@ -95,7 +94,7 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
                 publicMessage = "This is a public picklist that is shared with your team members.";
             else
                 publicMessage = "These are public picklists that are shared with your team members.";
-        } else {
+        } else if (deletionData.numShared) {
             publicMessage = deletionData.numShared + " of the " + deletionData.numDeletable + " lists " + (deletionData.numShared === 1 ? "is a public picklist" : "are public picklists") + " shared with your team members.";
         }
         return (

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -1,47 +1,52 @@
 import React, { FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { getPicklistDeleteData, PicklistDeletionData } from './actions';
-import { PicklistModel } from './models';
+
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { User } from '../base/models/User';
 import { Alert } from '../base/Alert';
 import { ConfirmModal } from '../base/ConfirmModal';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
+import { PicklistModel } from './models';
+import { getPicklistDeleteData, PicklistDeletionData } from './actions';
+
 interface Props {
-    model: QueryModel,
-    user: User,
-    useSelection: boolean,
-    onConfirm: (listsToDelete: any[]) => void,
-    onCancel: () => void
+    model: QueryModel;
+    user: User;
+    useSelection: boolean;
+    onConfirm: (listsToDelete: any[]) => void;
+    onCancel: () => void;
 }
 
 interface DeleteConfirmMessageProps {
-    deletionData: PicklistDeletionData,
-    numSelected: number,
-    noun: string,
+    deletionData: PicklistDeletionData;
+    numSelected: number;
+    noun: string;
 }
 
 // exported for jest testing
 export const PicklistDeleteConfirmMessage: FC<DeleteConfirmMessageProps> = memo(props => {
-    const {deletionData, numSelected, noun} = props;
+    const { deletionData, numSelected, noun } = props;
 
-    if (!deletionData)
-        return null;
+    if (!deletionData) return null;
 
     let restrictionMessage = null;
 
     if (deletionData.numDeletable === 0) {
         if (numSelected > 1) {
-            restrictionMessage =
-                <p>All of the selected picklists were created by other users and cannot be deleted.</p>;
+            restrictionMessage = (
+                <p>All of the selected picklists were created by other users and cannot be deleted.</p>
+            );
         } else {
             restrictionMessage = <p>The selected picklist was created by another user and cannot be deleted.</p>;
         }
     } else if (deletionData.numNotDeletable > 0) {
-        restrictionMessage =
-            <p>{deletionData.numNotDeletable} of the {numSelected} selected picklists
+        restrictionMessage = (
+            <p>
+                {deletionData.numNotDeletable} of the {numSelected} selected picklists
                 {deletionData.numNotDeletable === 1 ? ' was created by another user' : ' were created by other users'}
-                and cannot be deleted.</p>;
+                and cannot be deleted.
+            </p>
+        );
     }
 
     let publicMessage = null;
@@ -53,22 +58,28 @@ export const PicklistDeleteConfirmMessage: FC<DeleteConfirmMessageProps> = memo(
                 publicMessage = <p>These are public picklists that are shared with your team members.</p>;
             }
         } else if (deletionData.numShared) {
-            publicMessage = <p>{deletionData.numShared} of
-                the {deletionData.numDeletable} lists {(deletionData.numShared === 1 ? "is a public picklist" : "are public picklists")} shared
-                with your team members.</p>;
+            publicMessage = (
+                <p>
+                    {deletionData.numShared} of the {deletionData.numDeletable} lists{' '}
+                    {deletionData.numShared === 1 ? 'is a public picklist' : 'are public picklists'} shared with your
+                    team members.
+                </p>
+            );
         }
     }
 
-    const rUSure = deletionData.numDeletable === 0 ? null : (
-        <>
-            Are you sure you want to delete {deletionData.numDeletable === 1 && deletionData.deletableLists[0]?.name ?
-            <b>"{deletionData.deletableLists[0].name}"</b> :
-            'the selected lists'
-        }
-            ?
-        </>
-    );
-
+    const rUSure =
+        deletionData.numDeletable === 0 ? null : (
+            <>
+                Are you sure you want to delete{' '}
+                {deletionData.numDeletable === 1 && deletionData.deletableLists[0]?.name ? (
+                    <b>"{deletionData.deletableLists[0].name}"</b>
+                ) : (
+                    'the selected lists'
+                )}
+                ?
+            </>
+        );
 
     return (
         <>
@@ -80,31 +91,31 @@ export const PicklistDeleteConfirmMessage: FC<DeleteConfirmMessageProps> = memo(
             )}
             <span>
                 {rUSure}&nbsp;
-                {deletionData.numDeletable > 0 &&
-                <>
-                    Samples in the {noun} will not be affected.&nbsp;
-                    <p className={'top-spacing'}>
-                        <strong>Deletion cannot be undone.</strong>
-                        &nbsp;Do you want to proceed?
-                    </p>
-                </>}
+                {deletionData.numDeletable > 0 && (
+                    <>
+                        Samples in the {noun} will not be affected.&nbsp;
+                        <p className="top-spacing">
+                            <strong>Deletion cannot be undone.</strong>
+                            &nbsp;Do you want to proceed?
+                        </p>
+                    </>
+                )}
             </span>
         </>
     );
 });
 
 export const PicklistDeleteConfirm: FC<Props> = memo(props => {
-
     const { model, onConfirm, onCancel, useSelection, user } = props;
-    const [ errorMessage, setErrorMessage ] = useState(undefined);
-    const [ nounAndNumber, setNounAndNumber ] = useState('Picklist');
-    const [ deletionData, setDeletionData ]  = useState<PicklistDeletionData>(undefined);
+    const [errorMessage, setErrorMessage] = useState(undefined);
+    const [nounAndNumber, setNounAndNumber] = useState('Picklist');
+    const [deletionData, setDeletionData] = useState<PicklistDeletionData>(undefined);
 
     const numSelected = useSelection ? model.selections.size : 1;
-    const noun = (numSelected === 1) ? 'Picklist' : 'Picklists';
+    const noun = numSelected === 1 ? 'Picklist' : 'Picklists';
     const lcNoun = noun.toLowerCase();
 
-    useEffect(() =>  {
+    useEffect(() => {
         if (useSelection) {
             getPicklistDeleteData(model, user)
                 .then(data => {
@@ -112,20 +123,22 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
                     setDeletionData(data);
                 })
                 .catch(() => {
-                    setErrorMessage("There was a problem loading the deletion data. " +
-                        "Verify the " + lcNoun +
-                        (model.selections.size === 1 ? " is still valid and has " : " are still valid and have ")
-                        + "not already been deleted.");
+                    setErrorMessage(
+                        'There was a problem loading the deletion data. ' +
+                            'Verify the ' +
+                            lcNoun +
+                            (model.selections.size === 1 ? ' is still valid and has ' : ' are still valid and have ') +
+                            'not already been deleted.'
+                    );
                 });
-        }
-        else {
+        } else {
             setNounAndNumber('This Picklist');
             const picklist = new PicklistModel(model.getRow(undefined, true));
             setDeletionData({
                 numDeletable: 1,
                 numNotDeletable: 0,
                 numShared: picklist.isPublic() ? 1 : 0,
-                deletableLists: [picklist]
+                deletableLists: [picklist],
             });
         }
     }, [model, user]);
@@ -136,20 +149,21 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
 
     return (
         <ConfirmModal
-            title={"Delete " + nounAndNumber}
+            title={'Delete ' + nounAndNumber}
             msg={
                 errorMessage ??
-                (deletionData
-                    ? <PicklistDeleteConfirmMessage deletionData={deletionData} numSelected={numSelected} noun={lcNoun}/>
-                    : <LoadingSpinner />
-                )
+                (deletionData ? (
+                    <PicklistDeleteConfirmMessage deletionData={deletionData} numSelected={numSelected} noun={lcNoun} />
+                ) : (
+                    <LoadingSpinner />
+                ))
             }
             onConfirm={deletionData?.numDeletable ? onConfirmDelete : undefined}
             onCancel={onCancel}
-            confirmVariant='danger'
+            confirmVariant="danger"
             confirmButtonText={'Yes, Delete ' + nounAndNumber}
-            cancelButtonText='Cancel'
-            submitting={!!errorMessage } // disable submit button if there are errors
+            cancelButtonText="Cancel"
+            submitting={!!errorMessage} // disable submit button if there are errors
         />
-    )
+    );
 });

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -89,10 +89,18 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
                 ?
             </>
         );
+        let publicMessage = null;
+        if (deletionData.numDeletable == deletionData.numShared) {
+            if (deletionData.numShared === 1)
+                publicMessage = "This is a public picklist that is shared with your team members.";
+            else
+                publicMessage = "These are public picklists that are shared with your team members.";
+        } else {
+            publicMessage = deletionData.numShared + " of the " + deletionData.numDeletable + " lists " + (deletionData.numShared === 1 ? "is a public picklist" : "are public picklists") + " shared with your team members.";
+        }
         return (
             <>
-                {deletionData.numShared === 1 && <Alert bsStyle="warning">This is a public picklist that is shared with your team members.</Alert>}
-                {deletionData.numShared > 1 && <Alert bsStyle="warning">These are public picklists that are shared with your team members.</Alert>}
+                <Alert bsStyle="warning">{publicMessage}</Alert>
                 <span>
                     {restrictionMessage}
                     {rUSure}&nbsp;

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -1,0 +1,126 @@
+import React, { FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { getPicklistDeleteData, PicklistDeletionData } from './actions';
+import { PicklistModel } from './models';
+import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { Actions } from '../../../public/QueryModel/withQueryModels';
+import { User } from '../base/models/User';
+import { Alert } from '../base/Alert';
+import { ConfirmModal } from '../base/ConfirmModal';
+import { LoadingSpinner } from '../base/LoadingSpinner';
+
+
+interface Props {
+    model: QueryModel,
+    actions: Actions,
+    user: User,
+    useSelection: boolean,
+    onConfirm: (listsToDelete: any[]) => void,
+    onCancel: () => void
+}
+
+export const PicklistDeleteConfirm: FC<Props> = memo(props => {
+
+    const { model, actions, onConfirm, onCancel, useSelection, user } = props;
+    const [ errorMessage, setErrorMessage ] = useState(undefined);
+    const [ nounAndNumber, setNounAndNumber ] = useState('Picklist');
+    const [ deletionData, setDeletionData ]  = useState<PicklistDeletionData>(undefined);
+
+    const numSelected = useSelection ? model.selections.size : 1;
+    const noun = (numSelected === 1) ? 'Picklist' : 'Picklists';
+    const lcNoun = noun.toLowerCase();
+
+    useEffect(() =>  {
+        if (useSelection) {
+            getPicklistDeleteData(model, actions, user)
+                .then(data => {
+                    setNounAndNumber(data.numDeletable === 1 ? '1 Picklist' : data.numDeletable + ' Picklists');
+                    setDeletionData(data);
+                })
+                .catch(() => {
+                    setErrorMessage("There was a problem loading the deletion data. " +
+                        "Verify the " + lcNoun +
+                        (model.selections.size === 1 ? " is still valid and has " : " are still valid and have ")
+                        + "not already been deleted.");
+                });
+        }
+        else {
+            setNounAndNumber('This Picklist');
+            const picklist = new PicklistModel(model.getRow(undefined, true));
+            setDeletionData({
+                numDeletable: 1,
+                numNotDeletable: 0,
+                numShared: picklist.isPublic() ? 1 : 0,
+                deletableLists: [picklist]
+            });
+        }
+    }, [model, actions, user]);
+
+    const onConfirmDelete = useCallback(() => {
+        onConfirm(deletionData.deletableLists);
+    }, [deletionData, onConfirm]);
+
+    const getConfirmMessage = useMemo((): ReactNode => {
+        if (!deletionData)
+            return null;
+
+        let restrictionMessage = '';
+
+        if (deletionData.numDeletable === 0) {
+            if (numSelected > 1) {
+                restrictionMessage += 'None of the selected picklists can be deleted.';
+            }
+            else {
+                restrictionMessage += 'The selected picklist cannot be deleted.';
+            }
+        }
+        if (deletionData.numNotDeletable > 0) {
+            if (deletionData.numDeletable > 0) {
+                restrictionMessage += 'Only ' + deletionData.numDeletable + ' of the ' + numSelected + ' selected picklists can be deleted.';
+            }
+            restrictionMessage += " You are not allowed to delete picklists created by other users.  ";
+        }
+        const rUSure = deletionData.numDeletable === 0 ? null : (
+            <>
+                Are you sure you want to delete&nbsp;
+                {deletionData.numDeletable === 1 && deletionData.deletableLists[0]?.name ?
+                    <b>"{deletionData.deletableLists[0].name}"</b> :
+                    'the selected lists'
+                }
+                ?
+            </>
+        );
+        return (
+            <>
+                {deletionData.numShared === 1 && <Alert bsStyle="warning">This is a public picklist that is shared with your team members.</Alert>}
+                {deletionData.numShared > 1 && <Alert bsStyle="warning">These are public picklists that are shared with your team members.</Alert>}
+                <span>
+                    {restrictionMessage}
+                    {rUSure}&nbsp;
+                    {deletionData.numDeletable > 0 &&
+                    <>
+                        Samples in the {lcNoun} will not be affected.&nbsp;
+                        <p className={'top-spacing'}>
+                            <strong>Deletion cannot be undone.</strong>
+                            &nbsp;Do you want to proceed?
+                        </p>
+                    </>}
+                </span>
+            </>
+        );
+    }, [deletionData, lcNoun]);
+
+    return (
+        <ConfirmModal
+            title={"Delete " + nounAndNumber}
+            msg={
+                errorMessage ?? getConfirmMessage ?? <LoadingSpinner />
+            }
+            onConfirm={deletionData?.numDeletable ? onConfirmDelete : undefined}
+            onCancel={onCancel}
+            confirmVariant='danger'
+            confirmButtonText={'Yes, Delete ' + nounAndNumber}
+            cancelButtonText='Cancel'
+            submitting={!!errorMessage }
+        />
+    )
+});

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { PicklistEditModal } from './PicklistEditModal';
+
 import { mount, ReactWrapper } from 'enzyme';
 import { Button, Modal, ModalFooter, ModalTitle } from 'react-bootstrap';
+
 import { PicklistModel, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../../../index';
 
-describe("PicklistEditModal", () => {
+import { PicklistEditModal } from './PicklistEditModal';
+
+describe('PicklistEditModal', () => {
     function validateText(wrapper: ReactWrapper, expectedTitle: string, expectedFinishText: string) {
-        const modal=wrapper.find(Modal);
+        const modal = wrapper.find(Modal);
         const title = modal.find(ModalTitle);
         expect(title.text()).toBe(expectedTitle);
         const footer = modal.find(ModalFooter);
@@ -18,142 +21,128 @@ describe("PicklistEditModal", () => {
     function validateForm(wrapper: ReactWrapper, existingList?: PicklistModel) {
         const labels = wrapper.find('label');
         expect(labels).toHaveLength(3);
-        expect(labels.at(0).text()).toBe("Name *");
-        expect(labels.at(1).text()).toBe("Description");
-        expect(labels.at(2).text()).toBe("Share this picklist publicly with team members");
+        expect(labels.at(0).text()).toBe('Name *');
+        expect(labels.at(1).text()).toBe('Description');
+        expect(labels.at(2).text()).toBe('Share this picklist publicly with team members');
         if (existingList) {
             expect(wrapper.find('input').at(0).prop('value')).toBe(existingList.name);
-        }
-        else {
+        } else {
             expect(wrapper.find('input').at(0).prop('value')).toBeFalsy();
         }
         if (existingList) {
             expect(wrapper.find('input').at(1).prop('checked')).toBe(existingList.isPublic());
-        }
-        else {
+        } else {
             expect(wrapper.find('input').at(1).prop('checked')).toBe(false);
         }
         if (existingList) {
             expect(wrapper.find('textarea').prop('value')).toBe(existingList.Description);
-        }
-        else {
+        } else {
             expect(wrapper.find('textarea').prop('value')).toBeFalsy();
         }
     }
 
-    test("create empty picklist", () => {
-       const wrapper = mount(
-           <PicklistEditModal
-               show={true}
-               selectionKey={"selection"}
-               selectedQuantity={0}
-               onCancel={jest.fn()}
-               onFinish={jest.fn()}
-           />
-       );
-       validateText(wrapper, 'Create an Empty Picklist', 'Create Picklist');
-       validateForm(wrapper);
-       wrapper.unmount();
+    test('create empty picklist', () => {
+        const wrapper = mount(
+            <PicklistEditModal
+                show={true}
+                selectionKey="selection"
+                selectedQuantity={0}
+                onCancel={jest.fn()}
+                onFinish={jest.fn()}
+            />
+        );
+        validateText(wrapper, 'Create an Empty Picklist', 'Create Picklist');
+        validateForm(wrapper);
+        wrapper.unmount();
     });
 
-    test("create picklist from multiple selections", () => {
-        const wrapper = mount(<PicklistEditModal
-            show={true}
-            selectionKey={"selection"}
-            selectedQuantity={2}
-            onCancel={jest.fn()}
-            onFinish={jest.fn()}
-        />);
+    test('create picklist from multiple selections', () => {
+        const wrapper = mount(
+            <PicklistEditModal
+                show={true}
+                selectionKey="selection"
+                selectedQuantity={2}
+                onCancel={jest.fn()}
+                onFinish={jest.fn()}
+            />
+        );
         validateText(wrapper, 'Create a New Picklist with the 2 Selected Samples', 'Create Picklist');
 
         wrapper.unmount();
     });
 
-    test("create picklist from one selection", () => {
-        const wrapper = mount(<PicklistEditModal
-            show={true}
-            selectionKey={"selection"}
-            selectedQuantity={1}
-            onCancel={jest.fn()}
-            onFinish={jest.fn()}
-        />);
+    test('create picklist from one selection', () => {
+        const wrapper = mount(
+            <PicklistEditModal
+                show={true}
+                selectionKey="selection"
+                selectedQuantity={1}
+                onCancel={jest.fn()}
+                onFinish={jest.fn()}
+            />
+        );
         validateText(wrapper, 'Create a New Picklist with the 1 Selected Sample', 'Create Picklist');
 
         wrapper.unmount();
     });
 
-    test("create empty picklist from sampleIds", () => {
-        const wrapper = mount(<PicklistEditModal
-            show={true}
-            sampleIds={[]}
-            onCancel={jest.fn()}
-            onFinish={jest.fn()}
-        />);
+    test('create empty picklist from sampleIds', () => {
+        const wrapper = mount(
+            <PicklistEditModal show={true} sampleIds={[]} onCancel={jest.fn()} onFinish={jest.fn()} />
+        );
         validateText(wrapper, 'Create an Empty Picklist', 'Create Picklist');
 
         wrapper.unmount();
     });
 
-    test("create picklist from one sampleId", () => {
-        const wrapper = mount(<PicklistEditModal
-            show={true}
-            sampleIds={["1"]}
-            onCancel={jest.fn()}
-            onFinish={jest.fn()}
-        />);
+    test('create picklist from one sampleId', () => {
+        const wrapper = mount(
+            <PicklistEditModal show={true} sampleIds={['1']} onCancel={jest.fn()} onFinish={jest.fn()} />
+        );
         validateText(wrapper, 'Create a New Picklist with This Sample', 'Create Picklist');
 
         wrapper.unmount();
     });
 
-    test("create picklist from multiple sampleIds", () => {
-        const wrapper = mount(<PicklistEditModal
-            show={true}
-            sampleIds={["1", "2"]}
-            onCancel={jest.fn()}
-            onFinish={jest.fn()}
-        />);
+    test('create picklist from multiple sampleIds', () => {
+        const wrapper = mount(
+            <PicklistEditModal show={true} sampleIds={['1', '2']} onCancel={jest.fn()} onFinish={jest.fn()} />
+        );
         validateText(wrapper, 'Create a New Picklist with These Samples', 'Create Picklist');
 
         wrapper.unmount();
     });
 
-    test("Update private picklist", () => {
-        const existingList=new PicklistModel({
+    test('Update private picklist', () => {
+        const existingList = new PicklistModel({
             Category: PRIVATE_PICKLIST_CATEGORY,
-            name: "Existing list",
-            Description: "My test description"
+            name: 'Existing list',
+            Description: 'My test description',
         });
-        const wrapper = mount(<PicklistEditModal
-            show={true}
-            picklist={existingList}
-            onCancel={jest.fn()}
-            onFinish={jest.fn()}
-        />);
+        const wrapper = mount(
+            <PicklistEditModal show={true} picklist={existingList} onCancel={jest.fn()} onFinish={jest.fn()} />
+        );
         validateText(wrapper, 'Update Picklist Data', 'Update Picklist');
         const labels = wrapper.find('label');
         expect(labels).toHaveLength(3);
-        expect(labels.at(0).text()).toBe("Name *");
-        expect(labels.at(1).text()).toBe("Description");
-        expect(labels.at(2).text()).toBe("Share this picklist publicly with team members");
+        expect(labels.at(0).text()).toBe('Name *');
+        expect(labels.at(1).text()).toBe('Description');
+        expect(labels.at(2).text()).toBe('Share this picklist publicly with team members');
         expect(wrapper.find('input').at(0).prop('value')).toBe(existingList.name);
         expect(wrapper.find('input').at(1).prop('checked')).toBe(false);
         expect(wrapper.find('textarea').prop('value')).toBe(existingList.Description);
         wrapper.unmount();
     });
 
-    test("Update public picklist", () => {
-        const existingList=new PicklistModel({
+    test('Update public picklist', () => {
+        const existingList = new PicklistModel({
             Category: PUBLIC_PICKLIST_CATEGORY,
-            name: "Existing list",
-            Description: "My test description"
+            name: 'Existing list',
+            Description: 'My test description',
         });
-        const wrapper = mount(<PicklistEditModal
-            show={true}
-            picklist={existingList}
-            onCancel={jest.fn()}
-            onFinish={jest.fn()}
-        />);
+        const wrapper = mount(
+            <PicklistEditModal show={true} picklist={existingList} onCancel={jest.fn()} onFinish={jest.fn()} />
+        );
         expect(wrapper.find('input').at(1).prop('checked')).toBe(true);
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { PicklistEditModal } from './PicklistEditModal';
+import { mount, ReactWrapper } from 'enzyme';
+import { Button, Modal, ModalFooter, ModalTitle } from 'react-bootstrap';
+import { PicklistModel, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../../../index';
+
+describe("PicklistEditModal", () => {
+    function validateText(wrapper: ReactWrapper, expectedTitle: string, expectedFinishText: string) {
+        const modal=wrapper.find(Modal);
+        const title = modal.find(ModalTitle);
+        expect(title.text()).toBe(expectedTitle);
+        const footer = modal.find(ModalFooter);
+        const buttons = footer.find(Button);
+        expect(buttons).toHaveLength(2);
+        expect(buttons.at(1).text()).toBe(expectedFinishText);
+    }
+
+    function validateForm(wrapper: ReactWrapper, existingList?: PicklistModel) {
+        const labels = wrapper.find('label');
+        expect(labels).toHaveLength(3);
+        expect(labels.at(0).text()).toBe("Name *");
+        expect(labels.at(1).text()).toBe("Description");
+        expect(labels.at(2).text()).toBe("Share this picklist publicly with team members");
+        if (existingList) {
+            expect(wrapper.find('input').at(0).prop('value')).toBe(existingList.name);
+        }
+        else {
+            expect(wrapper.find('input').at(0).prop('value')).toBeFalsy();
+        }
+        if (existingList) {
+            expect(wrapper.find('input').at(1).prop('checked')).toBe(existingList.isPublic());
+        }
+        else {
+            expect(wrapper.find('input').at(1).prop('checked')).toBe(false);
+        }
+        if (existingList) {
+            expect(wrapper.find('textarea').prop('value')).toBe(existingList.Description);
+        }
+        else {
+            expect(wrapper.find('textarea').prop('value')).toBeFalsy();
+        }
+    }
+
+    test("create empty picklist", () => {
+       const wrapper = mount(
+           <PicklistEditModal
+               show={true}
+               selectionKey={"selection"}
+               selectedQuantity={0}
+               onCancel={jest.fn()}
+               onFinish={jest.fn()}
+           />
+       );
+       validateText(wrapper, 'Create an Empty Picklist', 'Create Picklist');
+       validateForm(wrapper);
+       wrapper.unmount();
+    });
+
+    test("create picklist from multiple selections", () => {
+        const wrapper = mount(<PicklistEditModal
+            show={true}
+            selectionKey={"selection"}
+            selectedQuantity={2}
+            onCancel={jest.fn()}
+            onFinish={jest.fn()}
+        />);
+        validateText(wrapper, 'Create a New Picklist with the 2 Selected Samples', 'Create Picklist');
+
+        wrapper.unmount();
+    });
+
+    test("create picklist from one selection", () => {
+        const wrapper = mount(<PicklistEditModal
+            show={true}
+            selectionKey={"selection"}
+            selectedQuantity={1}
+            onCancel={jest.fn()}
+            onFinish={jest.fn()}
+        />);
+        validateText(wrapper, 'Create a New Picklist with the 1 Selected Sample', 'Create Picklist');
+
+        wrapper.unmount();
+    });
+
+    test("create empty picklist from sampleIds", () => {
+        const wrapper = mount(<PicklistEditModal
+            show={true}
+            sampleIds={[]}
+            onCancel={jest.fn()}
+            onFinish={jest.fn()}
+        />);
+        validateText(wrapper, 'Create an Empty Picklist', 'Create Picklist');
+
+        wrapper.unmount();
+    });
+
+    test("create picklist from one sampleId", () => {
+        const wrapper = mount(<PicklistEditModal
+            show={true}
+            sampleIds={["1"]}
+            onCancel={jest.fn()}
+            onFinish={jest.fn()}
+        />);
+        validateText(wrapper, 'Create a New Picklist with This Sample', 'Create Picklist');
+
+        wrapper.unmount();
+    });
+
+    test("create picklist from multiple sampleIds", () => {
+        const wrapper = mount(<PicklistEditModal
+            show={true}
+            sampleIds={["1", "2"]}
+            onCancel={jest.fn()}
+            onFinish={jest.fn()}
+        />);
+        validateText(wrapper, 'Create a New Picklist with These Samples', 'Create Picklist');
+
+        wrapper.unmount();
+    });
+
+    test("Update private picklist", () => {
+        const existingList=new PicklistModel({
+            Category: PRIVATE_PICKLIST_CATEGORY,
+            name: "Existing list",
+            Description: "My test description"
+        });
+        const wrapper = mount(<PicklistEditModal
+            show={true}
+            picklist={existingList}
+            onCancel={jest.fn()}
+            onFinish={jest.fn()}
+        />);
+        validateText(wrapper, 'Update Picklist Data', 'Update Picklist');
+        const labels = wrapper.find('label');
+        expect(labels).toHaveLength(3);
+        expect(labels.at(0).text()).toBe("Name *");
+        expect(labels.at(1).text()).toBe("Description");
+        expect(labels.at(2).text()).toBe("Share this picklist publicly with team members");
+        expect(wrapper.find('input').at(0).prop('value')).toBe(existingList.name);
+        expect(wrapper.find('input').at(1).prop('checked')).toBe(false);
+        expect(wrapper.find('textarea').prop('value')).toBe(existingList.Description);
+        wrapper.unmount();
+    });
+
+    test("Update public picklist", () => {
+        const existingList=new PicklistModel({
+            Category: PUBLIC_PICKLIST_CATEGORY,
+            name: "Existing list",
+            Description: "My test description"
+        });
+        const wrapper = mount(<PicklistEditModal
+            show={true}
+            picklist={existingList}
+            onCancel={jest.fn()}
+            onFinish={jest.fn()}
+        />);
+        expect(wrapper.find('input').at(1).prop('checked')).toBe(true);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -66,9 +66,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                 }));
             }
             else {
-                updatedList = await createPicklist(trimmedName, description, shared);
-                await addSamplesToPicklist(trimmedName, selectionKey, sampleIds);
-                await setPicklistDefaultView(trimmedName)
+                updatedList = await createPicklist(trimmedName, description, shared, selectionKey, sampleIds);
             }
             setIsSubmitting(false);
             onFinish(updatedList);

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -89,9 +89,9 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         else if (selectionKey) {
             title = <>Create a New Picklist with the {Utils.pluralize(selectedQuantity, 'Selected Sample', 'Selected Samples')}</>;
         } else if (count === 1) {
-            title = 'Create a New Picklist with this Sample';
+            title = 'Create a New Picklist with This Sample';
         } else {
-            title = 'Create a New Picklist with these Samples';
+            title = 'Create a New Picklist with These Samples';
         }
     }
 

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -116,7 +116,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                         <textarea placeholder="Add a description" className="form-control" value={description} onChange={onDescriptionChange}/>
 
                         <Checkbox checked={shared} onChange={onSharedChanged} >
-                            <span>Share this picklist with team members</span>
+                            <span>Share this picklist publicly with team members</span>
                         </Checkbox>
                     </div>
                 </form>

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -21,7 +21,7 @@ interface Props {
 export const PicklistEditModal: FC<Props> = memo(props => {
     const { show, onCancel, onFinish, selectionKey, selectedQuantity, sampleIds, picklist } = props;
     const [ name, setName ] = useState<string>(picklist ? picklist.name : '');
-    const onNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setName(evt.target.value), []);
+    const onNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setName(evt.target.value.trim()), []);
 
     const [ description, setDescription ] = useState<string>(picklist ? picklist.Description : '');
     const onDescriptionChange = useCallback((evt: ChangeEvent<HTMLTextAreaElement>) => setDescription(evt.target.value), []);

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -21,7 +21,7 @@ interface Props {
 export const PicklistEditModal: FC<Props> = memo(props => {
     const { show, onCancel, onFinish, selectionKey, selectedQuantity, sampleIds, picklist } = props;
     const [ name, setName ] = useState<string>(picklist ? picklist.name : '');
-    const onNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setName(evt.target.value.trim()), []);
+    const onNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setName(evt.target.value), []);
 
     const [ description, setDescription ] = useState<string>(picklist ? picklist.Description : '');
     const onDescriptionChange = useCallback((evt: ChangeEvent<HTMLTextAreaElement>) => setDescription(evt.target.value), []);
@@ -56,18 +56,19 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         setIsSubmitting(true);
         try {
             let updatedList;
+            const trimmedName = name.trim();
             if (isUpdate) {
                 updatedList = await updatePicklist(new PicklistModel({
-                    name: name,
+                    name: trimmedName,
                     listId: picklist.listId,
                     Description: description,
                     Category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
                 }));
             }
             else {
-                updatedList = await createPicklist(name, description, shared);
-                await addSamplesToPicklist(name, selectionKey, sampleIds);
-                await setPicklistDefaultView(name)
+                updatedList = await createPicklist(trimmedName, description, shared);
+                await addSamplesToPicklist(trimmedName, selectionKey, sampleIds);
+                await setPicklistDefaultView(trimmedName)
             }
             setIsSubmitting(false);
             onFinish(updatedList);

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, FC, FormEvent, memo, useCallback, useState } from '
 import { Checkbox, Modal } from 'react-bootstrap';
 import { WizardNavButtons } from '../buttons/WizardNavButtons';
 import { QueryGridModel } from '../../QueryGridModel';
-import { addSamplesToPicklist, createPicklist, updatePicklist } from './actions';
+import { addSamplesToPicklist, createPicklist, setPicklistDefaultView, updatePicklist } from './actions';
 import { Alert } from '../base/Alert';
 import { resolveErrorMessage } from '../../util/messaging';
 import { PicklistModel } from './models';
@@ -42,7 +42,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         finishingVerb = "Updating";
     } else {
         finishVerb = "Create";
-        finishingVerb = "Creating."
+        finishingVerb = "Creating"
     }
 
     const onHide = useCallback((data: any) => {
@@ -69,6 +69,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                     name,
                     useSelection ? samplesModel.selectionKey : undefined,
                     useSelection ? undefined : [samplesModel.getRow().getIn(['RowId', 'value'])]);
+                await setPicklistDefaultView(name)
             }
             onFinish(updatedList);
         } catch (e) {
@@ -104,7 +105,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
 
                 <form>
                     <div className="form-group">
-                        <label className="control-label">Name</label>
+                        <label className="control-label">Name *</label>
 
                         <input placeholder="Give this list a name" className="form-control" value={name} onChange={onNameChange} type="text"/>
                     </div>
@@ -124,7 +125,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                 <WizardNavButtons
                     cancel={onHide}
                     cancelText={'Cancel'}
-                    canFinish={true}
+                    canFinish={!!name}
                     containerClassName=""
                     isFinishing={isSubmitting}
                     isFinishingText={finishingVerb + " Picklist..."}

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -1,49 +1,57 @@
 import React, { ChangeEvent, FC, FormEvent, memo, useCallback, useState } from 'react';
 import { Checkbox, Modal } from 'react-bootstrap';
-import { WizardNavButtons } from '../buttons/WizardNavButtons';
-import { addSamplesToPicklist, createPicklist, setPicklistDefaultView, updatePicklist } from './actions';
-import { Alert } from '../base/Alert';
-import { resolveErrorMessage } from '../../util/messaging';
-import { PicklistModel } from './models';
-import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
+
 import { Utils } from '@labkey/api';
 
+import { WizardNavButtons } from '../buttons/WizardNavButtons';
+
+import { Alert } from '../base/Alert';
+import { resolveErrorMessage } from '../../util/messaging';
+
+import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
+
+import { PicklistModel } from './models';
+import { addSamplesToPicklist, createPicklist, setPicklistDefaultView, updatePicklist } from './actions';
+
 interface Props {
-    show: boolean,
-    selectionKey?: string, // pass in either selectionKey and selectedQuantity or sampleIds.
-    selectedQuantity?: number,
-    sampleIds?: string[],
-    picklist?: PicklistModel,
-    onCancel: () => void,
-    onFinish: (picklist: PicklistModel) => void,
+    show: boolean;
+    selectionKey?: string; // pass in either selectionKey and selectedQuantity or sampleIds.
+    selectedQuantity?: number;
+    sampleIds?: string[];
+    picklist?: PicklistModel;
+    onCancel: () => void;
+    onFinish: (picklist: PicklistModel) => void;
 }
 
 export const PicklistEditModal: FC<Props> = memo(props => {
     const { show, onCancel, onFinish, selectionKey, selectedQuantity, sampleIds, picklist } = props;
-    const [ name, setName ] = useState<string>(picklist ? picklist.name : '');
+    const [name, setName] = useState<string>(picklist ? picklist.name : '');
     const onNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setName(evt.target.value), []);
 
-    const [ description, setDescription ] = useState<string>(picklist ? picklist.Description : '');
-    const onDescriptionChange = useCallback((evt: ChangeEvent<HTMLTextAreaElement>) => setDescription(evt.target.value), []);
+    const [description, setDescription] = useState<string>(picklist ? picklist.Description : '');
+    const onDescriptionChange = useCallback(
+        (evt: ChangeEvent<HTMLTextAreaElement>) => setDescription(evt.target.value),
+        []
+    );
 
-    const [ shared, setShared ] = useState<boolean>(picklist ? picklist.isPublic() : false);
+    const [shared, setShared] = useState<boolean>(picklist ? picklist.isPublic() : false);
     // Using a type for evt here causes difficulties.  It wants a FormEvent<Checkbox> but
     // then it doesn't recognize checked as a valid field on current target.
-    const onSharedChanged = useCallback((evt) => {
+    const onSharedChanged = useCallback(evt => {
         setShared(evt.currentTarget.checked);
     }, []);
 
-    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const [ picklistError, setPicklistError ] = useState<string>(undefined);
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+    const [picklistError, setPicklistError] = useState<string>(undefined);
 
     const isUpdate = picklist !== undefined;
     let finishVerb, finishingVerb;
     if (isUpdate) {
-        finishVerb = "Update";
-        finishingVerb = "Updating";
+        finishVerb = 'Update';
+        finishingVerb = 'Updating';
     } else {
-        finishVerb = "Create";
-        finishingVerb = "Creating"
+        finishVerb = 'Create';
+        finishingVerb = 'Creating';
     }
 
     const onHide = useCallback(() => {
@@ -58,14 +66,15 @@ export const PicklistEditModal: FC<Props> = memo(props => {
             let updatedList;
             const trimmedName = name.trim();
             if (isUpdate) {
-                updatedList = await updatePicklist(new PicklistModel({
-                    name: trimmedName,
-                    listId: picklist.listId,
-                    Description: description,
-                    Category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
-                }));
-            }
-            else {
+                updatedList = await updatePicklist(
+                    new PicklistModel({
+                        name: trimmedName,
+                        listId: picklist.listId,
+                        Description: description,
+                        Category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY,
+                    })
+                );
+            } else {
                 updatedList = await createPicklist(trimmedName, description, shared, selectionKey, sampleIds);
             }
             setIsSubmitting(false);
@@ -79,14 +88,17 @@ export const PicklistEditModal: FC<Props> = memo(props => {
     let title;
     if (isUpdate) {
         title = 'Update Picklist Data';
-    }
-    else {
+    } else {
         const count = sampleIds?.length ?? selectedQuantity;
         if (count === 0) {
             title = 'Create an Empty Picklist';
-        }
-        else if (selectionKey) {
-            title = <>Create a New Picklist with the {Utils.pluralize(selectedQuantity, 'Selected Sample', 'Selected Samples')}</>;
+        } else if (selectionKey) {
+            title = (
+                <>
+                    Create a New Picklist with the{' '}
+                    {Utils.pluralize(selectedQuantity, 'Selected Sample', 'Selected Samples')}
+                </>
+            );
         } else if (count === 1) {
             title = 'Create a New Picklist with This Sample';
         } else {
@@ -107,14 +119,25 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                     <div className="form-group">
                         <label className="control-label">Name *</label>
 
-                        <input placeholder="Give this list a name" className="form-control" value={name} onChange={onNameChange} type="text"/>
+                        <input
+                            placeholder="Give this list a name"
+                            className="form-control"
+                            value={name}
+                            onChange={onNameChange}
+                            type="text"
+                        />
                     </div>
                     <div className="form-group">
                         <label className="control-label">Description</label>
 
-                        <textarea placeholder="Add a description" className="form-control" value={description} onChange={onDescriptionChange}/>
+                        <textarea
+                            placeholder="Add a description"
+                            className="form-control"
+                            value={description}
+                            onChange={onDescriptionChange}
+                        />
 
-                        <Checkbox checked={shared} onChange={onSharedChanged} >
+                        <Checkbox checked={shared} onChange={onSharedChanged}>
                             <span>Share this picklist publicly with team members</span>
                         </Checkbox>
                     </div>
@@ -124,16 +147,16 @@ export const PicklistEditModal: FC<Props> = memo(props => {
             <Modal.Footer>
                 <WizardNavButtons
                     cancel={onHide}
-                    cancelText={'Cancel'}
+                    cancelText="Cancel"
                     canFinish={!!name}
                     containerClassName=""
                     isFinishing={isSubmitting}
-                    isFinishingText={finishingVerb + " Picklist..."}
+                    isFinishingText={finishingVerb + ' Picklist...'}
                     finish
-                    finishText={finishVerb + " Picklist"}
+                    finishText={finishVerb + ' Picklist'}
                     nextStep={onSavePicklist}
                 />
             </Modal.Footer>
         </Modal>
-    )
+    );
 });

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -58,6 +58,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
             if (isUpdate) {
                 updatedList = await updatePicklist(new PicklistModel({
                     name: name,
+                    listId: picklist.listId,
                     Description: description,
                     Category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
                 }));

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -13,10 +13,50 @@ import { PicklistModel } from './models';
 import { flattenValuesFromRow } from '../../../public/QueryModel/utils';
 import { buildURL } from '../../url/AppURL';
 import { fetchListDesign } from '../domainproperties/list/actions';
+import { resolveErrorMessage } from '../../util/messaging';
 
 interface CreatePicklistResponse {
     domainId: number,
     name: string
+}
+
+export function setPicklistDefaultView(name: string): Promise<CreatePicklistResponse> {
+    return new Promise((resolve, reject) => {
+        let jsonData = {
+            schemaName: "lists",
+            queryName: name,
+            views: [{
+                columns:[
+                    {fieldKey: "SampleID/Name"},
+                    {fieldKey: "SampleID/LabelColor"},
+                    {fieldKey: "SampleID/SampleSet"},
+                    {fieldKey: "SampleID/StoredAmount"},
+                    {fieldKey: "SampleID/Units"},
+                    {fieldKey: "SampleID/freezeThawCount"},
+                    {fieldKey: "SampleID/StorageStatus"},
+                    {fieldKey: "SampleID/checkedOutBy"},
+                    {fieldKey: "SampleID/Created"},
+                    {fieldKey: "SampleID/CreatedBy"},
+                    {fieldKey: "SampleID/StorageLocation"},
+                    {fieldKey: "SampleID/StorageRow"},
+                    {fieldKey: "SampleID/StorageCol"},
+                    {fieldKey: "SampleID/isAliquot"},
+                ]
+            }]
+        };
+        return Ajax.request({
+            url: buildURL('query', 'saveQueryViews.api'),
+            method: 'POST',
+            jsonData,
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response);
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                console.error(response);
+                reject("There was a problem creating the default view for the picklist. " + resolveErrorMessage(response));
+            }),
+        });
+    });
 }
 
 export function createPicklist(name: string, description: string, shared: boolean) : Promise<CreatePicklistResponse> {

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -8,7 +8,7 @@ import { getSelected } from '../../actions';
 import { List } from 'immutable';
 
 interface CreatePicklistResponse {
-    listId: number,
+    domainId: number,
     name: string
 }
 
@@ -40,7 +40,7 @@ export function createPicklist(name: string, description: string, shared: boolea
                 keyType: 'AutoIncrementInteger',
                 category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
             },
-            success: (response) => { resolve({name: response.name, listId: response.domainId}); },
+            success: (response) => { resolve({name: response.name, domainId: response.domainId}); },
             failure: (err) => { reject(err); }
         });
     });

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -10,12 +10,13 @@ import { User } from '../base/models/User';
 import { PicklistModel } from './models';
 import { flattenValuesFromRow } from '../../../public/QueryModel/utils';
 import { buildURL } from '../../url/AppURL';
-import { fetchListDesign } from '../domainproperties/list/actions';
+import { fetchListDesign, getListIdFromDomainId } from '../domainproperties/list/actions';
 import { resolveErrorMessage } from '../../util/messaging';
 import { SCHEMAS } from '../../../index';
 
 interface CreatePicklistResponse {
     domainId: number,
+    listId: number,
     name: string
 }
 
@@ -87,7 +88,15 @@ export function createPicklist(name: string, description: string, shared: boolea
                 description,
                 category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
             },
-            success: (response) => { resolve({name: response.name, domainId: response.domainId}); },
+            success: (response) => {
+                getListIdFromDomainId(response.domainId)
+                    .then(listId => {
+                        resolve({listId, name: response.name, domainId: response.domainId});
+                    })
+                    .catch(error => {
+                        reject(error);
+                    })
+            },
             failure: (err) => { reject(err); }
         });
     });

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -1,11 +1,17 @@
-import { QueryGridModel } from '../../QueryGridModel';
 import { Domain } from '@labkey/api';
 import { SCHEMAS } from '../../schemas';
 import { PICKLIST, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 import { insertRows, InsertRowsResponse } from '../../query/api';
 import { SchemaQuery } from '../../../public/SchemaQuery';
-import { getSelected } from '../../actions';
+import { getSelected, getSelectedData } from '../../actions';
 import { List } from 'immutable';
+import { saveDomain } from '../domainproperties/actions';
+import { DomainDesign, DomainField, DomainIndex } from '../domainproperties/models';
+import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { Actions } from '../../../public/QueryModel/withQueryModels';
+import { User } from '../base/models/User';
+import { PicklistModel } from './models';
+import { flattenValuesFromRow } from '../../../public/QueryModel/utils';
 
 interface CreatePicklistResponse {
     domainId: number,
@@ -47,6 +53,62 @@ export function createPicklist(name: string, description: string, shared: boolea
     });
 }
 
+// TODO one of these two is not needed
+export function updatePicklist(picklist: PicklistModel) :Promise<PicklistModel>  {
+    return new Promise((resolve, reject) => {
+        resolve(picklist);
+        // updateRows({
+        //     schemaQuery:
+        // })
+        // Domain.save({
+        //     domainId: domainId,
+        //     domainDesign: {
+        //         name: name,
+        //     },
+        //     options: {
+        //         description,
+        //         category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
+        //     },
+        //     success: (response) => { resolve({name: response.name, domainId: response.domainId})},
+        //     failure: (err) => { reject(err); }
+        // })
+    })
+}
+
+export function savePicklist(name: string, description: string, shared: boolean) : Promise<CreatePicklistResponse> {
+    return new Promise((resolve, reject) => {
+        saveDomain(
+            DomainDesign.create({
+                name: name,
+                fields: List<DomainField>([DomainField.create(
+                    {
+                        name: 'SampleID',
+                        // rangeURI: 'int',
+                        required: true,
+                        lookupContainer: LABKEY.container.path,
+                        lookupSchema: SCHEMAS.INVENTORY.SAMPLE_ITEMS.schemaName,
+                        lookupQuery: SCHEMAS.INVENTORY.SAMPLE_ITEMS.queryName,
+                    }),
+                ]),
+                indices: List<DomainIndex>([DomainIndex.fromJS(
+                    [{
+                        columns: ['SampleID'],
+                        type: 'unique',
+                    }])
+                ])
+            }),
+            PICKLIST,
+            {
+                keyName: 'id',
+                keyType: 'AutoIncrementInteger',
+                description,
+                category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
+            },
+            name
+        );
+    });
+}
+
 export function addSamplesToPicklist(listName: string, selectionKey?: string, sampleIds?: string[] ) : Promise<InsertRowsResponse> {
     let rows = List<any>();
     if (selectionKey) {
@@ -69,4 +131,53 @@ export function addSamplesToPicklist(listName: string, selectionKey?: string, sa
             rows
         });
     }
+}
+
+export interface PicklistDeletionData {
+    numDeletable: number,
+    numNotDeletable: number,
+    numShared: number,
+    deletableLists: PicklistModel[],
+}
+
+export function getPicklistDeleteData(model: QueryModel, actions: Actions, user: User) : Promise<PicklistDeletionData> {
+    return new Promise((resolve, reject) => {
+
+        const columnString = 'Name,listId,category,createdBy';
+        getSelectedData(model.schemaName, model.queryName, [...model.selections], columnString, undefined, undefined,'ListId')
+            .then(response => {
+                    const { data } = response;
+                    let numDeletable = 0;
+                    let numNotDeletable = 0;
+                    let numShared = 0;
+                    let deletableLists = [];
+                    data.valueSeq().forEach(row => {
+                        const picklist = new PicklistModel(flattenValuesFromRow(row.toJS(), row.keySeq().toArray()));
+                        if (picklist.isPublic()) {
+                            numShared++;
+                        }
+                        if (picklist.isDeletable(user)) {
+                            numDeletable++;
+                            deletableLists.push(picklist);
+                        } else {
+                            numNotDeletable++;
+                        }
+                    });
+                    resolve({
+                        numDeletable,
+                        numNotDeletable,
+                        numShared,
+                        deletableLists
+                    });
+                }
+            )
+            .catch(reason => {
+                console.error(reason);
+                reject(reason);
+            });
+    });
+}
+
+export function deletePicklists() : void {
+    // TODO
 }

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -1,42 +1,48 @@
 import { Ajax, Domain, Utils } from '@labkey/api';
-import { PICKLIST, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
+
+import { List } from 'immutable';
+
 import { insertRows, InsertRowsResponse } from '../../query/api';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { getSelected, getSelectedData } from '../../actions';
-import { List } from 'immutable';
+import { PICKLIST, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 import { saveDomain } from '../domainproperties/actions';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { User } from '../base/models/User';
-import { PicklistModel } from './models';
+
 import { flattenValuesFromRow } from '../../../public/QueryModel/utils';
 import { buildURL } from '../../url/AppURL';
 import { fetchListDesign, getListIdFromDomainId } from '../domainproperties/list/actions';
 import { resolveErrorMessage } from '../../util/messaging';
 import { SCHEMAS } from '../../../index';
 
+import { PicklistModel } from './models';
+
 export function setPicklistDefaultView(name: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        let jsonData = {
-            schemaName: "lists",
+        const jsonData = {
+            schemaName: 'lists',
             queryName: name,
-            views: [{
-                columns:[
-                    {fieldKey: "SampleID/Name"},
-                    {fieldKey: "SampleID/LabelColor"},
-                    {fieldKey: "SampleID/SampleSet"},
-                    {fieldKey: "SampleID/StoredAmount"},
-                    {fieldKey: "SampleID/Units"},
-                    {fieldKey: "SampleID/freezeThawCount"},
-                    {fieldKey: "SampleID/StorageStatus"},
-                    {fieldKey: "SampleID/checkedOutBy"},
-                    {fieldKey: "SampleID/Created"},
-                    {fieldKey: "SampleID/CreatedBy"},
-                    {fieldKey: "SampleID/StorageLocation"},
-                    {fieldKey: "SampleID/StorageRow"},
-                    {fieldKey: "SampleID/StorageCol"},
-                    {fieldKey: "SampleID/isAliquot"},
-                ]
-            }],
+            views: [
+                {
+                    columns: [
+                        { fieldKey: 'SampleID/Name' },
+                        { fieldKey: 'SampleID/LabelColor' },
+                        { fieldKey: 'SampleID/SampleSet' },
+                        { fieldKey: 'SampleID/StoredAmount' },
+                        { fieldKey: 'SampleID/Units' },
+                        { fieldKey: 'SampleID/freezeThawCount' },
+                        { fieldKey: 'SampleID/StorageStatus' },
+                        { fieldKey: 'SampleID/checkedOutBy' },
+                        { fieldKey: 'SampleID/Created' },
+                        { fieldKey: 'SampleID/CreatedBy' },
+                        { fieldKey: 'SampleID/StorageLocation' },
+                        { fieldKey: 'SampleID/StorageRow' },
+                        { fieldKey: 'SampleID/StorageCol' },
+                        { fieldKey: 'SampleID/isAliquot' },
+                    ],
+                },
+            ],
             shared: true,
         };
         return Ajax.request({
@@ -48,17 +54,25 @@ export function setPicklistDefaultView(name: string): Promise<string> {
             }),
             failure: Utils.getCallbackWrapper(response => {
                 console.error(response);
-                reject("There was a problem creating the default view for the picklist. " + resolveErrorMessage(response));
+                reject(
+                    'There was a problem creating the default view for the picklist. ' + resolveErrorMessage(response)
+                );
             }),
         });
     });
 }
 
-export function createPicklist(name: string, description: string, shared: boolean, selectionKey: string, sampleIds: string[]) : Promise<PicklistModel> {
+export function createPicklist(
+    name: string,
+    description: string,
+    shared: boolean,
+    selectionKey: string,
+    sampleIds: string[]
+): Promise<PicklistModel> {
     return new Promise((resolve, reject) => {
         Domain.create({
             domainDesign: {
-                name: name,
+                name,
                 fields: [
                     {
                         name: 'SampleID',
@@ -72,131 +86,66 @@ export function createPicklist(name: string, description: string, shared: boolea
                     {
                         columnNames: ['SampleID'],
                         unique: true,
-                    }
-                ]
+                    },
+                ],
             },
             kind: PICKLIST,
             options: {
                 keyName: 'id',
                 keyType: 'AutoIncrementInteger',
                 description,
-                category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
+                category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY,
             },
-            success: (response) => {
+            success: response => {
                 Promise.all([
                     getListIdFromDomainId(response.domainId),
                     setPicklistDefaultView(name),
                     addSamplesToPicklist(name, selectionKey, sampleIds),
-                ]).then((responses) => {
-                    const [listId] = responses
-                    resolve(new PicklistModel({
-                        listId,
-                        name,
-                        Description: description,
-                        Category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
-                    }));
-                }).catch(error => {
-                    reject(error);
-                });
+                ])
+                    .then(responses => {
+                        const [listId] = responses;
+                        resolve(
+                            new PicklistModel({
+                                listId,
+                                name,
+                                Description: description,
+                                Category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY,
+                            })
+                        );
+                    })
+                    .catch(error => {
+                        reject(error);
+                    });
             },
-            failure: (err) => { reject(err); }
+            failure: err => {
+                reject(err);
+            },
         });
     });
 }
 
-export function updatePicklist(picklist: PicklistModel) :Promise<PicklistModel>  {
+export function updatePicklist(picklist: PicklistModel): Promise<PicklistModel> {
     return new Promise((resolve, reject) => {
         fetchListDesign(picklist.listId)
             .then(listDesign => {
-                let domain = listDesign.domain;
+                const domain = listDesign.domain;
                 const options = {
                     domainId: domain.domainId,
                     name: picklist.name,
                     keyName: 'id',
                     keyType: 'AutoIncrementInteger',
-                    description : picklist.Description,
+                    description: picklist.Description,
                     category: picklist.Category,
                 };
-                saveDomain(
-                    domain,
-                    PICKLIST,
-                    options,
-                    picklist.name
-                ).then(savedDomain => {
-                    resolve(picklist);
-                }).catch(errorDomain => {
-                    console.error(errorDomain.domainException);
-                    reject(errorDomain.domainException);
-                });
+                saveDomain(domain, PICKLIST, options, picklist.name)
+                    .then(savedDomain => {
+                        resolve(picklist);
+                    })
+                    .catch(errorDomain => {
+                        console.error(errorDomain.domainException);
+                        reject(errorDomain.domainException);
+                    });
             })
-            .catch(reason => {
-                console.error(reason);
-                reject(reason);
-            });
-    })
-}
-
-export function addSamplesToPicklist(listName: string, selectionKey?: string, sampleIds?: string[] ) : Promise<InsertRowsResponse> {
-    let rows = List<any>();
-    if (selectionKey) {
-        return getSelected(selectionKey).then(response => {
-            response.selected.forEach(id => {
-                rows = rows.push({ SampleID: id});
-            });
-            return insertRows({
-                schemaQuery: SchemaQuery.create("lists", listName),
-                rows
-            });
-        });
-    }
-    else {
-        sampleIds.forEach(id => {
-            rows = rows.push({ SampleID: id})
-        });
-        return insertRows({
-            schemaQuery: SchemaQuery.create("lists", listName),
-            rows
-        });
-    }
-}
-
-export interface PicklistDeletionData {
-    numDeletable: number,
-    numNotDeletable: number,
-    numShared: number,
-    deletableLists: PicklistModel[],
-}
-
-export function getPicklistDeleteData(model: QueryModel, user: User) : Promise<PicklistDeletionData> {
-    return new Promise((resolve, reject) => {
-
-        const columnString = 'Name,listId,category,createdBy';
-        getSelectedData(model.schemaName, model.queryName, [...model.selections], columnString, undefined, undefined,'ListId')
-            .then(response => {
-                    const { data } = response;
-                    let numNotDeletable = 0;
-                    let numShared = 0;
-                    let deletableLists = [];
-                    data.valueSeq().forEach(row => {
-                        const picklist = new PicklistModel(flattenValuesFromRow(row.toJS(), row.keySeq().toArray()));
-
-                        if (picklist.isDeletable(user)) {
-                            if (picklist.isPublic()) {
-                                numShared++;
-                            }
-                            deletableLists.push(picklist);
-                        } else {
-                            numNotDeletable++;
-                        }
-                    });
-                    resolve({
-                        numDeletable: deletableLists.length,
-                        numNotDeletable,
-                        numShared,
-                        deletableLists
-                    });
-                }
-            )
             .catch(reason => {
                 console.error(reason);
                 reject(reason);
@@ -204,25 +153,102 @@ export function getPicklistDeleteData(model: QueryModel, user: User) : Promise<P
     });
 }
 
-export function deletePicklists(picklists: PicklistModel[], selectionKey?: string) : Promise<any> {
+export function addSamplesToPicklist(
+    listName: string,
+    selectionKey?: string,
+    sampleIds?: string[]
+): Promise<InsertRowsResponse> {
+    let rows = List<any>();
+    if (selectionKey) {
+        return getSelected(selectionKey).then(response => {
+            response.selected.forEach(id => {
+                rows = rows.push({ SampleID: id });
+            });
+            return insertRows({
+                schemaQuery: SchemaQuery.create('lists', listName),
+                rows,
+            });
+        });
+    } else {
+        sampleIds.forEach(id => {
+            rows = rows.push({ SampleID: id });
+        });
+        return insertRows({
+            schemaQuery: SchemaQuery.create('lists', listName),
+            rows,
+        });
+    }
+}
+
+export interface PicklistDeletionData {
+    numDeletable: number;
+    numNotDeletable: number;
+    numShared: number;
+    deletableLists: PicklistModel[];
+}
+
+export function getPicklistDeleteData(model: QueryModel, user: User): Promise<PicklistDeletionData> {
+    return new Promise((resolve, reject) => {
+        const columnString = 'Name,listId,category,createdBy';
+        getSelectedData(
+            model.schemaName,
+            model.queryName,
+            [...model.selections],
+            columnString,
+            undefined,
+            undefined,
+            'ListId'
+        )
+            .then(response => {
+                const { data } = response;
+                let numNotDeletable = 0;
+                let numShared = 0;
+                const deletableLists = [];
+                data.valueSeq().forEach(row => {
+                    const picklist = new PicklistModel(flattenValuesFromRow(row.toJS(), row.keySeq().toArray()));
+
+                    if (picklist.isDeletable(user)) {
+                        if (picklist.isPublic()) {
+                            numShared++;
+                        }
+                        deletableLists.push(picklist);
+                    } else {
+                        numNotDeletable++;
+                    }
+                });
+                resolve({
+                    numDeletable: deletableLists.length,
+                    numNotDeletable,
+                    numShared,
+                    deletableLists,
+                });
+            })
+            .catch(reason => {
+                console.error(reason);
+                reject(reason);
+            });
+    });
+}
+
+export function deletePicklists(picklists: PicklistModel[], selectionKey?: string): Promise<any> {
     return new Promise((resolve, reject) => {
         let params;
         if (picklists.length === 1) {
             params = {
-                listId: picklists[0].listId
+                listId: picklists[0].listId,
             };
         } else if (selectionKey) {
             params = {
-                dataRegionSelectionKey: selectionKey
+                dataRegionSelectionKey: selectionKey,
             };
         } else {
-            let listIds = [];
+            const listIds = [];
             picklists.forEach(picklist => {
                 listIds.push(picklist.listId);
-            })
+            });
             params = {
-                listIds
-            }
+                listIds,
+            };
         }
         return Ajax.request({
             url: buildURL('list', 'deleteListDefinition.api'),

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -1,0 +1,19 @@
+import { QueryGridModel } from '../../QueryGridModel';
+
+interface CreatePicklistResponse {
+    listId: number,
+    name: string
+}
+
+export function createPicklist(name: string, description: string, shared: boolean, model: QueryGridModel) : Promise<CreatePicklistResponse> {
+    return new Promise((resolve, reject) => {
+        if (name.toLowerCase() === 'error')
+            reject("I'm sorry, Dave.");
+        else {
+            resolve({
+                name: name,
+                listId: 1
+            });
+        }
+    });
+}

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -5,7 +5,7 @@ interface CreatePicklistResponse {
     name: string
 }
 
-export function createPicklist(name: string, description: string, shared: boolean, model: QueryGridModel) : Promise<CreatePicklistResponse> {
+export function createPicklist(name: string, description: string, shared: boolean, model: QueryGridModel, useSelection: boolean) : Promise<CreatePicklistResponse> {
     return new Promise((resolve, reject) => {
         if (name.toLowerCase() === 'error')
             reject("I'm sorry, Dave.");

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -1,4 +1,11 @@
 import { QueryGridModel } from '../../QueryGridModel';
+import { Domain } from '@labkey/api';
+import { SCHEMAS } from '../../schemas';
+import { PICKLIST, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
+import { insertRows, InsertRowsResponse } from '../../query/api';
+import { SchemaQuery } from '../../../public/SchemaQuery';
+import { getSelected } from '../../actions';
+import { List } from 'immutable';
 
 interface CreatePicklistResponse {
     listId: number,
@@ -7,13 +14,58 @@ interface CreatePicklistResponse {
 
 export function createPicklist(name: string, description: string, shared: boolean, model: QueryGridModel, useSelection: boolean) : Promise<CreatePicklistResponse> {
     return new Promise((resolve, reject) => {
-        if (name.toLowerCase() === 'error')
-            reject("I'm sorry, Dave.");
-        else {
-            resolve({
+        Domain.create({
+            domainDesign: {
                 name: name,
-                listId: 1
-            });
-        }
+                fields: [
+                    {
+                        name: 'SampleID',
+                        rangeURI: 'int',
+                        required: true,
+                        lookupContainer: LABKEY.container.path,
+                        lookupSchema: SCHEMAS.INVENTORY.SAMPLE_ITEMS.schemaName,
+                        lookupQuery: SCHEMAS.INVENTORY.SAMPLE_ITEMS.queryName,
+                    },
+                ],
+                indices: [
+                    {
+                        columnNames: ['SampleID'],
+                        unique: true,
+                    }
+                ]
+            },
+            kind: PICKLIST,
+            options: {
+                keyName: 'id',
+                keyType: 'AutoIncrementInteger',
+                category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
+            },
+            success: (response) => { resolve({name: response.name, listId: response.domainId}); },
+            failure: (err) => { reject(err); }
+        });
     });
+}
+
+export function addSamplesToPicklist(listName: string, selectionKey?: string, sampleIds?: string[] ) : Promise<InsertRowsResponse> {
+    let rows = List<any>();
+    if (selectionKey) {
+        getSelected(selectionKey).then(response => {
+            response.selected.forEach(id => {
+                rows = rows.push({ SampleID: id});
+            });
+            return insertRows({
+                schemaQuery: SchemaQuery.create("lists", listName),
+                rows
+            });
+        });
+    }
+    else {
+        sampleIds.forEach(id => {
+            rows = rows.push({ SampleID: id})
+        });
+        return insertRows({
+            schemaQuery: SchemaQuery.create("lists", listName),
+            rows
+        });
+    }
 }

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -12,7 +12,7 @@ interface CreatePicklistResponse {
     name: string
 }
 
-export function createPicklist(name: string, description: string, shared: boolean, model: QueryGridModel, useSelection: boolean) : Promise<CreatePicklistResponse> {
+export function createPicklist(name: string, description: string, shared: boolean) : Promise<CreatePicklistResponse> {
     return new Promise((resolve, reject) => {
         Domain.create({
             domainDesign: {
@@ -38,6 +38,7 @@ export function createPicklist(name: string, description: string, shared: boolea
             options: {
                 keyName: 'id',
                 keyType: 'AutoIncrementInteger',
+                description,
                 category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY
             },
             success: (response) => { resolve({name: response.name, domainId: response.domainId}); },

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -132,18 +132,18 @@ export function getPicklistDeleteData(model: QueryModel, actions: Actions, user:
                     let deletableLists = [];
                     data.valueSeq().forEach(row => {
                         const picklist = new PicklistModel(flattenValuesFromRow(row.toJS(), row.keySeq().toArray()));
-                        if (picklist.isPublic()) {
-                            numShared++;
-                        }
+
                         if (picklist.isDeletable(user)) {
-                            numDeletable++;
+                            if (picklist.isPublic()) {
+                                numShared++;
+                            }
                             deletableLists.push(picklist);
                         } else {
                             numNotDeletable++;
                         }
                     });
                     resolve({
-                        numDeletable,
+                        numDeletable: deletableLists.length,
                         numNotDeletable,
                         numShared,
                         deletableLists

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -41,7 +41,8 @@ export function setPicklistDefaultView(name: string): Promise<CreatePicklistResp
                     {fieldKey: "SampleID/StorageCol"},
                     {fieldKey: "SampleID/isAliquot"},
                 ]
-            }]
+            }],
+            shared: true,
         };
         return Ajax.request({
             url: buildURL('query', 'saveQueryViews.api'),

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -16,6 +16,10 @@ export class PicklistModel {
         Object.assign(this, values);
     }
 
+    isValid(): boolean {
+        return !!this.name;
+    }
+
     isUserList(user: User): boolean {
         return this.CreatedBy === user.id
     }

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -1,0 +1,34 @@
+import { immerable } from 'immer';
+import { User } from '../base/models/User';
+import { PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
+import { userCanDeletePublicPicklists, userCanManagePicklists } from '../../app/utils';
+
+export class PicklistModel {
+    [immerable] = true;
+
+    readonly Category: string;
+    readonly CreatedBy: number;
+    readonly name: string;
+    readonly listId: number;
+    readonly Description: string;
+
+    constructor(values?: Partial<PicklistModel>) {
+        Object.assign(this, values);
+    }
+
+    isUserList(user: User): boolean {
+        return this.CreatedBy === user.id
+    }
+
+    isEditable(user: User): boolean {
+        return this.isUserList(user) && userCanManagePicklists(user);
+    }
+
+    isPublic(): boolean {
+        return this.Category === PUBLIC_PICKLIST_CATEGORY;
+    }
+
+    isDeletable(user: User): boolean {
+        return (this.isUserList(user) && userCanManagePicklists(user)) || (this.isPublic() && userCanDeletePublicPicklists(user));
+    }
+}

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -1,4 +1,4 @@
-import { immerable } from 'immer';
+import { Draft, immerable, produce } from 'immer';
 import { User } from '../base/models/User';
 import { PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 import { userCanDeletePublicPicklists, userCanManagePicklists } from '../../app/utils';
@@ -31,4 +31,12 @@ export class PicklistModel {
     isDeletable(user: User): boolean {
         return (this.isUserList(user) && userCanManagePicklists(user)) || (this.isPublic() && userCanDeletePublicPicklists(user));
     }
+
+    mutate(props: Partial<PicklistModel>): PicklistModel {
+        return produce(this, (draft: Draft<PicklistModel>) => {
+            Object.assign(draft, props);
+        });
+    }
+
+
 }

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -1,4 +1,5 @@
 import { Draft, immerable, produce } from 'immer';
+
 import { User } from '../base/models/User';
 import { PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 import { userCanDeletePublicPicklists, userCanManagePicklists } from '../../app/utils';
@@ -21,7 +22,7 @@ export class PicklistModel {
     }
 
     isUserList(user: User): boolean {
-        return this.CreatedBy === user.id
+        return this.CreatedBy === user.id;
     }
 
     isEditable(user: User): boolean {
@@ -41,6 +42,4 @@ export class PicklistModel {
             Object.assign(draft, props);
         });
     }
-
-
 }

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -33,7 +33,7 @@ export class PicklistModel {
     }
 
     isDeletable(user: User): boolean {
-        return (this.isUserList(user) && userCanManagePicklists(user)) || (this.isPublic() && userCanDeletePublicPicklists(user));
+        return this.isUserList(user) || (this.isPublic() && userCanDeletePublicPicklists(user));
     }
 
     mutate(props: Partial<PicklistModel>): PicklistModel {

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -17,7 +17,7 @@ export class PicklistModel {
     }
 
     isValid(): boolean {
-        return !!this.name;
+        return this.name?.trim().length > 0;
     }
 
     isUserList(user: User): boolean {

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -94,6 +94,14 @@ export const STUDY_TABLES = {
     COHORT: SchemaQuery.create(STUDY_SCHEMA, 'Cohort'),
 };
 
+// LIST
+const LIST_METADATA_SCHEMA = 'ListManager';
+export const LIST_METADATA_TABLES = {
+    SCHEMA: LIST_METADATA_SCHEMA,
+    LIST_MANAGER: SchemaQuery.create(LIST_METADATA_SCHEMA, "ListManager"),
+    PICKLISTS: SchemaQuery.create(LIST_METADATA_SCHEMA, "Picklists")
+}
+
 export const SCHEMAS = {
     ASSAY_TABLES,
     EXP_TABLES,
@@ -102,7 +110,8 @@ export const SCHEMAS = {
     DATA_CLASSES,
     CBMB,
     STUDY_TABLES,
-    INVENTORY
+    INVENTORY,
+    LIST_METADATA_TABLES
 };
 
 export function fetchSchemas(schemaName?: string): Promise<List<Map<string, SchemaDetails>>> {

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -70,6 +70,13 @@ export const DATA_CLASSES = {
     MIXTURES: SchemaQuery.create(DATA_CLASS_SCHEMA, 'Mixtures'),
 };
 
+// INVENTORY
+const INVENTORY_SCHEMA = 'inventory';
+export const INVENTORY = {
+    SCHEMA: INVENTORY_SCHEMA,
+    SAMPLE_ITEMS: SchemaQuery.create(INVENTORY_SCHEMA, 'SampleItems'),
+}
+
 // SAMPLE SETS
 const SAMPLE_SET_SCHEMA = 'samples';
 export const SAMPLE_SETS = {
@@ -95,6 +102,7 @@ export const SCHEMAS = {
     DATA_CLASSES,
     CBMB,
     STUDY_TABLES,
+    INVENTORY
 };
 
 export function fetchSchemas(schemaName?: string): Promise<List<Map<string, SchemaDetails>>> {

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -75,7 +75,7 @@ const INVENTORY_SCHEMA = 'inventory';
 export const INVENTORY = {
     SCHEMA: INVENTORY_SCHEMA,
     SAMPLE_ITEMS: SchemaQuery.create(INVENTORY_SCHEMA, 'SampleItems'),
-}
+};
 
 // SAMPLE SETS
 const SAMPLE_SET_SCHEMA = 'samples';
@@ -98,9 +98,9 @@ export const STUDY_TABLES = {
 const LIST_METADATA_SCHEMA = 'ListManager';
 export const LIST_METADATA_TABLES = {
     SCHEMA: LIST_METADATA_SCHEMA,
-    LIST_MANAGER: SchemaQuery.create(LIST_METADATA_SCHEMA, "ListManager"),
-    PICKLISTS: SchemaQuery.create(LIST_METADATA_SCHEMA, "Picklists")
-}
+    LIST_MANAGER: SchemaQuery.create(LIST_METADATA_SCHEMA, 'ListManager'),
+    PICKLISTS: SchemaQuery.create(LIST_METADATA_SCHEMA, 'Picklists'),
+};
 
 export const SCHEMAS = {
     ASSAY_TABLES,
@@ -111,7 +111,7 @@ export const SCHEMAS = {
     CBMB,
     STUDY_TABLES,
     INVENTORY,
-    LIST_METADATA_TABLES
+    LIST_METADATA_TABLES,
 };
 
 export function fetchSchemas(schemaName?: string): Promise<List<Map<string, SchemaDetails>>> {

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -166,8 +166,8 @@ export class ListResolver implements AppRouteResolver {
             // fetch it
             return new Promise(resolve => {
                 return selectRows({
-                    schemaName: 'ListManager',
-                    queryName: 'ListManager',
+                    schemaName: SCHEMAS.LIST_METADATA_TABLES.SCHEMA,
+                    queryName: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER.queryName,
                     columns: 'ListId,Name',
                 }).then(result => {
                     this.fetched = true;

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -454,11 +454,25 @@ const PIPELINE_MAPPER = new ActionMapper('pipeline-status', 'details', row => {
     return false;
 });
 
+export const PICKLIST_MAPPER =
+    new ActionMapper("picklist", "grid", row => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
+            if (params.listName) {
+                return AppURL.create('picklist', params.listName);
+            }
+        }
+        return false;
+    });
+
+
 export const URL_MAPPERS = {
     ASSAY_MAPPERS,
     DATA_CLASS_MAPPERS,
     SAMPLE_TYPE_MAPPERS,
     LIST_MAPPERS,
+    PICKLIST_MAPPER,
     DETAILS_QUERY_ROW_MAPPER,
     EXECUTE_QUERY_MAPPER,
     USER_DETAILS_MAPPERS,

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -459,8 +459,8 @@ export const PICKLIST_MAPPER =
         const url = row.get('url');
         if (url) {
             const params = ActionURL.getParameters(url);
-            if (params.listName) {
-                return AppURL.create('picklist', params.listName);
+            if (params.listId) {
+                return AppURL.create('picklist', params.listId);
             }
         }
         return false;

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -454,18 +454,16 @@ const PIPELINE_MAPPER = new ActionMapper('pipeline-status', 'details', row => {
     return false;
 });
 
-export const PICKLIST_MAPPER =
-    new ActionMapper("picklist", "grid", row => {
-        const url = row.get('url');
-        if (url) {
-            const params = ActionURL.getParameters(url);
-            if (params.listId) {
-                return AppURL.create('picklist', params.listId);
-            }
+export const PICKLIST_MAPPER = new ActionMapper('picklist', 'grid', row => {
+    const url = row.get('url');
+    if (url) {
+        const params = ActionURL.getParameters(url);
+        if (params.listId) {
+            return AppURL.create('picklist', params.listId);
         }
-        return false;
-    });
-
+    }
+    return false;
+});
 
 export const URL_MAPPERS = {
     ASSAY_MAPPERS,

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1470,10 +1470,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.4.0":
-  version "1.4.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.4.0.tgz#9b5deaca579a3329dee4e7c0050e476e7262dce1"
-  integrity sha1-m13qyleaMyne5OfABQ5HbnJi3OE=
+"@labkey/api@1.5.0":
+  version "1.5.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.5.0.tgz#89ec3489904151d9f1600e4d93b423b871dd021e"
+  integrity sha1-iew0iZBBUdnxYA5Nk7QjuHHdAh4=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"


### PR DESCRIPTION
#### Rationale
We are building support for user-defined picklists of samples within Sample Manager and eventually within Biologics as well.  These lists are built on top of our list implementation, but using a new domain kind with some properties specific to picklists. We create the picklists as a reference to a custom query that includes the storage data we want to show and, upon creation, change the default view for the list to include these extra columns. 

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/234
* https://github.com/LabKey/platform/pull/2243
* https://github.com/LabKey/sampleManagement/pull/565

#### Changes
* Add picklist-related components, models, and actions including:
    * PicklistCreationMenuItem
    * PicklistEditModal
    * PicklistDeleteConfirm
