### PR TITLE
LP: Extract Reusable Styles

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.36.0",
+  "version": "2.37.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.3#.#
-*Released*: ## May 2021
+### version 2.37.0
+*Released*: 28 May 2021
 * Define new Content Panel variant `panel-content` in `panel.scss`.
 * Update `<Section/>` component to make use of standard `panel-content` layout.
 * Define new Content Tabs styling `content-tabs` in `tabs.scss`.
@@ -17,17 +17,17 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Better handling when no specialty assays available in assay picker, including warning.
 * Upsell message in the assay picker is a candidate to be it's own component should we need further upsell messages.
 
-###  version 2.34.0
-*Release*: 26 May 2021
+### version 2.34.0
+*Released*: 26 May 2021
 * Add autoFocus prop to SelectInput
 
 ### version 2.33.1
-*Release*: 25 May 2021
+*Released*: 25 May 2021
 * Update SingleParentEntityPanel to handle multiple data source types
 * Update ParentEntityEditPanel to handle multiple data sources and not require a full model
 
 ### version 2.33.0
-*Release*: 25 May 2021
+*Released*: 25 May 2021
 * Add support for modifying the items in a picklist
     * Add AddToPicklistMenuItem that incorporates a new ChoosePicklistModal and actions
     * Add styling (lifted from ELN notebooks stylings) for choice panels in modal.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,12 +1,18 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.3#.#
+*Released*: ## May 2021
+* Define new Content Panel variant `panel-content` in `panel.scss`.
+* Update `<Section/>` component to make use of standard `panel-content` layout.
+* Define new Content Tabs styling `content-tabs` in `tabs.scss`.
+
 ### version 2.36.0
 *Released*: 28 May 2021
 * Item 8897: Remove default session event listeners from initWebSocketListeners (and rename it to registerWebSocketListeners)
 
 ### version 2.35.0
-*Release*: 27 May 2021
+*Released*: 27 May 2021
 * Specialty assays moved to premium module. Assay picker now has option to show upsell message.
 * Better handling when no specialty assays available in assay picker, including warning.
 * Upsell message in the assay picker is a candidate to be it's own component should we need further upsell messages.

--- a/packages/components/src/internal/components/base/Section.spec.tsx
+++ b/packages/components/src/internal/components/base/Section.spec.tsx
@@ -20,21 +20,19 @@ import { Section } from './Section';
 
 describe('<Section />', () => {
     test('default properties', () => {
-        const tree = renderer.create(<Section />).toJSON();
+        const tree = renderer.create(<Section />);
         expect(tree).toMatchSnapshot();
     });
 
     test('custom properties', () => {
-        const tree = renderer
-            .create(
-                <Section
-                    caption={<p>Testing Caption</p>}
-                    context={<div>Testing Context</div>}
-                    title="Testing Title"
-                    panelClassName="testing-class-name"
-                />
-            )
-            .toJSON();
+        const tree = renderer.create(
+            <Section
+                caption={<p>Testing Caption</p>}
+                context={<div>Testing Context</div>}
+                title="Testing Title"
+                panelClassName="testing-class-name"
+            />
+        );
         expect(tree).toMatchSnapshot();
     });
 });

--- a/packages/components/src/internal/components/base/Section.tsx
+++ b/packages/components/src/internal/components/base/Section.tsx
@@ -13,50 +13,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { FC, ReactNode } from 'react';
 
 interface SectionProps {
-    caption?: React.ReactNode;
-    context?: React.ReactNode;
+    caption?: ReactNode;
+    context?: ReactNode;
     panelClassName?: string;
     titleClassName?: string;
     titleContainerClassName?: string;
-    title?: string;
-    titleSize?: string;
+    title?: ReactNode;
+    titleSize?: 'large' | 'medium';
 }
 
-export class Section extends React.PureComponent<SectionProps> {
-    static defaultProps = {
-        titleSize: 'large',
-    };
+export const Section: FC<SectionProps> = props => {
+    const {
+        panelClassName,
+        titleClassName,
+        titleContainerClassName,
+        title,
+        titleSize = 'large',
+        context,
+        caption,
+        children,
+    } = props;
 
-    render() {
-        const {
-            panelClassName,
-            titleClassName,
-            titleContainerClassName,
-            title,
-            titleSize,
-            context,
-            caption,
-            children,
-        } = this.props;
-        const titleContainerCls = titleContainerClassName || 'section-panel--title-container-' + titleSize;
-        return (
-            <div className="g-section">
-                <div className={`panel panel-default ${panelClassName ? panelClassName : ''}`}>
-                    <div className="panel-body">
-                        <div className={title ? titleContainerCls : ''}>
+    const showHeader = !!title || !!caption || !!context;
+
+    return (
+        <div className="g-section">
+            <div className={`panel panel-content ${panelClassName ? panelClassName : ''}`}>
+                {showHeader && (
+                    <div className={`panel-heading panel-content-flex panel-content-${titleSize}`}>
+                        <div
+                            className={`panel-content-title-container ${
+                                titleContainerClassName ? titleContainerClassName : ''
+                            }`}
+                        >
                             {title && (
-                                <div className={titleClassName || 'section-panel--title-' + titleSize}>{title}</div>
+                                <div
+                                    className={`panel-content-title-${titleSize} ${
+                                        titleClassName ? titleClassName : ''
+                                    }`}
+                                >
+                                    {title}
+                                </div>
                             )}
-                            {context && <div className="pull-right">{context}</div>}
-                            {caption && <div className={'section-panel--title-caption-' + titleSize}>{caption}</div>}
+                            {caption && <div className="panel-content-caption">{caption}</div>}
                         </div>
-                        {children}
+                        {context && <div className="panel-content-context">{context}</div>}
                     </div>
-                </div>
+                )}
+                <div className="panel-body">{children}</div>
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
+
+Section.displayName = 'Section';

--- a/packages/components/src/internal/components/base/__snapshots__/Section.spec.tsx.snap
+++ b/packages/components/src/internal/components/base/__snapshots__/Section.spec.tsx.snap
@@ -5,35 +5,38 @@ exports[`<Section /> custom properties 1`] = `
   className="g-section"
 >
   <div
-    className="panel panel-default testing-class-name"
+    className="panel panel-content testing-class-name"
   >
     <div
-      className="panel-body"
+      className="panel-heading panel-content-flex panel-content-large"
     >
       <div
-        className="section-panel--title-container-large"
+        className="panel-content-title-container "
       >
         <div
-          className="section-panel--title-large"
+          className="panel-content-title-large "
         >
           Testing Title
         </div>
         <div
-          className="pull-right"
-        >
-          <div>
-            Testing Context
-          </div>
-        </div>
-        <div
-          className="section-panel--title-caption-large"
+          className="panel-content-caption"
         >
           <p>
             Testing Caption
           </p>
         </div>
       </div>
+      <div
+        className="panel-content-context"
+      >
+        <div>
+          Testing Context
+        </div>
+      </div>
     </div>
+    <div
+      className="panel-body"
+    />
   </div>
 </div>
 `;
@@ -43,15 +46,11 @@ exports[`<Section /> default properties 1`] = `
   className="g-section"
 >
   <div
-    className="panel panel-default "
+    className="panel panel-content "
   >
     <div
       className="panel-body"
-    >
-      <div
-        className=""
-      />
-    </div>
+    />
   </div>
 </div>
 `;

--- a/packages/components/src/internal/components/pipeline/__snapshots__/PipelineStatusDetailPage.spec.tsx.snap
+++ b/packages/components/src/internal/components/pipeline/__snapshots__/PipelineStatusDetailPage.spec.tsx.snap
@@ -15,20 +15,24 @@ Array [
     className="g-section"
   >
     <div
-      className="panel panel-default pipeline-job-status-detail"
+      className="panel panel-content pipeline-job-status-detail"
     >
       <div
-        className="panel-body"
+        className="panel-heading panel-content-flex panel-content-medium"
       >
         <div
-          className="section-panel--title-container-medium"
+          className="panel-content-title-container "
         >
           <div
-            className="section-panel--title-medium"
+            className="panel-content-title-medium "
           >
             Status
           </div>
         </div>
+      </div>
+      <div
+        className="panel-body"
+      >
         <table>
           <tbody>
             <tr
@@ -71,20 +75,24 @@ Array [
     className="g-section"
   >
     <div
-      className="panel panel-default pipeline-job-status-log"
+      className="panel panel-content pipeline-job-status-log"
     >
       <div
-        className="panel-body"
+        className="panel-heading panel-content-flex panel-content-medium"
       >
         <div
-          className="section-panel--title-container-medium"
+          className="panel-content-title-container "
         >
           <div
-            className="section-panel--title-medium"
+            className="panel-content-title-medium "
           >
             Log
           </div>
         </div>
+      </div>
+      <div
+        className="panel-body"
+      >
         <table>
           <tbody>
             <tr
@@ -194,20 +202,24 @@ Array [
     className="g-section"
   >
     <div
-      className="panel panel-default pipeline-job-status-detail"
+      className="panel panel-content pipeline-job-status-detail"
     >
       <div
-        className="panel-body"
+        className="panel-heading panel-content-flex panel-content-medium"
       >
         <div
-          className="section-panel--title-container-medium"
+          className="panel-content-title-container "
         >
           <div
-            className="section-panel--title-medium"
+            className="panel-content-title-medium "
           >
             Status
           </div>
         </div>
+      </div>
+      <div
+        className="panel-body"
+      >
         <table>
           <tbody>
             <tr
@@ -250,20 +262,24 @@ Array [
     className="g-section"
   >
     <div
-      className="panel panel-default pipeline-job-status-log"
+      className="panel panel-content pipeline-job-status-log"
     >
       <div
-        className="panel-body"
+        className="panel-heading panel-content-flex panel-content-medium"
       >
         <div
-          className="section-panel--title-container-medium"
+          className="panel-content-title-container "
         >
           <div
-            className="section-panel--title-medium"
+            className="panel-content-title-medium "
           >
             Log
           </div>
         </div>
+      </div>
+      <div
+        className="panel-body"
+      >
         <table>
           <tbody>
             <tr
@@ -328,20 +344,24 @@ Array [
     className="g-section"
   >
     <div
-      className="panel panel-default pipeline-job-status-detail"
+      className="panel panel-content pipeline-job-status-detail"
     >
       <div
-        className="panel-body"
+        className="panel-heading panel-content-flex panel-content-medium"
       >
         <div
-          className="section-panel--title-container-medium"
+          className="panel-content-title-container "
         >
           <div
-            className="section-panel--title-medium"
+            className="panel-content-title-medium "
           >
             Status
           </div>
         </div>
+      </div>
+      <div
+        className="panel-body"
+      >
         <table>
           <tbody>
             <tr
@@ -384,20 +404,24 @@ Array [
     className="g-section"
   >
     <div
-      className="panel panel-default pipeline-job-status-log"
+      className="panel panel-content pipeline-job-status-log"
     >
       <div
-        className="panel-body"
+        className="panel-heading panel-content-flex panel-content-medium"
       >
         <div
-          className="section-panel--title-container-medium"
+          className="panel-content-title-container "
         >
           <div
-            className="section-panel--title-medium"
+            className="panel-content-title-medium "
           >
             Log
           </div>
         </div>
+      </div>
+      <div
+        className="panel-body"
+      >
         <table>
           <tbody>
             <tr

--- a/packages/components/src/theme/index.scss
+++ b/packages/components/src/theme/index.scss
@@ -53,3 +53,5 @@
 @import "product-navigation";
 @import "ontologybrowser";
 @import "attachment-card";
+@import "panel";
+@import "tabs";

--- a/packages/components/src/theme/panel.scss
+++ b/packages/components/src/theme/panel.scss
@@ -1,0 +1,41 @@
+.panel-content {
+    @include panel-variant($panel-content-border, $panel-content-text, $panel-content-heading-bg, $panel-content-border);
+
+    & > .panel-heading {
+        border-bottom: 1px solid #ddd;
+        margin: 15px 15px 0 15px;
+        padding: 0;
+
+        & > div {
+            margin-bottom: 8px;
+        }
+
+        &.panel-content-flex {
+            display: flex;
+            justify-content: space-between;
+        }
+
+        &.panel-content-large {
+            margin-bottom: 32px;
+        }
+
+        .panel-content-title-container {
+            display: inline-block;
+        }
+
+        .panel-content-title,
+        .panel-content-title-medium {
+            display: inline-block;
+            font-size: 18px;
+        }
+
+        .panel-content-title-large {
+            display: inline-block;
+            font-size: 28px;
+        }
+
+        .panel-content-caption {
+            font-weight: 300;
+        }
+    }
+}

--- a/packages/components/src/theme/panel.scss
+++ b/packages/components/src/theme/panel.scss
@@ -2,7 +2,7 @@
     @include panel-variant($panel-content-border, $panel-content-text, $panel-content-heading-bg, $panel-content-border);
 
     & > .panel-heading {
-        border-bottom: 1px solid #ddd;
+        border-bottom: 1px solid $panel-content-border;
         margin: 15px 15px 0 15px;
         padding: 0;
 

--- a/packages/components/src/theme/section.scss
+++ b/packages/components/src/theme/section.scss
@@ -59,33 +59,6 @@
     color: darkgray
 }
 
-.section-panel--title-container-large {
-    border-bottom: 2px solid #cccccc;
-    margin-bottom: 30px;
-}
-
-.section-panel--title-large {
-    display: inline-block;
-    font-size: 200%;
-    margin-bottom: 8px;
-}
-
-.section-panel--title-caption-large, .section-panel--title-caption-medium {
-    font-weight: 300;
-    margin-bottom: 8px;
-}
-
-.section-panel--title-container-medium {
-    border-bottom: 2px solid #cccccc;
-    margin-bottom: 15px;
-}
-
-.section-panel--title-medium {
-    display: inline-block;
-    color: $gray;
-    margin-bottom: 8px;
-}
-
 .alert {
     .alert-button {
         padding: 0 12px;

--- a/packages/components/src/theme/section.scss
+++ b/packages/components/src/theme/section.scss
@@ -82,7 +82,6 @@
 
 .section-panel--title-medium {
     display: inline-block;
-    font-size: 125%;
     color: $gray;
     margin-bottom: 8px;
 }

--- a/packages/components/src/theme/tabs.scss
+++ b/packages/components/src/theme/tabs.scss
@@ -1,0 +1,33 @@
+.section-tabs {
+    .nav-tabs {
+        border-bottom: 0;
+        display: flex;
+
+        & > li {
+            flex: auto;
+
+            &:first-child {
+                max-width: 50%;
+            }
+
+            & > a {
+                background-color: inherit;
+                border: 3px solid transparent;
+                color: #999999;
+                font-weight: bold;
+                text-align: center;
+                text-transform: uppercase;
+                white-space: nowrap;
+            }
+        }
+
+        & > li.active {
+
+            & > a {
+                border: 3px solid transparent;
+                border-bottom: 3px solid $brand-secondary;
+                color: $gray-dark;
+            }
+        }
+    }
+}

--- a/packages/components/src/theme/tabs.scss
+++ b/packages/components/src/theme/tabs.scss
@@ -1,4 +1,4 @@
-.section-tabs {
+.content-tabs {
     .nav-tabs {
         border-bottom: 0;
         display: flex;

--- a/packages/components/src/theme/tabs.scss
+++ b/packages/components/src/theme/tabs.scss
@@ -13,7 +13,7 @@
             & > a {
                 background-color: inherit;
                 border: 3px solid transparent;
-                color: #999999;
+                color: $gray-lighten;
                 font-weight: bold;
                 text-align: center;
                 text-transform: uppercase;

--- a/packages/components/src/theme/variables.scss
+++ b/packages/components/src/theme/variables.scss
@@ -3,21 +3,22 @@ $white: #fff;
 
 $gray-base:              #000 !default;
 $gray-darker:            lighten($gray-base, 13.5%) !default; // #222
-$gray-dark:              lighten($gray-base, 20%) !default;   // #333
+$gray-dark:              lighten($gray-base, 20%)   !default; // #333
 $gray:                   lighten($gray-base, 33.5%) !default; // #555
 $gray-light:             lighten($gray-base, 46.7%) !default; // #777
+$gray-lighten:           lighten($gray-base, 60%)   !default; // #999
 $gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
 
 //TODO: how to set or get these from the app instead or make sure the app can override them?
-$brand-danger: #d9534f;
-$brand-warning: #f0ad4e;
-$brand-primary: #2980b9;
+$brand-danger:    #d9534f;
+$brand-warning:   #f0ad4e;
+$brand-primary:   #2980b9;
 $brand-secondary: #236fa0;
-$brand-success: #5cb85c;
-$border-color: #cccccc;
+$brand-success:   #5cb85c;
+$border-color:    #cccccc;
 
-$blue-highlight: #2980B9;
-$gray-no-highlight: #999999;
+$blue-highlight:       #2980B9;
+$gray-no-highlight:    $gray-lighten;
 $blue-icon-background: #CCE5FF;
 
 $text-color:            $gray-dark !default;
@@ -26,7 +27,8 @@ $link-hover-color:      darken($brand-primary, 15%) !default;
 $font-family-sans-serif:  "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 
 // Domain properties variables
-$gray-border:           #CCC;
+$gray-border:           #cccccc;
+$gray-border-light:     #dddddd;
 $gray-shadow:           #F3F3F4;
 
 $red-border:            rgba(220, 53, 69, 1);
@@ -110,13 +112,13 @@ $omnibox-item-disabled-border-color: darken($omnibox-item-disabled-bg, 10%);
 // Navigation variables
 
 //-- Z-index master list
-$zindex-navbar:            1000 !default;
+$zindex-navbar: 1000 !default;
 
 $footer-height: 40px;
 $header-height: 62px;
 $header-spacing-no-scroll: 104px;
 
 // Panels
-$panel-content-text: #333333 !default;
-$panel-content-border: #dddddd !default;
+$panel-content-text: $text-color !default;
+$panel-content-border: $gray-border-light !default;
 $panel-content-heading-bg: $white !default;

--- a/packages/components/src/theme/variables.scss
+++ b/packages/components/src/theme/variables.scss
@@ -115,3 +115,8 @@ $zindex-navbar:            1000 !default;
 $footer-height: 40px;
 $header-height: 62px;
 $header-spacing-no-scroll: 104px;
+
+// Panels
+$panel-content-text: #333333 !default;
+$panel-content-border: #dddddd !default;
+$panel-content-heading-bg: $white !default;


### PR DESCRIPTION
This is a pass at coalescing some reusable styling for use in our apps. This introduces two concepts specifically and refactors the `<Section/>` component to make use of one of them.

### Content Panels
The design team started introducing an alternative look for panels/sections in our apps starting with LKSM. This work codifies this into a new Bootstrap panel variant `panel-content` (like `panel-default`, `panel-success`, etc). This panel design is intended to be reusable either via a component, namely `<Section/>` which has been updated to use `panel-content`, or directly via CSS if more custom layout is needed by applying `panel panel-content` and the defacto panel sub-sections accepted by Bootstrap's conventions. Example markup:

```html
<div class="panel panel-content">
    <div class="panel-heading">
        <div class="panel-content-title">Title</div>
        <div class="panel-content-caption">This is a caption</div>
    </div>
    <!-- body -->
    <!-- footer -->
</div>
```

Here is a basic example from storybook using the `<Section/>` component:

![image](https://user-images.githubusercontent.com/3926239/119896461-e6984000-bef3-11eb-909c-eef4b8ed5322.png)

As you can see this very much echoes what Section's looked like previously with only some minor changes to meet current design specification.

### Content Tabs
Content tabs are an alternative tab styling that are intended to be used to break up functions or functional groups. These will look familiar from ELN:

![image](https://user-images.githubusercontent.com/3926239/119894049-f95d4580-bef0-11eb-9dab-35b4224b03e6.png)

Here you can see them being reused in FM:

![image](https://user-images.githubusercontent.com/3926239/119893872-c31fc600-bef0-11eb-9522-6d4c694dc8f8.png)

These are implemented as restylized Bootstrap tabs. They can be applied by adding the CSS class `content-tabs` to any container of Bootstrap `nav-tabs`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/541
* https://github.com/LabKey/biologics/pull/897
* https://github.com/LabKey/sampleManagement/pull/581
* https://github.com/LabKey/inventory/pull/248

#### Changes
* Define new Content Panel variant `panel-content` in `panel.scss`.
* Update `<Section/>` component to make use of standard `panel-content` layout.
* Define new Content Tabs styling in `tabs.scss`.
