### PR TITLE
GridPanel.omniBoxChange fix for JS error on removing action text

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.42.0",
+  "version": "2.42.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.0",
+  "version": "2.41.0-fb-gridPanelOmniboxChangeFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.42.1
+*Released*: 8 June 2021
 * GridPanel.omniBoxChange fix for JS error on removing action text
 
 ### version 2.42.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* GridPanel.omniBoxChange fix for JS error on removing action text
+
 ### version 2.41.0
 *Released*: 2 June 2021
 * Issue 43131: Files added to Sample Types show a path to "sampleset"

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -489,9 +489,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             keyword = this.state.actionValues[change.index]?.action.keyword;
         }
 
-        if (keyword) {
-            this.omniBoxChangeHandlers[keyword](actionValues, change);
-        }
+        this.omniBoxChangeHandlers[keyword]?.(actionValues, change);
     };
 
     /**

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -486,10 +486,12 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         if (change.type === ChangeType.add || change.type === ChangeType.modify) {
             keyword = actionValues[actionValues.length - 1].action.keyword;
         } else {
-            keyword = this.state.actionValues[change.index].action.keyword;
+            keyword = this.state.actionValues[change.index]?.action.keyword;
         }
 
-        this.omniBoxChangeHandlers[keyword](actionValues, change);
+        if (keyword) {
+            this.omniBoxChangeHandlers[keyword](actionValues, change);
+        }
     };
 
     /**


### PR DESCRIPTION
#### Rationale
Repro: From a GridPanel in one of the apps, click to get list of 4 actions (i.e. Filter, Search, Sort, etc.), click one (i.e. “Filter”) then delete the action text in the omnibox with the backspace/delete key.
Result: Uncaught TypeError: Cannot read property 'action' of undefined

#### Changes
* Add JS checks in GridPanel.omniBoxChange to prevent JS error when keyword can't be found
