### PR TITLE
43113: Respect QueryInfo show insert/import

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.2-fb-fix-43113.0",
+  "version": "2.42.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.2",
+  "version": "2.41.2-fb-fix-43113.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.4#.#
+*Released*: # June 2021
+* Introduce hasPermissions, hasAnyPermissions utility methods
+* Update `<RequiresPermission/>` component to be configurable for all options
+
 ### version 2.41.2
 *Released*: 4 June 2021
 * [Issue 43264](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43264) Trim field values

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.4#.#
-*Released*: # June 2021
+### version 2.42.0
+*Released*: 7 June 2021
 * Introduce hasPermissions, hasAnyPermissions utility methods
 * Update `<RequiresPermission/>` component to be configurable for all options
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -18,7 +18,7 @@ import { enableMapSet, enablePatches } from 'immer';
 import { AppURL, buildURL, createProductUrl, createProductUrlFromParts, spliceURL } from './internal/url/AppURL';
 import { hasParameter, imageURL, toggleParameter } from './internal/url/ActionURL';
 import { Container } from './internal/components/base/models/Container';
-import { hasAllPermissions, User } from './internal/components/base/models/User';
+import { hasAllPermissions, hasAnyPermissions, hasPermissions, User } from './internal/components/base/models/User';
 import { getSchemaQuery, resolveKey, resolveSchemaQuery, SchemaQuery } from './public/SchemaQuery';
 import { insertColumnFilter, QueryColumn, QueryLookup } from './public/QueryColumn';
 import { QuerySort } from './public/QuerySort';
@@ -737,6 +737,8 @@ export {
     BasePermissionsCheckPage,
     RequiresPermission,
     hasAllPermissions,
+    hasAnyPermissions,
+    hasPermissions,
     fetchContainerSecurityPolicy,
     PermissionAssignments,
     PermissionsPageContextProvider,

--- a/packages/components/src/internal/QueryGridModel.ts
+++ b/packages/components/src/internal/QueryGridModel.ts
@@ -502,15 +502,11 @@ export class QueryGridModel
     }
 
     showImportDataButton(): boolean {
-        const query = this.queryInfo;
-
-        return query && query.showInsertNewButton && query.importUrl && !query.importUrlDisabled;
+        return !!this.queryInfo?.getShowImportDataButton();
     }
 
     showInsertNewButton(): boolean {
-        const query = this.queryInfo;
-
-        return query && query.showInsertNewButton && query.insertUrl && !query.insertUrlDisabled;
+        return !!this.queryInfo?.getShowInsertNewButton();
     }
 
     getDataEdit(): List<Map<string, any>> {

--- a/packages/components/src/internal/components/base/Permissions.spec.tsx
+++ b/packages/components/src/internal/components/base/Permissions.spec.tsx
@@ -60,4 +60,61 @@ describe('<RequiresPermission/>', () => {
         // Assert
         expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(true);
     });
+    test('does not have any permissions', () => {
+        // Act
+        const wrapper = mountWithServerContext(
+            <RequiresPermission permissionCheck="any" perms={[PermissionTypes.Update, PermissionTypes.Delete]}>
+                {CONTENT}
+            </RequiresPermission>,
+            { user: TEST_USER_READER }
+        );
+
+        // Assert
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(false);
+    });
+    test('has any permissions', () => {
+        // Act
+        const wrapper = mountWithServerContext(
+            <RequiresPermission
+                permissionCheck="any"
+                perms={[PermissionTypes.Admin, PermissionTypes.Read, PermissionTypes.Insert]}
+            >
+                {CONTENT}
+            </RequiresPermission>,
+            { user: TEST_USER_READER }
+        );
+
+        // Assert
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(true);
+    });
+    test('respects checkIsAdmin', () => {
+        // Arrange
+        const ADMIN_READER = TEST_USER_READER.set('isAdmin', true);
+
+        // Act
+        // "checkIsAdmin" defaults to true
+        let wrapper = mountWithServerContext(
+            <RequiresPermission permissionCheck="any" perms={[PermissionTypes.Update, PermissionTypes.Delete]}>
+                {CONTENT}
+            </RequiresPermission>,
+            { user: ADMIN_READER }
+        );
+
+        // Assert
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(true);
+        wrapper.unmount();
+
+        wrapper = mountWithServerContext(
+            <RequiresPermission
+                checkIsAdmin={false}
+                permissionCheck="any"
+                perms={[PermissionTypes.Update, PermissionTypes.Delete]}
+            >
+                {CONTENT}
+            </RequiresPermission>,
+            { user: ADMIN_READER }
+        );
+
+        expect(wrapper.find(CONTENT_SELECTOR).exists()).toBe(false);
+    });
 });

--- a/packages/components/src/internal/components/base/Permissions.tsx
+++ b/packages/components/src/internal/components/base/Permissions.tsx
@@ -15,9 +15,18 @@
  */
 import React, { FC, useMemo } from 'react';
 
-import { hasAllPermissions, useServerContext } from '../../..';
+import { hasPermissions, useServerContext } from '../../..';
 
 interface Props {
+    /** Indicates if user.isAdmin should override check */
+    checkIsAdmin?: boolean;
+    /**
+     * Sets which "has permissions" check logic is used.
+     * `all` - Require user to have all of the specified permissions (default).
+     * `any` - Require user to have any of the specified permissions.
+     */
+    permissionCheck?: 'all' | 'any';
+    /** The permission(s) to check against the user. */
     perms: string | string[];
 }
 
@@ -27,13 +36,16 @@ interface Props {
  * importing PermissionTypes. The component uses "useServerContext" to access the current user so it
  * requires access to the "ServerContext".
  */
-export const RequiresPermission: FC<Props> = ({ children, perms }) => {
+export const RequiresPermission: FC<Props> = props => {
+    const { checkIsAdmin, children, permissionCheck, perms } = props;
     const { user } = useServerContext();
 
-    const allow = useMemo<boolean>(() => hasAllPermissions(user, typeof perms === 'string' ? [perms] : perms), [
-        perms,
-        user,
-    ]);
+    const allow = useMemo<boolean>(
+        () => hasPermissions(user, typeof perms === 'string' ? [perms] : perms, checkIsAdmin, permissionCheck),
+        [checkIsAdmin, permissionCheck, perms, user]
+    );
 
     return <>{React.Children.map(children, child => (allow ? child : null))}</>;
 };
+
+RequiresPermission.displayName = 'RequiresPermission';

--- a/packages/components/src/internal/components/base/models/User.spec.tsx
+++ b/packages/components/src/internal/components/base/models/User.spec.tsx
@@ -10,9 +10,15 @@ import {
     TEST_USER_READER,
 } from '../../../../test/data/users';
 
-import { hasAllPermissions } from './User';
+import { hasAllPermissions, hasAnyPermissions } from './User';
 
 describe('hasAllPermissions', () => {
+    test('empty permissions', () => {
+        expect(hasAllPermissions(TEST_USER_APP_ADMIN, undefined)).toBe(false);
+        expect(hasAllPermissions(TEST_USER_APP_ADMIN, null)).toBe(false);
+        expect(hasAllPermissions(TEST_USER_APP_ADMIN, [])).toBe(false);
+    });
+
     test('user without permission', () => {
         expect(hasAllPermissions(TEST_USER_READER, [PermissionTypes.Insert])).toBe(false);
     });
@@ -38,6 +44,41 @@ describe('hasAllPermissions', () => {
         expect(hasAllPermissions(TEST_USER_FOLDER_ADMIN, [PermissionTypes.ApplicationAdmin], false)).toBe(false);
         expect(hasAllPermissions(TEST_USER_APP_ADMIN, [PermissionTypes.ApplicationAdmin], true)).toBe(true);
         expect(hasAllPermissions(TEST_USER_APP_ADMIN, [PermissionTypes.ApplicationAdmin], false)).toBe(true);
+    });
+});
+
+describe('hasAnyPermissions', () => {
+    test('empty permissions', () => {
+        expect(hasAnyPermissions(TEST_USER_APP_ADMIN, undefined)).toBe(false);
+        expect(hasAnyPermissions(TEST_USER_APP_ADMIN, null)).toBe(false);
+        expect(hasAnyPermissions(TEST_USER_APP_ADMIN, [])).toBe(false);
+    });
+
+    test('user without permission', () => {
+        expect(hasAnyPermissions(TEST_USER_READER, [PermissionTypes.Insert])).toBe(false);
+    });
+
+    test('user has some but not all permissions', () => {
+        expect(hasAnyPermissions(TEST_USER_READER, [PermissionTypes.Insert, PermissionTypes.Read])).toBe(true);
+    });
+
+    test('user has only required permission', () => {
+        expect(hasAnyPermissions(TEST_USER_AUTHOR, [PermissionTypes.Insert])).toBe(true);
+    });
+
+    test('user has more permission', () => {
+        expect(hasAnyPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert])).toBe(true);
+    });
+
+    test('user permissions do not intersect', () => {
+        expect(hasAnyPermissions(TEST_USER_ASSAY_DESIGNER, [PermissionTypes.Insert])).toBe(false);
+    });
+
+    test('user permissions admin prop', () => {
+        expect(hasAnyPermissions(TEST_USER_FOLDER_ADMIN, [PermissionTypes.ApplicationAdmin], true)).toBe(true);
+        expect(hasAnyPermissions(TEST_USER_FOLDER_ADMIN, [PermissionTypes.ApplicationAdmin], false)).toBe(false);
+        expect(hasAnyPermissions(TEST_USER_APP_ADMIN, [PermissionTypes.ApplicationAdmin], true)).toBe(true);
+        expect(hasAnyPermissions(TEST_USER_APP_ADMIN, [PermissionTypes.ApplicationAdmin], false)).toBe(true);
     });
 });
 

--- a/packages/components/src/internal/components/base/models/User.ts
+++ b/packages/components/src/internal/components/base/models/User.ts
@@ -95,27 +95,51 @@ export class User extends Record(defaultUser) implements IUserProps {
 }
 
 /**
- * Determines if a user has all of the permissions given.  If the user has only some
- * of these permissions, returns false.
- * @param user the user in question
- * @param perms the list of permission strings (See models/constants)
- * @param checkIsAdmin boolean indicating if user.isAdmin should be used as a fallback check
+ * Determines if a user has the permissions given.
+ * @param user User in question
+ * @param perms Array of permission strings (See models/constants)
+ * @param checkIsAdmin Indicates if user.isAdmin should override check. Defaults to true.
+ * @param permissionCheck Sets which "has permissions" check logic is used.
+ *   `all` - Require user to have all of the specified permissions (default).
+ *   `any` - Require user to have any of the specified permissions.
  */
-export function hasAllPermissions(user: User, perms: string[], checkIsAdmin = true): boolean {
-    let allow = false;
-
-    if (perms) {
+export function hasPermissions(
+    user: User,
+    perms: string[],
+    checkIsAdmin = true,
+    permissionCheck: 'all' | 'any' = 'all'
+): boolean {
+    if (checkIsAdmin && user.isAdmin) {
+        return perms?.length > 0;
+    } else if (perms) {
         const allPerms = user.get('permissionsList');
 
-        let hasAll = true;
-        for (let i = 0; i < perms.length; i++) {
-            if (allPerms.indexOf(perms[i]) === -1) {
-                hasAll = false;
-                break;
-            }
+        if (permissionCheck === 'any') {
+            return perms.some(p => allPerms.indexOf(p) > -1);
+        } else {
+            return perms.every(p => allPerms.indexOf(p) > -1);
         }
-        allow = hasAll || (checkIsAdmin && user.isAdmin);
     }
 
-    return allow;
+    return false;
+}
+
+/**
+ * Determines if a user has all of the permissions given. If the user has only some of these permissions, returns false.
+ * @param user User in question
+ * @param perms Array of permission strings (See models/constants)
+ * @param checkIsAdmin Indicates if user.isAdmin should override check
+ */
+export function hasAllPermissions(user: User, perms: string[], checkIsAdmin?: boolean): boolean {
+    return hasPermissions(user, perms, checkIsAdmin, 'all');
+}
+
+/**
+ * Determines if a user has any of the permissions given. If the user has any of the permissions then return true.
+ * @param user User in question
+ * @param perms Array of permission strings (See models/constants)
+ * @param checkIsAdmin Indicates if user.isAdmin should override check
+ */
+export function hasAnyPermissions(user: User, perms: string[], checkIsAdmin?: boolean): boolean {
+    return hasPermissions(user, perms, checkIsAdmin, 'any');
 }

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -175,4 +175,34 @@ describe('QueryInfo', () => {
             expect(fieldKeys.join(',')).toBe('test3');
         });
     });
+
+    describe('getShowImportDataButton', () => {
+        test('respects settings', () => {
+            const qi = QueryInfo.create({
+                importUrl: '#/importUrl',
+                importUrlDisabled: false,
+                showInsertNewButton: true, // yes, "getShowImportDataButton()" respects the "showInsertNewButton" flag
+            });
+
+            expect(qi.getShowImportDataButton()).toBe(true);
+            expect((qi.set('importUrl', undefined) as QueryInfo).getShowImportDataButton()).toBe(false);
+            expect((qi.set('importUrlDisabled', true) as QueryInfo).getShowImportDataButton()).toBe(false);
+            expect((qi.set('showInsertNewButton', false) as QueryInfo).getShowImportDataButton()).toBe(false);
+        });
+    });
+
+    describe('getShowInsertNewButton', () => {
+        test('respects settings', () => {
+            const qi = QueryInfo.create({
+                insertUrl: '#/insertUrl',
+                insertUrlDisabled: false,
+                showInsertNewButton: true,
+            });
+
+            expect(qi.getShowInsertNewButton()).toBe(true);
+            expect((qi.set('insertUrl', undefined) as QueryInfo).getShowInsertNewButton()).toBe(false);
+            expect((qi.set('insertUrlDisabled', true) as QueryInfo).getShowInsertNewButton()).toBe(false);
+            expect((qi.set('showInsertNewButton', false) as QueryInfo).getShowInsertNewButton()).toBe(false);
+        });
+    });
 });

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -365,11 +365,11 @@ export class QueryInfo extends Record({
     }
 
     getShowImportDataButton(): boolean {
-        return this.showInsertNewButton && this.importUrl && !this.importUrlDisabled;
+        return !!(this.showInsertNewButton && this.importUrl && !this.importUrlDisabled);
     }
 
     getShowInsertNewButton(): boolean {
-        return this.showInsertNewButton && this.insertUrl && !this.insertUrlDisabled;
+        return !!(this.showInsertNewButton && this.insertUrl && !this.insertUrlDisabled);
     }
 
     getInsertQueryInfo(): QueryInfo {

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -776,11 +776,11 @@ export class QueryModel {
     }
 
     get showImportDataButton(): boolean {
-        return this.queryInfo?.getShowImportDataButton();
+        return !!this.queryInfo?.getShowImportDataButton();
     }
 
     get showInsertNewButton(): boolean {
-        return this.queryInfo?.getShowInsertNewButton();
+        return !!this.queryInfo?.getShowInsertNewButton();
     }
 
     get isFiltered(): boolean {


### PR DESCRIPTION
#### Rationale
This PR is a part of a broader set of changes for [43113](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=43113) which describes how certain pages in our apps don't respect the settings for displaying insert/import buttons consistently.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/548
* https://github.com/LabKey/biologics/pull/902
* https://github.com/LabKey/sampleManagement/pull/587

#### Changes
* Introduce hasPermissions, hasAnyPermissions utility methods
* Update `<RequiresPermission/>` component to be configurable for all options
* Cleanup duplicated logic in QGM and update methods to consistently return `boolean` values.
