### PR TITLE
Item 8908: fix Biologics disabled sample creation menu option for non sample grids

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.45.0",
+  "version": "2.45.1-fb-smSampleActions.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.45.1-fb-smSampleActions.1",
+  "version": "2.45.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 2.45.1
+*Released*: 14 June 2021
 * Fix CreateSamplesSubMenuBase disabled option for non sample grids
 
 ### version 2.45.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Fix CreateSamplesSubMenuBase disabled option for non sample grids
+
 ### version 2.45.0
 *Released*: 11 June 2021
 * Added SampleDeleteMenuItem

--- a/packages/components/src/internal/components/samples/CreateSamplesSubMenuBase.tsx
+++ b/packages/components/src/internal/components/samples/CreateSamplesSubMenuBase.tsx
@@ -61,9 +61,10 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
     }, [isSelectingSamples, schemaName]);
 
     let disabledMsg: string;
-    if (selectingSampleParents && selectedQuantity > maxParentPerSample) {
-        disabledMsg = 'At most ' + maxParentPerSample + ' samples can be selected';
+    if (selectedQuantity > maxParentPerSample) {
+        disabledMsg = `At most ${maxParentPerSample} ${selectingSampleParents ? 'samples' : 'items'} can be selected`;
     }
+
     const useOnClick = parentKey !== undefined || (selectingSampleParents && selectedQuantity > 0);
 
     const onSampleCreationMenuSelect = useCallback(


### PR DESCRIPTION
#### Rationale
The related pull request was merged prematurely.  Teamcity revealed an issue when selecting too many media items, the sample options in create menu is no longer disabled: 
https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsBPostgres/1442784?buildTab=tests&expandedTest=-4615906326374872342

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/552
* https://github.com/LabKey/biologics/pull/905

#### Changes
* disable sample options regardless of current grid schema type
