### PR TITLE
Issue 42637: Fix for fileMatchesAcceptedFormat() to check for file extensions that might have multiple parts

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.49.0-fb-issue42637AssayXARExtension.0",
+  "version": "2.49.0-fb-issue42637AssayXARExtension.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.49.0",
+  "version": "2.49.0-fb-issue42637AssayXARExtension.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.49.0-fb-issue42637AssayXARExtension.1",
+  "version": "2.49.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD June 2021
+### version 2.49.1
+*Released*: 25 June 2021
 * Issue 42637: Fix for fileMatchesAcceptedFormat() to check for file extensions that might have multiple parts
 
 ### version 2.49.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD June 2021
+* Issue 42637: Fix for fileMatchesAcceptedFormat() to check for file extensions that might have multiple parts
+
 ### version 2.49.0
 *Released*: 22 June 2021
 * Introduce SelectViewInput component

--- a/packages/components/src/internal/components/files/actions.spec.ts
+++ b/packages/components/src/internal/components/files/actions.spec.ts
@@ -187,7 +187,7 @@ describe('fileMatchesAcceptedFormat', () => {
 
     test('multiple file extension', () => {
         let response = fileMatchesAcceptedFormat('testing.xar.xml', '.xar.xml');
-        expect(response.get('extension')).toBe('.xml');
+        expect(response.get('extension')).toBe('.xar.xml');
         expect(response.get('isMatch')).toBeTruthy();
 
         response = fileMatchesAcceptedFormat('testing.xar.xml', '.xml');

--- a/packages/components/src/internal/components/files/actions.spec.ts
+++ b/packages/components/src/internal/components/files/actions.spec.ts
@@ -148,6 +148,10 @@ describe('getFileExtension', () => {
     test('multiple extensions', () => {
         expect(getFileExtension('find.the.last.one')).toBe('.one');
     });
+
+    test('multiple extensions, find first', () => {
+        expect(getFileExtension('find.the.last.one', false)).toBe('.the.last.one');
+    });
 });
 
 describe('fileMatchesAcceptedFormat', () => {
@@ -179,6 +183,16 @@ describe('fileMatchesAcceptedFormat', () => {
         const response = fileMatchesAcceptedFormat('testing', '.csv, .tsv, .xlsx');
         expect(response.get('extension')).toBe('');
         expect(response.get('isMatch')).toBeFalsy();
+    });
+
+    test('multiple file extension', () => {
+        let response = fileMatchesAcceptedFormat('testing.xar.xml', '.xar.xml');
+        expect(response.get('extension')).toBe('.xml');
+        expect(response.get('isMatch')).toBeTruthy();
+
+        response = fileMatchesAcceptedFormat('testing.xar.xml', '.xml');
+        expect(response.get('extension')).toBe('.xml');
+        expect(response.get('isMatch')).toBeTruthy();
     });
 });
 

--- a/packages/components/src/internal/components/files/actions.spec.ts
+++ b/packages/components/src/internal/components/files/actions.spec.ts
@@ -1,12 +1,13 @@
 import { Map, fromJS } from 'immutable';
 
+import { FileSizeLimitProps } from '../../../public/files/models';
+
 import {
     convertRowDataIntoPreviewData,
     fileMatchesAcceptedFormat,
     fileSizeLimitCompare,
     getFileExtension,
 } from './actions';
-import {FileSizeLimitProps} from "../../../public/files/models";
 
 const DATA = fromJS([
     ['str', 'int', 'int-excelupload', 'double', 'date'],

--- a/packages/components/src/internal/components/files/actions.ts
+++ b/packages/components/src/internal/components/files/actions.ts
@@ -55,11 +55,13 @@ export function convertRowDataIntoPreviewData(
     return rows;
 }
 
-// Finds the last extension on the given file name, including the '.'.  If there is no extension returns the empty string.
-// if fileName is undefined, returns undefined.
-export function getFileExtension(fileName: string) {
+// Finds the extension on the given file name, including the '.'. Optionally, returning the type based on the first or
+// last index of '.' in the file name.
+// If there is no extension returns the empty string.
+// If fileName is undefined, returns undefined.
+export function getFileExtension(fileName: string, lastIndex = true): string {
     if (fileName) {
-        const dotIndex = fileName.lastIndexOf('.');
+        const dotIndex = lastIndex ? fileName.lastIndexOf('.') : fileName.indexOf('.');
         return dotIndex >= 0 ? fileName.slice(dotIndex) : '';
     }
     return undefined;
@@ -68,7 +70,13 @@ export function getFileExtension(fileName: string) {
 export function fileMatchesAcceptedFormat(fileName: string, formatExtensionStr: string): Map<string, any> {
     const acceptedFormatArray: string[] = formatExtensionStr.replace(/\s/g, '').split(',');
     const extension = getFileExtension(fileName);
-    const isMatch = extension && extension.length > 0 && acceptedFormatArray.indexOf(extension) >= 0;
+    let isMatch = extension?.length > 0 && acceptedFormatArray.indexOf(extension) >= 0;
+
+    // Issue 42637: some file name extensions may not be based off of the last index of '.' in the file name
+    if (!isMatch) {
+        const altExtension = getFileExtension(fileName, false);
+        isMatch = altExtension?.length > 0 && acceptedFormatArray.indexOf(altExtension) >= 0;
+    }
 
     return fromJS({
         extension,

--- a/packages/components/src/internal/components/files/actions.ts
+++ b/packages/components/src/internal/components/files/actions.ts
@@ -69,13 +69,13 @@ export function getFileExtension(fileName: string, lastIndex = true): string {
 
 export function fileMatchesAcceptedFormat(fileName: string, formatExtensionStr: string): Map<string, any> {
     const acceptedFormatArray: string[] = formatExtensionStr.replace(/\s/g, '').split(',');
-    const extension = getFileExtension(fileName);
+    let extension = getFileExtension(fileName);
     let isMatch = extension?.length > 0 && acceptedFormatArray.indexOf(extension) >= 0;
 
     // Issue 42637: some file name extensions may not be based off of the last index of '.' in the file name
     if (!isMatch) {
-        const altExtension = getFileExtension(fileName, false);
-        isMatch = altExtension?.length > 0 && acceptedFormatArray.indexOf(altExtension) >= 0;
+        extension = getFileExtension(fileName, false);
+        isMatch = extension?.length > 0 && acceptedFormatArray.indexOf(extension) >= 0;
     }
 
     return fromJS({


### PR DESCRIPTION
#### Rationale
Issue [42637](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42637): Assay import gets error when selecting .xar.xml for import

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/565
* https://github.com/LabKey/testAutomation/pull/780
* https://github.com/LabKey/platform/pull/2398

#### Changes
* Fix for fileMatchesAcceptedFormat() to check for file extensions that might have multiple parts
