### PR TITLE
Move build output to resources/web/gen

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "3.1.0",
+  "version": "3.2.0-fb-output-web-gen",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "3.2.0-fb-output-web-gen",
+  "version": "4.0.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,13 @@
 # @labkey/build
 
+### version 4.0.0
+*Released*: ? June 2021
+* Move build output to resources/gen
+    * This is a breaking change because this change requires you to update the path you import your scripts from if you
+      use `LABKEY.requiresScript` or `dependencies.add` in a JSP. Examples:
+        * `LABKEY.requiresScript('<module_name>/gen/<scriptName>', () => {})` -> `LABKEY.requiresScript('gen/<scriptName>', () => {})`
+        * `dependencies.add("<module_name>/gen/<scriptName>");` -> `dependencies.add("gen/<scriptName>");`
+
 ### version 3.1.0
 *Released*: 3 June 2021
 * Use current working directory to determine module name and modules directory

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
 ### version 4.0.0
-*Released*: ? June 2021
+*Released*: 9 June 2021
 * Move build output to resources/gen
     * This is a breaking change because this change requires you to update the path you import your scripts from if you
       use `LABKEY.requiresScript` or `dependencies.add` in a JSP. Examples:

--- a/packages/build/webpack/app.view.template.xml
+++ b/packages/build/webpack/app.view.template.xml
@@ -25,14 +25,14 @@
     <% if (options.mode !== 'dev') { %>
         <%
             const publicPath = files.publicPath;
-            const modulePath = options.module + '/gen/';
+            const resourcesPath = 'gen/';
             [...files.css, ...files.js].forEach((filePath) => {
                 // It would be preferred to map these by entryPoint rather than hard code the file paths.
                 // This could theoretically be done by poking the "compilation" object from webpack but I could not
                 // find a strategy that works.
                 if (filePath.indexOf('vendors') > -1 || filePath.indexOf(options.name) > -1) {
         %>
-        <dependency path="<%= filePath.replace(publicPath, modulePath) %>"/>
+        <dependency path="<%= filePath.replace(publicPath, resourcesPath) %>"/>
         <%  }}); %>
     <% } %>
     </dependencies>

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -234,7 +234,7 @@ module.exports = {
             '@labkey/workflow-scss': workflowPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
         },
     },
-    outputPath: path.resolve('./resources/web/' + lkModule + '/gen'),
+    outputPath: path.resolve('./resources/web/gen'),
     processEntries: function(entryPoints) {
         return entryPoints.apps.reduce((entries, app) => {
             entries[app.name] = app.path + '/app.tsx';
@@ -253,7 +253,7 @@ module.exports = {
                         title: app.title,
                         permission: app.permission,
                         viewTemplate: app.template,
-                        filename: '../../../web/' + lkModule + '/gen/' + app.name + '.lib.xml',
+                        filename: '../../web/gen/' + app.name + '.lib.xml',
                         template: 'node_modules/@labkey/build/webpack/lib.template.xml',
                         minify: minifyTemplateOptions
                     }),
@@ -268,13 +268,13 @@ module.exports = {
                         permission: app.permission,
                         permissionClasses: app.permissionClasses,
                         viewTemplate: app.template,
-                        filename: '../../../views/gen/' + app.name + '.view.xml',
+                        filename: '../../views/gen/' + app.name + '.view.xml',
                         template: 'node_modules/@labkey/build/webpack/app.view.template.xml',
                         minify: minifyTemplateOptions
                     }),
                     new HtmlWebpackPlugin({
                         inject: false,
-                        filename: '../../../views/gen/' + app.name + '.html',
+                        filename: '../../views/gen/' + app.name + '.html',
                         template: 'node_modules/@labkey/build/webpack/app.template.html',
                         minify: minifyTemplateOptions
                     }),
@@ -287,7 +287,7 @@ module.exports = {
                         permission: app.permission,
                         permissionClasses: app.permissionClasses,
                         viewTemplate: app.template,
-                        filename: '../../../views/gen/' + app.name + 'Dev.view.xml',
+                        filename: '../../views/gen/' + app.name + 'Dev.view.xml',
                         template: 'node_modules/@labkey/build/webpack/app.view.template.xml',
                         minify: minifyTemplateOptions
                     }),
@@ -296,7 +296,7 @@ module.exports = {
                         mode: 'dev',
                         port: watchPort,
                         name: app.name,
-                        filename: '../../../views/gen/' + app.name + 'Dev.html',
+                        filename: '../../views/gen/' + app.name + 'Dev.html',
                         template: 'node_modules/@labkey/build/webpack/app.template.html',
                         minify: minifyTemplateOptions
                     })

--- a/packages/build/webpack/dev.config.js
+++ b/packages/build/webpack/dev.config.js
@@ -14,7 +14,7 @@ module.exports = {
     output: {
         path: constants.outputPath,
         publicPath: './', // allows context path to resolve in both js/css
-        filename: '[name].js'
+        filename: '[name].[contenthash].js'
     },
     module: {
         rules: constants.loaders.TYPESCRIPT.concat(constants.loaders.STYLE).concat(constants.loaders.FILES),

--- a/packages/build/webpack/lib.template.xml
+++ b/packages/build/webpack/lib.template.xml
@@ -2,7 +2,7 @@
     <dependencies>
         <%
             const { files, options } = htmlWebpackPlugin;
-            const publicPath = files.publicPath
+            const publicPath = files.publicPath;
             const resourcesPath = 'gen/';
             // It would be preferred to map these by entryPoint rather than hard code the file paths.
             // This could theoretically be done by poking the "compilation" object from webpack but I could not

--- a/packages/build/webpack/lib.template.xml
+++ b/packages/build/webpack/lib.template.xml
@@ -2,14 +2,15 @@
     <dependencies>
         <%
             const { files, options } = htmlWebpackPlugin;
-            const publicPath = files.publicPath, modulePath = options.module + '/gen/';
+            const publicPath = files.publicPath
+            const resourcesPath = 'gen/';
             // It would be preferred to map these by entryPoint rather than hard code the file paths.
             // This could theoretically be done by poking the "compilation" object from webpack but I could not
             // find a strategy that works.
             [...files.css, ...files.js].forEach((filePath) => {
                 if (filePath.indexOf('vendors') > -1 || filePath.indexOf(options.name) > -1) {
         %>
-        <dependency path="<%= filePath.replace(publicPath, modulePath) %>"/>
+        <dependency path="<%= filePath.replace(publicPath, resourcesPath) %>"/>
         <%  }}); %>
     </dependencies>
 </libraries>


### PR DESCRIPTION
#### Rationale
This PR changes our shared build to output all built artifacts to `resources/web/gen` instead of `resources/web/<module name>/gen`. This should address [Issue 39148](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39148`). This should be a safe change, because our build uses content hashes for all built artifact names, so anything that overlaps should be ok.

#### Related Pull Requests
* Will be opening PRs for all repos that use the build, and updating the `clean` scripts to rimraf `web/gen` instead of `web/<module name>/gen`.

#### Changes
* Move build output to resources/gen
