### PR TITLE
Item 9121: Aliquots "Roll up", Samples listing and Source Samples grids

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.0",
+  "version": "2.56.1-fb-smAliquotRollup.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.55.0",
+  "version": "2.55.1-fb-smAliquotRollup.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.1-fb-smAliquotRollup.1",
+  "version": "2.56.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* getLineageFilterValue
+
 ### version 2.55.0
 *Released*: 7 July 2021
 * add SharedSampleTypeAdminConfirmModal

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 2.56.1
+*Released*: 19 July 2021
 * Added getLineageFilterValue to support linage queries to a given depth.
 
 ### version 2.56.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -325,7 +325,11 @@ import {
 import { BaseBarChart } from './internal/components/chart/BaseBarChart';
 import { processChartData } from './internal/components/chart/utils';
 import { ReportItemModal, ReportList, ReportListItem } from './internal/components/report-list/ReportList';
-import { getImmediateChildLineageFilterValue, getLineageFilterValue, invalidateLineageResults } from './internal/components/lineage/actions';
+import {
+    getImmediateChildLineageFilterValue,
+    getLineageFilterValue,
+    invalidateLineageResults,
+} from './internal/components/lineage/actions';
 import {
     LINEAGE_DIRECTIONS,
     LINEAGE_GROUPING_GENERATIONS,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -325,7 +325,7 @@ import {
 import { BaseBarChart } from './internal/components/chart/BaseBarChart';
 import { processChartData } from './internal/components/chart/utils';
 import { ReportItemModal, ReportList, ReportListItem } from './internal/components/report-list/ReportList';
-import { getImmediateChildLineageFilterValue, invalidateLineageResults } from './internal/components/lineage/actions';
+import { getImmediateChildLineageFilterValue, getLineageFilterValue, invalidateLineageResults } from './internal/components/lineage/actions';
 import {
     LINEAGE_DIRECTIONS,
     LINEAGE_GROUPING_GENERATIONS,
@@ -906,6 +906,7 @@ export {
     SampleTypeLineageCounts,
     invalidateLineageResults,
     getImmediateChildLineageFilterValue,
+    getLineageFilterValue,
     // Navigation
     MenuSectionConfig,
     ProductMenuModel,

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -389,7 +389,7 @@ export function getPageNumberChangeURL(location: Location, seed: string, pageNum
     return url;
 }
 
-export function getLineageFilterValue(lsid: string, depth: number|string): string {
+export function getLineageFilterValue(lsid: string, depth: number | string): string {
     const filterVals = [lsid, depth];
     return '{json:' + JSON.stringify(filterVals) + '}';
 }

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -389,7 +389,11 @@ export function getPageNumberChangeURL(location: Location, seed: string, pageNum
     return url;
 }
 
-export function getImmediateChildLineageFilterValue(lsid: string): string {
-    const filterVals = [lsid, '1']; // depth 1
+export function getLineageFilterValue(lsid: string, depth: number|string): string {
+    const filterVals = [lsid, depth];
     return '{json:' + JSON.stringify(filterVals) + '}';
+}
+
+export function getImmediateChildLineageFilterValue(lsid: string): string {
+    return getLineageFilterValue(lsid, 1);
 }


### PR DESCRIPTION
#### Rationale
For source/samples in LKSM, we want to expand to show 3 generations of source children.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2450
* https://github.com/LabKey/labkey-ui-components/pull/580
* https://github.com/LabKey/inventory/pull/275
* https://github.com/LabKey/sampleManagement/pull/625
* https://github.com/LabKey/biologics/pull/938

#### Changes
* add getLineageFilterValue util