### PR TITLE
Remove LK_MODULE & LK_MODULE_CONTAINER build vars

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "3.1.0-fb-remove-build-vars.2",
+  "version": "3.1.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "3.1.0-fb-remove-build-vars.1",
+  "version": "3.1.0-fb-remove-build-vars.2",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "3.0.0",
+  "version": "3.1.0-fb-remove-build-vars.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "3.1.0-fb-remove-build-vars.0",
+  "version": "3.1.0-fb-remove-build-vars.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
 ### version 3.1.0
-*Released*: ? June 2021
+*Released*: 3 June 2021
 * Use current working directory to determine module name and modules directory
     * This removes the need for LK_MODULE and LK_MODULE_CONTAINER build vars
 

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,10 @@
 # @labkey/build
 
+### version 3.1.0
+*Released*: ? June 2021
+* Use current working directory to determine module name and modules directory
+    * This removes the need for LK_MODULE and LK_MODULE_CONTAINER build vars
+
 ### version 3.0.0
 *Released*: 1 June 2021
 * Package updates

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -234,9 +234,7 @@ module.exports = {
             '@labkey/workflow-scss': workflowPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
         },
     },
-    outputPath: function(dir) {
-        return path.resolve(dir, '../resources/web/' + lkModule + '/gen');
-    },
+    outputPath: path.resolve('./resources/web/' + lkModule + '/gen'),
     processEntries: function(entryPoints) {
         return entryPoints.apps.reduce((entries, app) => {
             entries[app.name] = app.path + '/app.tsx';

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -145,16 +145,15 @@ const TS_CHECKER_DEV_CONFIG = {
 };
 
 module.exports = {
-    labkeyUIComponentsPath: labkeyUIComponentsPath,
-    freezerManagerPath: freezerManagerPath,
-    workflowPath: workflowPath,
-    tsconfigPath: tsconfigPath,
-    watchPort: watchPort,
-    TS_CHECKER_CONFIG: TS_CHECKER_CONFIG,
-    TS_CHECKER_DEV_CONFIG: TS_CHECKER_DEV_CONFIG,
-    context: function(dir) {
-        return path.resolve(dir, '..');
-    },
+    lkModule,
+    labkeyUIComponentsPath,
+    freezerManagerPath,
+    workflowPath,
+    tsconfigPath,
+    watchPort,
+    TS_CHECKER_CONFIG,
+    TS_CHECKER_DEV_CONFIG,
+    context: path.resolve(lkModule, '..'),
     extensions: {
         TYPESCRIPT: [ '.jsx', '.js', '.tsx', '.ts' ]
     },

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -3,14 +3,19 @@
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
-const lkModule = process.env.LK_MODULE;
-const lkModuleContainer = process.env.LK_MODULE_CONTAINER;
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
-// Conditionalize the path to use for the @labkey packages based on if the user wants to LINK their labkey-ui-components repo.
+const FREEZER_MANAGER_DIRS = ['inventory', 'packages', 'freezermanager', 'src'];
+const WORKFLOW_DIRS = ['sampleManagement', 'packages', 'workflow', 'src'];
+const cwd = path.resolve('./').split(path.sep);
+const lkModule = cwd[cwd.length - 1];
+
+// Default to the @labkey packages in the node_moules directory.
+// If LINK is set we configure the paths of @labkey modules to point to the source files (see below), which enables
+// hot module reload to work across packages.
 // NOTE: the LABKEY_UI_COMPONENTS_HOME environment variable must be set for this to work.
 let labkeyUIComponentsPath = path.resolve('./node_modules/@labkey/components');
 let freezerManagerPath = path.resolve('./node_modules/@labkey/freezermanager');
@@ -23,21 +28,14 @@ if (process.env.LINK) {
     }
 
     labkeyUIComponentsPath = process.env.LABKEY_UI_COMPONENTS_HOME + '/packages/components/src';
+    // lastIndexOf just in case someone is weird and has their LKS deployment under a directory named modules.
+    const lkModulesPath = cwd.slice(0, cwd.lastIndexOf('modules') + 1);
+    freezerManagerPath = lkModulesPath.concat(FREEZER_MANAGER_DIRS).join(path.sep);
+    workflowPath = lkModulesPath.concat(WORKFLOW_DIRS).join(path.sep);
 
-    const freezerManagerRelPath = (lkModuleContainer ? '../../../../../../' : '../../../../../') + 'inventory/packages/freezermanager/src';
-    freezerManagerPath = path.resolve(__dirname, freezerManagerRelPath);
-
-    const workflowRelPath = (lkModuleContainer ? '../../../../../../' : '../../../../../') + 'sampleManagement/packages/workflow/src';
-    workflowPath = path.resolve(__dirname, workflowRelPath);
-}
-if (process.env.npm_package_dependencies__labkey_components) {
-    console.log('Using @labkey/components path: ' + labkeyUIComponentsPath);
-}
-if (process.env.npm_package_dependencies__labkey_freezermanager) {
-    console.log('Using @labkey/freezermanager path: ' + freezerManagerPath);
-}
-if (process.env.npm_package_dependencies__labkey_workflow) {
-    console.log('Using @labkey/workflow path: ' + workflowPath);
+    console.log('Using @labkey/components path:', labkeyUIComponentsPath);
+    console.log('Using @labkey/freezermanager path:', freezerManagerPath);
+    console.log('Using @labkey/workflow path:', workflowPath);
 }
 
 const watchPort = process.env.WATCH_PORT || 3001;

--- a/packages/build/webpack/dev.config.js
+++ b/packages/build/webpack/dev.config.js
@@ -3,15 +3,11 @@
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
-const lkModule = process.env.LK_MODULE;
 const entryPoints = require('../../../../src/client/entryPoints');
 const constants = require('./constants');
 
-// set based on the lk module calling this config
-__dirname = lkModule;
-
 module.exports = {
-    context: constants.context(__dirname),
+    context: constants.context,
 
     mode: 'development',
 
@@ -36,4 +32,3 @@ module.exports = {
 
     plugins: constants.processPlugins(entryPoints),
 };
-

--- a/packages/build/webpack/dev.config.js
+++ b/packages/build/webpack/dev.config.js
@@ -8,27 +8,20 @@ const constants = require('./constants');
 
 module.exports = {
     context: constants.context,
-
     mode: 'development',
-
     devtool: 'eval',
-
     entry: constants.processEntries(entryPoints),
-
     output: {
-        path: constants.outputPath(__dirname),
+        path: constants.outputPath,
         publicPath: './', // allows context path to resolve in both js/css
         filename: '[name].js'
     },
-
     module: {
         rules: constants.loaders.TYPESCRIPT.concat(constants.loaders.STYLE).concat(constants.loaders.FILES),
     },
-
     resolve: {
         alias: constants.aliases.LABKEY_PACKAGES,
         extensions: constants.extensions.TYPESCRIPT
     },
-
     plugins: constants.processPlugins(entryPoints),
 };

--- a/packages/build/webpack/prod.config.js
+++ b/packages/build/webpack/prod.config.js
@@ -3,37 +3,26 @@
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
-const lkModule = process.env.LK_MODULE;
 const entryPoints = require('../../../../src/client/entryPoints');
 const constants = require('./constants');
 
-// set based on the lk module calling this config
-__dirname = lkModule;
-
 module.exports = {
-    context: constants.context(__dirname),
-
+    context: constants.context,
     mode: 'production',
-
     devtool: process.env.PROD_SOURCE_MAP || 'nosources-source-map',
-
     entry: constants.processEntries(entryPoints),
-
     output: {
-        path: constants.outputPath(__dirname),
+        path: constants.outputPath,
         publicPath: './', // allows context path to resolve in both js/css
         filename: '[name].[contenthash].cache.js'
     },
-
     module: {
         rules: constants.loaders.TYPESCRIPT.concat(constants.loaders.STYLE).concat(constants.loaders.FILES),
     },
-
     resolve: {
         alias: constants.aliases.LABKEY_PACKAGES,
         extensions: constants.extensions.TYPESCRIPT
     },
-
     optimization: {
         splitChunks: {
             maxSize: 2 * 1000000, // 2 MB
@@ -46,7 +35,6 @@ module.exports = {
             }
         }
     },
-
     plugins: constants.processPlugins(entryPoints),
 };
 

--- a/packages/build/webpack/watch.config.js
+++ b/packages/build/webpack/watch.config.js
@@ -3,17 +3,12 @@
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
-const lkModule = process.env.LK_MODULE;
 const webpack = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const constants = require('./constants');
 const path = require('path');
-
 // relative to the <lk_module>/node_modules/@labkey/build/webpack dir
 const entryPoints = require('../../../../src/client/entryPoints');
-
-// set based on the lk module calling this config
-__dirname = lkModule;
 
 const devServer = {
     host: 'localhost',
@@ -55,38 +50,30 @@ for (let i = 0; i < entryPoints.apps.length; i++) {
 }
 
 module.exports = {
-    context: constants.context(__dirname),
-
+    context: constants.context,
     mode: 'development',
-
     devServer: devServer,
-
     entry: entries,
-
     output: {
-        path: constants.outputPath(__dirname),
+        path: constants.outputPath,
         publicPath: devServerURL + '/',
         filename: "[name].js"
     },
-
     resolve: {
         alias: {
             ...constants.aliases.LABKEY_PACKAGES_DEV,
             // This assures there is only one copy of react used while doing start-link
-            react: path.resolve(__dirname, "../node_modules/react"),
+            react: path.resolve('./node_modules/react'),
         },
         extensions: constants.extensions.TYPESCRIPT.concat('.scss')
     },
-
     module: {
         rules: constants.loaders.TYPESCRIPT_DEV.concat(constants.loaders.STYLE_DEV).concat(constants.loaders.FILES)
     },
-
     optimization: {
         // do not emit compiled assets that include errors
         emitOnErrors: false,
     },
-
     plugins: [
         new webpack.HotModuleReplacementPlugin(), // enable HMR globally
         // This Plugin type checks our TS code, @babel/preset-typescript does not type check, it only transforms

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.1-fb-remove-build-vars.0",
+  "version": "2.41.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.0",
+  "version": "2.41.1-fb-remove-build-vars.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.41.?
+*Released*: ? June 2021
+* Fix FileSizeLimitProps export
+
 ### version 2.41.0
 *Released*: 2 June 2021
 * Issue 43131: Files added to Sample Types show a path to "sampleset"

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.41.?
-*Released*: ? June 2021
+### version 2.41.1
+*Released*: 3 June 2021
 * Fix FileSizeLimitProps export
 
 ### version 2.41.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -95,7 +95,6 @@ import { FormSection } from './internal/components/base/FormSection';
 import { Section } from './internal/components/base/Section';
 import { FileAttachmentForm } from './public/files/FileAttachmentForm';
 import { DEFAULT_FILE } from './internal/components/files/models';
-import { FileSizeLimitProps } from './public/files/models';
 import { FilesListing } from './internal/components/files/FilesListing';
 import { FilesListingForm } from './internal/components/files/FilesListingForm';
 import { FileAttachmentEntry } from './internal/components/files/FileAttachmentEntry';
@@ -946,7 +945,6 @@ export {
     fetchIssuesListDefDesign,
     // file / webdav related items
     DEFAULT_FILE,
-    FileSizeLimitProps,
     FilesListing,
     FilesListingForm,
     FileAttachmentEntry,
@@ -1179,3 +1177,4 @@ export type {
 } from './internal/app/reducers';
 export type { IAttachment } from './internal/renderers/AttachmentCard';
 export type { Field, FormSchema, Option } from './internal/components/AutoForm';
+export type { FileSizeLimitProps } from './public/files/models';


### PR DESCRIPTION
#### Rationale
This PR changes our build to crawl the path of the current working directory to determine the current module name, as well as the labkey modules directory. This change removes the need for LK_MODULE and LK_MODULE_CONTAINER build vars to be set by the package.json files.

#### Related Pull Requests
* https://github.com/LabKey/assayreport/pull/54
* https://github.com/LabKey/biologics/pull/900
* https://github.com/LabKey/commonAssays/pull/339
* https://github.com/LabKey/inventory/pull/251
* https://github.com/LabKey/platform/pull/2316
* https://github.com/LabKey/puppeteer/pull/14
* https://github.com/LabKey/sampleManagement/pull/585
* https://github.com/LabKey/tutorialModules/pull/56

#### Changes
* Use current working directory to determine module name and modules directory
* Fix FileSizeLimitProps export
