### PR TITLE
LP: Extract Reusable Styles (Part II)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.46.1",
+  "version": "2.47.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.47.0
+*Released*: 18 June 2021
+* Add `<ContentGroup/>` and `<ContentGroupLabel/>` components.
+* Update `<SelectInput/>` to respect `valueKey` when processing multiple values.
+* Add reusables styles for `content-form`, `form-step-tabs`, and `clickable-text`.
+
 ### version 2.46.1
 *Released*: 18 June 2021
 * Addresses [Issue 43372](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43372) by:

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -93,6 +93,7 @@ import { Tip } from './internal/components/base/Tip';
 import { Grid, GridColumn } from './internal/components/base/Grid';
 import { FormSection } from './internal/components/base/FormSection';
 import { Section } from './internal/components/base/Section';
+import { ContentGroup, ContentGroupLabel } from './internal/components/base/ContentGroup';
 import { FileAttachmentForm } from './public/files/FileAttachmentForm';
 import { DEFAULT_FILE } from './internal/components/files/models';
 import { FilesListing } from './internal/components/files/FilesListing';
@@ -1039,6 +1040,8 @@ export {
     Tip,
     Grid,
     GridColumn,
+    ContentGroup,
+    ContentGroupLabel,
     Section,
     ConfirmModal,
     Cards,

--- a/packages/components/src/internal/components/assay/actions.spec.ts
+++ b/packages/components/src/internal/components/assay/actions.spec.ts
@@ -54,7 +54,7 @@ describe('getImportItemsForAssayDefinitions', () => {
 
     test('providerType filter', () => {
         let items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, undefined);
-        expect(items.size).toBe(3);
+        expect(items.size).toBe(5);
         items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, GENERAL_ASSAY_PROVIDER_NAME);
         expect(items.size).toBe(2);
         items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, 'NAb');

--- a/packages/components/src/internal/components/assay/models.spec.ts
+++ b/packages/components/src/internal/components/assay/models.spec.ts
@@ -29,13 +29,16 @@ describe('AssayStateModel', () => {
         expect(TEST_ASSAY_STATE_MODEL.getByName('NAb 1')?.id).toBe(3);
     });
 
-    test('getDefinitionsByType', () => {
-        expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(['BOGUS'])).toHaveLength(0);
-        expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes([GENERAL_ASSAY_PROVIDER_NAME])).toHaveLength(2);
-        expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(['NAb'])).toHaveLength(1);
-        expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(['nab'])).toHaveLength(1);
-
-        expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(undefined, ['NAb'])).toHaveLength(2);
-        expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(undefined, [GENERAL_ASSAY_PROVIDER_NAME])).toHaveLength(1);
+    describe('getDefinitionsByType', () => {
+        test('included list', () => {
+            expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(['BOGUS'])).toHaveLength(0);
+            expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes([GENERAL_ASSAY_PROVIDER_NAME])).toHaveLength(2);
+            expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(['NAb'])).toHaveLength(1);
+            expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(['nab'])).toHaveLength(1);
+        });
+        test('excluded list', () => {
+            expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(undefined, ['NAb'])).toHaveLength(4);
+            expect(TEST_ASSAY_STATE_MODEL.getDefinitionsByTypes(undefined, [GENERAL_ASSAY_PROVIDER_NAME])).toHaveLength(3);
+        });
     });
 });

--- a/packages/components/src/internal/components/base/ContentGroup.tsx
+++ b/packages/components/src/internal/components/base/ContentGroup.tsx
@@ -1,0 +1,18 @@
+import React, { FC, ReactNode } from 'react';
+
+interface Props {
+    label?: ReactNode;
+}
+
+export const ContentGroupLabel: FC = ({ children }) => {
+    return <div className="content-group-label">{children}</div>;
+};
+
+export const ContentGroup: FC<Props> = ({ children, label }) => {
+    return (
+        <div className="content-group">
+            {label && <ContentGroupLabel>{label}</ContentGroupLabel>}
+            {children}
+        </div>
+    );
+};

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -301,7 +301,7 @@ export class SelectInputImpl extends DisableableInput<SelectInputProps, SelectIn
     };
 
     _setOptionsAndValue(options: any): any {
-        const { delimiter, formsy, multiple, joinValues, setValue } = this.props;
+        const { delimiter, formsy, multiple, joinValues, setValue, valueKey } = this.props;
         let selectedOptions;
 
         if (options === undefined || options === null || (Array.isArray(options) && options.length === 0)) {
@@ -320,7 +320,7 @@ export class SelectInputImpl extends DisableableInput<SelectInputProps, SelectIn
             if (multiple) {
                 if (Array.isArray(selectedOptions)) {
                     formValue = selectedOptions.reduce((arr, option) => {
-                        arr.push(option.value);
+                        arr.push(valueKey ? option[valueKey] : option.value);
                         return arr;
                     }, []);
 

--- a/packages/components/src/public/LoadingState.spec.ts
+++ b/packages/components/src/public/LoadingState.spec.ts
@@ -1,0 +1,15 @@
+import { isLoading, LoadingState } from './LoadingState';
+
+describe('isLoading', () => {
+    test('states', () => {
+        expect(isLoading(undefined)).toEqual(false);
+        expect(isLoading(null)).toEqual(false);
+        expect(isLoading(undefined, null)).toEqual(false);
+        expect(isLoading(undefined, null, LoadingState.LOADING)).toEqual(true);
+        expect(isLoading(undefined, null, LoadingState.LOADED)).toEqual(false);
+        expect(isLoading(LoadingState.INITIALIZED, LoadingState.LOADING, LoadingState.LOADED)).toEqual(true);
+        expect(isLoading(LoadingState.INITIALIZED)).toEqual(true);
+        expect(isLoading(LoadingState.LOADED)).toEqual(false);
+        expect(isLoading(LoadingState.LOADED, LoadingState.INITIALIZED)).toEqual(true);
+    });
+});

--- a/packages/components/src/public/LoadingState.ts
+++ b/packages/components/src/public/LoadingState.ts
@@ -7,6 +7,12 @@ export enum LoadingState {
     LOADED = 'LOADED',
 }
 
-export const isLoading = (loadingState: LoadingState): boolean => {
-    return loadingState === LoadingState.INITIALIZED || loadingState === LoadingState.LOADING;
+/**
+ * Returns true if any LoadingState(s) are considered to be loading. Falsy values are considered not loading.
+ */
+export const isLoading = (...loadingStates: LoadingState[]): boolean => {
+    return (
+        !!loadingStates &&
+        loadingStates.find(ls => ls === LoadingState.INITIALIZED || ls === LoadingState.LOADING) !== undefined
+    );
 };

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -4,6 +4,7 @@ import { Filter, Query } from '@labkey/api';
 
 import {
     GRID_CHECKBOX_OPTIONS,
+    isLoading,
     LoadingState,
     naturalSort,
     QueryColumn,
@@ -729,29 +730,21 @@ export class QueryModel {
      * True if either the query info or rows of the QueryModel are still loading.
      */
     get isLoading(): boolean {
-        const { queryInfoLoadingState, rowsLoadingState } = this;
-        return (
-            queryInfoLoadingState === LoadingState.INITIALIZED ||
-            queryInfoLoadingState === LoadingState.LOADING ||
-            rowsLoadingState === LoadingState.INITIALIZED ||
-            rowsLoadingState === LoadingState.LOADING
-        );
+        return isLoading(this.queryInfoLoadingState, this.rowsLoadingState);
     }
 
     /**
      * True if the QueryModel is loading its chart definitions.
      */
     get isLoadingCharts(): boolean {
-        const { chartsLoadingState } = this;
-        return chartsLoadingState === LoadingState.INITIALIZED || chartsLoadingState === LoadingState.LOADING;
+        return isLoading(this.chartsLoadingState);
     }
 
     /**
      * True if the QueryModel is loading its row selections.
      */
     get isLoadingSelections(): boolean {
-        const { selectionsLoadingState } = this;
-        return selectionsLoadingState === LoadingState.INITIALIZED || selectionsLoadingState === LoadingState.LOADING;
+        return isLoading(this.selectionsLoadingState);
     }
 
     /**

--- a/packages/components/src/test/data/constants.ts
+++ b/packages/components/src/test/data/constants.ts
@@ -395,8 +395,10 @@ export const TIMELINE_DATA = [
 export const TEST_ASSAY_STATE_MODEL = new AssayStateModel({
     definitionsLoadingState: LoadingState.LOADED,
     definitions: [
+        AssayDefinitionModel.create({ id: 3, name: 'NAb 1', type: 'NAb' }),
         AssayDefinitionModel.create({ id: 1, name: 'GPAT 1', type: GENERAL_ASSAY_PROVIDER_NAME }),
         AssayDefinitionModel.create({ id: 2, name: 'GPAT 2', type: GENERAL_ASSAY_PROVIDER_NAME }),
-        AssayDefinitionModel.create({ id: 3, name: 'NAb 1', type: 'NAb' }),
+        AssayDefinitionModel.create({ id: 5, name: 'Luminex', type: 'Luminex' }),
+        AssayDefinitionModel.create({ id: 4, name: 'Protein', type: 'Protein Expression Matrix' }),
     ],
 });

--- a/packages/components/src/theme/contentGroup.scss
+++ b/packages/components/src/theme/contentGroup.scss
@@ -1,0 +1,11 @@
+.content-group {
+    margin-bottom: 30px;
+}
+
+.content-group-label {
+    color: $gray-dark;
+    display: inline-block;
+    margin-bottom: 30px;
+    font-size: 14px;
+    font-weight: bold;
+}

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -270,3 +270,9 @@ div.react-datepicker__current-month {
     height: 16px;
     width: 16px;
 }
+
+.content-form {
+    label {
+        font-weight: normal;
+    }
+}

--- a/packages/components/src/theme/index.scss
+++ b/packages/components/src/theme/index.scss
@@ -55,3 +55,4 @@
 @import "attachment-card";
 @import "panel";
 @import "tabs";
+@import "contentGroup";

--- a/packages/components/src/theme/notification.scss
+++ b/packages/components/src/theme/notification.scss
@@ -110,3 +110,18 @@
         background: #FA6400;
     }
 }
+
+.clickable-text {
+    cursor: pointer;
+    color: $brand-primary;
+
+    &:hover {
+        text-decoration: underline;
+        color: darken($brand-primary, 15);
+    }
+
+    .fa {
+        // Ensures icon/text alignment when next to each other
+        width: 18px;
+    }
+}

--- a/packages/components/src/theme/tabs.scss
+++ b/packages/components/src/theme/tabs.scss
@@ -31,3 +31,34 @@
         }
     }
 }
+
+.form-step-tabs {
+    & > .nav-tabs {
+        border-bottom: 0;
+        display: flex;
+
+        & > li {
+            flex: auto;
+            max-width: 144px;
+            margin-right: 8px;
+
+            & > a {
+                background-color: $white;
+                border: 1px solid #C7C7C7;
+                border-radius: 0;
+                color: $gray-dark;
+                text-align: center;
+                white-space: nowrap;
+            }
+        }
+
+        & > li.active {
+
+            & > a {
+                background-color: $blue-bkgrd-selected;
+                border: 1px solid $brand-primary;
+                color: $brand-primary;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
Add additional reusable styling for use in our apps.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/596
* https://github.com/LabKey/biologics/pull/910
* https://github.com/LabKey/labkey-ui-components/pull/541 (Part I)

#### Changes
* Add `<ContentGroup/>` and `<ContentGroupLabel/>` components.
* Update `<SelectInput/>` to respect `valueKey` when processing multiple values.
* Add reusables styles for `content-form`, `form-step-tabs`, and `clickable-text`.
