### PR TITLE
Replace usages of LABKEY variable with getServerContext()

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.27.0",
+  "version": "2.27.0-fb-labkeyVarReplacement.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-fb-labkeyVarReplacement.2",
+  "version": "2.29.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-fb-labkeyVarReplacement.0",
+  "version": "2.28.0-fb-labkeyVarReplacement.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0-fb-labkeyVarReplacement.1",
+  "version": "2.28.0-fb-labkeyVarReplacement.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.28.0",
+  "version": "2.28.0-fb-labkeyVarReplacement.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Replace usages of LABKEY variable with getServerContext()
+* Add `Container.hasActiveModule()` utility method.
 
 ### version 2.28.0
 *Released*: 6 May 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Replace usages of LABKEY variable with getServerContext()
+
 ### version 2.27.0
 *Released*: 01 May 2021
 * Changes to allow data region filtration based on ontology concepts

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.29.0
+*Released*: 11 May 2021
 * Replace usages of LABKEY variable with getServerContext()
 * Add `Container.hasActiveModule()` utility method.
 

--- a/packages/components/src/internal/QueryGridModel.ts
+++ b/packages/components/src/internal/QueryGridModel.ts
@@ -1,12 +1,11 @@
-import { fromJS, List, Map, OrderedSet, Record } from 'immutable';
-import { Filter, Query, Utils } from '@labkey/api';
+import { List, Map, OrderedSet, Record } from 'immutable';
+import { Filter, getServerContext, Query, Utils } from '@labkey/api';
 
-import { formatDate, formatDateTime, QueryColumn, QueryInfo, resolveKey, SchemaQuery, ViewInfo } from '..';
+import { QueryColumn, QueryInfo, resolveKey, SchemaQuery, ViewInfo } from '..';
 
 import { intersect, toLowerSafe } from './util/utils';
 
 import { GRID_CHECKBOX_OPTIONS, GRID_EDIT_INDEX, GRID_SELECTION_INDEX } from './constants';
-import { STORAGE_UNIQUE_ID_CONCEPT_URI } from './components/domainproperties/constants';
 
 const emptyList = List<string>();
 const emptyColumns = List<QueryColumn>();
@@ -197,7 +196,7 @@ export class QueryGridModel
     constructor(values?: IQueryGridModel) {
         super(values);
 
-        if (LABKEY.devMode) {
+        if (getServerContext().devMode) {
             // ensure that requiredColumns and omittedColumns do not intersect
             const i = intersect(this.requiredColumns, this.omittedColumns);
             if (i.size > 0) {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -750,9 +750,10 @@ export function getExportParams(
     }
 
     // 32052: Apply default headers (CRSF, etc)
-    for (const i in getServerContext().defaultHeaders) {
-        if (getServerContext().defaultHeaders.hasOwnProperty(i)) {
-            params[i] = getServerContext().defaultHeaders[i];
+    const { defaultHeaders } = getServerContext();
+    for (const i in defaultHeaders) {
+        if (defaultHeaders.hasOwnProperty(i)) {
+            params[i] = defaultHeaders[i];
         }
     }
 

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { fromJS, List, Map, OrderedMap, Set } from 'immutable';
-import { Ajax, Filter, Query, Utils } from '@labkey/api';
+import { Ajax, Filter, getServerContext, Query, Utils } from '@labkey/api';
 import $ from 'jquery';
 
 import {
@@ -750,9 +750,9 @@ export function getExportParams(
     }
 
     // 32052: Apply default headers (CRSF, etc)
-    for (const i in LABKEY.defaultHeaders) {
-        if (LABKEY.defaultHeaders.hasOwnProperty(i)) {
-            params[i] = LABKEY.defaultHeaders[i];
+    for (const i in getServerContext().defaultHeaders) {
+        if (getServerContext().defaultHeaders.hasOwnProperty(i)) {
+            params[i] = getServerContext().defaultHeaders[i];
         }
     }
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -2,7 +2,6 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { useMemo } from 'react';
 import { List, Map } from 'immutable';
 import { ActionURL, getServerContext, PermissionTypes } from '@labkey/api';
 
@@ -34,6 +33,7 @@ import {
     BIOLOGICS_PRODUCT_NAME,
     LABKEY_SERVER_PRODUCT_NAME,
 } from './constants';
+import { LABKEY_WEBSOCKET } from '../constants';
 
 // Type definition not provided for event codes so here we provide our own
 // Source: https://www.iana.org/assignments/websocket/websocket.xml#close-code-number
@@ -69,19 +69,18 @@ export function initWebSocketListeners(
         }
     }
 
-    // TODO: Make "WebSocket" available from @labkey/api
-    LABKEY.WebSocket.addServerEventListener(CloseEventCode.NORMAL_CLOSURE, _logOutCallback);
-    LABKEY.WebSocket.addServerEventListener(CloseEventCode.UNSUPPORTED_DATA, _logOutCallback);
+    LABKEY_WEBSOCKET.addServerEventListener(CloseEventCode.NORMAL_CLOSURE, _logOutCallback);
+    LABKEY_WEBSOCKET.addServerEventListener(CloseEventCode.UNSUPPORTED_DATA, _logOutCallback);
 
     // register websocket listener for session timeout code
-    LABKEY.WebSocket.addServerEventListener(CloseEventCode.POLICY_VIOLATION, function (evt) {
+    LABKEY_WEBSOCKET.addServerEventListener(CloseEventCode.POLICY_VIOLATION, function (evt) {
         if (evt.wasClean) {
             window.setTimeout(() => store.dispatch({ type: SECURITY_SESSION_TIMEOUT }), 1000);
         }
     });
 
     // register websocket listener for server being shutdown
-    LABKEY.WebSocket.addServerEventListener(CloseEventCode.GOING_AWAY, function (evt) {
+    LABKEY_WEBSOCKET.addServerEventListener(CloseEventCode.GOING_AWAY, function (evt) {
         // Issue 39473: 1001 sent when server is shutdown normally (AND on page reload in FireFox, but that one doesn't have a reason)
         if (evt.wasClean && evt.reason && evt.reason !== '') {
             window.setTimeout(() => store.dispatch({ type: SECURITY_SERVER_UNAVAILABLE }), 1000);
@@ -90,7 +89,7 @@ export function initWebSocketListeners(
 
     if (notificationListeners) {
         notificationListeners.forEach(listener => {
-            LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
+            LABKEY_WEBSOCKET.addServerEventListener(listener, function (evt) {
                 // not checking evt.wasClean since we want this event for all user sessions
                 window.setTimeout(() => store.dispatch({ type: SERVER_NOTIFICATIONS_INVALIDATE }), 1000);
             });
@@ -99,7 +98,7 @@ export function initWebSocketListeners(
 
     if (menuReloadListeners) {
         menuReloadListeners.forEach(listener => {
-            LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
+            LABKEY_WEBSOCKET.addServerEventListener(listener, function (evt) {
                 // not checking evt.wasClean since we want this event for all user sessions
                 window.setTimeout(() => store.dispatch({ type: MENU_RELOAD }), 1000);
             });
@@ -108,7 +107,7 @@ export function initWebSocketListeners(
 
     if (resetQueryGridListeners) {
         resetQueryGridListeners.forEach(listener => {
-            LABKEY.WebSocket.addServerEventListener(listener, function (evt) {
+            LABKEY_WEBSOCKET.addServerEventListener(listener, function (evt) {
                 window.setTimeout(() => store.dispatch({ type: SET_RESET_QUERY_GRID_STATE }), 1000);
             });
         });

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -7,6 +7,8 @@ import { ActionURL, getServerContext, PermissionTypes } from '@labkey/api';
 
 import { AppURL, buildURL, imageURL, MenuSectionConfig, hasAllPermissions, User } from '../..';
 
+import { LABKEY_WEBSOCKET } from '../constants';
+
 import {
     ASSAYS_KEY,
     HOME_KEY,
@@ -33,7 +35,6 @@ import {
     BIOLOGICS_PRODUCT_NAME,
     LABKEY_SERVER_PRODUCT_NAME,
 } from './constants';
-import { LABKEY_WEBSOCKET } from '../constants';
 
 // Type definition not provided for event codes so here we provide our own
 // Source: https://www.iana.org/assignments/websocket/websocket.xml#close-code-number

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { List, Map, OrderedMap } from 'immutable';
-import { ActionURL, Ajax, Assay, AssayDOM, Filter, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Assay, AssayDOM, Filter, getServerContext, Utils } from '@labkey/api';
 
 import {
     AssayDefinitionModel,
@@ -153,7 +153,7 @@ export function uploadAssayRunFiles(data: IAssayUploadOptions): Promise<IAssayUp
 
         // N.B. assayFileUpload's success response is not handled well by Utils.getCallbackWrapper.
         Ajax.request({
-            url: ActionURL.buildURL('assay', 'assayFileUpload.view', LABKEY.container.path),
+            url: ActionURL.buildURL('assay', 'assayFileUpload.view', getServerContext().container.path),
             method: 'POST',
             form: formData,
             success: result => {

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { List, Map, OrderedMap } from 'immutable';
-import { ActionURL, Ajax, Assay, AssayDOM, Filter, getServerContext, Utils } from '@labkey/api';
+import { Ajax, Assay, AssayDOM, Filter, Utils } from '@labkey/api';
 
 import {
     AssayDefinitionModel,
@@ -153,7 +153,7 @@ export function uploadAssayRunFiles(data: IAssayUploadOptions): Promise<IAssayUp
 
         // N.B. assayFileUpload's success response is not handled well by Utils.getCallbackWrapper.
         Ajax.request({
-            url: ActionURL.buildURL('assay', 'assayFileUpload.view', getServerContext().container.path),
+            url: buildURL('assay', 'assayFileUpload.view'),
             method: 'POST',
             form: formData,
             success: result => {

--- a/packages/components/src/internal/components/base/models/Container.spec.ts
+++ b/packages/components/src/internal/components/base/models/Container.spec.ts
@@ -1,0 +1,12 @@
+import { Container } from './Container';
+
+describe('Container', () => {
+    test('hasActiveModule', () => {
+        const container = new Container({ activeModules: ['Query'] });
+        expect(container.hasActiveModule(undefined)).toBeFalsy();
+        expect(container.hasActiveModule(null)).toBeFalsy();
+        expect(container.hasActiveModule('bogus')).toBeFalsy();
+        expect(container.hasActiveModule('query')).toBeFalsy();
+        expect(container.hasActiveModule('Query')).toBeTruthy();
+    });
+});

--- a/packages/components/src/internal/components/base/models/Container.ts
+++ b/packages/components/src/internal/components/base/models/Container.ts
@@ -34,4 +34,8 @@ export class Container extends Record(defaultContainer) implements Partial<ICont
     declare sortOrder: number;
     declare title: string;
     declare type: string;
+
+    hasActiveModule(moduleName: string): boolean {
+        return this.activeModules?.indexOf(moduleName) > -1;
+    }
 }

--- a/packages/components/src/internal/components/base/models/Container.ts
+++ b/packages/components/src/internal/components/base/models/Container.ts
@@ -35,6 +35,11 @@ export class Container extends Record(defaultContainer) implements Partial<ICont
     declare title: string;
     declare type: string;
 
+    /**
+     * Verify if the given moduleName parameter is in the array of active modules for this container object.
+     * Note that this check is case-sensitive.
+     * @param moduleName
+     */
     hasActiveModule(moduleName: string): boolean {
         return this.activeModules?.indexOf(moduleName) > -1;
     }

--- a/packages/components/src/internal/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/internal/components/chart/BaseBarChart.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import { debounce, generateId } from '../../..';
+import { LABKEY_VIS } from '../../constants';
 
 import { ChartData } from './types';
 import { getBarChartPlotConfig } from './utils';
@@ -71,7 +72,7 @@ export class BaseBarChart extends Component<Props> {
 
     renderPlot = (): void => {
         this.getPlotElement().innerHTML = '';
-        const plot = new LABKEY.vis.BarPlot(this.getPlotConfig());
+        const plot = new LABKEY_VIS.BarPlot(this.getPlotConfig());
         plot.render();
     };
 

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -20,6 +20,7 @@ import { Filter } from '@labkey/api';
 import { DataViewInfo, VisualizationConfigModel } from '../../models';
 import { getVisualizationConfig } from '../../actions';
 import { debounce, generateId, LoadingSpinner } from '../../..';
+import { LABKEY_VIS } from '../../constants';
 
 interface Props {
     chart: DataViewInfo;
@@ -104,7 +105,7 @@ export class Chart extends React.Component<Props, State> {
             }
 
             this.getPlotElement().html('');
-            LABKEY.vis.GenericChartHelper.renderChartSVG(
+            LABKEY_VIS.GenericChartHelper.renderChartSVG(
                 this.state.divId,
                 processedConfig.queryConfig,
                 processedConfig.chartConfig

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { List } from 'immutable';
 import { Button, Checkbox, Col, FormControl, Modal, Row } from 'react-bootstrap';
-import { ActionURL, getServerContext } from '@labkey/api';
+import { ActionURL } from '@labkey/api';
 
 import { LabelHelpTip } from '../../..';
 
@@ -191,7 +191,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 params['providerName'] = ActionURL.getParameter('providerName');
             }
 
-            window.location.href = ActionURL.buildURL(controller, action, getServerContext().container.path, params);
+            window.location.href = ActionURL.buildURL(controller, action, undefined, params);
         }
     };
 

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { List } from 'immutable';
 import { Button, Checkbox, Col, FormControl, Modal, Row } from 'react-bootstrap';
-import { ActionURL } from '@labkey/api';
+import { ActionURL, getServerContext } from '@labkey/api';
 
 import { LabelHelpTip } from '../../..';
 
@@ -191,7 +191,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 params['providerName'] = ActionURL.getParameter('providerName');
             }
 
-            window.location.href = ActionURL.buildURL(controller, action, LABKEY.container.path, params);
+            window.location.href = ActionURL.buildURL(controller, action, getServerContext().container.path, params);
         }
     };
 

--- a/packages/components/src/internal/components/domainproperties/actions.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.spec.ts
@@ -33,7 +33,6 @@ import {
     getDomainPanelHeaderId,
     getDomainPanelStatus,
     getOntologyUpdatedFieldName,
-    hasActiveModule,
     setDomainFields,
     updateDomainException,
     updateOntologyFieldProperties,
@@ -323,14 +322,6 @@ describe('domain properties actions', () => {
         expect(getDomainHeaderName('Test Name', undefined, 'test')).toBe('Test Name');
         expect(getDomainHeaderName('Test Name', 'Test Header Title', 'test')).toBe('Test Header Title');
         expect(getDomainHeaderName('Data Fields')).toBe('Results Fields');
-    });
-
-    test('hasActiveModule', () => {
-        expect(hasActiveModule(undefined)).toBeFalsy();
-        expect(hasActiveModule(null)).toBeFalsy();
-        expect(hasActiveModule('bogus')).toBeFalsy();
-        expect(hasActiveModule('query')).toBeFalsy();
-        expect(hasActiveModule('Query')).toBeTruthy();
     });
 
     test('getAvailableTypes, all optional allowed', () => {

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -126,7 +126,7 @@ export function processContainers(payload: any, container?: Container): List<Con
 export function fetchDomain(domainId: number, schemaName: string, queryName: string): Promise<DomainDesign> {
     return new Promise((resolve, reject) => {
         Domain.getDomainDetails({
-            containerPath: LABKEY.container.path,
+            containerPath: getServerContext().container.path,
             domainId,
             schemaName,
             queryName,
@@ -149,7 +149,7 @@ export function fetchDomain(domainId: number, schemaName: string, queryName: str
 export function fetchDomainDetails(domainId: number, schemaName: string, queryName: string): Promise<DomainDetails> {
     return new Promise((resolve, reject) => {
         Domain.getDomainDetails({
-            containerPath: LABKEY.container.path,
+            containerPath: getServerContext().container.path,
             domainId,
             schemaName,
             queryName,
@@ -177,7 +177,7 @@ export function fetchQueries(containerPath: string, schemaName: string): Promise
             new Promise(resolve => {
                 if (schemaName) {
                     Query.getQueries({
-                        containerPath: containerPath || LABKEY.container.path,
+                        containerPath: containerPath || getServerContext().container.path,
                         schemaName,
                         queryDetailColumns: true,
                         success: data => {
@@ -221,7 +221,7 @@ export function fetchSchemas(containerPath: string): Promise<List<SchemaDetails>
             new Promise(resolve => {
                 Query.getSchemas({
                     apiVersion: 17.1,
-                    containerPath: containerPath || LABKEY.container.path,
+                    containerPath: containerPath || getServerContext().container.path,
                     includeHidden: false,
                     success: data => {
                         resolve(handleSchemas(data));
@@ -354,7 +354,7 @@ export function saveDomain(
 
         if (domain.domainId) {
             Domain.save({
-                containerPath: LABKEY.container.path,
+                containerPath: getServerContext().container.path,
                 domainId: domain.domainId,
                 options,
                 domainDesign: DomainDesign.serialize(domain),
@@ -364,7 +364,7 @@ export function saveDomain(
             });
         } else {
             Domain.create({
-                containerPath: LABKEY.container.path,
+                containerPath: getServerContext().container.path,
                 kind,
                 options,
                 domainDesign: DomainDesign.serialize(domain.set('name', name) as DomainDesign),

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -1,9 +1,8 @@
 import React, { FC, memo } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 import { List } from 'immutable';
-import { ActionURL, getServerContext } from '@labkey/api';
 
-import { Container, RemoveEntityButton, AddEntityButton } from '../../../..';
+import { Container, buildURL, RemoveEntityButton, AddEntityButton } from '../../../..';
 
 import {
     ASSAY_EDIT_PLATE_TEMPLATE_TOPIC,
@@ -137,10 +136,7 @@ export function PlateTemplatesInput(props: InputProps) {
                     </option>
                 ))}
             </FormControl>
-            <a
-                href={ActionURL.buildURL('plate', 'plateTemplateList', getServerContext().container.path)}
-                className="labkey-text-link"
-            >
+            <a className="labkey-text-link" href={buildURL('plate', 'plateTemplateList')}>
                 Configure Templates
             </a>
         </AssayPropertiesInput>
@@ -465,7 +461,7 @@ export class TransformScriptsInput extends React.PureComponent<TransformScriptsI
                         <Col xs={5} lg={4}>
                             <span className="pull-right">
                                 <a
-                                    href={ActionURL.buildURL('assay', 'downloadSampleQCData', getServerContext().container.path, {
+                                    href={buildURL('assay', 'downloadSampleQCData', {
                                         rowId: model.protocolId,
                                     })}
                                     target="_blank"

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 import { List } from 'immutable';
-import { ActionURL } from '@labkey/api';
+import { ActionURL, getServerContext } from '@labkey/api';
 
 import { Container, RemoveEntityButton, AddEntityButton } from '../../../..';
 
@@ -138,7 +138,7 @@ export function PlateTemplatesInput(props: InputProps) {
                 ))}
             </FormControl>
             <a
-                href={ActionURL.buildURL('plate', 'plateTemplateList', LABKEY.container.path)}
+                href={ActionURL.buildURL('plate', 'plateTemplateList', getServerContext().container.path)}
                 className="labkey-text-link"
             >
                 Configure Templates
@@ -465,7 +465,7 @@ export class TransformScriptsInput extends React.PureComponent<TransformScriptsI
                         <Col xs={5} lg={4}>
                             <span className="pull-right">
                                 <a
-                                    href={ActionURL.buildURL('assay', 'downloadSampleQCData', LABKEY.container.path, {
+                                    href={ActionURL.buildURL('assay', 'downloadSampleQCData', getServerContext().container.path, {
                                         rowId: model.protocolId,
                                     })}
                                     target="_blank"

--- a/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Ajax, Domain, getServerContext, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Domain, Utils } from '@labkey/api';
 
 import { SCHEMAS } from '../../../schemas';
 import { deleteEntityType } from '../../entities/actions';
@@ -40,7 +40,6 @@ export function fetchDataClass(queryName?: string, rowId?: number): Promise<Data
 function _fetchDataClass(queryName?: string, domainId?: number): Promise<DataClassModel> {
     return new Promise((resolve, reject) => {
         return Domain.getDomainDetails({
-            containerPath: getServerContext().container.path,
             schemaName: SCHEMAS.DATA_CLASSES.SCHEMA,
             queryName,
             domainId,

--- a/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Ajax, Domain, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Domain, getServerContext, Utils } from '@labkey/api';
 
 import { SCHEMAS } from '../../../schemas';
 import { deleteEntityType } from '../../entities/actions';
@@ -40,7 +40,7 @@ export function fetchDataClass(queryName?: string, rowId?: number): Promise<Data
 function _fetchDataClass(queryName?: string, domainId?: number): Promise<DataClassModel> {
     return new Promise((resolve, reject) => {
         return Domain.getDomainDetails({
-            containerPath: LABKEY.container.path,
+            containerPath: getServerContext().container.path,
             schemaName: SCHEMAS.DATA_CLASSES.SCHEMA,
             queryName,
             domainId,

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 
 import { List } from 'immutable';
 
-import { ActionURL, Domain, getServerContext } from '@labkey/api';
+import { Domain, getServerContext } from '@labkey/api';
 
 import produce, { Draft } from 'immer';
 
@@ -29,7 +29,7 @@ import { DomainDesign, DomainField, DomainFieldIndexChange } from '../models';
 import { getDomainPanelStatus, saveDomain } from '../actions';
 import DomainForm from '../DomainForm';
 
-import { importData, Progress, resolveErrorMessage } from '../../../..';
+import { buildURL, importData, Progress, resolveErrorMessage } from '../../../..';
 
 import { DOMAIN_FIELD_FULLY_LOCKED, DOMAIN_FIELD_NOT_LOCKED } from '../constants';
 
@@ -365,7 +365,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
             schemaName: 'study',
             queryName: savedModel.name,
             file,
-            importUrl: ActionURL.buildURL('study', 'import', getServerContext().container.path, {
+            importUrl: buildURL('study', 'import', {
                 name: savedModel.name,
                 participantId,
                 sequenceNum,

--- a/packages/components/src/internal/components/domainproperties/dataset/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/actions.ts
@@ -185,7 +185,7 @@ export function fetchDatasetDesign(datasetId?: number): Promise<DatasetModel> {
         getDatasetProperties(datasetId)
             .then((model: DatasetModel) => {
                 Domain.getDomainDetails({
-                    containerPath: LABKEY.container.path,
+                    containerPath: getServerContext().container.path,
                     domainId: model.domainId,
                     domainKind: datasetId === undefined ? 'StudyDatasetDate' : undefined, // NOTE there is also a StudyDatasetVisit domain kind but for this purpose either will work
                     success: data => {

--- a/packages/components/src/internal/components/domainproperties/dataset/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/actions.ts
@@ -185,7 +185,6 @@ export function fetchDatasetDesign(datasetId?: number): Promise<DatasetModel> {
         getDatasetProperties(datasetId)
             .then((model: DatasetModel) => {
                 Domain.getDomainDetails({
-                    containerPath: getServerContext().container.path,
                     domainId: model.domainId,
                     domainKind: datasetId === undefined ? 'StudyDatasetDate' : undefined, // NOTE there is also a StudyDatasetVisit domain kind but for this purpose either will work
                     success: data => {

--- a/packages/components/src/internal/components/domainproperties/issues/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/actions.ts
@@ -1,4 +1,4 @@
-import { ActionURL, Ajax, Domain, getServerContext, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Domain, Utils } from '@labkey/api';
 
 import { List } from 'immutable';
 
@@ -11,7 +11,6 @@ import { IssuesListDefModel, IssuesListDefOptionsConfig } from './models';
 export function fetchIssuesListDefDesign(issueDefName?: string): Promise<IssuesListDefModel> {
     return new Promise((resolve, reject) => {
         Domain.getDomainDetails({
-            containerPath: getServerContext().container.path,
             schemaName: 'issues',
             queryName: issueDefName,
             domainKind: issueDefName === undefined ? 'IssueDefinition' : undefined,

--- a/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { List } from 'immutable';
-import { ActionURL, Domain } from '@labkey/api';
+import { ActionURL, Domain, getServerContext } from '@labkey/api';
 
 import { importData, Progress, resolveErrorMessage } from '../../../..';
 
@@ -129,7 +129,7 @@ class ListDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDom
             schemaName: 'lists',
             queryName: savedModel.name,
             file,
-            importUrl: ActionURL.buildURL('list', 'UploadListItems', LABKEY.container.path, {
+            importUrl: ActionURL.buildURL('list', 'UploadListItems', getServerContext().container.path, {
                 name: savedModel.name,
             }),
         })

--- a/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { List } from 'immutable';
-import { ActionURL, Domain, getServerContext } from '@labkey/api';
+import { Domain } from '@labkey/api';
 
-import { importData, Progress, resolveErrorMessage } from '../../../..';
+import { buildURL, importData, Progress, resolveErrorMessage } from '../../../..';
 
 import { DomainDesign, DomainFieldIndexChange, IAppDomainHeader } from '../models';
 import DomainForm from '../DomainForm';
@@ -129,7 +129,7 @@ class ListDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDom
             schemaName: 'lists',
             queryName: savedModel.name,
             file,
-            importUrl: ActionURL.buildURL('list', 'UploadListItems', getServerContext().container.path, {
+            importUrl: buildURL('list', 'UploadListItems', {
                 name: savedModel.name,
             }),
         })

--- a/packages/components/src/internal/components/domainproperties/list/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/list/actions.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Ajax, Utils, Domain, getServerContext } from '@labkey/api';
+import { ActionURL, Ajax, Utils, Domain } from '@labkey/api';
 
 import { ListModel } from './models';
 import { INT_LIST } from './constants';
@@ -42,7 +42,6 @@ export function fetchListDesign(listId?: number): Promise<ListModel> {
             .then((model: ListModel) => {
                 // then we can use the getDomainDetails function to get the ListModel
                 Domain.getDomainDetails({
-                    containerPath: getServerContext().container.path,
                     domainId: model.domainId,
                     domainKind: listId === undefined ? INT_LIST : undefined, // NOTE there is also a VarList domain kind but for this purpose either will work
                     success: data => {

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -16,7 +16,7 @@
 import React, { FC, ReactNode } from 'react';
 import { withFormsy } from 'formsy-react';
 import ReactSelect, { Option } from 'react-select';
-import { Utils } from '@labkey/api';
+import { getServerContext, Utils } from '@labkey/api';
 
 import { FieldLabel } from '../FieldLabel';
 
@@ -249,7 +249,7 @@ export class SelectInputImpl extends DisableableInput<SelectInputProps, SelectIn
                 if (reactSelect.state.inputValue) {
                     if (reactSelect.select && Utils.isFunction(reactSelect.select.selectFocusedOption)) {
                         reactSelect.select.selectFocusedOption();
-                    } else if (LABKEY.devMode) {
+                    } else if (getServerContext().devMode) {
                         console.warn(
                             'ReactSelect.Async implementation may have changed. SelectInput "saveOnBlur" no longer working.'
                         );
@@ -260,7 +260,7 @@ export class SelectInputImpl extends DisableableInput<SelectInputProps, SelectIn
                 if (reactSelect.inputValue) {
                     if (Utils.isFunction(reactSelect.createNewOption)) {
                         reactSelect.createNewOption();
-                    } else if (LABKEY.devMode) {
+                    } else if (getServerContext().devMode) {
                         console.warn(
                             'ReactSelect.Creatable implementation may have changed. SelectInput "saveOnBlur" no longer working.'
                         );

--- a/packages/components/src/internal/components/navigation/UserMenu.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenu.tsx
@@ -16,6 +16,7 @@
 
 import React, { FC, ReactNode, useCallback, useMemo } from 'react';
 import { Dropdown, Image, MenuItem } from 'react-bootstrap';
+import { getServerContext } from '@labkey/api';
 
 import { User, devToolsActive, toggleDevTools } from '../../..';
 
@@ -75,7 +76,7 @@ export const UserMenu: FC<UserMenuProps> = props => {
                 <div className="navbar-connector" />
                 {menuItems}
                 {extraUserItems}
-                {LABKEY.devMode && (
+                {getServerContext().devMode && (
                     <>
                         <MenuItem divider />
                         <MenuItem header>Dev Tools</MenuItem>

--- a/packages/components/src/internal/components/notifications/Notification.tsx
+++ b/packages/components/src/internal/components/notifications/Notification.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import ReactN from 'reactn';
 import { List, Map } from 'immutable';
 import moment from 'moment';
+import { getServerContext } from '@labkey/api';
 
 import { User, getDateFormat } from '../../..';
 
@@ -44,8 +45,8 @@ export class Notification extends ReactN.Component<NotificationProps, any, Globa
     }
 
     renderTrialServicesNotification(props: NotificationItemProps, user: User) {
-        if (LABKEY.moduleContext.trialservices.trialEndDate) {
-            const endDate = moment(LABKEY.moduleContext.trialservices.trialEndDate, getDateFormat());
+        if (getServerContext().moduleContext.trialservices.trialEndDate) {
+            const endDate = moment(getServerContext().moduleContext.trialservices.trialEndDate, getDateFormat());
             const today = moment();
             const secondsDiff = endDate.diff(today, 'seconds');
             let dayDiff = endDate.diff(today, 'days');
@@ -54,13 +55,13 @@ export class Notification extends ReactN.Component<NotificationProps, any, Globa
             let message = '';
             if (dayDiff <= 0) message = 'This LabKey trial site has expired.';
             else message = 'This LabKey trial site will expire in ' + dayDiff + (dayDiff === 1 ? ' day.' : ' days.');
-            if (LABKEY.moduleContext.trialservices.upgradeLink && user && user.isAdmin)
+            if (getServerContext().moduleContext.trialservices.upgradeLink && user && user.isAdmin)
                 return (
                     <span>
                         {message}
                         &nbsp;
-                        <a href={LABKEY.moduleContext.trialservices.upgradeLink} target="_blank">
-                            {LABKEY.moduleContext.trialservices.upgradeLinkText}
+                        <a href={getServerContext().moduleContext.trialservices.upgradeLink} target="_blank">
+                            {getServerContext().moduleContext.trialservices.upgradeLinkText}
                         </a>
                     </span>
                 );
@@ -70,11 +71,7 @@ export class Notification extends ReactN.Component<NotificationProps, any, Globa
     }
 
     createSystemNotification(): void {
-        if (
-            LABKEY.moduleContext &&
-            LABKEY.moduleContext.trialservices &&
-            LABKEY.moduleContext.trialservices.trialEndDate
-        ) {
+        if (getServerContext().moduleContext?.trialservices?.trialEndDate) {
             createNotification({
                 alertClass: 'warning',
                 id: 'trial_ending',

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -1,7 +1,6 @@
 import React, { PureComponent, ReactNode, FC, memo } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 import { List } from 'immutable';
-import { getServerContext } from '@labkey/api';
 
 import { DomainField, LabelHelpTip } from '../../..';
 import { helpLinkNode, ONTOLOGY_LOOKUP_TOPIC } from '../../util/helpLinks';
@@ -40,7 +39,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
 
     loadData = async (): Promise<void> => {
         try {
-            const newOntologies = await fetchOntologies(getServerContext().container.path);
+            const newOntologies = await fetchOntologies();
             this.setState(
                 () => ({
                     loading: false,

--- a/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.tsx
@@ -173,7 +173,7 @@ export function getProductProjectsMap(products?: ProductModel[], projects?: Cont
         products.forEach(product => (map[product.productId] = []));
         for (const project of projects) {
             for (const product of products) {
-                if (project.activeModules.indexOf(product.moduleName) > -1) {
+                if (project.hasActiveModule(product.moduleName)) {
                     map[product.productId].push(project);
                     break;
                 }

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import moment from 'moment';
 import { Panel, Row, Col, Button } from 'react-bootstrap';
 import { List, Map } from 'immutable';
-import { Utils } from '@labkey/api';
+import { getServerContext, Utils } from '@labkey/api';
 
 import { SecurityPolicy, SecurityRole, getUserProperties, LoadingSpinner, caseInsensitive } from '../../..';
 import { EffectiveRolesList } from '../permissions/EffectiveRolesList';
@@ -145,7 +145,7 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
     renderBody() {
         const { onUsersStateChangeComplete, userId } = this.props;
         const { loading, userProperties } = this.state;
-        const isSelf = userId === LABKEY.user.id;
+        const isSelf = userId === getServerContext().user.id;
 
         if (loading) {
             return <LoadingSpinner />;

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { List, Map, OrderedMap } from 'immutable';
-import { ActionURL, Ajax, PermissionRoles, PermissionTypes, Utils } from '@labkey/api';
+import { ActionURL, Ajax, getServerContext, PermissionRoles, PermissionTypes, Utils } from '@labkey/api';
 
 import { buildURL, caseInsensitive, hasAllPermissions, QueryGridModel, SchemaQuery, User } from '../../..';
 
@@ -113,7 +113,7 @@ export function getUserDetailsRowData(user: User, data: OrderedMap<string, any>,
 export function updateUserDetails(schemaQuery: SchemaQuery, data: FormData): Promise<any> {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: ActionURL.buildURL('user', 'updateUserDetails.api', LABKEY.container.path),
+            url: ActionURL.buildURL('user', 'updateUserDetails.api', getServerContext().container.path),
             method: 'POST',
             form: data,
             success: Utils.getCallbackWrapper((response, request) => {

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { List, Map, OrderedMap } from 'immutable';
-import { ActionURL, Ajax, getServerContext, PermissionRoles, PermissionTypes, Utils } from '@labkey/api';
+import { Ajax, PermissionRoles, PermissionTypes, Utils } from '@labkey/api';
 
 import { buildURL, caseInsensitive, hasAllPermissions, QueryGridModel, SchemaQuery, User } from '../../..';
 
@@ -113,7 +113,7 @@ export function getUserDetailsRowData(user: User, data: OrderedMap<string, any>,
 export function updateUserDetails(schemaQuery: SchemaQuery, data: FormData): Promise<any> {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: ActionURL.buildURL('user', 'updateUserDetails.api', getServerContext().container.path),
+            url: buildURL('user', 'updateUserDetails.api'),
             method: 'POST',
             form: data,
             success: Utils.getCallbackWrapper((response, request) => {

--- a/packages/components/src/internal/constants.ts
+++ b/packages/components/src/internal/constants.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 import { Set } from 'immutable';
+import { getServerContext } from '@labkey/api';
+
+export const LABKEY_VIS = getServerContext().vis;
+export const LABKEY_WEBSOCKET = getServerContext().WebSocket;
 
 export const QUERY_GRID_PREFIX = 'labkey-querygrid-';
 export const FASTA_EXPORT_CONTROLLER = 'biologics';

--- a/packages/components/src/internal/constants.ts
+++ b/packages/components/src/internal/constants.ts
@@ -16,6 +16,8 @@
 import { Set } from 'immutable';
 import { getServerContext } from '@labkey/api';
 
+// We are currently accessing these vis and WebSocket namespaces off of the global context,
+// but hopefully these can become their own packages or part of this package directly
 export const LABKEY_VIS = getServerContext().vis;
 export const LABKEY_WEBSOCKET = getServerContext().WebSocket;
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -15,7 +15,7 @@
  */
 import { fromJS, List, Map, OrderedMap, Record, Set } from 'immutable';
 import { normalize, schema } from 'normalizr';
-import { AuditBehaviorTypes, Filter, Query, QueryDOM } from '@labkey/api';
+import { AuditBehaviorTypes, Filter, getServerContext, Query, QueryDOM } from '@labkey/api';
 
 import { getQueryMetadata } from '../global';
 import { resolveKeyFromJson } from '../../public/SchemaQuery';
@@ -744,7 +744,7 @@ interface IUpdateRowsOptions {
 export function updateRows(options: IUpdateRowsOptions): Promise<any> {
     return new Promise((resolve, reject) => {
         Query.updateRows({
-            containerPath: options.containerPath ? options.containerPath : LABKEY.container.path,
+            containerPath: options.containerPath ? options.containerPath : getServerContext().container.path,
             schemaName: options.schemaQuery.schemaName,
             queryName: options.schemaQuery.queryName,
             rows: options.rows,

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -15,7 +15,7 @@
  */
 import { fromJS, List, Map, OrderedMap, Record, Set } from 'immutable';
 import { normalize, schema } from 'normalizr';
-import { AuditBehaviorTypes, Filter, getServerContext, Query, QueryDOM } from '@labkey/api';
+import { AuditBehaviorTypes, Filter, Query, QueryDOM } from '@labkey/api';
 
 import { getQueryMetadata } from '../global';
 import { resolveKeyFromJson } from '../../public/SchemaQuery';
@@ -744,7 +744,7 @@ interface IUpdateRowsOptions {
 export function updateRows(options: IUpdateRowsOptions): Promise<any> {
     return new Promise((resolve, reject) => {
         Query.updateRows({
-            containerPath: options.containerPath ? options.containerPath : getServerContext().container.path,
+            containerPath: options.containerPath,
             schemaName: options.schemaQuery.schemaName,
             queryName: options.schemaQuery.queryName,
             rows: options.rows,

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { List, Map, Record } from 'immutable';
-import { ActionURL, Filter } from '@labkey/api';
+import { ActionURL, Filter, getServerContext } from '@labkey/api';
 
 export function createProductUrlFromParts(
     urlProductId: string,
@@ -97,7 +97,7 @@ export function buildURL(controller: string, action: string, params?: any, optio
     return ActionURL.buildURL(
         controller,
         action,
-        options && options.container ? options.container : LABKEY.container.path,
+        options && options.container ? options.container : getServerContext().container.path,
         parameters
     );
 }

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { List, Map, Record } from 'immutable';
-import { ActionURL, Filter, getServerContext } from '@labkey/api';
+import { ActionURL, Filter } from '@labkey/api';
 
 export function createProductUrlFromParts(
     urlProductId: string,
@@ -94,12 +94,7 @@ export function buildURL(controller: string, action: string, params?: any, optio
 
     const parameters = Object.assign(params ? params : {}, constructedParams);
 
-    return ActionURL.buildURL(
-        controller,
-        action,
-        options && options.container ? options.container : getServerContext().container.path,
-        parameters
-    );
+    return ActionURL.buildURL(controller, action, options?.container, parameters);
 }
 
 export class AppURL extends Record({

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { fromJS, List, Map, OrderedSet } from 'immutable';
-import { ActionURL, Experiment, Filter } from '@labkey/api';
+import { ActionURL, Experiment, Filter, getServerContext } from '@labkey/api';
 
 import { AppURL, createProductUrl } from '../..';
 import { LineageLinkMetadata } from '../components/lineage/types';
@@ -484,7 +484,7 @@ export class URLResolver {
             return _url;
         }
 
-        if (_url !== false && LABKEY.devMode) {
+        if (_url !== false && getServerContext().devMode) {
             console.warn('Unable to map URL:', mapper.url);
         }
 

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -16,6 +16,7 @@
 import moment from 'moment-jdateformatparser';
 import momentTZ from 'moment-timezone';
 import numeral from 'numeral';
+import { getServerContext } from '@labkey/api';
 
 import { QueryColumn } from '../..';
 
@@ -55,11 +56,11 @@ export function isDateTimeCol(col: QueryColumn): boolean {
 
 // 30834: get look and feel display formats
 export function getDateFormat(): string {
-    return moment().toMomentFormatString(LABKEY.container.formats.dateFormat);
+    return moment().toMomentFormatString(getServerContext().container.formats.dateFormat);
 }
 
 export function getDateTimeFormat(): string {
-    return moment().toMomentFormatString(LABKEY.container.formats.dateTimeFormat);
+    return moment().toMomentFormatString(getServerContext().container.formats.dateTimeFormat);
 }
 
 export function parseDate(dateStr: string, dateFormat?: string): Date {

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Iterable, List, Map, Set } from 'immutable';
-import { Utils } from '@labkey/api';
+import { getServerContext, Utils } from '@labkey/api';
 
 import { hasParameter, toggleParameter } from '../url/ActionURL'; // do not refactor to '../..', cause jest test to failure with typescript constructor error due to circular loading
 import { QueryInfo } from '../../public/QueryInfo';
@@ -118,11 +118,11 @@ export function applyDevTools() {
 const DEV_TOOLS_URL_PARAMETER = 'devTools';
 
 export function devToolsActive(): boolean {
-    return LABKEY.devMode === true && hasParameter(DEV_TOOLS_URL_PARAMETER);
+    return getServerContext().devMode === true && hasParameter(DEV_TOOLS_URL_PARAMETER);
 }
 
 export function toggleDevTools(): void {
-    if (LABKEY.devMode) {
+    if (getServerContext().devMode) {
         toggleParameter(DEV_TOOLS_URL_PARAMETER, 1);
     }
 }


### PR DESCRIPTION
#### Rationale
There are several LK modules which have a copy of a main.d.ts file just for the case of using npm start-link. Without that main.d.ts file, the link will result in many typescript errors because the LABKEY const isn't declared. This PR addresses that by swapping out those LABKEY const usages with getServerContext(). Note that it looks like keeping the LABKEY const usages in the spec jest files is fine and works as expected for both running the test and for the npm start-link (which must ignore the .spec files.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/523
* https://github.com/LabKey/platform/pull/2248
* https://github.com/LabKey/ontology/pull/40
* https://github.com/LabKey/puppeteer/pull/13
* https://github.com/LabKey/inventory/pull/235
* https://github.com/LabKey/biologics/pull/881
* https://github.com/LabKey/provenance/pull/69
* https://github.com/LabKey/commonAssays/pull/330
* https://github.com/LabKey/moduleEditor/pull/39
* https://github.com/LabKey/sampleManagement/pull/566

#### Changes
* Convert usages of LABKEY const to getServerContext()
* Add constants for LABKEY_VIS and LABKEY_WEBSOCKET to be used within the package
