### PR TITLE
(No longer needed?) Issue 43000: FM: Position value in Export from Storage Location Grid is encoded value instead of display value

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.50.0",
+  "version": "2.50.1-fb-issue43000",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Issue 43000: FM: Position value in Export from Storage Location Grid is encoded value instead of display value
+    * Allow QueryGridModel and QueryModel to specify excludeColumn and includeColumnToBeginning advancedExportOptions
+
 ### version 2.50.0
 *Released*: 25 June 2021
 * Item 8998: Field designer ontology lookup field support for conceptSubtree prop

--- a/packages/components/src/internal/QueryGridModel.ts
+++ b/packages/components/src/internal/QueryGridModel.ts
@@ -323,9 +323,14 @@ export class QueryGridModel
         return rows;
     }
 
-    getExportColumnsString(): string {
+    getExportColumnsString(excludeColumns?: string[]): string {
         // does not include required columns -- app only
+        let excludeColumnsLower = [];
+        if (excludeColumns) {
+            excludeColumnsLower = excludeColumns.map(col => col.toLowerCase());
+        }
         return this.getDisplayColumns()
+            .filter((c => !excludeColumnsLower.includes(c.fieldKey.toLowerCase())))
             .map(c => c.fieldKey)
             .join(',');
     }

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -764,8 +764,13 @@ export function getExportParams(
 
     if (options) {
         if (options.columns) {
-            if (advancedOptions && advancedOptions['includeColumn'])
-                params['query.columns'] = options.columns + ',' + advancedOptions['includeColumn'].join(',');
+            if (advancedOptions && advancedOptions['includeColumn']) {
+                const includeColsStr = advancedOptions['includeColumn'].join(',');
+                if (advancedOptions['includeColumnToBeginning'])
+                    params['query.columns'] = includeColsStr + ',' + options.columns;
+                else
+                    params['query.columns'] = options.columns + ',' + includeColsStr;
+            }
             else params['query.columns'] = options.columns;
         }
 
@@ -825,7 +830,7 @@ export function gridExport(model: QueryGridModel, type: EXPORT_TYPES, advancedOp
     const showRows = allowSelection && selectedState !== GRID_CHECKBOX_OPTIONS.NONE ? 'SELECTED' : 'ALL';
     const options: ExportOptions = {
         filters: model.getFilters(),
-        columns: model.getExportColumnsString(),
+        columns: model.getExportColumnsString(advancedOptions?.['excludeColumn']),
         sorts: model.getSorts(),
         showRows,
         selectionKey: model.getId(),

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -501,6 +501,16 @@ export class QueryModel {
         return this.displayColumns.map(column => column.fieldKey).join(',');
     }
 
+    getExportColumnString(excludeColumns?: string[]): string {
+        let excludeColumnsLower = [];
+        if (excludeColumns) {
+            excludeColumnsLower = excludeColumns.map(col => col.toLowerCase());
+        }
+        return this.displayColumns
+            .filter((c => !excludeColumnsLower.includes(c.fieldKey.toLowerCase())))
+            .map(column => column.fieldKey).join(',');
+    }
+
     /**
      * Comma-delimited string of sorts from the [[QueryInfo]] sorts property. If the view has defined sorts, they
      * will be concatenated with the sorts property.

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -149,7 +149,7 @@ export function getQueryModelExportParams(
     const showRows = hasSelections ? 'SELECTED' : 'ALL';
     const exportOptions: ExportOptions = {
         filters: List(filters),
-        columns: exportColumnString,
+        columns: model.getExportColumnString(advancedOptions?.['excludeColumn']),
         sorts: sortString,
         selectionKey: id,
         showRows,


### PR DESCRIPTION
#### Rationale
Allow additional advancedExportOptions.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/569
* https://github.com/LabKey/inventory/pull/266

#### Changes
* Allow QueryGridModel and QueryModel to specify excludeColumn and includeColumnToBeginning advancedExportOptions
