### PR TITLE
Issue 43530: Filter dialog for ontology lookup field does not open to intended Vocabulary scope

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.3",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.6.2",
+    "@labkey/api": "1.6.3",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.55.0",
+  "version": "2.55.0-fb-conceptSubtreeFilterDialog.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.55.0-fb-conceptSubtreeFilterDialog.1",
+  "version": "2.55.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.55.0-fb-conceptSubtreeFilterDialog.0",
+  "version": "2.55.0-fb-conceptSubtreeFilterDialog.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.55.1
+*Released*: 14 July 2021
 * Issue 43530: Filter dialog for ontology lookup field does not open to intended Vocabulary scope
 
 ### version 2.55.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 43530: Filter dialog for ontology lookup field does not open to intended Vocabulary scope
+
 ### version 2.55.0
 *Released*: 7 July 2021
 * add SharedSampleTypeAdminConfirmModal

--- a/packages/components/src/internal/components/ontology/OntologyBrowserFilterPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserFilterPanel.spec.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { OntologyBrowserFilterPanel } from './OntologyBrowserFilterPanel';
+
 import { Filter } from '@labkey/api';
 import { mount, ReactWrapper } from 'enzyme';
-import { OntologyBrowserPanel } from './OntologyBrowserPanel';
+
 import { Alert } from '../base/Alert';
 import { waitForLifecycle } from '../../testHelpers';
+
+import { OntologyBrowserPanel } from './OntologyBrowserPanel';
+import { OntologyBrowserFilterPanel } from './OntologyBrowserFilterPanel';
 import { PathModel } from './models';
 
 const DEFAULT_PROPS = {
@@ -20,21 +23,19 @@ jest.mock('./actions.ts', () => {
     const originalModule = jest.requireActual('./actions.ts');
     return {
         ...originalModule,
-        fetchPathModel: jest.fn().mockReturnValue(
-            {
-                path: 'root',
-                code: 'testroot',
-                label: 'test root',
-                hasChildren: false,
-                children: undefined,
-            } as PathModel
-        ),
+        fetchPathModel: jest.fn().mockReturnValue({
+            path: 'root',
+            code: 'testroot',
+            label: 'test root',
+            hasChildren: false,
+            children: undefined,
+        } as PathModel),
     };
 });
 
-const EqStub = {getURLSuffix: () => 'eq'} as Filter.IFilterType;
-const InSubtreeStub = {getURLSuffix: () => 'concept:insubtree'} as Filter.IFilterType;
-const NotInSubtreeStub = {getURLSuffix: () => 'concept:notinsubtree'} as Filter.IFilterType;
+const EqStub = { getURLSuffix: () => 'eq' } as Filter.IFilterType;
+const InSubtreeStub = { getURLSuffix: () => 'concept:insubtree' } as Filter.IFilterType;
+const NotInSubtreeStub = { getURLSuffix: () => 'concept:notinsubtree' } as Filter.IFilterType;
 
 describe('OntologyBrowserFilterPanel', () => {
     const validate = (wrapper: ReactWrapper): void => {
@@ -65,21 +66,24 @@ describe('OntologyBrowserFilterPanel', () => {
         validate(wrapper);
         expect(changeHandler).toHaveBeenCalledTimes(0);
 
-        await waitForLifecycle(wrapper.setProps({filterValue: 'Mock:Code2'}));
+        await waitForLifecycle(wrapper.setProps({ filterValue: 'Mock:Code2' }));
         // Shouldn't call out to handler unless change is from the panel
         expect(changeHandler).toHaveBeenCalledTimes(0);
-        expect(wrapper.find(OntologyBrowserPanel).prop("filters")).toHaveProperty('size', 1);
+        expect(wrapper.find(OntologyBrowserPanel).prop('filters')).toHaveProperty('size', 1);
 
-        //Multi valued filter
-        await waitForLifecycle(wrapper.setProps({filterValue: 'Mock:Code2;Mock:Code3;Mock:Code1'}));
+        // Multi valued filter
+        await waitForLifecycle(wrapper.setProps({ filterValue: 'Mock:Code2;Mock:Code3;Mock:Code1' }));
         expect(changeHandler).toHaveBeenCalledTimes(0);
-        expect(wrapper.find(OntologyBrowserPanel).prop("filters")).toHaveProperty('size', 3);
-        expect(wrapper.find(OntologyBrowserPanel).prop("filters").get('Mock:Code3')).toHaveProperty('code', 'Mock:Code3');
+        expect(wrapper.find(OntologyBrowserPanel).prop('filters')).toHaveProperty('size', 3);
+        expect(wrapper.find(OntologyBrowserPanel).prop('filters').get('Mock:Code3')).toHaveProperty(
+            'code',
+            'Mock:Code3'
+        );
 
-        //Path valued filter
-        await waitForLifecycle(wrapper.setProps({filterValue: 'Mock:Code2/Mock:Code3/Mock:Code1'}));
+        // Path valued filter
+        await waitForLifecycle(wrapper.setProps({ filterValue: 'Mock:Code2/Mock:Code3/Mock:Code1' }));
         expect(changeHandler).toHaveBeenCalledTimes(0);
-        expect(wrapper.find(OntologyBrowserPanel).prop("filters")).toHaveProperty('size', 1);
+        expect(wrapper.find(OntologyBrowserPanel).prop('filters')).toHaveProperty('size', 1);
 
         wrapper.unmount();
     });
@@ -98,16 +102,16 @@ describe('OntologyBrowserFilterPanel', () => {
         validate(wrapper);
         expect(changeHandler).toHaveBeenCalledTimes(0);
 
-        await waitForLifecycle(wrapper.setProps({filterType: InSubtreeStub}));
+        await waitForLifecycle(wrapper.setProps({ filterType: InSubtreeStub }));
         // Shouldn't call out to handler unless change is from the panel
         expect(changeHandler).toHaveBeenCalledTimes(0);
 
-        //Multi valued filter
-        await waitForLifecycle(wrapper.setProps({filterType: NotInSubtreeStub}));
+        // Multi valued filter
+        await waitForLifecycle(wrapper.setProps({ filterType: NotInSubtreeStub }));
         expect(changeHandler).toHaveBeenCalledTimes(0);
 
-        //Path valued filter
-        await waitForLifecycle(wrapper.setProps({filterType: EqStub}));
+        // Path valued filter
+        await waitForLifecycle(wrapper.setProps({ filterType: EqStub }));
         expect(changeHandler).toHaveBeenCalledTimes(0);
 
         wrapper.unmount();

--- a/packages/components/src/internal/components/ontology/OntologyBrowserFilterPanel.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserFilterPanel.spec.tsx
@@ -7,13 +7,12 @@ import { Alert } from '../base/Alert';
 import { waitForLifecycle } from '../../testHelpers';
 import { PathModel } from './models';
 
-const onFilterChange = jest.fn();
-
 const DEFAULT_PROPS = {
     ontologyId: 'TestOntology',
+    conceptSubtree: undefined,
     filterValue: undefined,
     filterType: undefined,
-    onFilterChange
+    onFilterChange: jest.fn,
 };
 
 jest.mock('./actions.ts', () => {
@@ -38,7 +37,7 @@ const InSubtreeStub = {getURLSuffix: () => 'concept:insubtree'} as Filter.IFilte
 const NotInSubtreeStub = {getURLSuffix: () => 'concept:notinsubtree'} as Filter.IFilterType;
 
 describe('OntologyBrowserFilterPanel', () => {
-    const validate = (wrapper: ReactWrapper) => {
+    const validate = (wrapper: ReactWrapper): void => {
         expect(wrapper.find(Alert)).toHaveLength(2);
         expect(wrapper.find(Alert).first().text()).toBe('');
         expect(wrapper.find(OntologyBrowserPanel)).toHaveLength(1);
@@ -56,11 +55,11 @@ describe('OntologyBrowserFilterPanel', () => {
     test('Concept filter value changed', async () => {
         const changeHandler = jest.fn();
         const props = {
-            ontologyId: 'TestOntology',
+            ...DEFAULT_PROPS,
             filterValue: 'Test:Code',
             filterType: EqStub,
             onFilterChange: changeHandler,
-        }
+        };
 
         const wrapper = mount(<OntologyBrowserFilterPanel {...props} />);
         validate(wrapper);
@@ -89,11 +88,11 @@ describe('OntologyBrowserFilterPanel', () => {
     test('Concept filter type changed', async () => {
         const changeHandler = jest.fn();
         const props = {
-            ontologyId: 'TestOntology',
+            ...DEFAULT_PROPS,
             filterValue: 'Test:Code',
             filterType: EqStub,
             onFilterChange: changeHandler,
-        }
+        };
 
         const wrapper = mount(<OntologyBrowserFilterPanel {...props} />);
         validate(wrapper);

--- a/packages/components/src/internal/components/ontology/OntologyBrowserFilterPanel.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyBrowserFilterPanel.tsx
@@ -10,7 +10,7 @@ import { fetchParentPaths, fetchPathModel, getParentsConceptCodePath } from './a
 
 interface OntologyBrowserFilterPanelProps {
     ontologyId: string;
-    conceptSubtree: string;
+    conceptSubtree?: string;
     filterValue: string;
     filterType: Filter.IFilterType;
     onFilterChange: (filterValue: string) => void;

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -700,10 +700,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.2":
-  version "1.6.2"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.2.tgz#8028a8c56cc741e5260ef8507a99e519baf864fa"
-  integrity sha1-gCioxWzHQeUmDvhQepnlGbr4ZPo=
+"@labkey/api@1.6.3":
+  version "1.6.3"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.3.tgz#4c3bdf94a58b33d8d46f8dbb241d1b2c8b95404b"
+  integrity sha1-TDvflKWLM9jUb427JB0bLIuVQEs=
 
 "@labkey/eslint-config-base@0.0.8":
   version "0.0.8"


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43530

A previous dev story added a conceptSubtree option to a domain field lookup definition. This conceptSubtree would allow the concept picker dialog to be loaded to a specific subtree path. This property was applied to the insert/updated form case but was missed from the filter dialog case.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/578
* https://github.com/LabKey/platform/pull/2448
* https://github.com/LabKey/ontology/pull/55

#### Changes
* OntologyBrowserFilterPanel update to use conceptSubtree to load initPath for OntologyBrowserPanel
