### PR TITLE
Trim field values entered in editable grid (Issue 43264) and fix getInitialParentChoices to align with new value type

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.1-smMiscFixesSusan217.1",
+  "version": "2.41.1-smMiscFixesSusan217.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.0",
+  "version": "2.41.1-smMiscFixesSusan217.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.1-smMiscFixesSusan217.0",
+  "version": "2.41.1-smMiscFixesSusan217.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.41.2-smMiscFixesSusan217.2",
+  "version": "2.41.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * [Issue 43264](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43264) Trim field values
   entered in grid
+* Fix for change of parentTypeOptions type value from an array to a single value (from https://github.com/LabKey/platform/pull/2310)
 
 ### version 2.41.0
 *Released*: 2 June 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,16 +3,12 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version TBD
-
 *Released*: TBD
-
 * [Issue 43264](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43264) Trim field values
   entered in grid
 
 ### version 2.41.0
-
 *Released*: 2 June 2021
-
 * Issue 43131: Files added to Sample Types show a path to "sampleset"
 * Issue 43254: Trailing spaces in field editor field names are not getting trimmed
 * Issue 37850: Include display format string in form field label help tip and editable grid cell header

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -16,7 +16,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Check to make sure model has selection before showing choose picklist modal
 
 ### version 2.40.0
-
 *Released*: 1 June 2021
 * Package updates
 * Updated to build using Webpack 5.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,14 +1,25 @@
 # @labkey/components
+
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+
+*Released*: TBD
+
+* [Issue 43264](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43264) Trim field values
+  entered in grid
+
 ### version 2.41.0
+
 *Released*: 2 June 2021
+
 * Issue 43131: Files added to Sample Types show a path to "sampleset"
 * Issue 43254: Trailing spaces in field editor field names are not getting trimmed
 * Issue 37850: Include display format string in form field label help tip and editable grid cell header
 * Check to make sure model has selection before showing choose picklist modal
 
 ### version 2.40.0
+
 *Released*: 1 June 2021
 * Package updates
 * Updated to build using Webpack 5.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.41.2
+*Released*: 4 June 2021
 * [Issue 43264](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43264) Trim field values
   entered in grid
 * Fix for change of parentTypeOptions type value from an array to a single value (from https://github.com/LabKey/platform/pull/2310)

--- a/packages/components/src/internal/components/entities/utils.spec.ts
+++ b/packages/components/src/internal/components/entities/utils.spec.ts
@@ -185,19 +185,19 @@ describe('getInitialParentChoices', () => {
             'Inputs/Data/First/DataClass': [
                 {
                     displayValue: '321',
-                    value: [321],
+                    value: 321,
                 },
                 {
                     displayValue: '321',
-                    value: [321],
+                    value: 321,
                 },
                 {
                     displayValue: '321',
-                    value: [321],
+                    value: 321,
                 },
                 {
                     displayValue: '322',
-                    value: [322],
+                    value: 322,
                 },
             ],
             Run: {

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -52,8 +52,7 @@ export function getInitialParentChoices(
         if (inputs && inputTypes) {
             // group the inputs by parent type so we can show each in its own grid.
             inputTypes.forEach((typeMap, index) => {
-                // I'm not sure when the type could have more than one value here, but 'value' is an array
-                const typeValue = typeMap['value']?.[0];
+                const typeValue = typeMap.value;
                 const typeOption = parentTypeOptions.find(
                     option => option[parentDataType.inputTypeValueField] === typeValue
                 );

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -455,7 +455,7 @@ export class EditorModel
                     }
                     row = row.set(col.name, dateVal);
                 } else {
-                    row = row.set(col.name, values.size === 1 ? values.first().raw : undefined);
+                    row = row.set(col.name, values.size === 1 ? values.first().raw.toString().trim() : undefined);
                 }
             });
             if (forUpdate) {

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -455,7 +455,7 @@ export class EditorModel
                     }
                     row = row.set(col.name, dateVal);
                 } else {
-                    row = row.set(col.name, values.size === 1 ? values.first().raw.toString().trim() : undefined);
+                    row = row.set(col.name, values.size === 1 ? values.first().raw?.toString().trim() : undefined);
                 }
             });
             if (forUpdate) {


### PR DESCRIPTION
#### Rationale
When spaces are included at the beginning or end of field values are very hard to find see.  
The fix in platform [PR 2310](from https://github.com/LabKey/platform/pull/2310) changed the value returned when getting the parent types from an array (which was weird) to a single value (which makes much more sense).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2310
* https://github.com/LabKey/sampleManagement/pull/588

#### Changes
* [Issue 43264](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43264) Trim field values
  entered in grid
* Fix for change of parentTypeOptions type value from an array to a single value ()
