### PR TITLE
42403: Shared test utility updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.51.1",
+  "version": "2.51.1-fb-test-helpers.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.51.1-fb-test-helpers.0",
+  "version": "2.52.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,13 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.##.#
-*Released*: ## July 2021
+### version 2.52.0
+*Released*: 1 July 2021
 * Introduce mountWithServerContextOptions test utility method.
 * Stop exporting mountWithServerContext, waitForLifecycle as these do not work external to the package.
 
 ### version 2.51.1
-*Released*: 01 July 2021
+*Released*: 1 July 2021
 * getMenuSectionConfigs() update for WF. Do not limit menu options. Update "see all" URL.
 
 ### version 2.51.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.##.#
+*Released*: ## July 2021
+* Introduce mountWithServerContextOptions test utility method.
+* Stop exporting mountWithServerContext, waitForLifecycle as these do not work external to the package.
+
 ### version 2.51.1
 *Released*: 01 July 2021
 * getMenuSectionConfigs() update for WF. Do not limit menu options. Update "see all" URL.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -422,7 +422,7 @@ import { DataClassModel } from './internal/components/domainproperties/dataclass
 import { deleteDataClass, fetchDataClass } from './internal/components/domainproperties/dataclasses/actions';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { AssayImportPanels } from './internal/components/assay/AssayImportPanels';
-import { makeQueryInfo, mountWithServerContext, sleep, waitForLifecycle } from './internal/testHelpers';
+import { makeQueryInfo, mountWithServerContextOptions, sleep } from './internal/testHelpers';
 import { QueryModel } from './public/QueryModel/QueryModel';
 import { withQueryModels } from './public/QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './public/QueryModel/GridPanel';
@@ -1115,11 +1115,10 @@ export {
     PipelineJobsPage,
     PipelineStatusDetailPage,
     // Test Helpers
-    mountWithServerContext,
     sleep,
-    waitForLifecycle,
     createMockWithRouterProps,
     makeQueryInfo,
+    mountWithServerContextOptions,
     // Ontology
     OntologyBrowserPanel,
     OntologyConceptOverviewPanel,

--- a/packages/components/src/internal/components/assay/AssayTypeSummary.spec.tsx
+++ b/packages/components/src/internal/components/assay/AssayTypeSummary.spec.tsx
@@ -3,7 +3,8 @@ import ReactSelect from 'react-select';
 
 import { mount } from 'enzyme';
 
-import { AssayTypeSummary, waitForLifecycle } from '../../..';
+import { AssayTypeSummary } from '../../..';
+import { waitForLifecycle } from '../../testHelpers';
 import { initUnitTestMocks } from '../../testHelperMocks';
 
 beforeAll(() => {

--- a/packages/components/src/internal/components/base/SelectViewInput.spec.tsx
+++ b/packages/components/src/internal/components/base/SelectViewInput.spec.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactSelect from 'react-select';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { SelectView, SelectViewInput, waitForLifecycle } from '../../..';
+import { SelectView, SelectViewInput } from '../../..';
+import { waitForLifecycle } from '../../testHelpers';
 
 import {
     clearSelectViewsInLocalStorage,

--- a/packages/components/src/internal/components/samples/SampleSetSummary.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleSetSummary.spec.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactSelect from 'react-select';
 import { mount } from 'enzyme';
 
-import { SampleSetSummary, waitForLifecycle } from '../../..';
+import { SampleSetSummary } from '../../..';
+import { waitForLifecycle } from '../../testHelpers';
 import { initUnitTestMocks } from '../../testHelperMocks';
 import { TEST_USER_APP_ADMIN } from '../../../test/data/users';
 

--- a/packages/components/src/internal/testHelpers.ts
+++ b/packages/components/src/internal/testHelpers.ts
@@ -83,6 +83,41 @@ export const makeTestData = (getQueryResponse): RowsResponse => {
 
 /**
  * Use this if you're testing a component that requires a wrapping <ServerContextProvider/> to provide context.
+ * This utility method provides the `MountRenderProps` that can be supplied to enzyme's mount() method. The specified
+ * `initialContext` will be provided to the wrapped component under test. Additionally, with these options supplied
+ * the returned mounted component will still be the component under test (as opposed to <ServerContextProvider />).
+ * Example:
+ * ```ts
+ * import { mount } from 'enzyme';
+ * import { mountWithServerContextOptions } from '@labkey/components';
+ *
+ * describe('a test suite', () => {
+ *     test('test with default context', () => {
+ *         const wrapper = mount(<MyReactComponent />, mountWithServerContextOptions());
+ *     });
+ *     test('test with specified context, () => {
+ *         const wrapper = mount(<MyReactComponent />, mountWithServerContextOptions({
+ *             user: MY_TEST_USER,
+ *         }));
+ *     });
+ * });
+ * ```
+ * @param initialContext The server context to be provided by the wrapping <ServerContextProvider/>
+ * @param options Pass through for mount's rendering options
+ */
+export const mountWithServerContextOptions = (
+    initialContext: any = {},
+    options?: MountRendererProps
+): MountRendererProps => {
+    return {
+        wrappingComponent: ServerContextProvider,
+        wrappingComponentProps: { initialContext },
+        ...options,
+    };
+};
+
+/**
+ * Use this if you're testing a component that requires a wrapping <ServerContextProvider/> to provide context.
  * This test method wraps enzyme's mount() method and provides the wrapping component with "initialContext".
  * With this the returned mounted component will still be the component under test
  * (as opposed to <ServerContextProvider />).
@@ -95,11 +130,8 @@ export const mountWithServerContext = (
     initialContext: any,
     options?: MountRendererProps
 ): ReactWrapper => {
-    return mount(node, {
-        wrappingComponent: ServerContextProvider,
-        wrappingComponentProps: { initialContext },
-        ...options,
-    });
+    // NOTE: For internal package use only. Do not export externally as it will not work for external usages.
+    return mount(node, mountWithServerContextOptions(initialContext, options));
 };
 
 /**
@@ -127,6 +159,7 @@ export const sleep = (ms = 0): Promise<void> => {
  * @param wrapper: enzyme ReactWrapper
  */
 export const waitForLifecycle = (wrapper: ReactWrapper): Promise<undefined> => {
+    // NOTE: For internal package use only. Do not export externally as it will not work for external usages.
     // Wrap in react-dom/utils act so we don't get errors in our test logs
     return act(async () => {
         await sleep();


### PR DESCRIPTION
#### Rationale
[Issue 42403](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42403) outlines how the test helpers provided by `@labkey/components`, specifically `mountWithServerContext` and `waitForLifecycle` do not work for external usages. This PR introduces a new utility method, `mountWithServerContextOptions`, which can be used to provide configuration properties to `mount` when needing to make use of `<ServerContextProvider/>`. Because the original test helper methods do not work for external usages they've been removed from `index.ts`.

The reason for this is that the test imports do not align across package deployment boundaries. This means imported methods like `mount` from `enzyme` and `act` from `react-dom/test-utils` are not easily replaced in situ and [more complex workarounds](https://stackoverflow.com/questions/50411719/shared-utils-functions-for-testing-with-jest/52910794) are needed. After iterating on several of these ideas I determined the approach used in this PR to be the most reasonable for now.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/573
* https://github.com/LabKey/biologics/pull/930
* https://github.com/LabKey/sampleManagement/pull/616
* https://github.com/LabKey/inventory/pull/267

#### Changes
* Introduce mountWithServerContextOptions test utility method.
* Stop exporting mountWithServerContext, waitForLifecycle as these do not work external to the package.
