### PR TITLE
Remove msg from ConfirmModal, use children

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.52.0",
+  "version": "2.53.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.??.0
-*Released*: ? July 2021
+### version 2.53.0
+*Released*: 5 July 2021
 * Remove msg prop from ConfirmModal, uses children prop instead
 
 ### version 2.52.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.??.0
+*Released*: ? July 2021
+* Remove msg prop from ConfirmModal, uses children prop instead
+
 ### version 2.52.0
 *Released*: 1 July 2021
 * Introduce mountWithServerContextOptions test utility method.

--- a/packages/components/src/internal/components/assay/AssayDesignDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/assay/AssayDesignDeleteConfirmModal.tsx
@@ -24,22 +24,20 @@ export class AssayDesignDeleteConfirmModal extends React.Component<Props, any> {
         return (
             <ConfirmModal
                 title="Permanently delete assay design?"
-                msg={
-                    <span>
-                        {assayDesignName}
-                        {runsMsg} will be permanently deleted.&nbsp;
-                        <p className="top-spacing">
-                            <strong>Deletion cannot be undone.</strong>
-                            &nbsp;Do you want to proceed?
-                        </p>
-                    </span>
-                }
                 onConfirm={onConfirm}
                 onCancel={onCancel}
                 confirmVariant="danger"
                 confirmButtonText="Yes, Delete"
                 cancelButtonText="Cancel"
-            />
+            >
+                <span>
+                    {assayDesignName}
+                    {runsMsg} will be permanently deleted.
+                    <p className="top-spacing">
+                        <strong>Deletion cannot be undone.</strong> Do you want to proceed?
+                    </p>
+                </span>
+            </ConfirmModal>
         );
     }
 }

--- a/packages/components/src/internal/components/assay/AssayResultDeleteModal.tsx
+++ b/packages/components/src/internal/components/assay/AssayResultDeleteModal.tsx
@@ -45,12 +45,10 @@ export const AssayResultDeleteModal: FC<Props> = props => {
 
     if (maxToDelete && numToDelete > maxToDelete) {
         return (
-            <ConfirmModal
-                cancelButtonText="Dismiss"
-                msg={`You cannot delete more than ${maxToDelete} individual assay results at a time. Please select fewer results and try again.`}
-                onCancel={onCancel}
-                title="Cannot Delete Assay Results"
-            />
+            <ConfirmModal cancelButtonText="Dismiss" onCancel={onCancel} title="Cannot Delete Assay Results">
+                You cannot delete more than {maxToDelete} individual assay results at a time. Please select fewer
+                results and try again.
+            </ConfirmModal>
         );
     }
 
@@ -60,18 +58,17 @@ export const AssayResultDeleteModal: FC<Props> = props => {
                 <ConfirmModal
                     cancelButtonText="Cancel"
                     confirmButtonText="Yes, Delete"
-                    msg={
-                        <span>
-                            The {numToDelete > 1 ? numToDelete : ''} selected {noun} will be permanently deleted.&nbsp;
-                            <p className="top-spacing">
-                                <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                            </p>
-                        </span>
-                    }
                     onCancel={onCancel}
                     onConfirm={onConfirm}
                     title={`Permanently delete ${numToDelete}${noun}?`}
-                />
+                >
+                    <span>
+                        The {numToDelete > 1 ? numToDelete : ''} selected {noun} will be permanently deleted.
+                        <p className="top-spacing">
+                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
+                        </p>
+                    </span>
+                </ConfirmModal>
             )}
             <Progress
                 estimate={numToDelete * 10}

--- a/packages/components/src/internal/components/assay/AssayRunDeleteModal.tsx
+++ b/packages/components/src/internal/components/assay/AssayRunDeleteModal.tsx
@@ -56,20 +56,18 @@ export const AssayRunDeleteModal: FC<Props> = props => {
                 <ConfirmModal
                     cancelButtonText="Cancel"
                     confirmButtonText="Yes, Delete"
-                    msg={
-                        <span>
-                            The entirety of the {numToDelete > 1 ? numToDelete : ''} selected {noun} and any of{' '}
-                            {numToDelete === 1 ? 'its' : 'their'} previously replaced versions will be permanently
-                            deleted.&nbsp;
-                            <p className="top-spacing">
-                                <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                            </p>
-                        </span>
-                    }
                     onCancel={onCancel}
                     onConfirm={onConfirm}
                     title={'Permanently delete ' + numToDelete + noun + '?'}
-                />
+                >
+                    <span>
+                        The entirety of the {numToDelete > 1 ? numToDelete : ''} selected {noun} and any of{' '}
+                        {numToDelete === 1 ? 'its' : 'their'} previously replaced versions will be permanently deleted.
+                        <p className="top-spacing">
+                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
+                        </p>
+                    </span>
+                </ConfirmModal>
             )}
             <Progress
                 estimate={numToDelete * 10}

--- a/packages/components/src/internal/components/assay/ImportWithRenameConfirmModal.tsx
+++ b/packages/components/src/internal/components/assay/ImportWithRenameConfirmModal.tsx
@@ -10,34 +10,28 @@ interface Props {
     folderType?: string;
 }
 
-export class ImportWithRenameConfirmModal extends React.Component<Props, any> {
+export class ImportWithRenameConfirmModal extends React.Component<Props> {
     render() {
-        const { onConfirm, onCancel } = this.props;
+        const { folderType, newName, onConfirm, onCancel, originalName } = this.props;
 
         return (
             <ConfirmModal
                 title="Rename duplicate file?"
-                msg={
-                    <>
-                        <p>
-                            A file named <span className="import-rename-filename">{this.props.originalName}</span>{' '}
-                            already exists in this {this.props.folderType} folder.
-                        </p>
-                        <p>
-                            To import this file, either give it a new name or it will be renamed to the following on
-                            import:
-                        </p>
-                        <p>
-                            <span className="import-rename-filename">{this.props.newName}</span>
-                        </p>
-                    </>
-                }
                 onConfirm={onConfirm}
                 onCancel={onCancel}
                 confirmVariant="success"
                 confirmButtonText="Import and Rename"
                 cancelButtonText="Cancel"
-            />
+            >
+                <p>
+                    A file named <span className="import-rename-filename">{originalName}</span> already exists in
+                    this {folderType} folder.
+                </p>
+                <p>To import this file, either give it a new name or it will be renamed to the following on import:</p>
+                <p>
+                    <span className="import-rename-filename">{newName}</span>
+                </p>
+            </ConfirmModal>
         );
     }
 }

--- a/packages/components/src/internal/components/base/ConfirmModal.spec.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.spec.tsx
@@ -8,7 +8,7 @@ import { ConfirmModal } from './ConfirmModal';
 describe('<ConfirmModal/>', () => {
     test('default props', () => {
         const msg = 'Testing confirm modal message';
-        const modal = mount(<ConfirmModal msg={msg} />);
+        const modal = mount(<ConfirmModal>{msg}</ConfirmModal>);
 
         expect(modal.find(Modal)).toHaveLength(1);
         expect(modal.find('.modal-title').text()).toBe('Confirm');
@@ -16,13 +16,12 @@ describe('<ConfirmModal/>', () => {
         expect(modal.find('.close')).toHaveLength(0);
         expect(modal.find('.btn')).toHaveLength(0);
         expect(modal.find('.btn-danger')).toHaveLength(0);
-        modal.unmount();
     });
 
     test('with callback functions', () => {
         const title = 'Callback Title';
         const msg = 'Callback confirm modal message';
-        const modal = mount(<ConfirmModal title={title} msg={msg} onConfirm={jest.fn()} onCancel={jest.fn()} />);
+        const modal = mount(<ConfirmModal title={title} onConfirm={jest.fn()} onCancel={jest.fn()}>{msg}</ConfirmModal>);
 
         expect(modal.find(Modal)).toHaveLength(1);
         expect(modal.find('.modal-title').text()).toBe(title);
@@ -31,18 +30,16 @@ describe('<ConfirmModal/>', () => {
         expect(modal.find('.btn')).toHaveLength(2);
         expect(modal.find('.btn-danger')).toHaveLength(1);
         expect(modal.find('.btn-danger').prop('disabled')).toBe(false);
-        modal.unmount();
     });
 
     test('submitting', () => {
         const msg = 'Submitting confirm modal message';
-        const modal = mount(<ConfirmModal msg={msg} onConfirm={jest.fn()} onCancel={jest.fn()} submitting={true} />);
+        const modal = mount(<ConfirmModal onConfirm={jest.fn()} onCancel={jest.fn()} submitting={true}>{msg}</ConfirmModal>);
 
         expect(modal.find(Modal)).toHaveLength(1);
         expect(modal.find('.close')).toHaveLength(1);
         expect(modal.find('.btn')).toHaveLength(2);
         expect(modal.find('.btn-danger')).toHaveLength(1);
         expect(modal.find('.btn-danger').prop('disabled')).toBe(true);
-        modal.unmount();
     });
 });

--- a/packages/components/src/internal/components/base/ConfirmModal.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.tsx
@@ -13,23 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import classNames from 'classnames';
 
 interface Props {
     show?: boolean;
     title?: string;
-    msg: any;
-    onConfirm?: (any) => void;
-    onCancel?: (any) => void;
+    onConfirm?: () => void;
+    onCancel?: () => void;
     confirmButtonText?: string;
     cancelButtonText?: string;
     confirmVariant?: string;
     submitting?: boolean;
 }
 
-export class ConfirmModal extends React.PureComponent<Props, any> {
+export class ConfirmModal extends React.PureComponent<Props> {
     static defaultProps = {
         show: true,
         title: 'Confirm',
@@ -38,11 +37,11 @@ export class ConfirmModal extends React.PureComponent<Props, any> {
         confirmVariant: 'danger',
     };
 
-    render() {
+    render(): ReactNode {
         const {
+            children,
             show,
             title,
-            msg,
             onConfirm,
             onCancel,
             confirmButtonText,
@@ -60,7 +59,7 @@ export class ConfirmModal extends React.PureComponent<Props, any> {
                     <Modal.Title>{title}</Modal.Title>
                 </Modal.Header>
 
-                <Modal.Body>{msg}</Modal.Body>
+                <Modal.Body>{children}</Modal.Body>
 
                 <Modal.Footer>
                     {onCancel && (

--- a/packages/components/src/internal/components/domainproperties/ConfirmImportTypes.tsx
+++ b/packages/components/src/internal/components/domainproperties/ConfirmImportTypes.tsx
@@ -18,33 +18,27 @@ export default class ConfirmImportTypes extends PureComponent<Props> {
             <ConfirmModal
                 show={show}
                 title={`Create ${designerType} without importing data?`}
-                msg={
-                    <>
-                        <div>
-                            <p>
-                                There was an error importing this file. To import this data now, check your file for
-                                issues or resolve the error below:
-                            </p>
-                            <ul>
-                                {error && error.errors.map((error, index) => <li key={index}> {error.exception} </li>)}
-                            </ul>
-                            <p>
-                                If you create this {designerType} without resolving the error, no file data will be
-                                imported at this time.{' '}
-                                <b>
-                                    {' '}
-                                    Are you sure you want to create the {designerType} without importing the file data?{' '}
-                                </b>
-                            </p>
-                        </div>
-                    </>
-                }
                 confirmVariant="primary"
                 onConfirm={onConfirm}
                 onCancel={onCancel}
                 confirmButtonText="Yes, Create Without Data"
                 cancelButtonText="No, Go Back to Field Editor"
-            />
+            >
+                <div>
+                    <p>
+                        There was an error importing this file. To import this data now, check your file for issues or
+                        resolve the error below:
+                    </p>
+                    <ul>{error && error.errors.map((error, index) => <li key={index}>{error.exception}</li>)}</ul>
+                    <p>
+                        If you create this {designerType} without resolving the error, no file data will be imported at
+                        this time.{' '}
+                        <strong>
+                            Are you sure you want to create the {designerType} without importing the file data?
+                        </strong>
+                    </p>
+                </div>
+            </ConfirmModal>
         );
     }
 }

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -528,38 +528,34 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             return (
                 <ConfirmModal
                     title="Cannot Delete Required Fields"
-                    msg={
-                        <div>
-                            {' '}
-                            <p> None of the selected fields can be deleted. </p>{' '}
-                        </div>
-                    }
                     onCancel={this.onConfirmBulkCancel}
                     cancelButtonText="Close"
-                />
+                >
+                    <div>
+                        <p> None of the selected fields can be deleted. </p>
+                    </div>
+                </ConfirmModal>
             );
         }
 
         return (
             <ConfirmModal
                 title="Confirm Delete Selected Fields"
-                msg={
-                    <div>
-                        <p> {howManyDeleted} will be deleted. </p>
-                        <p> {undeletableWarning} </p>
-                        <p>
-                            {' '}
-                            Are you sure you want to delete {thisFieldPlural}? All of the related field data will also
-                            be deleted.{' '}
-                        </p>
-                    </div>
-                }
                 onConfirm={this.onBulkDeleteConfirm}
                 onCancel={this.onConfirmBulkCancel}
                 confirmVariant="danger"
                 confirmButtonText="Yes, Delete Fields"
                 cancelButtonText="Cancel"
-            />
+            >
+                <div>
+                    <p>{howManyDeleted} will be deleted.</p>
+                    <p>{undeletableWarning}</p>
+                    <p>
+                        Are you sure you want to delete {thisFieldPlural}? All of the related field data will also be
+                        deleted.
+                    </p>
+                </div>
+            </ConfirmModal>
         );
     };
 
@@ -871,23 +867,18 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     renderFieldRemoveConfirm() {
         const { confirmDeleteRowIndex } = this.state;
         const field = this.props.domain.fields.get(confirmDeleteRowIndex);
-
+        const fieldName = field && field.name && field.name.trim().length > 0 ? <b>{field.name}</b> : 'this field';
         return (
             <ConfirmModal
                 title="Confirm Remove Field"
-                msg={
-                    <div>
-                        Are you sure you want to remove{' '}
-                        {field && field.name && field.name.trim().length > 0 ? <b>{field.name}</b> : 'this field'}? All
-                        of its data will be deleted as well.
-                    </div>
-                }
                 onConfirm={() => this.onDeleteConfirm(confirmDeleteRowIndex)}
                 onCancel={this.onConfirmCancel}
                 confirmVariant="danger"
                 confirmButtonText="Yes, Remove Field"
                 cancelButtonText="Cancel"
-            />
+            >
+                <div>Are you sure you want to remove {fieldName}? All of its data will be deleted as well.</div>
+            </ConfirmModal>
         );
     }
 

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -484,10 +484,10 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
             const updatedModel = exception
                 ? (model.set('exception', exception) as SampleTypeModel)
                 : (model.merge({
-                      // since the isNew case adds in the Name column, we need to go back to the state model's domain to merge in the error info
-                      domain: domain.merge({ domainException: response.domainException }) as DomainDesign,
-                      exception: undefined,
-                  }) as SampleTypeModel);
+                    // since the isNew case adds in the Name column, we need to go back to the state model's domain to merge in the error info
+                    domain: domain.merge({ domainException: response.domainException }) as DomainDesign,
+                    exception: undefined,
+                }) as SampleTypeModel);
 
             setSubmitting(false, () => {
                 this.setState(() => ({ model: updatedModel }));
@@ -549,7 +549,18 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
         const numNewUniqueIdFields = this.getNumNewUniqueIdFields();
         // For non-premium LKSM the showLinkToStudy will be true, but the study module will not be present.
         // We also don't want to always show the link to study even if the study module is available (the LKB case).
-        const _showLinkToStudy = showLinkToStudy && hasModule("study");
+        const _showLinkToStudy = showLinkToStudy && hasModule('study');
+        const confirmModalMessage =
+            'You have added ' +
+            numNewUniqueIdFields +
+            ' ' +
+            UNIQUE_ID_TYPE.display +
+            ' field' +
+            (numNewUniqueIdFields !== 1 ? 's' : '') +
+            ' to this Sample Type. ' +
+            'Values for ' +
+            (numNewUniqueIdFields !== 1 ? 'these fields' : 'this field') +
+            ' will be created for all existing samples.';
 
         return (
             <BaseDomainDesigner
@@ -631,24 +642,14 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
                 {showUniqueIdConfirmation && (
                     <ConfirmModal
                         title={'Updating Sample Type with Unique ID field' + (numNewUniqueIdFields !== 1 ? 's' : '')}
-                        msg={
-                            'You have added ' +
-                            numNewUniqueIdFields +
-                            ' ' +
-                            UNIQUE_ID_TYPE.display +
-                            ' field' +
-                            (numNewUniqueIdFields !== 1 ? 's' : '') +
-                            ' to this Sample Type. ' +
-                            'Values for ' +
-                            (numNewUniqueIdFields !== 1 ? 'these fields' : 'this field') +
-                            ' will be created for all existing samples.'
-                        }
                         onCancel={this.onUniqueIdCancel}
                         onConfirm={this.onUniqueIdConfirm}
                         confirmButtonText="Finish Updating Sample Type"
                         confirmVariant="success"
                         cancelButtonText="Cancel"
-                    />
+                    >
+                        {confirmModalMessage}
+                    </ConfirmModal>
                 )}
             </BaseDomainDesigner>
         );

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
@@ -90,12 +90,9 @@ export class EntityDeleteConfirmModal extends PureComponent<Props, State> {
 
         if (this.state.isLoading) {
             return (
-                <ConfirmModal
-                    title="Loading confirmation data"
-                    msg={<LoadingSpinner />}
-                    onCancel={onCancel}
-                    cancelButtonText="Cancel"
-                />
+                <ConfirmModal title="Loading confirmation data" onCancel={onCancel} cancelButtonText="Cancel">
+                    <LoadingSpinner />
+                </ConfirmModal>
             );
         }
 
@@ -104,10 +101,11 @@ export class EntityDeleteConfirmModal extends PureComponent<Props, State> {
                 <ConfirmModal
                     title="Deletion Error"
                     onCancel={onCancel}
-                    msg={<Alert>{this.state.error}</Alert>}
                     onConfirm={undefined}
                     cancelButtonText="Dismiss"
-                />
+                >
+                    <Alert>{this.state.error}</Alert>
+                </ConfirmModal>
             );
         }
 

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -119,13 +119,14 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props> {
         return (
             <ConfirmModal
                 title={confirmProps.title}
-                msg={confirmProps.message}
                 onConfirm={confirmProps.canDelete ? this.onConfirm : undefined}
                 onCancel={onCancel}
                 confirmVariant="danger"
                 confirmButtonText={confirmProps.canDelete ? 'Yes, Delete' : undefined}
                 cancelButtonText={confirmProps.canDelete ? 'Cancel' : 'Dismiss'}
-            />
+            >
+                {confirmProps.message}
+            </ConfirmModal>
         );
     }
 }

--- a/packages/components/src/internal/components/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteModal.tsx
@@ -109,10 +109,12 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
             <ConfirmModal
                 title={'Cannot Delete ' + capitalizeFirstChar(nounPlural)}
                 onCancel={onCancel}
-                msg={`You cannot delete more than ${maxSelected} individual ${nounPlural} at a time. Please select fewer ${nounPlural} and try again.`}
                 onConfirm={undefined}
                 cancelButtonText="Dismiss"
-            />
+            >
+                You cannot delete more than {maxSelected} individual {nounPlural} at a time. Please select fewer
+                {nounPlural} and try again.
+            </ConfirmModal>
         );
     }
 

--- a/packages/components/src/internal/components/entities/EntityTypeDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityTypeDeleteConfirmModal.tsx
@@ -32,21 +32,19 @@ export class EntityTypeDeleteConfirmModal extends React.Component<Props, any> {
         return (
             <ConfirmModal
                 title={'Permanently delete ' + noun.toLowerCase() + ' type?'}
-                msg={
-                    <span>
-                        The {noun.toLowerCase()} type and all of its {dependencies} will be permanently deleted.
-                        <p className="top-spacing">
-                            <strong>Deletion cannot be undone. </strong>
-                            Do you want to proceed?
-                        </p>
-                    </span>
-                }
                 onConfirm={onConfirm}
                 onCancel={onCancel}
                 confirmVariant="danger"
                 confirmButtonText="Yes, Delete"
                 cancelButtonText="Cancel"
-            />
+            >
+                <span>
+                    The {noun.toLowerCase()} type and all of its {dependencies} will be permanently deleted.
+                    <p className="top-spacing">
+                        <strong>Deletion cannot be undone.</strong> Do you want to proceed?
+                    </p>
+                </span>
+            </ConfirmModal>
         );
     }
 }

--- a/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistDeleteConfirm.tsx
@@ -148,20 +148,20 @@ export const PicklistDeleteConfirm: FC<Props> = memo(props => {
     return (
         <ConfirmModal
             title={'Delete ' + nounAndNumber}
-            msg={
-                errorMessage ??
-                (deletionData ? (
-                    <PicklistDeleteConfirmMessage deletionData={deletionData} numSelected={numSelected} noun={lcNoun} />
-                ) : (
-                    <LoadingSpinner />
-                ))
-            }
             onConfirm={deletionData?.numDeletable ? onConfirmDelete : undefined}
             onCancel={onCancel}
             confirmVariant="danger"
             confirmButtonText={'Yes, Delete ' + nounAndNumber}
             cancelButtonText="Cancel"
             submitting={!!errorMessage} // disable submit button if there are errors
-        />
+        >
+            {errorMessage}
+
+            {errorMessage === undefined && deletionData && (
+                <PicklistDeleteConfirmMessage deletionData={deletionData} numSelected={numSelected} noun={lcNoun} />
+            )}
+
+            {errorMessage === undefined && !deletionData && <LoadingSpinner />}
+        </ConfirmModal>
     );
 });

--- a/packages/components/src/internal/components/user/UserActivateChangeConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserActivateChangeConfirmModal.tsx
@@ -51,32 +51,29 @@ export class UserActivateChangeConfirmModal extends React.Component<Props, State
         return (
             <ConfirmModal
                 title={action + ' ' + Utils.pluralBasic(userCount, 'User') + '?'}
-                msg={
-                    <>
-                        {!reactivate && (
-                            <p>
-                                Deactivated users will <b>no longer be able to login</b>. However, their information
-                                will be preserved for display purposes, and their group memberships and role assignments
-                                will be preserved in case they are reactivated at a later time.
-                            </p>
-                        )}
-                        {reactivate && (
-                            <p>
-                                Reactivated users will be able to <b>login normally</b>, and all their previous group
-                                memberships and role assignments will apply.
-                            </p>
-                        )}
-                        <p>{Utils.pluralBasic(userCount, 'user')} will be updated. Do you want to proceed?</p>
-                        {error && <Alert>{error}</Alert>}
-                    </>
-                }
                 onConfirm={this.onConfirm}
                 onCancel={onCancel}
                 confirmVariant={reactivate ? 'success' : 'danger'}
                 confirmButtonText={'Yes, ' + action}
                 cancelButtonText="Cancel"
                 submitting={submitting}
-            />
+            >
+                {!reactivate && (
+                    <p>
+                        Deactivated users will <b>no longer be able to login</b>. However, their information will be
+                        preserved for display purposes, and their group memberships and role assignments will be
+                        preserved in case they are reactivated at a later time.
+                    </p>
+                )}
+                {reactivate && (
+                    <p>
+                        Reactivated users will be able to <b>login normally</b>, and all their previous group
+                        memberships and role assignments will apply.
+                    </p>
+                )}
+                <p>{Utils.pluralBasic(userCount, 'user')} will be updated. Do you want to proceed?</p>
+                {error && <Alert>{error}</Alert>}
+            </ConfirmModal>
         );
     }
 }

--- a/packages/components/src/internal/components/user/UserDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserDeleteConfirmModal.tsx
@@ -49,31 +49,28 @@ export class UserDeleteConfirmModal extends React.Component<Props, State> {
         return (
             <ConfirmModal
                 title={'Delete ' + Utils.pluralBasic(userCount, 'User') + '?'}
-                msg={
-                    <>
-                        <p>
-                            Generally, <b>deactivation of a user is recommended</b>. Deactivated users may not login,
-                            but their information will be preserved in case they are reactivated at a later time.
-                        </p>
-                        <p>
-                            Deletion of a user is <b>permanent and cannot be undone</b>. Deleted users:
-                            <ul>
-                                <li>will no longer be displayed with actions taken or data uploaded by them</li>
-                                <li>will be removed from groups and permissions settings</li>
-                                <li>cannot be reactivated</li>
-                            </ul>
-                        </p>
-                        <p>{Utils.pluralBasic(userCount, 'user')} will be deleted. Do you want to proceed?</p>
-                        {error && <Alert>{error}</Alert>}
-                    </>
-                }
                 onConfirm={this.onConfirm}
                 onCancel={onCancel}
                 confirmVariant="danger"
                 confirmButtonText="Yes, Permanently Delete"
                 cancelButtonText="Cancel"
                 submitting={submitting}
-            />
+            >
+                <p>
+                    Generally, <b>deactivation of a user is recommended</b>. Deactivated users may not login, but their
+                    information will be preserved in case they are reactivated at a later time.
+                </p>
+                <p>
+                    Deletion of a user is <b>permanent and cannot be undone</b>. Deleted users:
+                    <ul>
+                        <li>will no longer be displayed with actions taken or data uploaded by them</li>
+                        <li>will be removed from groups and permissions settings</li>
+                        <li>cannot be reactivated</li>
+                    </ul>
+                </p>
+                <p>{Utils.pluralBasic(userCount, 'user')} will be deleted. Do you want to proceed?</p>
+                {error && <Alert>{error}</Alert>}
+            </ConfirmModal>
         );
     }
 }

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
@@ -48,30 +48,27 @@ export class UserResetPasswordConfirmModal extends React.Component<Props, State>
         return (
             <ConfirmModal
                 title="Reset Password?"
-                msg={
-                    <>
-                        {hasLogin ? (
-                            <p>
-                                You are about to clear the current password for <b>{email}</b>. This will send the user
-                                a reset password email and force them to pick a new password to access the site.
-                            </p>
-                        ) : (
-                            <p>
-                                You are about to send <b>{email}</b> a reset password email. This will let them pick a
-                                password to access the site.
-                            </p>
-                        )}
-                        <p>Do you want to proceed?</p>
-                        {error && <Alert>{error}</Alert>}
-                    </>
-                }
                 onConfirm={this.onConfirm}
                 onCancel={onCancel}
                 confirmVariant="success"
                 confirmButtonText="Yes, Reset Password"
                 cancelButtonText="Cancel"
                 submitting={submitting}
-            />
+            >
+                {hasLogin ? (
+                    <p>
+                        You are about to clear the current password for <b>{email}</b>. This will send the user a reset
+                        password email and force them to pick a new password to access the site.
+                    </p>
+                ) : (
+                    <p>
+                        You are about to send <b>{email}</b> a reset password email. This will let them pick a password
+                        to access the site.
+                    </p>
+                )}
+                <p>Do you want to proceed?</p>
+                {error && <Alert>{error}</Alert>}
+            </ConfirmModal>
         );
     }
 }


### PR DESCRIPTION
#### Rationale
Having a msg prop in ConfirmModal makes using it pretty awkward because you have to write JSX inside your JSX. In general, if you only have a single prop that is a `ReactNode` then you should use the children prop that comes with all components.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/269
* https://github.com/LabKey/moduleEditor/pull/42
* https://github.com/LabKey/platform/pull/2425
* https://github.com/LabKey/sampleManagement/pull/619

#### Changes
* Remove msg from ConfirmModal, use children
* Update consumers of ConfirmModal
