### PR TITLE
Add eslint-plugin-react-hooks, fix issue with no-use-before-define

### DIFF
--- a/packages/eslint-config-base/CHANGELOG.md
+++ b/packages/eslint-config-base/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.10 - 2021-06-08
+- Fix conflicting configuration with no-use-before-define and @typescript-eslint/no-use-before-define
+
 ## 0.0.9 - 2021-06-07
 - Update eslint packages
 

--- a/packages/eslint-config-base/CHANGELOG.md
+++ b/packages/eslint-config-base/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.10 - 2021-06-08
 - Fix conflicting configuration with no-use-before-define and @typescript-eslint/no-use-before-define
+- Fix conflicting configuration with no-shadow and @typescript-estlin/no-shadow
 
 ## 0.0.9 - 2021-06-07
 - Update eslint packages

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -119,10 +119,9 @@ module.exports = {
     'no-label-var': 'error',
     'no-shadow-restricted-names': 'error',
     'no-undef-init': 'error',
-    'no-use-before-define': ["error", {
-      "functions": false,
-      "classes": false
-    }],
+    // Conflicts with "@typescript-eslint/no-use-before-define"
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md#how-to-use
+    "no-use-before-define": "off",
 
     // Stylistic Issues (https://eslint.org/docs/rules/#stylistic-issues)
     'new-cap': [

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -115,7 +115,9 @@ module.exports = {
     //strict: ['error', 'global'], // CONSIDER: add '--alwaysStrict' to tsconfig.json
 
     // Variables (https://eslint.org/docs/rules/#variables)
-    'no-shadow': 'warn', // CONSIDER: error?
+    // no-shadow conflicts with typescript no-shadow
+    'no-shadow': 'off', // CONSIDER: error?
+    "@typescript-eslint/no-shadow": ["warn"],
     'no-label-var': 'error',
     'no-shadow-restricted-names': 'error',
     'no-undef-init': 'error',

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/eslint-config-base",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "shareable eslint config for typescript",
   "main": "index.js",
   "files": [

--- a/packages/eslint-config-react/CHANGELOG.md
+++ b/packages/eslint-config-react/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.10 - 2021-06-08
+- Add eslint-plugin-react-hooks
+
 ## 0.0.9 - 2021-06-07
 - Update eslint packages
 

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -11,6 +11,7 @@ module.exports = {
   extends: [
     '@labkey/eslint-config-base',
     'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
   ],
   plugins: ['react'],
   settings: {
@@ -68,44 +69,44 @@ module.exports = {
     'react/require-default-props': 'off',
     'react/require-optimization': 'off',
     'react/require-render-return': 'error',
-    //'react/self-closing-comp': 'error', // conflits with prettier
     'react/sort-comp': 'error',
     'react/sort-prop-types': 'off',
     'react/style-prop-object': 'error',
     'react/void-dom-elements-no-children': 'error',
 
     'react/jsx-boolean-value': 'off',
-    //'react/jsx-child-element-spacing': 'error', // conflicts with prettier
-    //'react/jsx-closing-bracket-location': 'error', // conflicts with prettier
-    //'react/jsx-closing-tag-location': 'error', // conflicts with prettier
     'react/jsx-curly-brace-presence': 'error',
-    //'react/jsx-curly-spacing': 'error', // conflicts with prettier
-    //'react/jsx-equals-spacing': 'error', // conflicts with prettier
     'react/jsx-filename-extension': 'off',
-    //'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'], // conflits with prettier
     'react/jsx-handler-names': 'off',
     //'react/jsx-indent': ['error', 2],
     //'react/jsx-indent-props': ['error', 2],
     'react/jsx-key': 'error',
     'react/jsx-max-depth': 'off',
-    // conflicts with prettier
-    //'react/jsx-max-props-per-line': [
-    //  'error',
-    //  { maximum: 1, when: 'multiline' }
-    //],
     'react/jsx-no-bind': 'warn',
     'react/jsx-no-comment-textnodes': 'error',
     'react/jsx-no-duplicate-props': ['error', { ignoreCase: true }],
     'react/jsx-no-literals': 'off',
     'react/jsx-no-target-blank': 'error',
     'react/jsx-no-undef': 'error',
-    //'react/jsx-one-expression-per-line': ['error', { allow: 'single-child' }], // conflits with prettier
     'react/jsx-pascal-case': ['error', { allowAllCaps: true }],
-    //'react/jsx-props-no-multi-spaces': 'error', // conflits with prettier
     'react/jsx-sort-default-props': 'off',
     'react/jsx-sort-props': 'off',
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
-    //'react/jsx-wrap-multilines': 'error' // conflits with prettier
+    // The rules below conflict with prettier
+    //'react/self-closing-comp': 'error',
+    //'react/jsx-child-element-spacing': 'error',
+    //'react/jsx-closing-bracket-location': 'error',
+    //'react/jsx-closing-tag-location': 'error',
+    //'react/jsx-curly-spacing': 'error',
+    //'react/jsx-equals-spacing': 'error',
+    //'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
+    //'react/jsx-one-expression-per-line': ['error', { allow: 'single-child' }],
+    //'react/jsx-max-props-per-line': [
+    //  'error',
+    //  { maximum: 1, when: 'multiline' }
+    //],
+    //'react/jsx-props-no-multi-spaces': 'error',
+    //'react/jsx-wrap-multilines': 'error'
   }
 };

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/eslint-config-react",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "shareable eslint config for typescript and react",
   "main": "index.js",
   "files": [
@@ -13,7 +13,8 @@
   "author": "kevink@labkey.com",
   "license": "Apache-2.0",
   "dependencies": {
-    "@labkey/eslint-config-base": "0.0.9",
-    "eslint-plugin-react": "7.24.0"
+    "@labkey/eslint-config-base": "0.0.10",
+    "eslint-plugin-react": "7.24.0",
+    "eslint-plugin-react-hooks": "4.2.0"
   }
 }


### PR DESCRIPTION
#### Rationale
Now that we're using hooks regularly we should add the hooks plugin. I also disabled `no-use-before-define`, it conflicts with `@typescript-eslint/no-use-before-define`.

#### Related Pull Requests
* n/a
#### Changes
* eslint-config-base: Fix conflicting configuration with no-use-before-define and @typescript-eslint/no-use-before-define
* eslint-config-base: Fix conflicting configuration with no-shadow and @typescript-estlin/no-shadow
* eslint-config-react: Add eslint-plugin-react-hooks
