### PR TITLE
43299: Ignore required property on checkbox inputs

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.50.2",
+  "version": "2.50.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,5 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
+
+### version 2.50.3
+*Released*: 29 June 2021
+* [Issue 43299](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43299) Ignore required property on checkbox inputs
+
 ### version 2.50.2
 *Released*: 29 June 2021
 * Parameterize support for showing study field types

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -137,7 +137,9 @@ export function resolveDetailEditRenderer(
                 return (
                     <Checkbox
                         name={col.name}
-                        required={col.required}
+                        // Issue 43299: Ignore "required" property for boolean columns as this will
+                        // cause any false value (i.e. unchecked) to prevent submission.
+                        // required={col.required}
                         validatePristine={true}
                         value={value && value.toString().toLowerCase() === 'true'}
                     />

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -119,7 +119,9 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
                     <input
                         disabled={this.state.isDisabled}
                         name={name ?? queryColumn.fieldKey}
-                        required={queryColumn.required}
+                        // Issue 43299: Ignore "required" property for boolean columns as this will
+                        // cause any false value (i.e. unchecked) to prevent submission.
+                        // required={queryColumn.required}
                         type="checkbox"
                         value={this.props.formsy ? this.props.getValue() : this.state.checked}
                         checked={this.state.checked}


### PR DESCRIPTION
#### Rationale
[Issue 43299](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43299) outlines an issue where having a checkbox field in a form that is marked as required would not allow users to submit the form with the field unchecked (i.e. false). This PR updates our primary checkbox components to ignore the `queryColumn.required` bit on the inputs explicitly. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/570
* https://github.com/LabKey/biologics/pull/928
* https://github.com/LabKey/sampleManagement/pull/615

#### Changes
* Ignore `queryColumn.required` bit on checkbox inputs.
