### PR TITLE
Item 8784: Support CRUD operations for picklist data

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.32.0-smPicklistData.5",
+  "version": "2.32.0-smPicklistData.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.13",
+  "version": "2.33.0-smPicklistData.14",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.32.0-smPicklistData.4",
+  "version": "2.32.0-smPicklistData.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.9",
+  "version": "2.33.0-smPicklistData.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.10",
+  "version": "2.33.0-smPicklistData.11",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.7",
+  "version": "2.33.0-smPicklistData.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.14",
+  "version": "2.33.0-smPicklistData.15",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.32.0-smPicklistData.0",
+  "version": "2.32.0-smPicklistData.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.31.0",
+  "version": "2.32.0-smPicklistData.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.11",
+  "version": "2.33.0-smPicklistData.12",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.32.0-smPicklistData.6",
+  "version": "2.33.0-smPicklistData.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.32.0-smPicklistData.1",
+  "version": "2.32.0-smPicklistData.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.32.0-smPicklistData.3",
+  "version": "2.32.0-smPicklistData.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.15",
+  "version": "2.33.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.32.0-smPicklistData.2",
+  "version": "2.32.0-smPicklistData.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.8",
+  "version": "2.33.0-smPicklistData.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.33.0-smPicklistData.12",
+  "version": "2.33.0-smPicklistData.13",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Release*: TBD
+### version 2.33.0
+*Release*: 25 May 2021
 * Add support for modifying the items in a picklist
     * Add AddToPicklistMenuItem that incorporates a new ChoosePicklistModal and actions
     * Add styling (lifted from ELN notebooks stylings) for choice panels in modal.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,19 @@
 # @labkey/components
+
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+
+*Release*: TBD
+
+* Add support for modifying the items in a picklist
+    * Add ChoosePicklistModal and actions
+    * Add styling (lifted from ELN notebooks stylings) for choice panels in modal.
+
 ### version 2.31.0
+
 *Released*: 13 May 2021
+
 * Remove isSampleAliquotEnabled experimental flag
 * Allow QueryGridModel export to include extra columns
 * Allow QueryModel to export LABEL

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,12 +2,12 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version TBD
-
 *Release*: TBD
-
 * Add support for modifying the items in a picklist
-    * Add ChoosePicklistModal and actions
+    * Add AddToPicklistMenuItem that incorporates a new ChoosePicklistModal and actions
     * Add styling (lifted from ELN notebooks stylings) for choice panels in modal.
+* Update `getSelection` so you can pass in a `queryName` and `schemaName` and not have to parse the selection key
+* Add utility method `getCofirmDeleteMessage`
 
 ### version 2.32.0
 *Released*: 19 May 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -8,6 +8,7 @@ Components, models, actions, and utility functions for LabKey applications and p
     * Add styling (lifted from ELN notebooks stylings) for choice panels in modal.
 * Update `getSelection` so you can pass in a `queryName` and `schemaName` and not have to parse the selection key
 * Add utility method `getCofirmDeleteMessage`
+* Issue 42843: Sample Creation modal allows more than the max number of rows to be created
 
 ### version 2.32.0
 *Released*: 19 May 2021

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -62,7 +62,7 @@ import { AutoForm } from './internal/components/AutoForm';
 import { HelpIcon } from './internal/components/HelpIcon';
 import { getUserProperties, getUserRoleDisplay } from './internal/components/user/actions';
 import { BeforeUnload } from './internal/util/BeforeUnload';
-import { getActionErrorMessage, resolveErrorMessage } from './internal/util/messaging';
+import { getActionErrorMessage, getConfirmDeleteMessage, resolveErrorMessage } from './internal/util/messaging';
 import { WHERE_FILTER_TYPE } from './internal/url/WhereFilterType';
 import { AddEntityButton } from './internal/components/buttons/AddEntityButton';
 import { RemoveEntityButton } from './internal/components/buttons/RemoveEntityButton';
@@ -443,7 +443,8 @@ import { PicklistEditModal } from './internal/components/picklist/PicklistEditMo
 import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
 import { PicklistModel } from './internal/components/picklist/models';
-import { deletePicklists, updatePicklist } from './internal/components/picklist/actions';
+import { ChoosePicklistModal } from './internal/components/picklist/ChoosePicklistModal';
+import { deletePicklists, removeSamplesFromPicklist, updatePicklist } from './internal/components/picklist/actions';
 import {
     AppReducers,
     ProductMenuReducers,
@@ -732,6 +733,7 @@ export {
     Principal,
     UserProvider,
     // sample picklist items
+    ChoosePicklistModal,
     PicklistCreationMenuItem,
     PicklistEditModal,
     PicklistDeleteConfirm,
@@ -739,6 +741,7 @@ export {
     PRIVATE_PICKLIST_CATEGORY,
     PicklistModel,
     deletePicklists,
+    removeSamplesFromPicklist,
     updatePicklist,
     // data class and sample type related items
     DataClassModel,
@@ -956,6 +959,7 @@ export {
     debounce,
     valueIsEmpty,
     getActionErrorMessage,
+    getConfirmDeleteMessage,
     resolveErrorMessage,
     getHelpLink,
     helpLinkNode,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -442,7 +442,7 @@ import {
 import { PicklistEditModal } from './internal/components/picklist/PicklistEditModal';
 import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
-import { PicklistModel } from './internal/components/picklist/models';
+import { Picklist } from './internal/components/picklist/models';
 import { ChoosePicklistModal } from './internal/components/picklist/ChoosePicklistModal';
 import { deletePicklists, removeSamplesFromPicklist, updatePicklist } from './internal/components/picklist/actions';
 import {
@@ -739,7 +739,7 @@ export {
     PicklistDeleteConfirm,
     PUBLIC_PICKLIST_CATEGORY,
     PRIVATE_PICKLIST_CATEGORY,
-    PicklistModel,
+    Picklist,
     deletePicklists,
     removeSamplesFromPicklist,
     updatePicklist,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -258,10 +258,10 @@ import { SearchResultsModel } from './internal/components/search/models';
 import {
     deleteSampleSet,
     fetchSamples,
+    getGroupedSampleDisplayColumns,
     getSampleSet,
     getSampleTypeDetails,
     loadSelectedSamples,
-    getGroupedSampleDisplayColumns,
 } from './internal/components/samples/actions';
 import { SampleEmptyAlert, SampleTypeEmptyAlert } from './internal/components/samples/SampleEmptyAlert';
 import { SamplesBulkUpdateFormBase } from './internal/components/samples/SamplesBulkUpdateForm';
@@ -439,12 +439,21 @@ import {
     PRIVATE_PICKLIST_CATEGORY,
     PUBLIC_PICKLIST_CATEGORY,
 } from './internal/components/domainproperties/list/constants';
+import {
+    PICKLIST_SAMPLE_ID_COLUMN,
+    PICKLIST_KEY_COLUMN,
+} from './internal/components/picklist/models';
 import { PicklistEditModal } from './internal/components/picklist/PicklistEditModal';
 import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
 import { Picklist } from './internal/components/picklist/models';
 import { ChoosePicklistModal } from './internal/components/picklist/ChoosePicklistModal';
-import { deletePicklists, removeSamplesFromPicklist, updatePicklist } from './internal/components/picklist/actions';
+import {
+    deletePicklists,
+    removeSamplesFromPicklist,
+    updatePicklist
+} from './internal/components/picklist/actions';
+
 import {
     AppReducers,
     ProductMenuReducers,
@@ -739,6 +748,8 @@ export {
     PicklistDeleteConfirm,
     PUBLIC_PICKLIST_CATEGORY,
     PRIVATE_PICKLIST_CATEGORY,
+    PICKLIST_KEY_COLUMN,
+    PICKLIST_SAMPLE_ID_COLUMN,
     Picklist,
     deletePicklists,
     removeSamplesFromPicklist,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -440,19 +440,17 @@ import {
     PRIVATE_PICKLIST_CATEGORY,
     PUBLIC_PICKLIST_CATEGORY,
 } from './internal/components/domainproperties/list/constants';
-import {
-    PICKLIST_SAMPLE_ID_COLUMN,
-    PICKLIST_KEY_COLUMN,
-} from './internal/components/picklist/models';
+import { PICKLIST_SAMPLE_ID_COLUMN, PICKLIST_KEY_COLUMN, Picklist } from './internal/components/picklist/models';
 import { PicklistEditModal } from './internal/components/picklist/PicklistEditModal';
 import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
-import { Picklist } from './internal/components/picklist/models';
+
 import { AddToPicklistMenuItem } from './internal/components/picklist/AddToPicklistMenuItem';
 import {
     deletePicklists,
     removeSamplesFromPicklist,
-    updatePicklist
+    updatePicklist,
+    getSelectedPicklistSamples,
 } from './internal/components/picklist/actions';
 
 import {
@@ -461,9 +459,7 @@ import {
     RoutingTableReducers,
     ServerNotificationReducers,
 } from './internal/app/reducers';
-import {
-    getSelectedPicklistSamples,
-} from './internal/components/picklist/actions';
+
 import {
     CloseEventCode,
     getDateFormat as getAppDateFormat,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -447,7 +447,7 @@ import { PicklistEditModal } from './internal/components/picklist/PicklistEditMo
 import { PicklistDeleteConfirm } from './internal/components/picklist/PicklistDeleteConfirm';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
 import { Picklist } from './internal/components/picklist/models';
-import { ChoosePicklistModal } from './internal/components/picklist/ChoosePicklistModal';
+import { AddToPicklistMenuItem } from './internal/components/picklist/AddToPicklistMenuItem';
 import {
     deletePicklists,
     removeSamplesFromPicklist,
@@ -745,7 +745,7 @@ export {
     Principal,
     UserProvider,
     // sample picklist items
-    ChoosePicklistModal,
+    AddToPicklistMenuItem,
     PicklistCreationMenuItem,
     PicklistEditModal,
     PicklistDeleteConfirm,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -461,6 +461,9 @@ import {
     ServerNotificationReducers,
 } from './internal/app/reducers';
 import {
+    getSelectedPicklistSamples,
+} from './internal/components/picklist/actions';
+import {
     CloseEventCode,
     getDateFormat as getAppDateFormat,
     getMenuSectionConfigs,
@@ -752,6 +755,7 @@ export {
     PICKLIST_SAMPLE_ID_COLUMN,
     Picklist,
     deletePicklists,
+    getSelectedPicklistSamples,
     removeSamplesFromPicklist,
     updatePicklist,
     // data class and sample type related items

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1300,7 +1300,14 @@ export function getSelection(location: any, schemaName?: string, queryName?: str
             }
 
             if (!schemaQuery) {
-                reject('No schema found for selection with selectionKey ' + location.query.selectionKey + ' schemaName ' + schemaName + ' queryName ' + queryName);
+                reject(
+                    'No schema found for selection with selectionKey ' +
+                    location.query.selectionKey +
+                    ' schemaName ' +
+                    schemaName +
+                    ' queryName ' +
+                    queryName
+                );
             }
 
             return getSelected(

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1278,12 +1278,12 @@ export function getFilterListFromQuery(location: Location): List<Filter.IFilter>
     return undefined;
 }
 
-export function getSelection(location: any): Promise<ISelectionResponse> {
-    if (location && location.query && location.query.selectionKey) {
+export function getSelection(location: any, schemaName?: string, queryName?: string): Promise<ISelectionResponse> {
+    if (location?.query?.selectionKey) {
         const key = location.query.selectionKey;
 
-        return new Promise(resolve => {
-            const { keys, schemaQuery } = SchemaQuery.parseSelectionKey(key);
+        return new Promise((resolve, reject) => {
+            let {keys, schemaQuery} = SchemaQuery.parseSelectionKey(key);
 
             if (keys !== undefined) {
                 return resolve({
@@ -1291,6 +1291,15 @@ export function getSelection(location: any): Promise<ISelectionResponse> {
                     schemaQuery,
                     selected: keys.split(';'),
                 });
+            }
+            if (!schemaQuery) {
+                if (schemaName && queryName) {
+                    schemaQuery = SchemaQuery.create(schemaName, queryName);
+                }
+            }
+
+            if (!schemaQuery) {
+                reject('No schema found for selection with selectionKey ' + location.query.selectionKey + ' schemaName ' + schemaName + ' queryName ' + queryName);
             }
 
             return getSelected(

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -151,7 +151,7 @@ function isFreezerManagerEnabledInBiologics(): boolean {
 }
 
 export function isSamplePicklistEnabled(): boolean {
-    return getServerContext().experimental?.['samplePicklist'] === true && (!isBiologicsEnabled());
+    return getServerContext().experimental?.['samplePicklist'] === true && !isBiologicsEnabled();
 }
 
 export function hasModule(moduleName: string) {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -151,7 +151,7 @@ function isFreezerManagerEnabledInBiologics(): boolean {
 }
 
 export function isSamplePicklistEnabled(): boolean {
-    return getServerContext().experimental && getServerContext().experimental['samplePicklist'] === true;
+    return getServerContext().experimental?.['samplePicklist'] === true && (!isBiologicsEnabled());
 }
 
 export function hasModule(moduleName: string) {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -151,7 +151,7 @@ function isFreezerManagerEnabledInBiologics(): boolean {
 }
 
 export function isSamplePicklistEnabled(): boolean {
-    return getServerContext().experimental?.['samplePicklist'] === true && !isBiologicsEnabled();
+    return !isBiologicsEnabled();
 }
 
 export function hasModule(moduleName: string) {

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
@@ -16,9 +16,6 @@ describe('AddToPicklistMenuItem', () => {
     const text = 'Picklist Testing';
 
     test('with queryModel', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
         let queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
         queryModel = queryModel.mutate({selections: new Set(['1', '2'])});
         const wrapper = mount(
@@ -38,10 +35,6 @@ describe('AddToPicklistMenuItem', () => {
     });
 
     test('with selectedIds', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
-
         const wrapper = mount(
             <AddToPicklistMenuItem itemText={text} sampleIds={['1']} key={key} user={TEST_USER_EDITOR}/>
         );
@@ -56,10 +49,6 @@ describe('AddToPicklistMenuItem', () => {
     });
 
     test('not Editor', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
-
         const wrapper = mount(
             <AddToPicklistMenuItem itemText={text} sampleIds={['1']} key={key} user={TEST_USER_READER}/>
         );
@@ -68,10 +57,6 @@ describe('AddToPicklistMenuItem', () => {
     });
 
     test('modal open', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
-
         const wrapper = mount(
             <AddToPicklistMenuItem itemText={text} sampleIds={['1']} key={key} user={TEST_USER_EDITOR}/>
         );

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
@@ -4,10 +4,12 @@ import { mount } from 'enzyme';
 import { Modal } from 'react-bootstrap';
 
 import { TEST_USER_EDITOR, TEST_USER_READER } from '../../../test/data/users';
-import { AddToPicklistMenuItem } from './AddToPicklistMenuItem';
+
 import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SelectionMenuItem } from '../menus/SelectionMenuItem';
+
+import { AddToPicklistMenuItem } from './AddToPicklistMenuItem';
 
 describe('AddToPicklistMenuItem', () => {
     const key = 'picklists';
@@ -15,17 +17,12 @@ describe('AddToPicklistMenuItem', () => {
 
     test('with queryModel', () => {
         LABKEY.experimental = {
-            samplePicklist: true
+            samplePicklist: true,
         } as any;
         let queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
         queryModel = queryModel.mutate({selections: new Set(['1', '2'])});
         const wrapper = mount(
-            <AddToPicklistMenuItem
-                itemText={text}
-                queryModel={queryModel}
-                key={key}
-                user={TEST_USER_EDITOR}
-            />
+            <AddToPicklistMenuItem itemText={text} queryModel={queryModel} key={key} user={TEST_USER_EDITOR}/>
         );
         const menuItem = wrapper.find(SelectionMenuItem);
         expect(menuItem).toHaveLength(1);
@@ -42,16 +39,11 @@ describe('AddToPicklistMenuItem', () => {
 
     test('with selectedIds', () => {
         LABKEY.experimental = {
-            samplePicklist: true
+            samplePicklist: true,
         } as any;
 
         const wrapper = mount(
-            <AddToPicklistMenuItem
-                itemText={text}
-                sampleIds={['1']}
-                key={key}
-                user={TEST_USER_EDITOR}
-            />
+            <AddToPicklistMenuItem itemText={text} sampleIds={['1']} key={key} user={TEST_USER_EDITOR}/>
         );
         const menuItem = wrapper.find('MenuItem');
         expect(menuItem).toHaveLength(1);
@@ -65,16 +57,11 @@ describe('AddToPicklistMenuItem', () => {
 
     test('not Editor', () => {
         LABKEY.experimental = {
-            samplePicklist: true
+            samplePicklist: true,
         } as any;
 
         const wrapper = mount(
-            <AddToPicklistMenuItem
-                itemText={text}
-                sampleIds={['1']}
-                key={key}
-                user={TEST_USER_READER}
-            />
+            <AddToPicklistMenuItem itemText={text} sampleIds={['1']} key={key} user={TEST_USER_READER}/>
         );
         expect(wrapper.find('MenuItem')).toHaveLength(0);
         wrapper.unmount();
@@ -82,16 +69,11 @@ describe('AddToPicklistMenuItem', () => {
 
     test('modal open', () => {
         LABKEY.experimental = {
-            samplePicklist: true
+            samplePicklist: true,
         } as any;
 
         const wrapper = mount(
-            <AddToPicklistMenuItem
-                itemText={text}
-                sampleIds={['1']}
-                key={key}
-                user={TEST_USER_EDITOR}
-            />
+            <AddToPicklistMenuItem itemText={text} sampleIds={['1']} key={key} user={TEST_USER_EDITOR}/>
         );
         const menuItem = wrapper.find('MenuItem a');
         expect(menuItem).toHaveLength(1);

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+import { Modal } from 'react-bootstrap';
+
+import { TEST_USER_EDITOR, TEST_USER_READER } from '../../../test/data/users';
+import { AddToPicklistMenuItem } from './AddToPicklistMenuItem';
+import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
+import { SchemaQuery } from '../../../public/SchemaQuery';
+import { SelectionMenuItem } from '../menus/SelectionMenuItem';
+
+describe('AddToPicklistMenuItem', () => {
+    const key = 'picklists';
+    const text = 'Picklist Testing';
+
+    test('with queryModel', () => {
+        LABKEY.experimental = {
+            samplePicklist: true
+        } as any;
+        let queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        queryModel = queryModel.mutate({selections: new Set(['1', '2'])});
+        const wrapper = mount(
+            <AddToPicklistMenuItem
+                itemText={text}
+                queryModel={queryModel}
+                key={key}
+                user={TEST_USER_EDITOR}
+            />
+        );
+        const menuItem = wrapper.find(SelectionMenuItem);
+        expect(menuItem).toHaveLength(1);
+        expect(menuItem.text()).toBe(text);
+        const memoWrapper = wrapper.find('Memo()');
+        expect(memoWrapper).toHaveLength(1);
+        expect(memoWrapper.prop('selectionKey')).toBe(queryModel.id);
+        expect(memoWrapper.prop('selectedQuantity')).toBe(2);
+        const modal = memoWrapper.find(Modal);
+        expect(modal).toHaveLength(1);
+        expect(modal.prop('show')).toBe(false);
+        wrapper.unmount();
+    });
+
+    test('with selectedIds', () => {
+        LABKEY.experimental = {
+            samplePicklist: true
+        } as any;
+
+        const wrapper = mount(
+            <AddToPicklistMenuItem
+                itemText={text}
+                sampleIds={['1']}
+                key={key}
+                user={TEST_USER_EDITOR}
+            />
+        );
+        const menuItem = wrapper.find('MenuItem');
+        expect(menuItem).toHaveLength(1);
+        expect(menuItem.text()).toBe(text);
+        const memoWrapper = wrapper.find('Memo()');
+        expect(memoWrapper).toHaveLength(1);
+        expect(memoWrapper.prop('selectionKey')).toBe(undefined);
+        expect(memoWrapper.prop('selectedQuantity')).toBe(1);
+        wrapper.unmount();
+    });
+
+    test('not Editor', () => {
+        LABKEY.experimental = {
+            samplePicklist: true
+        } as any;
+
+        const wrapper = mount(
+            <AddToPicklistMenuItem
+                itemText={text}
+                sampleIds={['1']}
+                key={key}
+                user={TEST_USER_READER}
+            />
+        );
+        expect(wrapper.find('MenuItem')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('modal open', () => {
+        LABKEY.experimental = {
+            samplePicklist: true
+        } as any;
+
+        const wrapper = mount(
+            <AddToPicklistMenuItem
+                itemText={text}
+                sampleIds={['1']}
+                key={key}
+                user={TEST_USER_EDITOR}
+            />
+        );
+        const menuItem = wrapper.find('MenuItem a');
+        expect(menuItem).toHaveLength(1);
+        menuItem.simulate('click');
+        const modal = wrapper.find(Modal);
+        expect(modal).toHaveLength(2);
+        expect(modal.at(0).prop('show')).toBe(true);
+        expect(modal.at(1).prop('show')).toBe(false);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -90,6 +90,7 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
                 show={showCreatePicklist}
                 onFinish={afterCreatePicklist}
                 onCancel={closeCreatePicklist}
+                showNotification={true}
             />
         </>
     );

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 import { MenuItem } from 'react-bootstrap';
 import { PicklistEditModal } from './PicklistEditModal';
 import { ChoosePicklistModal } from './ChoosePicklistModal';
@@ -15,35 +15,35 @@ interface Props {
     user: User;
 }
 
-export const AddToPicklistMenuItem: FC<Props> = props => {
+export const AddToPicklistMenuItem: FC<Props> = memo(props => {
     const {sampleIds, key, itemText, user, queryModel} = props;
     const [showChoosePicklist, setShowChoosePicklist] = useState<boolean>(false);
     const [showCreatePicklist, setShowCreatePicklist] = useState<boolean>(false);
 
-    const closeAddToPicklist = (closeToCreate?: boolean) => {
+    const closeAddToPicklist = useCallback((closeToCreate?: boolean) => {
         setShowChoosePicklist(false);
         if (closeToCreate) {
             setShowCreatePicklist(true);
         }
-    };
+    }, [setShowChoosePicklist]);
 
-    const afterAddToPicklist = () => {
+    const afterAddToPicklist = useCallback(() => {
         setShowChoosePicklist(false);
-    };
+    }, [setShowChoosePicklist]);
 
-    const closeCreatePicklist = () => {
+    const closeCreatePicklist = useCallback(() => {
         setShowCreatePicklist(false);
-    };
+    }, [setShowCreatePicklist]);
 
-    const afterCreatePicklist = () => {
+    const afterCreatePicklist = useCallback(() => {
         setShowCreatePicklist(false);
-    };
+    }, [setShowCreatePicklist]);
 
-    const onClick = () => {
+    const onClick = useCallback(() => {
         if (!queryModel || queryModel.selections.size > 0) {
             setShowChoosePicklist(true);
         }
-    };
+    }, [queryModel]);
 
     if (!userCanManagePicklists(user) || !isSamplePicklistEnabled()) {
         return null;
@@ -88,7 +88,7 @@ export const AddToPicklistMenuItem: FC<Props> = props => {
             />
         </>
     );
-};
+});
 
 AddToPicklistMenuItem.defaultProps = {
     itemText: 'Add to Picklist',

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -1,11 +1,13 @@
 import React, { FC, memo, useCallback, useState } from 'react';
 import { MenuItem } from 'react-bootstrap';
-import { PicklistEditModal } from './PicklistEditModal';
-import { ChoosePicklistModal } from './ChoosePicklistModal';
+
 import { User } from '../base/models/User';
 import { isSamplePicklistEnabled, userCanManagePicklists } from '../../app/utils';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { SelectionMenuItem } from '../menus/SelectionMenuItem';
+
+import { ChoosePicklistModal } from './ChoosePicklistModal';
+import { PicklistEditModal } from './PicklistEditModal';
 
 interface Props {
     queryModel?: QueryModel;
@@ -20,12 +22,15 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
     const [showChoosePicklist, setShowChoosePicklist] = useState<boolean>(false);
     const [showCreatePicklist, setShowCreatePicklist] = useState<boolean>(false);
 
-    const closeAddToPicklist = useCallback((closeToCreate?: boolean) => {
-        setShowChoosePicklist(false);
-        if (closeToCreate) {
-            setShowCreatePicklist(true);
-        }
-    }, [setShowChoosePicklist]);
+    const closeAddToPicklist = useCallback(
+        (closeToCreate?: boolean) => {
+            setShowChoosePicklist(false);
+            if (closeToCreate) {
+                setShowCreatePicklist(true);
+            }
+        },
+        [setShowChoosePicklist]
+    );
 
     const afterAddToPicklist = useCallback(() => {
         setShowChoosePicklist(false);
@@ -55,29 +60,29 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
 
     return (
         <>
-            {useSelection ?
+            {useSelection ? (
                 <SelectionMenuItem
                     id={key}
                     text={itemText}
                     onClick={onClick}
                     queryModel={queryModel}
-                    nounPlural={'samples'}
+                    nounPlural="samples"
                 />
-                :
+            ) : (
                 <MenuItem onClick={onClick} key={key}>
                     {itemText}
                 </MenuItem>
-            }
-            {showChoosePicklist &&
-            <ChoosePicklistModal
-                onCancel={closeAddToPicklist}
-                afterAddToPicklist={afterAddToPicklist}
-                user={user}
-                selectionKey={id}
-                numSelected={numSelected}
-                sampleIds={sampleIds}
-            />
-            }
+            )}
+            {showChoosePicklist && (
+                <ChoosePicklistModal
+                    onCancel={closeAddToPicklist}
+                    afterAddToPicklist={afterAddToPicklist}
+                    user={user}
+                    selectionKey={id}
+                    numSelected={numSelected}
+                    sampleIds={sampleIds}
+                />
+            )}
             <PicklistEditModal
                 selectionKey={id}
                 selectedQuantity={numSelected}
@@ -92,5 +97,5 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
 
 AddToPicklistMenuItem.defaultProps = {
     itemText: 'Add to Picklist',
-    key: 'add-to-picklist-menu-item'
+    key: 'add-to-picklist-menu-item',
 };

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -1,0 +1,94 @@
+import React, { FC, useState } from 'react';
+import { MenuItem } from 'react-bootstrap';
+import { PicklistEditModal } from './PicklistEditModal';
+import { ChoosePicklistModal } from './ChoosePicklistModal';
+import { User } from '../base/models/User';
+import { isSamplePicklistEnabled, userCanManagePicklists } from '../../app/utils';
+import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { SelectionMenuItem } from '../menus/SelectionMenuItem';
+
+interface Props {
+    queryModel?: QueryModel;
+    sampleIds?: string[];
+    key?: string;
+    itemText?: string;
+    user: User;
+}
+
+export const AddToPicklistMenuItem: FC<Props> = props => {
+    const {sampleIds, key, itemText, user, queryModel} = props;
+    const [showChoosePicklist, setShowChoosePicklist] = useState<boolean>(false);
+    const [showCreatePicklist, setShowCreatePicklist] = useState<boolean>(false);
+
+    const closeAddToPicklist = (closeToCreate?: boolean) => {
+        setShowChoosePicklist(false);
+        if (closeToCreate) {
+            setShowCreatePicklist(true);
+        }
+    };
+
+    const afterAddToPicklist = () => {
+        setShowChoosePicklist(false);
+    };
+
+    const closeCreatePicklist = () => {
+        setShowChoosePicklist(false);
+    };
+
+    const afterCreatePicklist = () => {
+        setShowChoosePicklist(false);
+    };
+
+    const onClick = () => {
+        if (!queryModel || queryModel.selections.size > 0) {
+            setShowChoosePicklist(true);
+        }
+    };
+
+    if (!userCanManagePicklists(user) || !isSamplePicklistEnabled()) {
+        return null;
+    }
+
+    const useSelection = queryModel !== undefined;
+
+    return (
+        <>
+            {useSelection ?
+                <SelectionMenuItem
+                    id={key}
+                    text={itemText}
+                    onClick={onClick}
+                    queryModel={queryModel}
+                    nounPlural={'samples'}
+                />
+                :
+                <MenuItem onClick={onClick} key={key}>
+                    {itemText}
+                </MenuItem>
+            }
+            {showChoosePicklist &&
+            <ChoosePicklistModal
+                onCancel={closeAddToPicklist}
+                afterAddToPicklist={afterAddToPicklist}
+                user={user}
+                selectionKey={queryModel?.id}
+                numSelected={queryModel?.selections?.size ?? sampleIds.length}
+                sampleIds={sampleIds}
+            />
+            }
+            <PicklistEditModal
+                selectionKey={queryModel?.id}
+                selectedQuantity={queryModel?.selections?.size ?? sampleIds.length}
+                sampleIds={sampleIds}
+                show={showCreatePicklist}
+                onFinish={afterCreatePicklist}
+                onCancel={closeCreatePicklist}
+            />
+        </>
+    );
+};
+
+AddToPicklistMenuItem.defaultProps = {
+    itemText: 'Add to Picklist',
+    key: 'add-to-picklist-menu-item'
+};

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -32,11 +32,11 @@ export const AddToPicklistMenuItem: FC<Props> = props => {
     };
 
     const closeCreatePicklist = () => {
-        setShowChoosePicklist(false);
+        setShowCreatePicklist(false);
     };
 
     const afterCreatePicklist = () => {
-        setShowChoosePicklist(false);
+        setShowCreatePicklist(false);
     };
 
     const onClick = () => {
@@ -50,6 +50,8 @@ export const AddToPicklistMenuItem: FC<Props> = props => {
     }
 
     const useSelection = queryModel !== undefined;
+    const id = queryModel?.id;
+    const numSelected = queryModel ? queryModel.selections?.size : sampleIds?.length;
 
     return (
         <>
@@ -71,14 +73,14 @@ export const AddToPicklistMenuItem: FC<Props> = props => {
                 onCancel={closeAddToPicklist}
                 afterAddToPicklist={afterAddToPicklist}
                 user={user}
-                selectionKey={queryModel?.id}
-                numSelected={queryModel?.selections?.size ?? sampleIds.length}
+                selectionKey={id}
+                numSelected={numSelected}
                 sampleIds={sampleIds}
             />
             }
             <PicklistEditModal
-                selectionKey={queryModel?.id}
-                selectedQuantity={queryModel?.selections?.size ?? sampleIds.length}
+                selectionKey={id}
+                selectedQuantity={numSelected}
                 sampleIds={sampleIds}
                 show={showCreatePicklist}
                 onFinish={afterCreatePicklist}

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -29,20 +29,20 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
                 setShowCreatePicklist(true);
             }
         },
-        [setShowChoosePicklist]
+        []
     );
 
     const afterAddToPicklist = useCallback(() => {
         setShowChoosePicklist(false);
-    }, [setShowChoosePicklist]);
+    }, []);
 
     const closeCreatePicklist = useCallback(() => {
         setShowCreatePicklist(false);
-    }, [setShowCreatePicklist]);
+    }, []);
 
     const afterCreatePicklist = useCallback(() => {
         setShowCreatePicklist(false);
-    }, [setShowCreatePicklist]);
+    }, []);
 
     const onClick = useCallback(() => {
         if (!queryModel || queryModel.selections.size > 0) {

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.spec.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.spec.tsx
@@ -1,0 +1,397 @@
+import React from 'react';
+import {
+    AddedToPicklistNotification,
+    ChoosePicklistModalDisplay,
+    PicklistDetails,
+    PicklistItemsSummaryDisplay,
+    PicklistList
+} from './ChoosePicklistModal';
+import { mount } from 'enzyme';
+import { TEST_USER_EDITOR } from '../../../test/data/users';
+import { NavItem } from 'react-bootstrap';
+import { Picklist } from './models';
+import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
+
+beforeAll(() => {
+    LABKEY.container = {
+        formats: {
+            dateFormat: 'yyyy-MM-dd',
+            dateTimeFormat: 'yyyy-MM-dd HH:mm',
+            numberFormat: null,
+        },
+    };
+});
+
+const PUBLIC_EDITOR_PICKLIST = new Picklist({
+    name: 'Test public list',
+    Category: PUBLIC_PICKLIST_CATEGORY,
+    ItemCount: 4,
+    CreatedBy: TEST_USER_EDITOR.id,
+    CreatedByDisplay: TEST_USER_EDITOR.displayName,
+    listId: 15,
+    Created: '2021-04-15',
+    Description: 'Editor\'s public picklist'
+});
+
+const PRIVATE_EDITOR_PICKLIST = new Picklist({
+    name: 'Test private list',
+    Category: PRIVATE_PICKLIST_CATEGORY,
+    ItemCount: 23,
+    CreatedBy: TEST_USER_EDITOR.id,
+    CreatedByDisplay: TEST_USER_EDITOR.displayName,
+    listId: 16,
+    Created: '2021-04-16',
+    Description: 'Editor\'s private picklist'
+});
+
+const EMPTY_EDITOR_PICKLIST = new Picklist({
+    name: 'Test public list',
+    Category: PUBLIC_PICKLIST_CATEGORY,
+    ItemCount: 0,
+    CreatedBy: TEST_USER_EDITOR.id,
+    CreatedByDisplay: TEST_USER_EDITOR.displayName,
+    listId: 17,
+    Created: '2021-04-17',
+    Description: 'Empty editor\'s public picklist'
+});
+
+describe('PicklistList', () => {
+    test('no items', () => {
+        const emptyMessage = 'This is empty';
+        const wrapper = mount(
+            <PicklistList
+                activeItem={undefined}
+                emptyMessage={emptyMessage}
+                onSelect={jest.fn()}
+                showSharedIcon={false}
+                items={[]}
+            />
+        );
+        expect(wrapper.find('.list-group-item')).toHaveLength(0);
+        const empty = wrapper.find('.choices-list__empty-message');
+        expect(empty).toHaveLength(1);
+        expect(empty.text()).toBe(emptyMessage);
+        wrapper.unmount();
+    });
+
+    test('several items, none active', () => {
+        const emptyMessage = 'This is empty';
+        const items = [PUBLIC_EDITOR_PICKLIST, PRIVATE_EDITOR_PICKLIST, EMPTY_EDITOR_PICKLIST];
+        const wrapper = mount(
+            <PicklistList
+                activeItem={undefined}
+                emptyMessage={emptyMessage}
+                onSelect={jest.fn()}
+                showSharedIcon={false}
+                items={items}
+            />
+        );
+        const empty = wrapper.find('.choices-list__empty-message');
+        expect(empty).toHaveLength(0);
+        const listItems = wrapper.find('.list-group-item');
+        expect(wrapper.find('.active')).toHaveLength(0);
+        expect(listItems).toHaveLength(3);
+        expect(listItems.at(0).text()).toBe(items[0].name);
+        expect(listItems.at(1).text()).toBe(items[1].name);
+        expect(listItems.at(2).text()).toBe(items[2].name);
+        expect(wrapper.find('.fa-users')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('several items, one active, show shared icon', () => {
+        const emptyMessage = 'This is empty';
+        const wrapper = mount(
+            <PicklistList
+                activeItem={PUBLIC_EDITOR_PICKLIST}
+                emptyMessage={emptyMessage}
+                onSelect={jest.fn()}
+                showSharedIcon={true}
+                items={[PUBLIC_EDITOR_PICKLIST, PRIVATE_EDITOR_PICKLIST, EMPTY_EDITOR_PICKLIST]}
+            />
+        );
+        const listItems = wrapper.find('.list-group-item');
+        expect(wrapper.find('.active')).toHaveLength(1);
+        expect(wrapper.find('.fa-users')).toHaveLength(2);
+
+        expect(listItems).toHaveLength(3);
+        expect(listItems.at(0).find('.fa-users')).toHaveLength(1);
+        expect(listItems.at(2).find('.fa-users')).toHaveLength(1);
+
+        wrapper.unmount();
+    });
+
+    test('several items, one active', () => {
+        const emptyMessage = 'This is empty';
+        const wrapper = mount(
+            <PicklistList
+                activeItem={PUBLIC_EDITOR_PICKLIST}
+                emptyMessage={emptyMessage}
+                onSelect={jest.fn()}
+                showSharedIcon={false}
+                items={[PUBLIC_EDITOR_PICKLIST, PRIVATE_EDITOR_PICKLIST, EMPTY_EDITOR_PICKLIST]}
+            />
+        );
+        const listItems = wrapper.find('.list-group-item');
+        expect(listItems).toHaveLength(3);
+        expect(wrapper.find('.active')).toHaveLength(1);
+        expect(wrapper.find('.fa-users')).toHaveLength(0);
+        wrapper.unmount();
+    });
+});
+
+describe('PicklistItemsSummaryDisplay', () => {
+    test('empty counts by type', () => {
+        const wrapper = mount(
+            <PicklistItemsSummaryDisplay
+                countsByType={[]}
+                picklist={EMPTY_EDITOR_PICKLIST}
+            />
+        );
+        const emptyMessage = wrapper.find('.choices-detail__empty-message');
+        expect(emptyMessage).toHaveLength(1);
+        expect(emptyMessage.text()).toBe('This list is empty.');
+        expect(wrapper.find('.picklist-items__header').text()).toBe('Sample Counts');
+        wrapper.unmount();
+    });
+
+    test('empty counts by type, non-zero item count', () => {
+        const wrapper = mount(
+            <PicklistItemsSummaryDisplay
+                countsByType={[]}
+                picklist={PUBLIC_EDITOR_PICKLIST}
+            />
+        );
+        const emptyMessage = wrapper.find('.choices-detail__empty-message');
+        expect(emptyMessage).toHaveLength(0);
+        expect(wrapper.text()).toBe('Sample Counts' + PUBLIC_EDITOR_PICKLIST.ItemCount + ' samples');
+        wrapper.unmount();
+    });
+
+    test('multiple items', () => {
+        const countsByType = [{
+            ItemCount: 42,
+            SampleType: 'Sample Type 1',
+            LabelColor: 'blue'
+        }, {
+            ItemCount: 88,
+            SampleType: 'Sample Type 2',
+            LabelColor: 'red'
+        }];
+        const wrapper = mount(
+            <PicklistItemsSummaryDisplay
+                countsByType={countsByType}
+                picklist={PUBLIC_EDITOR_PICKLIST}
+            />
+        );
+        const emptyMessage = wrapper.find('.choices-detail__empty-message');
+        expect(emptyMessage).toHaveLength(0);
+        const items = wrapper.find('.picklist-items__row');
+        expect(items).toHaveLength(2);
+        expect(items.at(0).find('ColorIcon')).toHaveLength(1);
+        expect(items.at(0).find('.picklist-items__sample-type').text()).toBe(countsByType[0].SampleType);
+        expect(items.at(0).find('.picklist-items__item-count').text()).toBe(countsByType[0].ItemCount.toString());
+        expect(items.at(1).find('ColorIcon')).toHaveLength(1);
+        expect(items.at(1).find('.picklist-items__sample-type').text()).toBe(countsByType[1].SampleType);
+        expect(items.at(1).find('.picklist-items__item-count').text()).toBe(countsByType[1].ItemCount.toString());
+
+        wrapper.unmount();
+    });
+});
+
+describe('PicklistDetails', () => {
+    test('public picklist', () => {
+        const wrapper = mount(
+            <PicklistDetails picklist={PUBLIC_EDITOR_PICKLIST}/>
+        );
+        const name = wrapper.find('.choice-details__name');
+        expect(name).toHaveLength(1);
+        expect(name.text()).toBe(PUBLIC_EDITOR_PICKLIST.name);
+
+        const metadata = wrapper.find('.choice-metadata-item');
+        expect(metadata).toHaveLength(2);
+        expect(metadata.at(0).text()).toBe('Created by:' + PUBLIC_EDITOR_PICKLIST.CreatedByDisplay);
+        expect(metadata.at(1).text()).toBe('Created:' + PUBLIC_EDITOR_PICKLIST.Created);
+        const description = wrapper.find('.choice-details__description');
+        expect(description).toHaveLength(1);
+        expect(description.text()).toBe(PUBLIC_EDITOR_PICKLIST.Description);
+        const summary = wrapper.find('.choice-details__summary');
+        expect(summary).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    test('private picklist', () => {
+        const wrapper = mount(
+            <PicklistDetails picklist={PRIVATE_EDITOR_PICKLIST}/>
+        );
+        const name = wrapper.find('.choice-details__name');
+        expect(name).toHaveLength(1);
+        expect(name.text()).toBe(PRIVATE_EDITOR_PICKLIST.name);
+
+        const metadata = wrapper.find('.choice-metadata-item');
+        expect(metadata).toHaveLength(1);
+        expect(metadata.at(0).text()).toBe('Created:' + PRIVATE_EDITOR_PICKLIST.Created);
+        const description = wrapper.find('.choice-details__description');
+        expect(description).toHaveLength(1);
+        expect(description.text()).toBe(PRIVATE_EDITOR_PICKLIST.Description);
+        const summary = wrapper.find('.choice-details__summary');
+        expect(summary).toHaveLength(1);
+        wrapper.unmount();
+    });
+});
+
+describe('AddToPicklistNotification', () => {
+    test('no samples added', () => {
+        const wrapper = mount(
+            <AddedToPicklistNotification
+                picklist={PUBLIC_EDITOR_PICKLIST}
+                numAdded={0}
+                numSelected={4}
+            />
+        );
+        expect(wrapper.text()).toBe('No samples added to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 4 samples were already in the list.');
+        const link = wrapper.find('a');
+        expect(link).toHaveLength(1);
+        expect(link.text()).toBe(PUBLIC_EDITOR_PICKLIST.name);
+        wrapper.unmount();
+    });
+
+    test('all samples added', () => {
+        const wrapper = mount(
+            <AddedToPicklistNotification
+                picklist={PUBLIC_EDITOR_PICKLIST}
+                numAdded={4}
+                numSelected={4}
+            />
+        );
+        expect(wrapper.text()).toBe('Successfully added 4 samples to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '".');
+        wrapper.unmount();
+    });
+
+    test('some samples added', () => {
+        const wrapper = mount(
+            <AddedToPicklistNotification
+                picklist={PUBLIC_EDITOR_PICKLIST}
+                numAdded={2}
+                numSelected={4}
+            />
+        );
+        expect(wrapper.text()).toBe('Successfully added 2 samples to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 2 samples were already in the list.');
+        wrapper.unmount();
+    });
+
+    test('one sample added', () => {
+        const wrapper = mount(
+            <AddedToPicklistNotification
+                picklist={PUBLIC_EDITOR_PICKLIST}
+                numAdded={1}
+                numSelected={4}
+            />
+        );
+        expect(wrapper.text()).toBe('Successfully added 1 sample to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 3 samples were already in the list.');
+        wrapper.unmount();
+    });
+
+    test('one sample not added', () => {
+        const wrapper = mount(
+            <AddedToPicklistNotification
+                picklist={PUBLIC_EDITOR_PICKLIST}
+                numAdded={3}
+                numSelected={4}
+            />
+        );
+        expect(wrapper.text()).toBe('Successfully added 3 samples to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 1 sample was already in the list.');
+        wrapper.unmount();
+    });
+});
+
+describe('ChoosePicklistModalDisplay', () => {
+    test('loading', () => {
+        const wrapper = mount(
+            <ChoosePicklistModalDisplay
+                picklists={[]}
+                picklistLoadError={undefined}
+                loading={true}
+                onCancel={jest.fn()}
+                afterAddToPicklist={jest.fn()}
+                user={TEST_USER_EDITOR}
+                sampleIds={['1', '2']}
+                numSelected={2}
+            />
+        );
+        const alert = wrapper.find('.alert-info');
+        expect(alert).toHaveLength(1);
+        expect(alert.text()).toBe('Adding 2 samples to selected picklist.');
+        const input = wrapper.find('input');
+        expect(input).toHaveLength(1);
+        expect(input.prop('placeholder')).toBe('Find a picklist');
+        const navItems = wrapper.find(NavItem);
+        expect(navItems).toHaveLength(2);
+        expect(navItems.at(0).text()).toBe('My Picklists');
+        expect(navItems.at(1).text()).toBe('Team Picklists');
+        const emptyMessages = wrapper.find('.choices-list__empty-message');
+        expect(emptyMessages).toHaveLength(3);
+        expect(emptyMessages.at(0).text()).toBe(' Loading...');
+        expect(emptyMessages.at(1).text()).toBe(' Loading...');
+        expect(emptyMessages.at(2).text()).toBe('Choose a picklist');
+        wrapper.unmount();
+    });
+
+    test('loading error', () => {
+        const errorText = 'Couldn\'t get your data';
+        const wrapper = mount(
+            <ChoosePicklistModalDisplay
+                picklists={[]}
+                picklistLoadError={errorText}
+                loading={false}
+                onCancel={jest.fn()}
+                afterAddToPicklist={jest.fn()}
+                user={TEST_USER_EDITOR}
+                sampleIds={['1', '2']}
+                numSelected={2}
+            />
+        );
+        const alert = wrapper.find('.alert-danger');
+        expect(alert).toHaveLength(1);
+        expect(alert.text()).toBe(errorText);
+        wrapper.unmount();
+    });
+
+    test('adding one sample', () => {
+        const wrapper = mount(
+            <ChoosePicklistModalDisplay
+                picklists={[]}
+                picklistLoadError={undefined}
+                loading={false}
+                onCancel={jest.fn()}
+                afterAddToPicklist={jest.fn()}
+                user={TEST_USER_EDITOR}
+                sampleIds={['1']}
+                numSelected={1}
+            />
+        );
+        const alert = wrapper.find('.alert-info');
+        expect(alert).toHaveLength(1);
+        expect(alert.text()).toBe('Adding 1 sample to selected picklist.');
+        wrapper.unmount();
+    });
+
+    test('with active item', () => {
+        const wrapper = mount(
+            <ChoosePicklistModalDisplay
+                picklists={[PUBLIC_EDITOR_PICKLIST]}
+                picklistLoadError={undefined}
+                loading={false}
+                onCancel={jest.fn()}
+                afterAddToPicklist={jest.fn()}
+                user={TEST_USER_EDITOR}
+                sampleIds={['1']}
+                numSelected={1}
+            />
+        );
+
+        const picklistButtons = wrapper.find('.list-group-item');
+        picklistButtons.at(0).simulate('click');
+        expect(wrapper.find('.choice-details')).toHaveLength(1);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.spec.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.spec.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
+
+import { mount } from 'enzyme';
+
+import { NavItem } from 'react-bootstrap';
+
+import { TEST_USER_EDITOR } from '../../../test/data/users';
+
+import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
+
+import { Picklist } from './models';
+
 import {
     AddedToPicklistNotification,
     ChoosePicklistModalDisplay,
     PicklistDetails,
     PicklistItemsSummaryDisplay,
-    PicklistList
+    PicklistList,
 } from './ChoosePicklistModal';
-import { mount } from 'enzyme';
-import { TEST_USER_EDITOR } from '../../../test/data/users';
-import { NavItem } from 'react-bootstrap';
-import { Picklist } from './models';
-import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 
 beforeAll(() => {
     LABKEY.container = {
@@ -30,7 +36,7 @@ const PUBLIC_EDITOR_PICKLIST = new Picklist({
     CreatedByDisplay: TEST_USER_EDITOR.displayName,
     listId: 15,
     Created: '2021-04-15',
-    Description: 'Editor\'s public picklist'
+    Description: 'Editor\'s public picklist',
 });
 
 const PRIVATE_EDITOR_PICKLIST = new Picklist({
@@ -41,7 +47,7 @@ const PRIVATE_EDITOR_PICKLIST = new Picklist({
     CreatedByDisplay: TEST_USER_EDITOR.displayName,
     listId: 16,
     Created: '2021-04-16',
-    Description: 'Editor\'s private picklist'
+    Description: 'Editor\'s private picklist',
 });
 
 const EMPTY_EDITOR_PICKLIST = new Picklist({
@@ -52,7 +58,7 @@ const EMPTY_EDITOR_PICKLIST = new Picklist({
     CreatedByDisplay: TEST_USER_EDITOR.displayName,
     listId: 17,
     Created: '2021-04-17',
-    Description: 'Empty editor\'s public picklist'
+    Description: 'Empty editor\'s public picklist',
 });
 
 describe('PicklistList', () => {
@@ -141,12 +147,7 @@ describe('PicklistList', () => {
 
 describe('PicklistItemsSummaryDisplay', () => {
     test('empty counts by type', () => {
-        const wrapper = mount(
-            <PicklistItemsSummaryDisplay
-                countsByType={[]}
-                picklist={EMPTY_EDITOR_PICKLIST}
-            />
-        );
+        const wrapper = mount(<PicklistItemsSummaryDisplay countsByType={[]} picklist={EMPTY_EDITOR_PICKLIST}/>);
         const emptyMessage = wrapper.find('.choices-detail__empty-message');
         expect(emptyMessage).toHaveLength(1);
         expect(emptyMessage.text()).toBe('This list is empty.');
@@ -155,12 +156,7 @@ describe('PicklistItemsSummaryDisplay', () => {
     });
 
     test('empty counts by type, non-zero item count', () => {
-        const wrapper = mount(
-            <PicklistItemsSummaryDisplay
-                countsByType={[]}
-                picklist={PUBLIC_EDITOR_PICKLIST}
-            />
-        );
+        const wrapper = mount(<PicklistItemsSummaryDisplay countsByType={[]} picklist={PUBLIC_EDITOR_PICKLIST}/>);
         const emptyMessage = wrapper.find('.choices-detail__empty-message');
         expect(emptyMessage).toHaveLength(0);
         expect(wrapper.text()).toBe('Sample Counts' + PUBLIC_EDITOR_PICKLIST.ItemCount + ' samples');
@@ -168,20 +164,20 @@ describe('PicklistItemsSummaryDisplay', () => {
     });
 
     test('multiple items', () => {
-        const countsByType = [{
-            ItemCount: 42,
-            SampleType: 'Sample Type 1',
-            LabelColor: 'blue'
-        }, {
-            ItemCount: 88,
-            SampleType: 'Sample Type 2',
-            LabelColor: 'red'
-        }];
+        const countsByType = [
+            {
+                ItemCount: 42,
+                SampleType: 'Sample Type 1',
+                LabelColor: 'blue',
+            },
+            {
+                ItemCount: 88,
+                SampleType: 'Sample Type 2',
+                LabelColor: 'red',
+            },
+        ];
         const wrapper = mount(
-            <PicklistItemsSummaryDisplay
-                countsByType={countsByType}
-                picklist={PUBLIC_EDITOR_PICKLIST}
-            />
+            <PicklistItemsSummaryDisplay countsByType={countsByType} picklist={PUBLIC_EDITOR_PICKLIST}/>
         );
         const emptyMessage = wrapper.find('.choices-detail__empty-message');
         expect(emptyMessage).toHaveLength(0);
@@ -200,9 +196,7 @@ describe('PicklistItemsSummaryDisplay', () => {
 
 describe('PicklistDetails', () => {
     test('public picklist', () => {
-        const wrapper = mount(
-            <PicklistDetails picklist={PUBLIC_EDITOR_PICKLIST}/>
-        );
+        const wrapper = mount(<PicklistDetails picklist={PUBLIC_EDITOR_PICKLIST}/>);
         const name = wrapper.find('.choice-details__name');
         expect(name).toHaveLength(1);
         expect(name.text()).toBe(PUBLIC_EDITOR_PICKLIST.name);
@@ -220,9 +214,7 @@ describe('PicklistDetails', () => {
     });
 
     test('private picklist', () => {
-        const wrapper = mount(
-            <PicklistDetails picklist={PRIVATE_EDITOR_PICKLIST}/>
-        );
+        const wrapper = mount(<PicklistDetails picklist={PRIVATE_EDITOR_PICKLIST}/>);
         const name = wrapper.find('.choice-details__name');
         expect(name).toHaveLength(1);
         expect(name.text()).toBe(PRIVATE_EDITOR_PICKLIST.name);
@@ -242,13 +234,11 @@ describe('PicklistDetails', () => {
 describe('AddToPicklistNotification', () => {
     test('no samples added', () => {
         const wrapper = mount(
-            <AddedToPicklistNotification
-                picklist={PUBLIC_EDITOR_PICKLIST}
-                numAdded={0}
-                numSelected={4}
-            />
+            <AddedToPicklistNotification picklist={PUBLIC_EDITOR_PICKLIST} numAdded={0} numSelected={4}/>
         );
-        expect(wrapper.text()).toBe('No samples added to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 4 samples were already in the list.');
+        expect(wrapper.text()).toBe(
+            'No samples added to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 4 samples were already in the list.'
+        );
         const link = wrapper.find('a');
         expect(link).toHaveLength(1);
         expect(link.text()).toBe(PUBLIC_EDITOR_PICKLIST.name);
@@ -257,11 +247,7 @@ describe('AddToPicklistNotification', () => {
 
     test('all samples added', () => {
         const wrapper = mount(
-            <AddedToPicklistNotification
-                picklist={PUBLIC_EDITOR_PICKLIST}
-                numAdded={4}
-                numSelected={4}
-            />
+            <AddedToPicklistNotification picklist={PUBLIC_EDITOR_PICKLIST} numAdded={4} numSelected={4}/>
         );
         expect(wrapper.text()).toBe('Successfully added 4 samples to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '".');
         wrapper.unmount();
@@ -269,37 +255,37 @@ describe('AddToPicklistNotification', () => {
 
     test('some samples added', () => {
         const wrapper = mount(
-            <AddedToPicklistNotification
-                picklist={PUBLIC_EDITOR_PICKLIST}
-                numAdded={2}
-                numSelected={4}
-            />
+            <AddedToPicklistNotification picklist={PUBLIC_EDITOR_PICKLIST} numAdded={2} numSelected={4}/>
         );
-        expect(wrapper.text()).toBe('Successfully added 2 samples to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 2 samples were already in the list.');
+        expect(wrapper.text()).toBe(
+            'Successfully added 2 samples to picklist "' +
+            PUBLIC_EDITOR_PICKLIST.name +
+            '". 2 samples were already in the list.'
+        );
         wrapper.unmount();
     });
 
     test('one sample added', () => {
         const wrapper = mount(
-            <AddedToPicklistNotification
-                picklist={PUBLIC_EDITOR_PICKLIST}
-                numAdded={1}
-                numSelected={4}
-            />
+            <AddedToPicklistNotification picklist={PUBLIC_EDITOR_PICKLIST} numAdded={1} numSelected={4}/>
         );
-        expect(wrapper.text()).toBe('Successfully added 1 sample to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 3 samples were already in the list.');
+        expect(wrapper.text()).toBe(
+            'Successfully added 1 sample to picklist "' +
+            PUBLIC_EDITOR_PICKLIST.name +
+            '". 3 samples were already in the list.'
+        );
         wrapper.unmount();
     });
 
     test('one sample not added', () => {
         const wrapper = mount(
-            <AddedToPicklistNotification
-                picklist={PUBLIC_EDITOR_PICKLIST}
-                numAdded={3}
-                numSelected={4}
-            />
+            <AddedToPicklistNotification picklist={PUBLIC_EDITOR_PICKLIST} numAdded={3} numSelected={4}/>
         );
-        expect(wrapper.text()).toBe('Successfully added 3 samples to picklist "' + PUBLIC_EDITOR_PICKLIST.name + '". 1 sample was already in the list.');
+        expect(wrapper.text()).toBe(
+            'Successfully added 3 samples to picklist "' +
+            PUBLIC_EDITOR_PICKLIST.name +
+            '". 1 sample was already in the list.'
+        );
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -1,0 +1,241 @@
+import React, { ChangeEvent, FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { Modal, Tab, Tabs } from 'react-bootstrap';
+import classNames from 'classnames';
+import { PicklistModel } from './models';
+import { formatDate, parseDate } from '../../util/Date';
+import { User } from '../base/models/User';
+import { Utils } from '@labkey/api';
+import { Alert } from '../base/Alert';
+import { addSamplesToPicklist, getPicklists } from './actions';
+import { resolveErrorMessage } from '../../util/messaging';
+
+interface PicklistListProps {
+    activeItem: PicklistModel;
+    emptyMessage: ReactNode;
+    onSelect: (picklist) => void;
+    showSharedIcon?: boolean
+    items: PicklistModel[];
+}
+
+const PicklistList: FC<PicklistListProps> = memo((props) => {
+    const {activeItem, emptyMessage, onSelect, showSharedIcon = false, items} = props;
+    return (
+        <div className="list-group choices-list">
+            {items.map(item => (
+                <button
+                    className={classNames('list-group-item', {active: activeItem?.listId === item.listId})}
+                    key={item.listId}
+                    onClick={onSelect.bind(this, item)}
+                    type="button"
+                >
+                    {showSharedIcon && item.isPublic() && (<span className="fa fa-users"/>)}
+                    {item.name}
+                </button>
+            ))}
+            {items.length === 0 && <p className="choices-list__empty-message">{emptyMessage}</p>}
+        </div>
+    );
+});
+
+interface PicklistDetailsProps {
+    picklist: PicklistModel;
+}
+
+const ItemDetails: FC<PicklistDetailsProps> = memo((props) => {
+    const {picklist} = props;
+
+    return (
+        <div className="choice-details">
+            <div className="choice-details__name">{picklist.name}</div>
+
+            <div className="choice-details__metadata">
+                {picklist.isPublic() && (
+                    <div className="choice-metadata-item">
+                        <span className="choice-metadata-item__name">Created by:</span>
+                        <span className="choice-metadata-item__value">{picklist.CreatedByDisplay}</span>
+                    </div>
+                )}
+
+                <div className="choice-metadata-item">
+                    <span className="choice-metadata-item__name">Created:</span>
+                    <span className="choice-metadata-item__value">{formatDate(parseDate(picklist.Created))}</span>
+                </div>
+
+                <div className="choice-metadata-item">
+                    <span className="choice-metadata-item__name">Last Modified:</span>
+                    <span className="choice-metadata-item__value">{formatDate(parseDate(picklist.Created))}</span>
+                </div>
+            </div>
+
+            <div className="choice-details__description">
+                {picklist.Description}
+            </div>
+
+            <div className="top-spacing">
+                Sample counts coming soon ....
+            </div>
+        </div>
+    );
+});
+
+
+interface ChooseItemModalProps {
+    onCancel: () => void;
+    afterAddToPicklist: (item: PicklistModel, numAdded: number) => void;
+    user: User;
+    selectionKey: string;
+    numSelected: number;
+}
+
+export const ChoosePicklistModal: FC<ChooseItemModalProps> = memo((props) => {
+    const {onCancel, afterAddToPicklist, user, selectionKey, numSelected} = props;
+    const [search, setSearch] = useState<string>('');
+    const [error, setError] = useState<string>(undefined);
+    const [items, setItems] = useState<PicklistModel[]>([]);
+
+    useEffect(() => {
+        getPicklists()
+            .then(picklists => {
+                setItems(picklists);
+            })
+            .catch(reason => {
+                setError('There was a problem retrieving the picklist data. ' + resolveErrorMessage(reason));
+            });
+
+    }, [getPicklists, setItems, setError]);
+
+    const onSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+        setSearch(event.target.value.trim().toLowerCase());
+    }, []);
+    const filteredItems = useMemo<PicklistModel[]>(() => {
+        if (search.trim() !== '') {
+            return items.filter(item => item.name.toLowerCase().indexOf(search) > -1);
+        }
+
+        return items;
+    }, [search, items]);
+
+    const [myItems, teamItems] = useMemo(() => {
+        const mine = [];
+        const team = [];
+
+        filteredItems.forEach((item) => {
+            if (item.isUserList(user)) {
+                mine.push(item);
+            }
+            if (item.isPublic()) {
+                team.push(item);
+            }
+        });
+
+        return [mine, team];
+    }, [filteredItems]);
+
+    const [activeItem, setActiveItem] = useState<PicklistModel>(undefined);
+    const onAddClicked = useCallback(async () => {
+        try {
+            const insertResponse = await addSamplesToPicklist(activeItem.name, selectionKey);
+            setError(undefined);
+            afterAddToPicklist(activeItem, insertResponse.rows.length);
+        }
+        catch (e) {
+            setError(resolveErrorMessage(e));
+        }
+    }, [activeItem]);
+    const isSearching = !!(search);
+    let myEmptyMessage = 'You do not have any picklists ';
+    let teamEmptyMessage = 'There are no shared picklists  ';
+
+    let suffix = '';
+    if (isSearching) {
+        suffix = ' matching your search';
+    }
+    suffix += ' to add ' + (numSelected === 1 ? 'this sample to.' : 'these samples to.');
+    myEmptyMessage += suffix;
+    teamEmptyMessage += suffix;
+
+    return (
+        <Modal show bsSize="large" onHide={close}>
+            <Modal.Header>
+                <Modal.Title>
+                    Choose a Picklist
+                </Modal.Title>
+            </Modal.Header>
+
+            <Modal.Body>
+                <Alert bsStyle="danger">{error}</Alert>
+                <div className="row">
+                    <div className={'col-md-12'}>
+                        <Alert bsStyle="info">
+                            Adding {Utils.pluralize(numSelected, 'sample', 'samples')} to selected picklist.
+                        </Alert>
+                    </div>
+                </div>
+                <div className="row">
+                    <div className="col-md-6">
+                        <input
+                            autoFocus
+                            className="form-control"
+                            onChange={onSearchChange}
+                            placeholder="Find a picklist"
+                        />
+                    </div>
+                </div>
+
+                <div className="row">
+                    <div className="col-md-6">
+                        <Tabs id="choose-items-tabs" className="choose-items-tabs" animation={false}>
+                            <Tab eventKey={1} title="My Picklists">
+                                <PicklistList
+                                    activeItem={activeItem}
+                                    emptyMessage={myEmptyMessage}
+                                    onSelect={setActiveItem}
+                                    showSharedIcon
+                                    items={myItems}
+                                />
+                            </Tab>
+
+                            <Tab eventKey={2} title="Team Picklists">
+                                <PicklistList
+                                    activeItem={activeItem}
+                                    emptyMessage={teamEmptyMessage}
+                                    onSelect={setActiveItem}
+                                    items={teamItems}
+                                />
+                            </Tab>
+                        </Tabs>
+                    </div>
+
+                    <div className="col-md-6">
+                        {activeItem === undefined && (
+                            <div className="choices-list__empty-message">Choose a picklist</div>
+                        )}
+
+                        {activeItem !== undefined && <ItemDetails picklist={activeItem}/>}
+                    </div>
+                </div>
+            </Modal.Body>
+
+            <Modal.Footer>
+                <div className="pull-left">
+                    <button type="button" className="btn btn-default" onClick={onCancel}>
+                        Cancel
+                    </button>
+                </div>
+
+                <div className="pull-right">
+                    <button
+                        type="button"
+                        className="btn btn-success"
+                        onClick={onAddClicked}
+                        disabled={activeItem === undefined}
+                    >
+                        Add to Picklist
+                    </button>
+                </div>
+            </Modal.Footer>
+        </Modal>
+    );
+});
+
+

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -189,7 +189,8 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
         afterAddToPicklist,
         user,
         selectionKey,
-        numSelected
+        numSelected,
+        sampleIds
     } = props;
     const [search, setSearch] = useState<string>('');
     const [error, setError] = useState<string>(undefined);
@@ -229,17 +230,17 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
     const onAddClicked = useCallback(async () => {
         setSubmitting(true);
         try {
-            const insertResponse = await addSamplesToPicklist(activeItem.name, selectionKey);
+            const insertResponse = await addSamplesToPicklist(activeItem.name, selectionKey, sampleIds);
             setError(undefined);
             setSubmitting(false);
-            createAddedToPicklistNotification(activeItem, insertResponse.rows.length, numSelected);
+            createAddedToPicklistNotification(activeItem, insertResponse.rows.length, numSelected ?? sampleIds.length);
             afterAddToPicklist();
         }
         catch (e) {
             setSubmitting(false);
             setError(resolveErrorMessage(e));
         }
-    }, [activeItem, selectionKey, setSubmitting, setError]);
+    }, [activeItem, selectionKey, setSubmitting, setError, sampleIds]);
 
     const closeModal = useCallback(() => {
         onCancel(false);
@@ -360,8 +361,9 @@ interface ChoosePicklistModalProps {
     onCancel: (cancelToCreate?: boolean) => void;
     afterAddToPicklist: () => void;
     user: User;
-    selectionKey: string;
-    numSelected: number;
+    selectionKey?: string;
+    numSelected?: number;
+    sampleIds?: string[]
 }
 
 export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo((props) => {

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -21,7 +21,7 @@ import { Picklist } from './models';
 interface PicklistListProps {
     activeItem: Picklist;
     emptyMessage: ReactNode;
-    onSelect: (picklist) => void;
+    onSelect: (picklist: Picklist) => void;
     showSharedIcon?: boolean;
     items: Picklist[];
 }
@@ -69,7 +69,7 @@ export const PicklistItemsSummaryDisplay: FC<PicklistItemsSummaryDisplayProps & 
                     </div>
                 );
             } else {
-                summaryData.push(<div key="summary">{picklist.ItemCount} samples</div>);
+                summaryData.push(<div key="summary">{Utils.pluralize(picklist.ItemCount, 'sample', 'samples')}</div>);
             }
         } else {
             countsByType.forEach(countData => {
@@ -157,14 +157,14 @@ export const PicklistDetails: FC<PicklistDetailsProps> = memo(props => {
     );
 });
 
-interface AddedToPicklistNoficationProps {
+interface AddedToPicklistNotificationProps {
     picklist: Picklist;
     numAdded: number;
     numSelected: number;
 }
 
 // export for jest testing
-export const AddedToPicklistNotification: FC<AddedToPicklistNoficationProps> = props => {
+export const AddedToPicklistNotification: FC<AddedToPicklistNotificationProps> = props => {
     const {picklist, numAdded, numSelected} = props;
     let numAddedNotification;
     if (numAdded == 0) {
@@ -219,7 +219,7 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
         }, []);
 
         const filteredItems = useMemo<Picklist[]>(() => {
-            if (search.trim() !== '') {
+            if (search !== '') {
                 return picklists.filter(item => item.name.toLowerCase().indexOf(search) > -1);
             }
 
@@ -265,7 +265,7 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
                 setSubmitting(false);
                 setError(resolveErrorMessage(e));
             }
-        }, [activeItem, selectionKey, setSubmitting, setError, sampleIds]);
+        }, [activeItem, selectionKey, setSubmitting, setError, sampleIds, numSelected]);
 
         const closeModal = useCallback(() => {
             onCancel(false);
@@ -275,6 +275,11 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
             onCancel(true);
         }, [onCancel]);
 
+        const createNewListMessage = (
+            <>
+                Do you want to <a onClick={goToCreateNewList}>create a new one</a>?
+            </>
+        );
         const isSearching = !!search;
         let myEmptyMessage: ReactNode = <LoadingSpinner/>;
         let teamEmptyMessage: ReactNode = <LoadingSpinner/>;
@@ -290,21 +295,15 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
             suffix += ' to add ' + (numSelected === 1 ? 'this sample to.' : 'these samples to.');
             myEmptyMessage += suffix;
             teamEmptyMessage += suffix;
-            let createNewList = null;
             if (!isSearching) {
-                createNewList = (
-                    <>
-                        Do you want to <a onClick={goToCreateNewList}>create a new one</a>?
-                    </>
-                );
                 myEmptyMessage = (
                     <>
-                        {myEmptyMessage} {createNewList}
+                        {myEmptyMessage} {createNewListMessage}
                     </>
                 );
                 teamEmptyMessage = (
                     <>
-                        {teamEmptyMessage} {createNewList}
+                        {teamEmptyMessage} {createNewListMessage}
                     </>
                 );
             }

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -1,12 +1,13 @@
 import React, { ChangeEvent, FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { Modal, Tab, Tabs } from 'react-bootstrap';
 import classNames from 'classnames';
-import { Picklist } from './models';
-import { formatDate, parseDate } from '../../util/Date';
-import { User } from '../base/models/User';
+
 import { Utils } from '@labkey/api';
+
+import { User } from '../base/models/User';
+import { formatDate, parseDate } from '../../util/Date';
 import { Alert } from '../base/Alert';
-import { addSamplesToPicklist, getPicklistCountsBySampleType, getPicklists, SampleTypeCount } from './actions';
+
 import { resolveErrorMessage } from '../../util/messaging';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { ColorIcon } from '../base/ColorIcon';
@@ -14,16 +15,19 @@ import { createNotification } from '../notifications/actions';
 import { AppURL } from '../../url/AppURL';
 import { PICKLIST_KEY } from '../../app/constants';
 
+import { addSamplesToPicklist, getPicklistCountsBySampleType, getPicklists, SampleTypeCount } from './actions';
+import { Picklist } from './models';
+
 interface PicklistListProps {
     activeItem: Picklist;
     emptyMessage: ReactNode;
     onSelect: (picklist) => void;
-    showSharedIcon?: boolean
+    showSharedIcon?: boolean;
     items: Picklist[];
 }
 
 // export for jest testing
-export const PicklistList: FC<PicklistListProps> = memo((props) => {
+export const PicklistList: FC<PicklistListProps> = memo(props => {
     const {activeItem, emptyMessage, onSelect, showSharedIcon = false, items} = props;
     return (
         <div className="list-group choices-list">
@@ -34,7 +38,7 @@ export const PicklistList: FC<PicklistListProps> = memo((props) => {
                     onClick={onSelect.bind(this, item)}
                     type="button"
                 >
-                    {showSharedIcon && item.isPublic() && (<span className="fa fa-users"/>)}
+                    {showSharedIcon && item.isPublic() && <span className="fa fa-users"/>}
                     {item.name}
                 </button>
             ))}
@@ -44,49 +48,57 @@ export const PicklistList: FC<PicklistListProps> = memo((props) => {
 });
 
 interface PicklistItemsSummaryDisplayProps {
-    countsByType: SampleTypeCount[]
+    countsByType: SampleTypeCount[];
 }
 
 interface PicklistItemsSummaryProps {
-    picklist: Picklist
+    picklist: Picklist;
 }
 
 // export for jest testing
-export const PicklistItemsSummaryDisplay: FC<PicklistItemsSummaryDisplayProps & PicklistItemsSummaryProps> = memo((props) => {
-    const {countsByType, picklist} = props;
+export const PicklistItemsSummaryDisplay: FC<PicklistItemsSummaryDisplayProps & PicklistItemsSummaryProps> = memo(
+    props => {
+        const {countsByType, picklist} = props;
 
-    const summaryData = [];
-    if (countsByType.length === 0) {
-        if (picklist.ItemCount === 0) {
-            summaryData.push(<div key="summary" className="choices-detail__empty-message">This list is empty.</div>);
+        const summaryData = [];
+        if (countsByType.length === 0) {
+            if (picklist.ItemCount === 0) {
+                summaryData.push(
+                    <div key="summary" className="choices-detail__empty-message">
+                        This list is empty.
+                    </div>
+                );
+            } else {
+                summaryData.push(<div key="summary">{picklist.ItemCount} samples</div>);
+            }
         } else {
-            summaryData.push(<div key="summary">{picklist.ItemCount} samples</div>);
+            countsByType.forEach(countData => {
+                summaryData.push(
+                    <div key={countData.SampleType} className="row picklist-items__row">
+                        <span className="col-md-1">
+                            <ColorIcon useSmall={true} value={countData.LabelColor}/>
+                        </span>
+                        <span className="col-md-5 picklist-items__sample-type choice-metadata-item__name">
+                            {countData.SampleType}
+                        </span>
+                        <span className="col-md-4 picklist-items__item-count">{countData.ItemCount}</span>
+                    </div>
+                );
+            });
         }
-    } else {
-        countsByType.forEach(countData => {
-            summaryData.push((
-                <div key={countData.SampleType} className="row picklist-items__row">
-                    <span className="col-md-1">
-                        <ColorIcon useSmall={true} value={countData.LabelColor}/>
-                    </span>
-                    <span className="col-md-5 picklist-items__sample-type choice-metadata-item__name">
-                        {countData.SampleType}
-                    </span>
-                    <span className="col-md-4 picklist-items__item-count">{countData.ItemCount}</span>
+
+        return (
+            <div key="picklist-items-summary">
+                <div key="header" className="picklist-items__header">
+                    Sample Counts
                 </div>
-            ));
-        });
+                {summaryData}
+            </div>
+        );
     }
+);
 
-    return (
-        <div key={'picklist-items-summary'}>
-            <div key="header" className={'picklist-items__header'}>Sample Counts</div>
-            {summaryData}
-        </div>
-    );
-});
-
-const PicklistItemsSummary: FC<PicklistItemsSummaryProps> = memo((props) => {
+const PicklistItemsSummary: FC<PicklistItemsSummaryProps> = memo(props => {
     const {picklist} = props;
     const [countsByType, setCountsByType] = useState<SampleTypeCount[]>(undefined);
     const [loadingCounts, setLoadingCounts] = useState<boolean>(true);
@@ -101,7 +113,6 @@ const PicklistItemsSummary: FC<PicklistItemsSummaryProps> = memo((props) => {
                 setCountsByType([]);
                 setLoadingCounts(false);
             });
-
     }, [picklist, getPicklistCountsBySampleType, setCountsByType, setLoadingCounts]);
 
     if (loadingCounts) {
@@ -116,7 +127,7 @@ interface PicklistDetailsProps {
 }
 
 // export for jest testing
-export const PicklistDetails: FC<PicklistDetailsProps> = memo((props) => {
+export const PicklistDetails: FC<PicklistDetailsProps> = memo(props => {
     const {picklist} = props;
 
     return (
@@ -135,12 +146,9 @@ export const PicklistDetails: FC<PicklistDetailsProps> = memo((props) => {
                     <span className="choice-metadata-item__name">Created:</span>
                     <span className="choice-metadata-item__value">{formatDate(parseDate(picklist.Created))}</span>
                 </div>
-
             </div>
 
-            <div className="choice-details__description">
-                {picklist.Description}
-            </div>
+            <div className="choice-details__description">{picklist.Description}</div>
 
             <div className="top-spacing choice-details__summary">
                 <PicklistItemsSummary picklist={picklist}/>
@@ -150,13 +158,13 @@ export const PicklistDetails: FC<PicklistDetailsProps> = memo((props) => {
 });
 
 interface AddedToPicklistNoficationProps {
-    picklist: Picklist,
-    numAdded: number,
-    numSelected: number,
+    picklist: Picklist;
+    numAdded: number;
+    numSelected: number;
 }
 
 // export for jest testing
-export const AddedToPicklistNotification: FC<AddedToPicklistNoficationProps> = (props) => {
+export const AddedToPicklistNotification: FC<AddedToPicklistNoficationProps> = props => {
     const {picklist, numAdded, numSelected} = props;
     let numAddedNotification;
     if (numAdded == 0) {
@@ -166,7 +174,7 @@ export const AddedToPicklistNotification: FC<AddedToPicklistNoficationProps> = (
     }
     let numNotAddedNotification = null;
     if (numAdded < numSelected) {
-        const notAdded = (numSelected - numAdded);
+        const notAdded = numSelected - numAdded;
         numNotAddedNotification = ' ' + Utils.pluralize(notAdded, 'sample', 'samples');
         numNotAddedNotification += notAdded === 1 ? ' was ' : ' were ';
         numNotAddedNotification += 'already in the list.';
@@ -174,205 +182,216 @@ export const AddedToPicklistNotification: FC<AddedToPicklistNoficationProps> = (
 
     return (
         <>
-            {numAddedNotification} to picklist "<a
-            href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>{picklist.name}</a>".
+            {numAddedNotification} to picklist "
+            <a href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>{picklist.name}</a>".
             {numNotAddedNotification}
         </>
     );
 };
 
 interface ChoosePicklistModalDisplayProps {
-    picklists: Picklist[],
-    picklistLoadError: ReactNode,
-    loading: boolean
+    picklists: Picklist[];
+    picklistLoadError: ReactNode;
+    loading: boolean;
 }
 
 // export for jest testing
-export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePicklistModalDisplayProps> = memo((props) => {
-    const {
-        picklists,
-        loading,
-        picklistLoadError,
-        onCancel,
-        afterAddToPicklist,
-        user,
-        selectionKey,
-        numSelected,
-        sampleIds
-    } = props;
-    const [search, setSearch] = useState<string>('');
-    const [error, setError] = useState<string>(undefined);
-    const [submitting, setSubmitting] = useState<boolean>(false);
-    const [activeItem, setActiveItem] = useState<Picklist>(undefined);
+export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePicklistModalDisplayProps> = memo(
+    props => {
+        const {
+            picklists,
+            loading,
+            picklistLoadError,
+            onCancel,
+            afterAddToPicklist,
+            user,
+            selectionKey,
+            numSelected,
+            sampleIds,
+        } = props;
+        const [search, setSearch] = useState<string>('');
+        const [error, setError] = useState<string>(undefined);
+        const [submitting, setSubmitting] = useState<boolean>(false);
+        const [activeItem, setActiveItem] = useState<Picklist>(undefined);
 
-    const onSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-        setSearch(event.target.value.trim().toLowerCase());
-    }, []);
+        const onSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+            setSearch(event.target.value.trim().toLowerCase());
+        }, []);
 
-    const filteredItems = useMemo<Picklist[]>(() => {
-        if (search.trim() !== '') {
-            return picklists.filter(item => item.name.toLowerCase().indexOf(search) > -1);
-        }
-
-        return picklists;
-    }, [search, picklists]);
-
-    const [myItems, teamItems] = useMemo(() => {
-        const mine = [];
-        const team = [];
-
-        filteredItems.forEach((item) => {
-            if (item.isUserList(user)) {
-                mine.push(item);
+        const filteredItems = useMemo<Picklist[]>(() => {
+            if (search.trim() !== '') {
+                return picklists.filter(item => item.name.toLowerCase().indexOf(search) > -1);
             }
-            if (item.isPublic()) {
-                team.push(item);
-            }
-        });
 
-        return [mine, team];
-    }, [filteredItems]);
+            return picklists;
+        }, [search, picklists]);
 
+        const [myItems, teamItems] = useMemo(() => {
+            const mine = [];
+            const team = [];
 
-    const onAddClicked = useCallback(async () => {
-        setSubmitting(true);
-        try {
-            const insertResponse = await addSamplesToPicklist(activeItem.name, selectionKey, sampleIds);
-            setError(undefined);
-            setSubmitting(false);
-            createNotification({
-                message: () => (
-                    <AddedToPicklistNotification
-                        picklist={activeItem}
-                        numAdded={insertResponse.rows.length}
-                        numSelected={numSelected}
-                    />
-                ),
-                alertClass: insertResponse.rows.length === 0 ? 'info' : 'success'
+            filteredItems.forEach(item => {
+                if (item.isUserList(user)) {
+                    mine.push(item);
+                }
+                if (item.isPublic()) {
+                    team.push(item);
+                }
             });
 
-            afterAddToPicklist();
-        }
-        catch (e) {
-            setSubmitting(false);
-            setError(resolveErrorMessage(e));
-        }
-    }, [activeItem, selectionKey, setSubmitting, setError, sampleIds]);
+            return [mine, team];
+        }, [filteredItems]);
 
-    const closeModal = useCallback(() => {
-        onCancel(false);
-    }, [onCancel]);
-
-    const goToCreateNewList = useCallback(() => {
-        onCancel(true);
-    }, [onCancel]);
-
-    const isSearching = !!(search);
-    let myEmptyMessage: ReactNode = <LoadingSpinner/>;
-    let teamEmptyMessage: ReactNode = <LoadingSpinner/>;
-
-    if (!loading) {
-        myEmptyMessage = 'You do not have any picklists ';
-        teamEmptyMessage = 'There are no shared picklists  ';
-
-        let suffix = '';
-        if (isSearching) {
-            suffix = ' matching your search';
-        }
-        suffix += ' to add ' + (numSelected === 1 ? 'this sample to.' : 'these samples to.');
-        myEmptyMessage += suffix;
-        teamEmptyMessage += suffix;
-        let createNewList = null;
-        if (!isSearching) {
-            createNewList = <>Do you want to <a onClick={goToCreateNewList}>create a new one</a>?</>;
-            myEmptyMessage = <>{myEmptyMessage} {createNewList}</>;
-            teamEmptyMessage = <>{teamEmptyMessage} {createNewList}</>;
-        }
-    }
-
-    return (
-        <Modal show bsSize="large" onHide={close}>
-            <Modal.Header>
-                <Modal.Title>
-                    Choose a Picklist
-                </Modal.Title>
-            </Modal.Header>
-
-            <Modal.Body>
-                <Alert bsStyle="danger">{picklistLoadError ?? error}</Alert>
-                <div className="row">
-                    <div className={'col-md-12'}>
-                        <Alert bsStyle="info">
-                            Adding {Utils.pluralize(numSelected, 'sample', 'samples')} to selected picklist.
-                        </Alert>
-                    </div>
-                </div>
-                <div className="row">
-                    <div className="col-md-6">
-                        <input
-                            autoFocus
-                            className="form-control"
-                            onChange={onSearchChange}
-                            placeholder="Find a picklist"
+        const onAddClicked = useCallback(async () => {
+            setSubmitting(true);
+            try {
+                const insertResponse = await addSamplesToPicklist(activeItem.name, selectionKey, sampleIds);
+                setError(undefined);
+                setSubmitting(false);
+                createNotification({
+                    message: () => (
+                        <AddedToPicklistNotification
+                            picklist={activeItem}
+                            numAdded={insertResponse.rows.length}
+                            numSelected={numSelected}
                         />
+                    ),
+                    alertClass: insertResponse.rows.length === 0 ? 'info' : 'success',
+                });
+
+                afterAddToPicklist();
+            }
+            catch (e) {
+                setSubmitting(false);
+                setError(resolveErrorMessage(e));
+            }
+        }, [activeItem, selectionKey, setSubmitting, setError, sampleIds]);
+
+        const closeModal = useCallback(() => {
+            onCancel(false);
+        }, [onCancel]);
+
+        const goToCreateNewList = useCallback(() => {
+            onCancel(true);
+        }, [onCancel]);
+
+        const isSearching = !!search;
+        let myEmptyMessage: ReactNode = <LoadingSpinner/>;
+        let teamEmptyMessage: ReactNode = <LoadingSpinner/>;
+
+        if (!loading) {
+            myEmptyMessage = 'You do not have any picklists ';
+            teamEmptyMessage = 'There are no shared picklists  ';
+
+            let suffix = '';
+            if (isSearching) {
+                suffix = ' matching your search';
+            }
+            suffix += ' to add ' + (numSelected === 1 ? 'this sample to.' : 'these samples to.');
+            myEmptyMessage += suffix;
+            teamEmptyMessage += suffix;
+            let createNewList = null;
+            if (!isSearching) {
+                createNewList = (
+                    <>
+                        Do you want to <a onClick={goToCreateNewList}>create a new one</a>?
+                    </>
+                );
+                myEmptyMessage = (
+                    <>
+                        {myEmptyMessage} {createNewList}
+                    </>
+                );
+                teamEmptyMessage = (
+                    <>
+                        {teamEmptyMessage} {createNewList}
+                    </>
+                );
+            }
+        }
+
+        return (
+            <Modal show bsSize="large" onHide={close}>
+                <Modal.Header>
+                    <Modal.Title>Choose a Picklist</Modal.Title>
+                </Modal.Header>
+
+                <Modal.Body>
+                    <Alert bsStyle="danger">{picklistLoadError ?? error}</Alert>
+                    <div className="row">
+                        <div className="col-md-12">
+                            <Alert bsStyle="info">
+                                Adding {Utils.pluralize(numSelected, 'sample', 'samples')} to selected picklist.
+                            </Alert>
+                        </div>
                     </div>
-                </div>
-
-                <div className="row">
-                    <div className="col-md-6">
-                        <Tabs id="choose-items-tabs" className="choose-items-tabs" animation={false}>
-                            <Tab eventKey={1} title="My Picklists">
-                                <PicklistList
-                                    activeItem={activeItem}
-                                    emptyMessage={myEmptyMessage}
-                                    onSelect={setActiveItem}
-                                    showSharedIcon
-                                    items={myItems}
-                                />
-                            </Tab>
-
-                            <Tab eventKey={2} title="Team Picklists">
-                                <PicklistList
-                                    activeItem={activeItem}
-                                    emptyMessage={teamEmptyMessage}
-                                    onSelect={setActiveItem}
-                                    items={teamItems}
-                                />
-                            </Tab>
-                        </Tabs>
+                    <div className="row">
+                        <div className="col-md-6">
+                            <input
+                                autoFocus
+                                className="form-control"
+                                onChange={onSearchChange}
+                                placeholder="Find a picklist"
+                            />
+                        </div>
                     </div>
 
-                    <div className="col-md-6">
-                        {activeItem === undefined && (
-                            <div className="choices-list__empty-message">Choose a picklist</div>
-                        )}
+                    <div className="row">
+                        <div className="col-md-6">
+                            <Tabs id="choose-items-tabs" className="choose-items-tabs" animation={false}>
+                                <Tab eventKey={1} title="My Picklists">
+                                    <PicklistList
+                                        activeItem={activeItem}
+                                        emptyMessage={myEmptyMessage}
+                                        onSelect={setActiveItem}
+                                        showSharedIcon
+                                        items={myItems}
+                                    />
+                                </Tab>
 
-                        {activeItem !== undefined && <PicklistDetails picklist={activeItem}/>}
+                                <Tab eventKey={2} title="Team Picklists">
+                                    <PicklistList
+                                        activeItem={activeItem}
+                                        emptyMessage={teamEmptyMessage}
+                                        onSelect={setActiveItem}
+                                        items={teamItems}
+                                    />
+                                </Tab>
+                            </Tabs>
+                        </div>
+
+                        <div className="col-md-6">
+                            {activeItem === undefined && (
+                                <div className="choices-list__empty-message">Choose a picklist</div>
+                            )}
+
+                            {activeItem !== undefined && <PicklistDetails picklist={activeItem}/>}
+                        </div>
                     </div>
-                </div>
-            </Modal.Body>
+                </Modal.Body>
 
-            <Modal.Footer>
-                <div className="pull-left">
-                    <button type="button" className="btn btn-default" onClick={closeModal}>
-                        Cancel
-                    </button>
-                </div>
+                <Modal.Footer>
+                    <div className="pull-left">
+                        <button type="button" className="btn btn-default" onClick={closeModal}>
+                            Cancel
+                        </button>
+                    </div>
 
-                <div className="pull-right">
-                    <button
-                        type="button"
-                        className="btn btn-success"
-                        onClick={onAddClicked}
-                        disabled={activeItem === undefined || submitting}
-                    >
-                        {submitting ? 'Adding to Picklist...' : 'Add to Picklist'}
-                    </button>
-                </div>
-            </Modal.Footer>
-        </Modal>
-    );
-});
+                    <div className="pull-right">
+                        <button
+                            type="button"
+                            className="btn btn-success"
+                            onClick={onAddClicked}
+                            disabled={activeItem === undefined || submitting}
+                        >
+                            {submitting ? 'Adding to Picklist...' : 'Add to Picklist'}
+                        </button>
+                    </div>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+);
 
 interface ChoosePicklistModalProps {
     onCancel: (cancelToCreate?: boolean) => void;
@@ -380,10 +399,10 @@ interface ChoosePicklistModalProps {
     user: User;
     selectionKey?: string;
     numSelected: number;
-    sampleIds?: string[]
+    sampleIds?: string[];
 }
 
-export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo((props) => {
+export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo(props => {
     const [error, setError] = useState<string>(undefined);
     const [items, setItems] = useState<Picklist[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
@@ -398,12 +417,7 @@ export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo((props) =>
                 setError('There was a problem retrieving the picklist data. ' + resolveErrorMessage(reason));
                 setLoading(false);
             });
-
     }, [getPicklists, setItems, setError, setLoading]);
 
-    return (
-        <ChoosePicklistModalDisplay {...props} picklists={items} picklistLoadError={error} loading={loading}/>
-    );
+    return <ChoosePicklistModalDisplay {...props} picklists={items} picklistLoadError={error} loading={loading}/>;
 });
-
-

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -92,6 +92,7 @@ export const ChoosePicklistModal: FC<ChooseItemModalProps> = memo((props) => {
     const [search, setSearch] = useState<string>('');
     const [error, setError] = useState<string>(undefined);
     const [items, setItems] = useState<PicklistModel[]>([]);
+    const [submitting, setSubmitting] = useState<boolean>(false);
 
     useEffect(() => {
         getPicklists()
@@ -133,15 +134,18 @@ export const ChoosePicklistModal: FC<ChooseItemModalProps> = memo((props) => {
 
     const [activeItem, setActiveItem] = useState<PicklistModel>(undefined);
     const onAddClicked = useCallback(async () => {
+        setSubmitting(true);
         try {
             const insertResponse = await addSamplesToPicklist(activeItem.name, selectionKey);
             setError(undefined);
+            setSubmitting(false);
             afterAddToPicklist(activeItem, insertResponse.rows.length);
         }
         catch (e) {
+            setSubmitting(false);
             setError(resolveErrorMessage(e));
         }
-    }, [activeItem]);
+    }, [activeItem, selectionKey, setSubmitting, setError]);
     const isSearching = !!(search);
     let myEmptyMessage = 'You do not have any picklists ';
     let teamEmptyMessage = 'There are no shared picklists  ';
@@ -228,9 +232,9 @@ export const ChoosePicklistModal: FC<ChooseItemModalProps> = memo((props) => {
                         type="button"
                         className="btn btn-success"
                         onClick={onAddClicked}
-                        disabled={activeItem === undefined}
+                        disabled={activeItem === undefined || submitting}
                     >
-                        Add to Picklist
+                        {submitting ? 'Adding to Picklist...' : 'Add to Picklist'}
                     </button>
                 </div>
             </Modal.Footer>

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -77,11 +77,11 @@ const PicklistItemsSummary: FC<PicklistItemsSummaryProps> = memo((props) => {
         countsByType.forEach(countData => {
             summaryData.push((
                 <div className="row picklist-items__row">
-                    <span className={'col-md-1'}>
+                    <span className="col-md-1">
                         <ColorIcon useSmall={true} value={countData.LabelColor}/>
                     </span>
                     <span
-                        className="col-md-4 picklist-items__sample-type choice-metadata-item__name">{countData.SampleType}</span>
+                        className="col-md-5 picklist-items__sample-type choice-metadata-item__name">{countData.SampleType}</span>
                     <span className="col-md-4 picklist-items__item-count">{countData.ItemCount}</span>
                 </div>
             ));
@@ -120,10 +120,6 @@ const PicklistDetails: FC<PicklistDetailsProps> = memo((props) => {
                     <span className="choice-metadata-item__value">{formatDate(parseDate(picklist.Created))}</span>
                 </div>
 
-                <div className="choice-metadata-item">
-                    <span className="choice-metadata-item__name">Last Modified:</span>
-                    <span className="choice-metadata-item__value">{formatDate(parseDate(picklist.Created))}</span>
-                </div>
             </div>
 
             <div className="choice-details__description">

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { Modal, Tab, Tabs } from 'react-bootstrap';
 import classNames from 'classnames';
-import { PicklistModel } from './models';
+import { Picklist } from './models';
 import { formatDate, parseDate } from '../../util/Date';
 import { User } from '../base/models/User';
 import { Utils } from '@labkey/api';
@@ -10,11 +10,11 @@ import { addSamplesToPicklist, getPicklists } from './actions';
 import { resolveErrorMessage } from '../../util/messaging';
 
 interface PicklistListProps {
-    activeItem: PicklistModel;
+    activeItem: Picklist;
     emptyMessage: ReactNode;
     onSelect: (picklist) => void;
     showSharedIcon?: boolean
-    items: PicklistModel[];
+    items: Picklist[];
 }
 
 const PicklistList: FC<PicklistListProps> = memo((props) => {
@@ -38,7 +38,7 @@ const PicklistList: FC<PicklistListProps> = memo((props) => {
 });
 
 interface PicklistDetailsProps {
-    picklist: PicklistModel;
+    picklist: Picklist;
 }
 
 const ItemDetails: FC<PicklistDetailsProps> = memo((props) => {
@@ -81,7 +81,7 @@ const ItemDetails: FC<PicklistDetailsProps> = memo((props) => {
 
 interface ChooseItemModalProps {
     onCancel: () => void;
-    afterAddToPicklist: (item: PicklistModel, numAdded: number) => void;
+    afterAddToPicklist: (item: Picklist, numAdded: number) => void;
     user: User;
     selectionKey: string;
     numSelected: number;
@@ -91,7 +91,7 @@ export const ChoosePicklistModal: FC<ChooseItemModalProps> = memo((props) => {
     const {onCancel, afterAddToPicklist, user, selectionKey, numSelected} = props;
     const [search, setSearch] = useState<string>('');
     const [error, setError] = useState<string>(undefined);
-    const [items, setItems] = useState<PicklistModel[]>([]);
+    const [items, setItems] = useState<Picklist[]>([]);
     const [submitting, setSubmitting] = useState<boolean>(false);
 
     useEffect(() => {
@@ -108,7 +108,7 @@ export const ChoosePicklistModal: FC<ChooseItemModalProps> = memo((props) => {
     const onSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
         setSearch(event.target.value.trim().toLowerCase());
     }, []);
-    const filteredItems = useMemo<PicklistModel[]>(() => {
+    const filteredItems = useMemo<Picklist[]>(() => {
         if (search.trim() !== '') {
             return items.filter(item => item.name.toLowerCase().indexOf(search) > -1);
         }
@@ -132,7 +132,7 @@ export const ChoosePicklistModal: FC<ChooseItemModalProps> = memo((props) => {
         return [mine, team];
     }, [filteredItems]);
 
-    const [activeItem, setActiveItem] = useState<PicklistModel>(undefined);
+    const [activeItem, setActiveItem] = useState<Picklist>(undefined);
     const onAddClicked = useCallback(async () => {
         setSubmitting(true);
         try {

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
@@ -14,10 +14,6 @@ describe('PicklistCreationMenuItem', () => {
     const text = 'Picklist';
 
     test('modal hidden', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
-
         const wrapper = mount(
             <PicklistCreationMenuItem
                 itemText={text}
@@ -41,10 +37,6 @@ describe('PicklistCreationMenuItem', () => {
     });
 
     test('modal shown', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
-
         const wrapper = mount(
             <PicklistCreationMenuItem
                 itemText={text}
@@ -64,10 +56,6 @@ describe('PicklistCreationMenuItem', () => {
     });
 
     test('not Editor', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
-
         const wrapper = mount(
             <PicklistCreationMenuItem
                 itemText={text}
@@ -82,10 +70,6 @@ describe('PicklistCreationMenuItem', () => {
     });
 
     test('not enabled for Biologics', () => {
-        LABKEY.experimental = {
-            samplePicklist: true,
-        } as any;
-
         LABKEY.moduleContext = {
             biologics: {}
         };

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
@@ -80,4 +80,26 @@ describe('PicklistCreationMenuItem', () => {
         expect(wrapper.find('MenuItem')).toHaveLength(0);
         wrapper.unmount();
     });
+
+    test('not enabled for Biologics', () => {
+        LABKEY.experimental = {
+            samplePicklist: true,
+        } as any;
+
+        LABKEY.moduleContext = {
+            biologics: {}
+        };
+
+        const wrapper = mount(
+            <PicklistCreationMenuItem
+                itemText={text}
+                selectionKey={selectionKey}
+                selectedQuantity={selectedQuantity}
+                key={key}
+                user={TEST_USER_READER}
+            />
+        );
+        expect(wrapper.find('MenuItem')).toHaveLength(0);
+        wrapper.unmount();
+    });
 });

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import { MenuItem, Modal } from 'react-bootstrap';
 
 import { PicklistCreationMenuItem } from './PicklistCreationMenuItem';
+import { TEST_USER_EDITOR, TEST_USER_READER } from '../../../test/data/users';
 
 describe('PicklistCreationMenuItem', () => {
     const key = 'picklists';
@@ -12,12 +13,17 @@ describe('PicklistCreationMenuItem', () => {
     const text = 'Picklist';
 
     test('modal hidden', () => {
+        LABKEY.experimental = {
+            samplePicklist: true
+        } as any;
+
         const wrapper = mount(
             <PicklistCreationMenuItem
                 itemText={text}
                 selectionKey={selectionKey}
                 selectedQuantity={selectedQuantity}
                 key={key}
+                user={TEST_USER_EDITOR}
             />
         );
         const menuItem = wrapper.find(MenuItem);
@@ -34,12 +40,17 @@ describe('PicklistCreationMenuItem', () => {
     });
 
     test('modal shown', () => {
+        LABKEY.experimental = {
+            samplePicklist: true
+        } as any;
+
         const wrapper = mount(
             <PicklistCreationMenuItem
                 itemText={text}
                 selectionKey={selectionKey}
                 selectedQuantity={selectedQuantity}
                 key={key}
+                user={TEST_USER_EDITOR}
             />
         );
         const menuItem = wrapper.find('MenuItem a');
@@ -48,6 +59,24 @@ describe('PicklistCreationMenuItem', () => {
         const modal = wrapper.find(Modal);
         expect(modal).toHaveLength(1);
         expect(modal.prop('show')).toBe(true);
+        wrapper.unmount();
+    });
+
+    test('not Editor', () => {
+        LABKEY.experimental = {
+            samplePicklist: true
+        } as any;
+
+        const wrapper = mount(
+            <PicklistCreationMenuItem
+                itemText={text}
+                selectionKey={selectionKey}
+                selectedQuantity={selectedQuantity}
+                key={key}
+                user={TEST_USER_READER}
+            />
+        );
+        expect(wrapper.find('MenuItem')).toHaveLength(0);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.spec.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { MenuItem, Modal } from 'react-bootstrap';
 
-import { PicklistCreationMenuItem } from './PicklistCreationMenuItem';
 import { TEST_USER_EDITOR, TEST_USER_READER } from '../../../test/data/users';
+
+import { PicklistCreationMenuItem } from './PicklistCreationMenuItem';
 
 describe('PicklistCreationMenuItem', () => {
     const key = 'picklists';
@@ -14,7 +15,7 @@ describe('PicklistCreationMenuItem', () => {
 
     test('modal hidden', () => {
         LABKEY.experimental = {
-            samplePicklist: true
+            samplePicklist: true,
         } as any;
 
         const wrapper = mount(
@@ -41,7 +42,7 @@ describe('PicklistCreationMenuItem', () => {
 
     test('modal shown', () => {
         LABKEY.experimental = {
-            samplePicklist: true
+            samplePicklist: true,
         } as any;
 
         const wrapper = mount(
@@ -64,7 +65,7 @@ describe('PicklistCreationMenuItem', () => {
 
     test('not Editor', () => {
         LABKEY.experimental = {
-            samplePicklist: true
+            samplePicklist: true,
         } as any;
 
         const wrapper = mount(

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -32,18 +32,6 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     const [showModal, setShowModal] = useState<boolean>(false);
 
     const onFinish = (picklist: Picklist) => {
-        const count = sampleIds ? sampleIds.length : selectedQuantity;
-        createNotification({
-            message: () => {
-                return (
-                    <>
-                        Successfully created "{picklist.name}" with {Utils.pluralize(count, 'sample', 'samples')}.&nbsp;
-                        <a href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>View picklist</a>.
-                    </>
-                );
-            },
-            alertClass: 'success',
-        });
         setShowModal(false);
     };
 
@@ -67,6 +55,7 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
             <PicklistEditModal
                 selectionKey={selectionKey}
                 selectedQuantity={selectedQuantity}
+                showNotification={true}
                 sampleIds={sampleIds}
                 show={showModal}
                 onFinish={onFinish}

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -13,6 +13,8 @@ import { PICKLIST_KEY } from '../../app/constants';
 import { PicklistEditModal } from './PicklistEditModal';
 
 import { Picklist } from './models';
+import { isSamplePicklistEnabled, userCanManagePicklists } from '../../app/utils';
+import { User } from '../base/models/User';
 
 interface Props {
     selectionKey?: string;
@@ -20,10 +22,11 @@ interface Props {
     sampleIds?: string[];
     key: string;
     itemText: string;
+    user: User;
 }
 
 export const PicklistCreationMenuItem: FC<Props> = props => {
-    const { sampleIds, selectionKey, selectedQuantity, key, itemText } = props;
+    const {sampleIds, selectionKey, selectedQuantity, key, itemText, user} = props;
     const [showModal, setShowModal] = useState<boolean>(false);
 
     const onFinish = (picklist: Picklist) => {
@@ -49,6 +52,10 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     const onClick = () => {
         setShowModal(true);
     };
+
+    if (!userCanManagePicklists(user) || !isSamplePicklistEnabled()) {
+        return null;
+    }
 
     return (
         <>

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -12,7 +12,7 @@ import { PICKLIST_KEY } from '../../app/constants';
 
 import { PicklistEditModal } from './PicklistEditModal';
 
-import { PicklistModel } from './models';
+import { Picklist } from './models';
 
 interface Props {
     selectionKey?: string;
@@ -26,7 +26,7 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
     const { sampleIds, selectionKey, selectedQuantity, key, itemText } = props;
     const [showModal, setShowModal] = useState<boolean>(false);
 
-    const onFinish = (picklist: PicklistModel) => {
+    const onFinish = (picklist: Picklist) => {
         const count = sampleIds ? sampleIds.length : selectedQuantity;
         createNotification({
             message: () => {

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -2,14 +2,6 @@ import React, { FC, useState } from 'react';
 
 import { MenuItem } from 'react-bootstrap';
 
-import { Utils } from '@labkey/api';
-
-import { createNotification } from '../notifications/actions';
-
-import { AppURL } from '../../url/AppURL';
-
-import { PICKLIST_KEY } from '../../app/constants';
-
 import { isSamplePicklistEnabled, userCanManagePicklists } from '../../app/utils';
 
 import { User } from '../base/models/User';

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -10,11 +10,13 @@ import { AppURL } from '../../url/AppURL';
 
 import { PICKLIST_KEY } from '../../app/constants';
 
+import { isSamplePicklistEnabled, userCanManagePicklists } from '../../app/utils';
+
+import { User } from '../base/models/User';
+
 import { PicklistEditModal } from './PicklistEditModal';
 
 import { Picklist } from './models';
-import { isSamplePicklistEnabled, userCanManagePicklists } from '../../app/utils';
-import { User } from '../base/models/User';
 
 interface Props {
     selectionKey?: string;

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.spec.tsx
@@ -5,7 +5,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import { Alert } from '../base/Alert';
 
 import { PicklistDeleteConfirmMessage } from './PicklistDeleteConfirm';
-import { PicklistModel } from './models';
+import { Picklist } from './models';
 
 describe('PicklistDeleteConfirmMessage', () => {
     function validateText(
@@ -161,7 +161,7 @@ describe('PicklistDeleteConfirmMessage', () => {
                     numDeletable: 1,
                     numNotDeletable: 3,
                     numShared: 1,
-                    deletableLists: [new PicklistModel({ name: 'Public Deletable', listId: 1 })],
+                    deletableLists: [new Picklist({name: 'Public Deletable', listId: 1})],
                 }}
                 numSelected={4}
                 noun="Picklist"
@@ -207,7 +207,7 @@ describe('PicklistDeleteConfirmMessage', () => {
                     numDeletable: 1,
                     numNotDeletable: 1,
                     numShared: 0,
-                    deletableLists: [new PicklistModel({ name: 'Public Deletable', listId: 1 })],
+                    deletableLists: [new Picklist({name: 'Public Deletable', listId: 1})],
                 }}
                 numSelected={2}
                 noun="Picklist"

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -6,7 +6,7 @@ import { Alert } from '../base/Alert';
 import { ConfirmModal } from '../base/ConfirmModal';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
-import { PicklistModel } from './models';
+import { Picklist } from './models';
 import { getPicklistDeleteData, PicklistDeletionData } from './actions';
 import { getConfirmDeleteMessage } from '../../util/messaging';
 
@@ -131,7 +131,7 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
                 });
         } else {
             setNounAndNumber('This Picklist');
-            const picklist = PicklistModel.create(model.getRow());
+            const picklist = Picklist.create(model.getRow());
             setDeletionData({
                 numDeletable: 1,
                 numNotDeletable: 0,

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { PicklistModel } from './models';
 import { getPicklistDeleteData, PicklistDeletionData } from './actions';
+import { getConfirmDeleteMessage } from '../../util/messaging';
 
 interface Props {
     model: QueryModel;
@@ -90,14 +91,11 @@ export const PicklistDeleteConfirmMessage: FC<DeleteConfirmMessageProps> = memo(
                 </Alert>
             )}
             <span>
-                {rUSure}&nbsp;
                 {deletionData.numDeletable > 0 && (
                     <>
+                        {rUSure}&nbsp;
                         Samples in the {noun} will not be affected.&nbsp;
-                        <p className="top-spacing">
-                            <strong>Deletion cannot be undone.</strong>
-                            &nbsp;Do you want to proceed?
-                        </p>
+                        {getConfirmDeleteMessage()}
                     </>
                 )}
             </span>
@@ -133,7 +131,7 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
                 });
         } else {
             setNounAndNumber('This Picklist');
-            const picklist = new PicklistModel(model.getRow(undefined, true));
+            const picklist = PicklistModel.create(model.getRow());
             setDeletionData({
                 numDeletable: 1,
                 numNotDeletable: 0,

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -6,9 +6,10 @@ import { Alert } from '../base/Alert';
 import { ConfirmModal } from '../base/ConfirmModal';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
+import { getConfirmDeleteMessage } from '../../util/messaging';
+
 import { Picklist } from './models';
 import { getPicklistDeleteData, PicklistDeletionData } from './actions';
-import { getConfirmDeleteMessage } from '../../util/messaging';
 
 interface Props {
     model: QueryModel;
@@ -93,8 +94,7 @@ export const PicklistDeleteConfirmMessage: FC<DeleteConfirmMessageProps> = memo(
             <span>
                 {deletionData.numDeletable > 0 && (
                     <>
-                        {rUSure}&nbsp;
-                        Samples in the {noun} will not be affected.&nbsp;
+                        {rUSure}&nbsp; Samples in the {noun} will not be affected.&nbsp;
                         {getConfirmDeleteMessage()}
                     </>
                 )}

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { Button, Modal, ModalFooter, ModalTitle } from 'react-bootstrap';
 
-import { PicklistModel, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../../../index';
+import { Picklist, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../../../index';
 
 import { PicklistEditModal } from './PicklistEditModal';
 
@@ -18,7 +18,7 @@ describe('PicklistEditModal', () => {
         expect(buttons.at(1).text()).toBe(expectedFinishText);
     }
 
-    function validateForm(wrapper: ReactWrapper, existingList?: PicklistModel) {
+    function validateForm(wrapper: ReactWrapper, existingList?: Picklist) {
         const labels = wrapper.find('label');
         expect(labels).toHaveLength(3);
         expect(labels.at(0).text()).toBe('Name *');
@@ -114,13 +114,13 @@ describe('PicklistEditModal', () => {
     });
 
     test('Update private picklist', () => {
-        const existingList = new PicklistModel({
+        const existingList = new Picklist({
             Category: PRIVATE_PICKLIST_CATEGORY,
             name: 'Existing list',
             Description: 'My test description',
         });
         const wrapper = mount(
-            <PicklistEditModal show={true} picklist={existingList} onCancel={jest.fn()} onFinish={jest.fn()} />
+            <PicklistEditModal show={true} picklist={existingList} onCancel={jest.fn()} onFinish={jest.fn()}/>
         );
         validateText(wrapper, 'Update Picklist Data', 'Update Picklist');
         const labels = wrapper.find('label');
@@ -135,13 +135,13 @@ describe('PicklistEditModal', () => {
     });
 
     test('Update public picklist', () => {
-        const existingList = new PicklistModel({
+        const existingList = new Picklist({
             Category: PUBLIC_PICKLIST_CATEGORY,
             name: 'Existing list',
             Description: 'My test description',
         });
         const wrapper = mount(
-            <PicklistEditModal show={true} picklist={existingList} onCancel={jest.fn()} onFinish={jest.fn()} />
+            <PicklistEditModal show={true} picklist={existingList} onCancel={jest.fn()} onFinish={jest.fn()}/>
         );
         expect(wrapper.find('input').at(1).prop('checked')).toBe(true);
         wrapper.unmount();

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -115,11 +115,11 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         const count = sampleIds?.length ?? selectedQuantity;
         if (count === 0) {
             title = 'Create an Empty Picklist';
-        } else if (selectionKey) {
+        } else if (selectionKey && count) {
             title = (
                 <>
                     Create a New Picklist with the{' '}
-                    {Utils.pluralize(selectedQuantity, 'Selected Sample', 'Selected Samples')}
+                    {Utils.pluralize(count, 'Selected Sample', 'Selected Samples')}
                 </>
             );
         } else if (count === 1) {

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -10,7 +10,7 @@ import { resolveErrorMessage } from '../../util/messaging';
 
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 
-import { PicklistModel } from './models';
+import { Picklist } from './models';
 import { addSamplesToPicklist, createPicklist, setPicklistDefaultView, updatePicklist } from './actions';
 
 interface Props {
@@ -18,9 +18,9 @@ interface Props {
     selectionKey?: string; // pass in either selectionKey and selectedQuantity or sampleIds.
     selectedQuantity?: number;
     sampleIds?: string[];
-    picklist?: PicklistModel;
+    picklist?: Picklist;
     onCancel: () => void;
-    onFinish: (picklist: PicklistModel) => void;
+    onFinish: (picklist: Picklist) => void;
 }
 
 export const PicklistEditModal: FC<Props> = memo(props => {
@@ -67,7 +67,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
             const trimmedName = name.trim();
             if (isUpdate) {
                 updatedList = await updatePicklist(
-                    new PicklistModel({
+                    new Picklist({
                         name: trimmedName,
                         listId: picklist.listId,
                         Description: description,

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -71,7 +71,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                 return (
                     <>
                         Successfully created "{picklist.name}" with{' '}
-                        {Utils.pluralize(selectedQuantity, 'sample', 'samples')}.&nbsp;
+                        {selectedQuantity ? Utils.pluralize(selectedQuantity, 'sample', 'samples') : ' no samples'}.&nbsp;
                         <a href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>View picklist</a>.
                     </>
                 );
@@ -114,15 +114,16 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         title = 'Update Picklist Data';
     } else {
         const count = sampleIds?.length ?? selectedQuantity;
-        if (count === 0) {
-            title = 'Create an Empty Picklist';
-        } else if (selectionKey && count) {
-            title = <>Create a New Picklist with the {Utils.pluralize(count, 'Selected Sample', 'Selected Samples')}</>;
-        } else if (count === 1) {
-            title = 'Create a New Picklist with This Sample';
-        } else {
-            title = 'Create a New Picklist with These Samples';
-        }
+            if (!count) {
+                title = 'Create an Empty Picklist';
+            } else if (selectionKey && count) {
+                title = <>Create a New Picklist with
+                    the {Utils.pluralize(count, 'Selected Sample', 'Selected Samples')}</>;
+            } else if (count === 1) {
+                title = 'Create a New Picklist with This Sample';
+            } else {
+                title = 'Create a New Picklist with These Samples';
+            }
     }
 
     return (

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -65,7 +65,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         onCancel();
     }, []);
 
-    const createSuccessNotification = () => {
+    const createSuccessNotification = (picklist: Picklist) => {
         createNotification({
             message: () => {
                 return (
@@ -99,7 +99,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
             }
             setIsSubmitting(false);
             if (showNotification) {
-                createSuccessNotification();
+                createSuccessNotification(updatedList);
             }
 
             onFinish(updatedList);

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -10,11 +10,12 @@ import { resolveErrorMessage } from '../../util/messaging';
 
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 
-import { Picklist } from './models';
-import { createPicklist, updatePicklist } from './actions';
 import { createNotification } from '../notifications/actions';
 import { AppURL } from '../../url/AppURL';
 import { PICKLIST_KEY } from '../../app/constants';
+
+import { createPicklist, updatePicklist } from './actions';
+import { Picklist } from './models';
 
 interface Props {
     show: boolean;
@@ -24,7 +25,7 @@ interface Props {
     picklist?: Picklist;
     onCancel: () => void;
     onFinish: (picklist: Picklist) => void;
-    showNotification?: boolean
+    showNotification?: boolean;
 }
 
 export const PicklistEditModal: FC<Props> = memo(props => {
@@ -69,8 +70,8 @@ export const PicklistEditModal: FC<Props> = memo(props => {
             message: () => {
                 return (
                     <>
-                        Successfully created "{picklist.name}"
-                        with {Utils.pluralize(selectedQuantity, 'sample', 'samples')}.&nbsp;
+                        Successfully created "{picklist.name}" with{' '}
+                        {Utils.pluralize(selectedQuantity, 'sample', 'samples')}.&nbsp;
                         <a href={AppURL.create(PICKLIST_KEY, picklist.listId).toHref()}>View picklist</a>.
                     </>
                 );
@@ -116,12 +117,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         if (count === 0) {
             title = 'Create an Empty Picklist';
         } else if (selectionKey && count) {
-            title = (
-                <>
-                    Create a New Picklist with the{' '}
-                    {Utils.pluralize(count, 'Selected Sample', 'Selected Samples')}
-                </>
-            );
+            title = <>Create a New Picklist with the {Utils.pluralize(count, 'Selected Sample', 'Selected Samples')}</>;
         } else if (count === 1) {
             title = 'Create a New Picklist with This Sample';
         } else {

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -1,4 +1,4 @@
-import { Ajax, Domain, Filter, Utils } from '@labkey/api';
+import { Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
 
 import { List } from 'immutable';
 
@@ -176,7 +176,34 @@ export function updatePicklist(picklist: Picklist): Promise<Picklist> {
     });
 }
 
-export function getPicklistSamples(listName): Promise<Set<string>> {
+export interface SampleTypeCount {
+    ItemCount: number,
+    SampleType: string,
+    LabelColor: string
+}
+
+export function getPicklistCountsBySampleType(listName: string): Promise<SampleTypeCount[]> {
+    return new Promise((resolve, reject) => {
+        Query.executeSql({
+            sql: 'SELECT COUNT(*) as ItemCount, \n' +
+                '       SampleId.SampleSet.Name AS SampleType, \n' +
+                '       SampleId.LabelColor\n' +
+                'FROM lists."' + listName + '"\n' +
+                'GROUP BY SampleId.SampleSet.Name, SampleId.LabelColor\n' +
+                'ORDER BY SampleId.SampleSet.Name',
+            schemaName: 'lists',
+            success: ((data) => {
+                resolve(data.rows);
+            }),
+            failure: (reason => {
+                console.error(reason);
+                reject(reason);
+            })
+        });
+    });
+}
+
+export function getPicklistSamples(listName: string): Promise<Set<string>> {
     return new Promise((resolve, reject) => {
         const schemaName = 'lists';
         selectRows({

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -280,12 +280,14 @@ export function getSamplesNotInList(listName: string, selectionKey?: string, sam
                         });
                         resolve(newSamples);
                     });
-                } else {
+                } else if (sampleIds) {
                     sampleIds.forEach(id => {
                         if (!existingSamples.has(id.toString())) {
                             newSamples.push(id.toString());
                         }
                     });
+                    resolve(newSamples);
+                } else {
                     resolve(newSamples);
                 }
             })

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -14,7 +14,7 @@ import { fetchListDesign, getListIdFromDomainId } from '../domainproperties/list
 import { resolveErrorMessage } from '../../util/messaging';
 import { SCHEMAS } from '../../../index';
 
-import { Picklist } from './models';
+import { Picklist, PICKLIST_KEY_COLUMN, PICKLIST_SAMPLE_ID_COLUMN } from './models';
 
 export function getPicklists(): Promise<Picklist[]> {
     return new Promise((resolve, reject) => {
@@ -60,9 +60,9 @@ export function setPicklistDefaultView(name: string): Promise<string> {
                         {fieldKey: 'SampleID/Created'},
                         {fieldKey: 'SampleID/CreatedBy'},
                         {fieldKey: 'SampleID/StorageLocation'},
-                        { fieldKey: 'SampleID/StorageRow' },
-                        { fieldKey: 'SampleID/StorageCol' },
-                        { fieldKey: 'SampleID/isAliquot' },
+                        {fieldKey: 'SampleID/StorageRow'},
+                        {fieldKey: 'SampleID/StorageCol'},
+                        {fieldKey: 'SampleID/isAliquot'},
                     ],
                 },
             ],
@@ -98,7 +98,7 @@ export function createPicklist(
                 name,
                 fields: [
                     {
-                        name: 'SampleID',
+                        name: PICKLIST_SAMPLE_ID_COLUMN,
                         rangeURI: 'int',
                         required: true,
                         lookupSchema: SCHEMAS.INVENTORY.SAMPLE_ITEMS.schemaName,
@@ -107,14 +107,14 @@ export function createPicklist(
                 ],
                 indices: [
                     {
-                        columnNames: ['SampleID'],
+                        columnNames: [PICKLIST_SAMPLE_ID_COLUMN],
                         unique: true,
                     },
                 ],
             },
             kind: PICKLIST,
             options: {
-                keyName: 'id',
+                keyName: PICKLIST_KEY_COLUMN,
                 keyType: 'AutoIncrementInteger',
                 description,
                 category: shared ? PUBLIC_PICKLIST_CATEGORY : PRIVATE_PICKLIST_CATEGORY,

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -268,8 +268,8 @@ export function getSamplesNotInList(listName: string, selectionKey?: string, sam
                     });
                 } else {
                     sampleIds.forEach(id => {
-                        if (!existingSamples.has(id)) {
-                            newSamples.push(id);
+                        if (!existingSamples.has(id.toString())) {
+                            newSamples.push(id.toString());
                         }
                     });
                     resolve(newSamples);

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -196,7 +196,7 @@ export function getPicklistCountsBySampleType(listName: string): Promise<SampleT
                 '"\n' +
                 'GROUP BY SampleId.SampleSet.Name, SampleId.LabelColor\n' +
                 'ORDER BY SampleId.SampleSet.Name',
-            schemaName: 'lists',
+            schemaName: SCHEMAS.PICKLIST_TABLES.SCHEMA,
             success: data => {
                 resolve(data.rows);
             },
@@ -210,7 +210,7 @@ export function getPicklistCountsBySampleType(listName: string): Promise<SampleT
 
 export function getPicklistSamples(listName: string): Promise<Set<string>> {
     return new Promise((resolve, reject) => {
-        const schemaName = 'lists';
+        const schemaName = SCHEMAS.PICKLIST_TABLES.SCHEMA;
         selectRows({
             schemaName,
             queryName: listName,
@@ -267,28 +267,16 @@ export function getSelectedPicklistSamples(
 
 export function getSamplesNotInList(listName: string, selectionKey?: string, sampleIds?: string[]): Promise<string[]> {
     return new Promise((resolve, reject) => {
-        const newSamples = [];
         getPicklistSamples(listName)
             .then(existingSamples => {
-                const rows = List<any>();
                 if (selectionKey) {
                     getSelected(selectionKey).then(response => {
-                        response.selected.forEach(id => {
-                            if (!existingSamples.has(id)) {
-                                newSamples.push(id);
-                            }
-                        });
-                        resolve(newSamples);
+                        resolve(response.selected.filter(id => !existingSamples.has(id.toString())));
                     });
                 } else if (sampleIds) {
-                    sampleIds.forEach(id => {
-                        if (!existingSamples.has(id.toString())) {
-                            newSamples.push(id.toString());
-                        }
-                    });
-                    resolve(newSamples);
+                    resolve(sampleIds.filter(id => !existingSamples.has(id.toString())));
                 } else {
-                    resolve(newSamples);
+                    resolve([]);
                 }
             })
             .catch(reason => {

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -14,9 +14,9 @@ import { fetchListDesign, getListIdFromDomainId } from '../domainproperties/list
 import { resolveErrorMessage } from '../../util/messaging';
 import { SCHEMAS } from '../../../index';
 
-import { PicklistModel } from './models';
+import { Picklist } from './models';
 
-export function getPicklists(): Promise<PicklistModel[]> {
+export function getPicklists(): Promise<Picklist[]> {
     return new Promise((resolve, reject) => {
         const schemaName = SCHEMAS.LIST_METADATA_TABLES.PICKLISTS.schemaName;
         const queryName = SCHEMAS.LIST_METADATA_TABLES.PICKLISTS.queryName;
@@ -31,7 +31,7 @@ export function getPicklists(): Promise<PicklistModel[]> {
             const data = models[dataKey];
             const picklists = [];
             orderedModels[dataKey].forEach(id => {
-                picklists.push(PicklistModel.create(data[id]));
+                picklists.push(Picklist.create(data[id]));
             });
             resolve(picklists);
         }).catch(reason => {
@@ -91,7 +91,7 @@ export function createPicklist(
     shared: boolean,
     selectionKey: string,
     sampleIds: string[]
-): Promise<PicklistModel> {
+): Promise<Picklist> {
     return new Promise((resolve, reject) => {
         Domain.create({
             domainDesign: {
@@ -128,7 +128,7 @@ export function createPicklist(
                     .then(responses => {
                         const [listId] = responses;
                         resolve(
-                            new PicklistModel({
+                            new Picklist({
                                 listId,
                                 name,
                                 Description: description,
@@ -147,7 +147,7 @@ export function createPicklist(
     });
 }
 
-export function updatePicklist(picklist: PicklistModel): Promise<PicklistModel> {
+export function updatePicklist(picklist: Picklist): Promise<Picklist> {
     return new Promise((resolve, reject) => {
         fetchListDesign(picklist.listId)
             .then(listDesign => {
@@ -265,7 +265,7 @@ export interface PicklistDeletionData {
     numDeletable: number;
     numNotDeletable: number;
     numShared: number;
-    deletableLists: PicklistModel[];
+    deletableLists: Picklist[];
 }
 
 export function getPicklistDeleteData(model: QueryModel, user: User): Promise<PicklistDeletionData> {
@@ -286,7 +286,7 @@ export function getPicklistDeleteData(model: QueryModel, user: User): Promise<Pi
                 let numShared = 0;
                 const deletableLists = [];
                 data.valueSeq().forEach(row => {
-                    const picklist = PicklistModel.create(row.toJS());
+                    const picklist = Picklist.create(row.toJS());
 
                     if (picklist.isDeletable(user)) {
                         if (picklist.isPublic()) {
@@ -311,7 +311,7 @@ export function getPicklistDeleteData(model: QueryModel, user: User): Promise<Pi
     });
 }
 
-export function deletePicklists(picklists: PicklistModel[], selectionKey?: string): Promise<any> {
+export function deletePicklists(picklists: Picklist[], selectionKey?: string): Promise<any> {
     return new Promise((resolve, reject) => {
         let params;
         if (picklists.length === 1) {
@@ -346,7 +346,7 @@ export function deletePicklists(picklists: PicklistModel[], selectionKey?: strin
     });
 }
 
-export function removeSamplesFromPicklist(picklist: PicklistModel, selectionModel: QueryModel): Promise<number> {
+export function removeSamplesFromPicklist(picklist: Picklist, selectionModel: QueryModel): Promise<number> {
     return new Promise((resolve, reject) => {
         const rows = [];
         selectionModel.selections.forEach((id) => {

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -3,15 +3,25 @@ import { Draft, immerable, produce } from 'immer';
 import { User } from '../base/models/User';
 import { PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 import { userCanDeletePublicPicklists, userCanManagePicklists } from '../../app/utils';
+import { flattenValuesFromRow } from '../../../public/QueryModel/utils';
 
 export class PicklistModel {
     [immerable] = true;
 
     readonly Category: string;
     readonly CreatedBy: number;
+    readonly CreatedByDisplay: string;
+    readonly Created: string;
     readonly name: string;
     readonly listId: number;
     readonly Description: string;
+
+    static create(data: any) {
+        return new PicklistModel({
+            ...flattenValuesFromRow(data, Object.keys(data)),
+            CreatedByDisplay: data.CreatedBy?.displayValue,
+        });
+    }
 
     constructor(values?: Partial<PicklistModel>) {
         Object.assign(this, values);

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -5,7 +5,7 @@ import { PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 import { userCanDeletePublicPicklists, userCanManagePicklists } from '../../app/utils';
 import { flattenValuesFromRow } from '../../../public/QueryModel/utils';
 
-export class PicklistModel {
+export class Picklist {
     [immerable] = true;
 
     readonly Category: string;
@@ -17,13 +17,13 @@ export class PicklistModel {
     readonly Description: string;
 
     static create(data: any) {
-        return new PicklistModel({
+        return new Picklist({
             ...flattenValuesFromRow(data, Object.keys(data)),
             CreatedByDisplay: data.CreatedBy?.displayValue,
         });
     }
 
-    constructor(values?: Partial<PicklistModel>) {
+    constructor(values?: Partial<Picklist>) {
         Object.assign(this, values);
     }
 
@@ -47,8 +47,8 @@ export class PicklistModel {
         return this.isUserList(user) || (this.isPublic() && userCanDeletePublicPicklists(user));
     }
 
-    mutate(props: Partial<PicklistModel>): PicklistModel {
-        return produce(this, (draft: Draft<PicklistModel>) => {
+    mutate(props: Partial<Picklist>): Picklist {
+        return produce(this, (draft: Draft<Picklist>) => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -5,6 +5,9 @@ import { PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 import { userCanDeletePublicPicklists, userCanManagePicklists } from '../../app/utils';
 import { flattenValuesFromRow } from '../../../public/QueryModel/utils';
 
+export const PICKLIST_SAMPLE_ID_COLUMN = 'SampleID';
+export const PICKLIST_KEY_COLUMN = 'id';
+
 export class Picklist {
     [immerable] = true;
 

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -18,6 +18,7 @@ export class Picklist {
     readonly name: string;
     readonly listId: number;
     readonly Description: string;
+    readonly ItemCount: number;
 
     static create(data: any) {
         return new Picklist({

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -51,6 +51,10 @@ export class Picklist {
         return this.isUserList(user) || (this.isPublic() && userCanDeletePublicPicklists(user));
     }
 
+    canRemoveItems(user: User): boolean {
+        return this.isUserList(user) || (this.isPublic() && userCanManagePicklists(user));
+    }
+
     mutate(props: Partial<Picklist>): Picklist {
         return produce(this, (draft: Draft<Picklist>) => {
             Object.assign(draft, props);

--- a/packages/components/src/internal/components/samples/SampleCreationTypeModal.tsx
+++ b/packages/components/src/internal/components/samples/SampleCreationTypeModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, FormControl, Modal } from 'react-bootstrap';
+import classNames from 'classnames';
 
 import { MAX_EDITABLE_GRID_ROWS } from '../../../index';
 
@@ -22,6 +23,9 @@ interface State {
 }
 
 export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
+
+    private readonly _maxPerParent;
+
     constructor(props: Props) {
         super(props);
 
@@ -30,6 +34,7 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
             numPerParent: 1,
             submitting: false,
         };
+        this._maxPerParent = MAX_EDITABLE_GRID_ROWS / props.parentCount;
     }
 
     onCancel = () => {
@@ -37,26 +42,32 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
     };
 
     onChange = event => {
-        const { name, value } = event.target;
-        this.setState({ [name]: value } as State);
+        const {name, value} = event.target;
+        this.setState({[name]: value} as State);
     };
 
+    isValidNumPerParent() {
+        const {numPerParent} = this.state;
+
+        return numPerParent >= 1 && (numPerParent <= this._maxPerParent);
+    }
+
     renderNumPerParent(): React.ReactNode {
-        const { parentCount, options } = this.props;
-        const { creationType, numPerParent } = this.state;
+        const {parentCount, options} = this.props;
+        const {creationType, numPerParent} = this.state;
 
         const selectedOption = options.find(option => option.type === creationType);
         const noun = creationType === SampleCreationType.Aliquots ? 'Aliquot' : 'Sample';
         return (
             <>
-                {this.shouldDisplayOptions() && <hr />}
+                {this.shouldDisplayOptions() && <hr/>}
                 <div>
                     <label className="creation-type-modal-label">{selectedOption.quantityLabel}</label>
                     <label className="creation-type-modal-label">
                         <FormControl
-                            className="creation-per-parent-select"
+                            className={classNames('creation-per-parent-select', {'has-error': !this.isValidNumPerParent()})}
                             min={1}
-                            max={MAX_EDITABLE_GRID_ROWS / parentCount}
+                            max={this._maxPerParent}
                             step={1}
                             name="numPerParent"
                             onChange={this.onChange}
@@ -87,7 +98,7 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
     }
 
     renderOptions(): React.ReactNode[] {
-        const { showIcons, options } = this.props;
+        const {showIcons} = this.props;
         const displayOptions = this.getOptionsToDisplay();
         if (displayOptions.length < 2) return null;
 
@@ -111,7 +122,7 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
         const { submitting, numPerParent } = this.state;
 
         const parentNoun = parentCount > 1 ? 'Parents' : 'Parent';
-        const canSubmit = !submitting && numPerParent > 0;
+        const canSubmit = !submitting && this.isValidNumPerParent();
         const title = 'Create Samples from Selected ' + parentNoun;
         return (
             <Modal show={show} onHide={this.onCancel}>

--- a/packages/components/src/internal/components/samples/SampleCreationTypeModal.tsx
+++ b/packages/components/src/internal/components/samples/SampleCreationTypeModal.tsx
@@ -23,7 +23,6 @@ interface State {
 }
 
 export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
-
     private readonly _maxPerParent;
 
     constructor(props: Props) {
@@ -49,7 +48,7 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
     isValidNumPerParent() {
         const {numPerParent} = this.state;
 
-        return numPerParent >= 1 && (numPerParent <= this._maxPerParent);
+        return numPerParent >= 1 && numPerParent <= this._maxPerParent;
     }
 
     renderNumPerParent(): React.ReactNode {
@@ -65,7 +64,9 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
                     <label className="creation-type-modal-label">{selectedOption.quantityLabel}</label>
                     <label className="creation-type-modal-label">
                         <FormControl
-                            className={classNames('creation-per-parent-select', {'has-error': !this.isValidNumPerParent()})}
+                            className={classNames('creation-per-parent-select', {
+                                'has-error': !this.isValidNumPerParent(),
+                            })}
                             min={1}
                             max={this._maxPerParent}
                             step={1}

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -102,6 +102,11 @@ export const LIST_METADATA_TABLES = {
     PICKLISTS: SchemaQuery.create(LIST_METADATA_SCHEMA, 'Picklists'),
 };
 
+const PICKLIST_SCHEMA = 'lists';
+export const PICKLIST_TABLES = {
+    SCHEMA: PICKLIST_SCHEMA,
+};
+
 export const SCHEMAS = {
     ASSAY_TABLES,
     EXP_TABLES,
@@ -112,6 +117,7 @@ export const SCHEMAS = {
     STUDY_TABLES,
     INVENTORY,
     LIST_METADATA_TABLES,
+    PICKLIST_TABLES,
 };
 
 export function fetchSchemas(schemaName?: string): Promise<List<Map<string, SchemaDetails>>> {

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
+import { capitalizeFirstChar } from './utils';
 
 export function getActionErrorMessage(
     problemStatement: string,
@@ -66,4 +67,13 @@ export function resolveErrorMessage(error: any, noun: string = 'data', nounPlura
         }
     }
     return errorMsg;
+}
+
+export function getConfirmDeleteMessage(verbNoun = 'Deletion'): ReactNode {
+    return (
+        <p className="top-spacing">
+            <strong>{capitalizeFirstChar(verbNoun)} cannot be undone.</strong>
+            &nbsp;Do you want to proceed?
+        </p>
+    );
 }

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -1,11 +1,8 @@
 import React, { ReactNode } from 'react';
+
 import { capitalizeFirstChar } from './utils';
 
-export function getActionErrorMessage(
-    problemStatement: string,
-    noun: string,
-    showRefresh: boolean = true
-): React.ReactNode {
+export function getActionErrorMessage(problemStatement: string, noun: string, showRefresh = true): React.ReactNode {
     return (
         <span>
             {problemStatement}
@@ -23,7 +20,7 @@ const IllegalArgumentMessage = 'java.lang.illegalargumentexception:';
 const ClassCastMessage = 'cannot be cast to class';
 const NullPointerExceptionMessage = 'java.lang.nullpointerexception';
 
-export function resolveErrorMessage(error: any, noun: string = 'data', nounPlural?: string, verb?: string): string {
+export function resolveErrorMessage(error: any, noun = 'data', nounPlural?: string, verb?: string): string {
     let errorMsg;
     if (!error) {
         return undefined;
@@ -44,26 +41,40 @@ export function resolveErrorMessage(error: any, noun: string = 'data', nounPlura
             lcMessage.indexOf('violation of unique key constraint') >= 0 ||
             lcMessage.indexOf('cannot insert duplicate key row') >= 0
         ) {
-            return `There was a problem ${verb || 'creating'} your ${noun || 'data'}.  Check the existing ${nounPlural || noun} for possible duplicates and make sure any referenced ${nounPlural || noun} are still valid.`;
+            return `There was a problem ${verb || 'creating'} your ${noun || 'data'}.  Check the existing ${
+                nounPlural || noun
+            } for possible duplicates and make sure any referenced ${nounPlural || noun} are still valid.`;
         } else if (lcMessage.indexOf('bad sql grammar') >= 0 || lcMessage.indexOf(ClassCastMessage) >= 0) {
-            return `There was a problem ${verb || 'creating'} your ${noun || 'data'}.  Check that the format of the data matches the expected type for each field.`;
+            return `There was a problem ${verb || 'creating'} your ${
+                noun || 'data'
+            }.  Check that the format of the data matches the expected type for each field.`;
         } else if (lcMessage.indexOf('existing row was not found') >= 0) {
-            return `We could not find the ${noun || 'data'} ${verb ? 'to ' + verb : ''}.  Try refreshing your page to see if it has been deleted.`;
+            return `We could not find the ${noun || 'data'} ${
+                verb ? 'to ' + verb : ''
+            }.  Try refreshing your page to see if it has been deleted.`;
         } else if (
             lcMessage.indexOf('communication failure') >= 0 ||
             lcMessage.match(/query.*in schema.*doesn't exist/) !== null ||
             lcMessage.match(/query.*in schema.*does not exist/) !== null
         ) {
-            return `There was a problem ${verb || 'retrieving'} your ${noun || 'data'}. Your session may have expired or the ${noun || 'data'} may no longer be valid.  Try refreshing your page.`;
+            return `There was a problem ${verb || 'retrieving'} your ${
+                noun || 'data'
+            }. Your session may have expired or the ${
+                noun || 'data'
+            } may no longer be valid.  Try refreshing your page.`;
         } else if (lcMessage.indexOf('either rowid or lsid is required') >= 0) {
-            return `There was a problem ${verb || 'retrieving or updating'} your ${noun || 'data'}.  The request did not contain the proper identifiers.  Make sure the ${noun || 'data'} are still valid.`;
+            return `There was a problem ${verb || 'retrieving or updating'} your ${
+                noun || 'data'
+            }.  The request did not contain the proper identifiers.  Make sure the ${noun || 'data'} are still valid.`;
         } else if (lcMessage.indexOf(IllegalArgumentMessage) >= 0) {
             const startIndex = lcMessage.indexOf(IllegalArgumentMessage);
             return errorMsg.substring(startIndex + IllegalArgumentMessage.length).trim();
         } else if (lcMessage.indexOf('at least one of "file", "runfilepath", or "datarows" is required') >= 0) {
             return `No data provided for ${verb || 'import'}.`;
         } else if (lcMessage.indexOf(NullPointerExceptionMessage) >= 0) {
-            return `There was a problem ${verb || 'processing'} your ${noun || 'data'}. This may be a problem in the application. Contact your administrator.`;
+            return `There was a problem ${verb || 'processing'} your ${
+                noun || 'data'
+            }. This may be a problem in the application. Contact your administrator.`;
         }
     }
     return errorMsg;

--- a/packages/components/src/public/QueryModel/ExportMenu.tsx
+++ b/packages/components/src/public/QueryModel/ExportMenu.tsx
@@ -62,11 +62,11 @@ export class ExportMenu extends PureComponent<ExportMenuProps> {
                                 if (option.type === EXPORT_TYPES.LABEL) {
                                     return (
                                         <>
-                                            <MenuItem header>
+                                            <MenuItem key={option.type + '_header'} header>
                                                 Export and Print {model.selections?.size > 0 ? 'Selected' : ''}
                                             </MenuItem>
-                                            <MenuItem onClick={() => this.export(option)}>
-                                                <span className={`fa ${option.icon} export-menu-icon`} />
+                                            <MenuItem key={option.type} onClick={() => this.export(option)}>
+                                                <span className={`fa ${option.icon} export-menu-icon`}/>
                                                 &nbsp; {option.label}
                                             </MenuItem>
                                         </>

--- a/packages/components/src/public/SchemaQuery.ts
+++ b/packages/components/src/public/SchemaQuery.ts
@@ -101,7 +101,7 @@ export class SchemaQuery extends Record({
 
         return {
             keys,
-            schemaQuery: getSchemaQuery(schemaQueryKey),
+            schemaQuery: schemaQueryKey ? getSchemaQuery(schemaQueryKey) : undefined,
         };
     }
 

--- a/packages/components/src/test/data/users.ts
+++ b/packages/components/src/test/data/users.ts
@@ -79,6 +79,7 @@ export const TEST_USER_EDITOR = new User({
         PermissionTypes.Read,
         PermissionTypes.Insert,
         PermissionTypes.Update,
+        PermissionTypes.ManagePicklists
     ]),
 });
 

--- a/packages/components/src/test/data/users.ts
+++ b/packages/components/src/test/data/users.ts
@@ -79,7 +79,7 @@ export const TEST_USER_EDITOR = new User({
         PermissionTypes.Read,
         PermissionTypes.Insert,
         PermissionTypes.Update,
-        PermissionTypes.ManagePicklists
+        PermissionTypes.ManagePicklists,
     ]),
 });
 

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -1,0 +1,33 @@
+
+.choice-details,
+.choose-items-tabs {
+    margin-top: 20px;
+}
+
+.choice-details__name {
+    font-size: 18px;
+    color: #777777;
+}
+
+.choice-metadata-item {
+    margin: 4px 0;
+}
+
+.choice-metadata-item__name {
+    margin-right: 8px;
+    color: #777777;
+}
+
+.choices-list {
+    height: 401px; // 10 items plus their borders
+    overflow: auto;
+}
+
+.choices-list .list-group-item .fa {
+    margin-right: 6px;
+}
+
+.choices-list__empty-message {
+    margin-top: 16px;
+    font-style: italic;
+}

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -4,6 +4,10 @@
     margin-top: 20px;
 }
 
+.choice-details > div {
+    margin-top: 16px;
+}
+
 .choice-details__name {
     font-size: 18px;
     color: #777777;

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -10,7 +10,7 @@
 
 .choice-details__name {
     font-size: 18px;
-    color: #777777;
+    color: $gray-light;
 }
 
 .choice-metadata-item {
@@ -19,7 +19,7 @@
 
 .choice-metadata-item__name {
     margin-right: 8px;
-    color: #777777;
+    color: $gray-light;
 }
 
 .choices-list {

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -27,7 +27,27 @@
     margin-right: 6px;
 }
 
+.choices-detail__empty-message,
 .choices-list__empty-message {
     margin-top: 16px;
     font-style: italic;
+}
+
+.picklist-items__sample-type {
+    margin-left: 16px;
+}
+
+.picklist-items__item-count {
+    float: right;
+    text-align: right;
+}
+
+.picklist-items__header {
+    margin-bottom: 8px;
+    font-weight: bold;
+}
+
+.picklist-items__row {
+    margin-bottom: 5px;
+    width: 75%;
 }

--- a/packages/components/src/theme/index.scss
+++ b/packages/components/src/theme/index.scss
@@ -31,6 +31,7 @@
 @import "fields";
 @import "paging";
 @import "detail";
+@import "choiceList";
 @import "samples";
 @import "entities";
 @import "search";

--- a/packages/components/src/theme/samples.scss
+++ b/packages/components/src/theme/samples.scss
@@ -29,7 +29,7 @@
 .creation-type {
     padding: 8px;
     &.selected {
-        background: $blue-bkgrd-selected
+        background: $blue-bkgrd-selected;
     }
 }
 
@@ -39,6 +39,10 @@
     margin-bottom: 5px;
     margin-left: 15px;
     width: 100px;
+
+    &.has-error {
+        border-color: $red-border;
+    }
 }
 
 .creation-type-icon {


### PR DESCRIPTION
#### Rationale
For LKSM we are adding the ability to create picklists of samples and various actions on these collections of samples. We need menu items and modals to support this.

#### Related Pull Requests
* TBD

#### Changes
* Add AddToPicklistMenuItem that incorporates a new ChoosePicklistModal and actions
* Add styling (lifted from ELN notebooks stylings) for choice panels in modal.
* Update `getSelection` so you can pass in a `queryName` and `schemaName` and not have to parse the selection key
* Add utility method `getCofirmDeleteMessage`