### PR TITLE
QuerySelect: Pass selectedItems to onQSChange event handlers

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.29.0",
+  "version": "2.29.0-fb-eln-id.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.29.0-fb-eln-id.0",
+  "version": "2.29.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.#.#
+*Released*: # May 2021
+* QuerySelect: Pass `selectedItems` to `onQSChange()` event handlers.
+
 ### version 2.29.0
 *Released*: 11 May 2021
 * Replace usages of LABKEY variable with getServerContext()

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.#.#
-*Released*: # May 2021
+### version 2.29.1
+*Released*: 12 May 2021
 * QuerySelect: Pass `selectedItems` to `onQSChange()` event handlers.
 
 ### version 2.29.0

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { ReactNode } from 'react';
-import { fromJS, List } from 'immutable';
+import { fromJS, List, Map } from 'immutable';
 import { Option } from 'react-select';
 import { Filter, Utils } from '@labkey/api';
 
@@ -156,8 +156,8 @@ export interface QuerySelectOwnProps extends InheritedSelectInputProps {
     loadOnChange?: boolean;
     loadOnFocus?: boolean;
     maxRows?: number;
-    onQSChange?: (name: string, value: string | any[], items: any) => any;
-    onInitValue?: (value: any, selectedValues: List<any>) => any;
+    onQSChange?: (name: string, value: string | any[], items: any, selectedItems: Map<string, any>) => void;
+    onInitValue?: (value: any, selectedValues: List<any>) => void;
     preLoad?: boolean;
     previewOptions?: boolean;
     queryFilters?: List<Filter.IFilter>;
@@ -265,7 +265,7 @@ export class QuerySelect extends React.Component<QuerySelectOwnProps, State> {
                     selectRef.loadOptions?.(FOCUS_FLAG);
                 }
 
-                onQSChange?.(name, value, selectedOptions);
+                onQSChange?.(name, value, selectedOptions, this.state.model.selectedItems);
             }
         );
     };

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -113,7 +113,7 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                                     items = items[0];
                                 }
 
-                                props.onQSChange(props.name, model.rawSelectedValue, items);
+                                props.onQSChange(props.name, model.rawSelectedValue, items, model.selectedItems);
                             }
 
                             // fire listener if given an initial value and a listener function


### PR DESCRIPTION
#### Rationale
Gives users of `QuerySelect` access to the underlying selected data items beyond just the selected "options".

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/882
* https://github.com/LabKey/labbook/pull/105
* https://github.com/LabKey/labkey-ui-components/pull/526

#### Changes
* Pass `selectedItems` from `QuerySelect` model to `onQSChange()` event handlers.
