### PR TITLE
Item 9252: Store ids to find in bulk in http session

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.1-findIdsInSession.1",
+  "version": "2.56.1-findIdsInSession.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.1-findIdsInSession.2",
+  "version": "2.56.1-findIdsInSession.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.2-findIdsInSession.4",
+  "version": "2.56.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.1-findIdsInSession.0",
+  "version": "2.56.1-findIdsInSession.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.2-findIdsInSession.3",
+  "version": "2.56.2-findIdsInSession.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.56.0",
+  "version": "2.56.1-findIdsInSession.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
-### vesrion TBD
-*Released*: TBD
+### vesrion 2.56.2
+*Released*: 20 July 2021
 * Save findIds to HTTP session instead of browser session for less exposure
 * don't request to `incrementClientSideMetricCount` if user is a guest
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,5 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
+### vesrion TBD
+*Released*: TBD
+* Save findIds to HTTP session instead of browser session for less exposure
+* don't request to `incrementClientSideMetricCount` if user is a guest
+
 ### version 2.56.0
 *Released*: 14 July 2021
 * Add option to SearchBox to show a dropdown for searching by Ids

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -197,7 +197,7 @@ import {
     SM_PIPELINE_JOB_NOTIFICATION_EVENT_START,
     SM_PIPELINE_JOB_NOTIFICATION_EVENT_SUCCESS,
 } from './internal/constants';
-import { getLocation, replaceParameter, replaceParameters, resetParameters } from './internal/util/URL';
+import { getLocation, pushParameter, replaceParameter, replaceParameters, resetParameters } from './internal/util/URL';
 import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
 import { getHelpLink, helpLinkNode, SAMPLE_ALIQUOT_TOPIC } from './internal/util/helpLinks';
 import { AssayResolver, AssayRunResolver, ListResolver, SamplesResolver } from './internal/url/AppURLResolver';
@@ -264,7 +264,6 @@ import { SearchResultsPanel } from './internal/components/search/SearchResultsPa
 import { searchUsingIndex } from './internal/components/search/actions';
 import { SearchResultsModel } from './internal/components/search/models';
 import {
-    clearIdsToFind,
     deleteSampleSet,
     fetchSamples,
     getDeleteSharedSampleTypeUrl,
@@ -453,6 +452,7 @@ import {
     SampleCreationType,
 } from './internal/components/samples/models';
 import {
+    FIND_BY_IDS_QUERY_PARAM,
     SAMPLE_ID_FIND_FIELD,
     SAMPLE_INVENTORY_ITEM_SELECTION_KEY,
     UNIQUE_ID_FIND_FIELD,
@@ -706,6 +706,7 @@ export {
     ListResolver,
     SamplesResolver,
     getLocation,
+    pushParameter,
     replaceParameter,
     replaceParameters,
     resetParameters,
@@ -802,7 +803,7 @@ export {
     DataClassModel,
     deleteDataClass,
     fetchDataClass,
-    clearIdsToFind,
+    FIND_BY_IDS_QUERY_PARAM,
     UNIQUE_ID_FIND_FIELD,
     SAMPLE_ID_FIND_FIELD,
     SampleTypeModel,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -3190,7 +3190,7 @@ export function incrementClientSideMetricCount(
     metricName: string
 ): Promise<IClientSideMetricCountResponse> {
     return new Promise((resolve, reject) => {
-        if (!featureArea || !metricName) {
+        if (!featureArea || !metricName || getServerContext().user.isGuest) {
             resolve(undefined);
         }
         else {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -3192,8 +3192,7 @@ export function incrementClientSideMetricCount(
     return new Promise((resolve, reject) => {
         if (!featureArea || !metricName || getServerContext().user.isGuest) {
             resolve(undefined);
-        }
-        else {
+        } else {
             return Ajax.request({
                 url: buildURL('core', 'incrementClientSideMetricCount.api'),
                 method: 'POST',

--- a/packages/components/src/internal/components/navigation/FindAndSearchDropdown.tsx
+++ b/packages/components/src/internal/components/navigation/FindAndSearchDropdown.tsx
@@ -26,10 +26,13 @@ export const FindAndSearchDropdown: FC<Props> = memo(props => {
         setShowFindModal(false);
     }, []);
 
-    const onFind = useCallback((sessionKey: string) => {
-        setShowFindModal(false);
-        onFindByIds(sessionKey);
-    }, [onFindByIds]);
+    const onFind = useCallback(
+        (sessionKey: string) => {
+            setShowFindModal(false);
+            onFindByIds(sessionKey);
+        },
+        [onFindByIds]
+    );
 
     return (
         <>

--- a/packages/components/src/internal/components/navigation/FindAndSearchDropdown.tsx
+++ b/packages/components/src/internal/components/navigation/FindAndSearchDropdown.tsx
@@ -9,7 +9,7 @@ interface Props {
     title: ReactNode;
     findNounPlural?: string;
     onSearch?: (form: any) => void;
-    onFindByIds?: () => void;
+    onFindByIds?: (sessionKey: string) => void;
     className?: string;
 }
 
@@ -26,9 +26,9 @@ export const FindAndSearchDropdown: FC<Props> = memo(props => {
         setShowFindModal(false);
     }, []);
 
-    const onFind = useCallback(() => {
+    const onFind = useCallback((sessionKey: string) => {
         setShowFindModal(false);
-        onFindByIds();
+        onFindByIds(sessionKey);
     }, [onFindByIds]);
 
     return (

--- a/packages/components/src/internal/components/navigation/FindByIdsModal.tsx
+++ b/packages/components/src/internal/components/navigation/FindByIdsModal.tsx
@@ -83,7 +83,7 @@ export const FindByIdsModal: FC<Props> = memo(props => {
                 setSubmitting(false);
                 reset();
                 onFind(_sessionKey);
-            } catch(e) {
+            } catch (e) {
                 setSubmitting(false);
                 setError(resolveErrorMessage(e));
             }

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -38,7 +38,7 @@ interface NavigationBarProps {
     model: ProductMenuModel;
     notificationsConfig?: ServerNotificationsConfig;
     onSearch?: (form: any) => void;
-    onFindByIds?: () => void;
+    onFindByIds?: (sessionkey: string) => void;
     projectName?: string;
     searchPlaceholder?: string;
     showNavMenu?: boolean;

--- a/packages/components/src/internal/components/navigation/SearchBox.tsx
+++ b/packages/components/src/internal/components/navigation/SearchBox.tsx
@@ -20,7 +20,7 @@ import { FindAndSearchDropdown } from './FindAndSearchDropdown';
 interface Props {
     onSearch: (value: string) => void;
     placeholder?: string;
-    onFindByIds?: () => void;
+    onFindByIds?: (sessionKey: string) => void;
     findNounPlural?: string;
 }
 

--- a/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
@@ -12,20 +12,21 @@ import { Alert } from '../base/Alert';
 import { FindByIdsModal } from '../navigation/FindByIdsModal';
 import { Section } from '../base/Section';
 
-import { FIND_IDS_SESSION_STORAGE_KEY, SAMPLE_ID_FIND_FIELD, UNIQUE_ID_FIND_FIELD } from './constants';
+import { SAMPLE_ID_FIND_FIELD, UNIQUE_ID_FIND_FIELD } from './constants';
 
 interface HeaderPanelProps {
     loadingState: LoadingState;
     listModel: QueryModel;
     error?: ReactNode;
     missingIds: { [key: string]: string[] };
-    onFindSamples: () => void;
+    ids: string[];
+    onFindSamples: (sessionKey: string) => void;
     onClearSamples: () => void;
+    sessionKey: string;
 }
 
 // exported for jest testing
-export function getFindIdCountsByTypeMessage(): string {
-    const findIds: string[] = JSON.parse(sessionStorage.getItem(FIND_IDS_SESSION_STORAGE_KEY));
+export function getFindIdCountsByTypeMessage(findIds: string[]): string {
     if (!findIds) {
         return undefined;
     }
@@ -47,9 +48,9 @@ export function getFindIdCountsByTypeMessage(): string {
 export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
     const [showFindModal, setShowFindModal] = useState<boolean>(false);
 
-    const { loadingState, listModel, onFindSamples, onClearSamples, missingIds, error } = props;
+    const { loadingState, listModel, onFindSamples, onClearSamples, missingIds, sessionKey, error, ids } = props;
 
-    const numIdsMsg = getFindIdCountsByTypeMessage();
+    const numIdsMsg = getFindIdCountsByTypeMessage(ids);
 
     const onAddMoreSamples = useCallback(() => {
         setShowFindModal(true);
@@ -59,9 +60,9 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
         setShowFindModal(false);
     }, []);
 
-    const onFind = useCallback(() => {
+    const onFind = useCallback((sessionKey) => {
         setShowFindModal(false);
-        onFindSamples();
+        onFindSamples(sessionKey);
     }, [onFindSamples]);
 
     let foundSamplesMsg;
@@ -109,7 +110,7 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
                 onCancel={onCancelAdd}
                 onFind={onFind}
                 nounPlural="samples"
-                addToExistingIds={true}
+                sessionKey={sessionKey}
             />
         </Section>
     );

--- a/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
@@ -23,7 +23,7 @@ interface HeaderPanelProps {
     onFindSamples: (sessionKey: string) => void;
     onClearSamples: () => void;
     sessionKey: string;
-    workWithSamplesMsg?: ReactNode
+    workWithSamplesMsg?: ReactNode;
 }
 
 // exported for jest testing
@@ -47,11 +47,21 @@ export function getFindIdCountsByTypeMessage(findIds: string[]): string {
 }
 
 export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
-    const title = "Find Samples in Bulk";
-    const panelClassName = "find-samples-header-panel";
+    const title = 'Find Samples in Bulk';
+    const panelClassName = 'find-samples-header-panel';
     const [showFindModal, setShowFindModal] = useState<boolean>(false);
 
-    const { loadingState, listModel, onFindSamples, onClearSamples, missingIds, sessionKey, error, ids, workWithSamplesMsg } = props;
+    const {
+        loadingState,
+        listModel,
+        onFindSamples,
+        onClearSamples,
+        missingIds,
+        sessionKey,
+        error,
+        ids,
+        workWithSamplesMsg,
+    } = props;
 
     const numIdsMsg = getFindIdCountsByTypeMessage(ids);
 
@@ -63,10 +73,13 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
         setShowFindModal(false);
     }, []);
 
-    const onFind = useCallback((sessionKey) => {
-        setShowFindModal(false);
-        onFindSamples(sessionKey);
-    }, [onFindSamples]);
+    const onFind = useCallback(
+        sessionKey => {
+            setShowFindModal(false);
+            onFindSamples(sessionKey);
+        },
+        [onFindSamples]
+    );
 
     let foundSamplesMsg;
     if (isLoading(loadingState) || (listModel?.isLoading && !listModel.queryInfoError)) {
@@ -110,11 +123,7 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
                     Reset
                 </Button>
             </div>
-            {hasSamples && (
-                <Alert bsStyle="info">
-                    {workWithSamplesMsg}
-                </Alert>
-            )}
+            {hasSamples && <Alert bsStyle="info">{workWithSamplesMsg}</Alert>}
             <FindByIdsModal
                 show={showFindModal}
                 onCancel={onCancelAdd}
@@ -127,8 +136,8 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
 });
 
 FindSamplesByIdHeaderPanel.defaultProps = {
-    workWithSamplesMsg: 'Work with the selected samples in the grid now or save them to a picklist for later use.'
-}
+    workWithSamplesMsg: 'Work with the selected samples in the grid now or save them to a picklist for later use.',
+};
 
 export const SamplesNotFoundMsg: FC<{ missingIds: { [key: string]: string[] } }> = memo(({ missingIds }) => {
     if (!missingIds) return null;

--- a/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
@@ -46,6 +46,8 @@ export function getFindIdCountsByTypeMessage(findIds: string[]): string {
 }
 
 export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
+    const title = "Find Samples in Bulk";
+    const panelClassName = "find-samples-header-panel";
     const [showFindModal, setShowFindModal] = useState<boolean>(false);
 
     const { loadingState, listModel, onFindSamples, onClearSamples, missingIds, sessionKey, error, ids } = props;
@@ -85,11 +87,18 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
         );
     }
 
+    if (error) {
+        return (
+            <Section title={title} panelClassName={panelClassName}>
+                <Alert>{error}</Alert>
+            </Section>
+        );
+    }
+
     const hasSamples = !listModel?.isLoading && listModel?.rowCount > 0;
 
     return (
-        <Section title="Find Samples in Bulk" panelClassName="find-samples-header-panel">
-            <Alert>{error}</Alert>
+        <Section title={title} panelClassName={panelClassName}>
             {foundSamplesMsg}
             <SamplesNotFoundMsg missingIds={missingIds} />
             <div className="bottom-spacing">

--- a/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByIdHeaderPanel.tsx
@@ -23,6 +23,7 @@ interface HeaderPanelProps {
     onFindSamples: (sessionKey: string) => void;
     onClearSamples: () => void;
     sessionKey: string;
+    workWithSamplesMsg?: ReactNode
 }
 
 // exported for jest testing
@@ -50,7 +51,7 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
     const panelClassName = "find-samples-header-panel";
     const [showFindModal, setShowFindModal] = useState<boolean>(false);
 
-    const { loadingState, listModel, onFindSamples, onClearSamples, missingIds, sessionKey, error, ids } = props;
+    const { loadingState, listModel, onFindSamples, onClearSamples, missingIds, sessionKey, error, ids, workWithSamplesMsg } = props;
 
     const numIdsMsg = getFindIdCountsByTypeMessage(ids);
 
@@ -111,7 +112,7 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
             </div>
             {hasSamples && (
                 <Alert bsStyle="info">
-                    Work with the selected samples in the grid now or save them to a picklist for later use.
+                    {workWithSamplesMsg}
                 </Alert>
             )}
             <FindByIdsModal
@@ -124,6 +125,10 @@ export const FindSamplesByIdHeaderPanel: FC<HeaderPanelProps> = memo(props => {
         </Section>
     );
 });
+
+FindSamplesByIdHeaderPanel.defaultProps = {
+    workWithSamplesMsg: 'Work with the selected samples in the grid now or save them to a picklist for later use.'
+}
 
 export const SamplesNotFoundMsg: FC<{ missingIds: { [key: string]: string[] } }> = memo(({ missingIds }) => {
     if (!missingIds) return null;

--- a/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
@@ -17,56 +17,41 @@ import {
     getFindIdCountsByTypeMessage,
     SamplesNotFoundMsg
 } from './FindSamplesByIdHeaderPanel';
-import { FIND_IDS_SESSION_STORAGE_KEY, SAMPLE_ID_FIND_FIELD, UNIQUE_ID_FIND_FIELD } from './constants';
+import { SAMPLE_ID_FIND_FIELD, UNIQUE_ID_FIND_FIELD } from './constants';
 
 describe('getFindIdCountsByTypeMessage', () => {
-    beforeEach(() => {
-        sessionStorage.clear();
-    });
 
     test('no data', () => {
-        expect(getFindIdCountsByTypeMessage()).toBeFalsy();
+        expect(getFindIdCountsByTypeMessage([])).toBeFalsy();
+        expect(getFindIdCountsByTypeMessage(undefined)).toBeFalsy();
     });
 
     test('data but with unknown prefix', () => {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(['x:id1', 'y:id2']));
-        expect(getFindIdCountsByTypeMessage()).toBeFalsy();
+        expect(getFindIdCountsByTypeMessage(['x:id1', 'y:id2'])).toBeFalsy();
     });
 
     test('one sampleId', () => {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(['s:S-1']));
-        expect(getFindIdCountsByTypeMessage()).toBe('1 Sample ID');
+        expect(getFindIdCountsByTypeMessage(['s:S-1'])).toBe('1 Sample ID');
     });
 
     test('multiple sampleIds', () => {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(['s:S-1', 's:B-52']));
-        expect(getFindIdCountsByTypeMessage()).toBe('2 Sample IDs');
+        expect(getFindIdCountsByTypeMessage(['s:S-1', 's:B-52'])).toBe('2 Sample IDs');
     });
 
     test('one uniqueId', () => {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(['u:U-2']));
-        expect(getFindIdCountsByTypeMessage()).toBe('1 Barcode');
+        expect(getFindIdCountsByTypeMessage(['u:U-2'])).toBe('1 Barcode');
     });
 
     test('multiple uniqueId', () => {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(['u:U-2', 'u:U-3', 'u:0000041', 'u:88']));
-        expect(getFindIdCountsByTypeMessage()).toBe('4 Barcodes');
+        expect(getFindIdCountsByTypeMessage(['u:U-2', 'u:U-3', 'u:0000041', 'u:88'])).toBe('4 Barcodes');
     });
 
     test('both sampleIds and uniqueIds', () => {
-        sessionStorage.setItem(
-            FIND_IDS_SESSION_STORAGE_KEY,
-            JSON.stringify(['u:U-2', 's:S-3', 'u:B', 'u:0000041', 's:X-88'])
-        );
-        expect(getFindIdCountsByTypeMessage()).toBe('2 Sample IDs and 3 Barcodes');
+        expect(getFindIdCountsByTypeMessage(['u:U-2', 's:S-3', 'u:B', 'u:0000041', 's:X-88'])).toBe('2 Sample IDs and 3 Barcodes');
     });
 });
 
 describe('FindSamplesByIdHeaderPanel', () => {
-    beforeEach(() => {
-        sessionStorage.clear();
-    });
-
     test('loading', () => {
         const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
 
@@ -77,6 +62,8 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 missingIds={{}}
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
+                ids={undefined}
+                sessionKey={undefined}
             />
         );
         const section = wrapper.find('Section');
@@ -93,7 +80,6 @@ describe('FindSamplesByIdHeaderPanel', () => {
     });
 
     test('no list model', () => {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(['u:U-2']));
         const wrapper = mount(
             <FindSamplesByIdHeaderPanel
                 loadingState={LoadingState.LOADED}
@@ -101,6 +87,8 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 missingIds={{}}
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
+                ids={['u:U-2']}
+                sessionKey={'test'}
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
@@ -120,6 +108,8 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 missingIds={{}}
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
+                ids={['u:U-2']}
+                sessionKey={'test'}
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
@@ -135,6 +125,8 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 missingIds={{}}
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
+                ids={[]}
+                sessionKey={'test'}
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
@@ -155,6 +147,8 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
                 error={<div>We have a problem here.</div>}
+                ids={[]}
+                sessionKey={'test'}
             />
         );
 
@@ -164,8 +158,6 @@ describe('FindSamplesByIdHeaderPanel', () => {
     });
 
     test('found multiple samples', () => {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(['u:U-2', 's:B-52']));
-
         const queryModel = makeTestQueryModel(
             SchemaQuery.create('test', 'query'),
             new QueryInfo(),
@@ -183,6 +175,8 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 }}
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
+                ids={['u:U-2', 's:B-52']}
+                sessionKey={'test'}
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);

--- a/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
@@ -15,12 +15,11 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 import {
     FindSamplesByIdHeaderPanel,
     getFindIdCountsByTypeMessage,
-    SamplesNotFoundMsg
+    SamplesNotFoundMsg,
 } from './FindSamplesByIdHeaderPanel';
 import { SAMPLE_ID_FIND_FIELD, UNIQUE_ID_FIND_FIELD } from './constants';
 
 describe('getFindIdCountsByTypeMessage', () => {
-
     test('no data', () => {
         expect(getFindIdCountsByTypeMessage([])).toBeFalsy();
         expect(getFindIdCountsByTypeMessage(undefined)).toBeFalsy();
@@ -47,7 +46,9 @@ describe('getFindIdCountsByTypeMessage', () => {
     });
 
     test('both sampleIds and uniqueIds', () => {
-        expect(getFindIdCountsByTypeMessage(['u:U-2', 's:S-3', 'u:B', 'u:0000041', 's:X-88'])).toBe('2 Sample IDs and 3 Barcodes');
+        expect(getFindIdCountsByTypeMessage(['u:U-2', 's:S-3', 'u:B', 'u:0000041', 's:X-88'])).toBe(
+            '2 Sample IDs and 3 Barcodes'
+        );
     });
 });
 
@@ -88,7 +89,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
                 ids={['u:U-2']}
-                sessionKey={'test'}
+                sessionKey="test"
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
@@ -109,7 +110,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
                 ids={['u:U-2']}
-                sessionKey={'test'}
+                sessionKey="test"
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
@@ -126,7 +127,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
                 ids={[]}
-                sessionKey={'test'}
+                sessionKey="test"
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
@@ -148,7 +149,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 onClearSamples={jest.fn()}
                 error={<div>We have a problem here.</div>}
                 ids={[]}
-                sessionKey={'test'}
+                sessionKey="test"
             />
         );
 
@@ -178,7 +179,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
                 ids={['u:U-2', 's:B-52']}
-                sessionKey={'test'}
+                sessionKey="test"
             />
         );
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
@@ -195,7 +196,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
         expect(wrapper.find(FindByIdsModal)).toHaveLength(1);
     });
 
-    test("custom workWithSamplesMsg", () => {
+    test('custom workWithSamplesMsg', () => {
         const queryModel = makeTestQueryModel(
             SchemaQuery.create('test', 'query'),
             new QueryInfo(),
@@ -212,7 +213,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
                 onFindSamples={jest.fn()}
                 onClearSamples={jest.fn()}
                 ids={['u:U-2', 's:B-52']}
-                sessionKey={'test'}
+                sessionKey="test"
                 workWithSamplesMsg={msg}
             />
         );

--- a/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
@@ -194,6 +194,31 @@ describe('FindSamplesByIdHeaderPanel', () => {
         expect(wrapper.find('.find-samples-warning')).toHaveLength(1);
         expect(wrapper.find(FindByIdsModal)).toHaveLength(1);
     });
+
+    test("custom workWithSamplesMsg", () => {
+        const queryModel = makeTestQueryModel(
+            SchemaQuery.create('test', 'query'),
+            new QueryInfo(),
+            { 1: {}, 2: {} },
+            ['1', '2'],
+            2
+        );
+        const msg = 'Work with your samples here';
+        const wrapper = mount(
+            <FindSamplesByIdHeaderPanel
+                loadingState={LoadingState.LOADED}
+                listModel={queryModel}
+                missingIds={undefined}
+                onFindSamples={jest.fn()}
+                onClearSamples={jest.fn()}
+                ids={['u:U-2', 's:B-52']}
+                sessionKey={'test'}
+                workWithSamplesMsg={msg}
+            />
+        );
+        const alert = wrapper.find(Alert);
+        expect(alert.text()).toBe(msg);
+    });
 });
 
 describe('SamplesNotFoundMsg', () => {

--- a/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/FindSamplesByidHeaderPanel.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { mount } from 'enzyme';
 
-import { Alert } from 'react-bootstrap';
+import { Alert, Button } from 'react-bootstrap';
 
 import { LoadingState } from '../../../public/LoadingState';
 
@@ -155,6 +155,8 @@ describe('FindSamplesByIdHeaderPanel', () => {
         const alert = wrapper.find(Alert);
         expect(alert).toHaveLength(1);
         expect(alert.text()).toBe('We have a problem here.');
+        expect(wrapper.exists(SamplesNotFoundMsg)).toBe(false);
+        expect(wrapper.exists(Button)).toBe(false);
     });
 
     test('found multiple samples', () => {

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -435,7 +435,7 @@ export function getFindSamplesByIdData(sessionKey: string): Promise<{ queryName:
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error('There was a problem creating the query for the samples.', error);
-                reject('There was a problem creating the query for the samples. Please try again.');
+                reject("There was a problem creating the query for the samples. Please try again using the 'Find Samples' option from the Search menu.");
             }),
         });
 

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -394,13 +394,15 @@ function getSamplesIdsNotFound(queryName: string, orderedIds: string[]): Promise
     });
 }
 
-export function getFindSamplesByIdData(sessionKey: string): Promise<{ queryName: string; ids: string[], missingIds?: { [key: string]: string[] } }> {
+export function getFindSamplesByIdData(
+    sessionKey: string
+): Promise<{ queryName: string; ids: string[]; missingIds?: { [key: string]: string[] } }> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('experiment', 'saveOrderedSamplesQuery.api'),
             method: 'POST',
             jsonData: {
-                sessionKey
+                sessionKey,
             },
             success: Utils.getCallbackWrapper(response => {
                 if (response.success) {
@@ -425,7 +427,7 @@ export function getFindSamplesByIdData(sessionKey: string): Promise<{ queryName:
                             console.error('Problem retrieving data about samples not found', reason);
                             resolve({
                                 queryName,
-                                ids
+                                ids,
                             });
                         });
                 } else {
@@ -435,10 +437,11 @@ export function getFindSamplesByIdData(sessionKey: string): Promise<{ queryName:
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error('There was a problem creating the query for the samples.', error);
-                reject("There was a problem retrieving the samples. Please try again using the 'Find Samples' option from the Search menu.");
+                reject(
+                    "There was a problem retrieving the samples. Please try again using the 'Find Samples' option from the Search menu."
+                );
             }),
         });
-
     });
 }
 
@@ -469,9 +472,8 @@ export function saveIdsToFind(fieldType: FindField, ids: string[], sessionKey: s
                     console.error('There was a problem saving the ids.', error);
                     reject('There was a problem saving the ids. Your session may have expired.');
                 }),
-            })
-        }
-        else {
+            });
+        } else {
             resolve(undefined);
         }
     });

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -430,12 +430,12 @@ export function getFindSamplesByIdData(sessionKey: string): Promise<{ queryName:
                         });
                 } else {
                     console.error('Unable to create session query');
-                    reject('There was a problem creating the query for the samples. Your session may have expired.');
+                    reject('There was a problem retrieving the samples. Your session may have expired.');
                 }
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error('There was a problem creating the query for the samples.', error);
-                reject("There was a problem creating the query for the samples. Please try again using the 'Find Samples' option from the Search menu.");
+                reject("There was a problem retrieving the samples. Please try again using the 'Find Samples' option from the Search menu.");
             }),
         });
 

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -37,7 +37,6 @@ import {
 import { findMissingValues } from '../../util/utils';
 
 import { GroupedSampleFields } from './models';
-import { FIND_IDS_SESSION_STORAGE_KEY } from './constants';
 
 export function initSampleSetSelects(isUpdate: boolean, ssName: string, includeDataClasses: boolean): Promise<any[]> {
     const promises = [];
@@ -350,7 +349,6 @@ export function getSelectedItemSamples(selectedItemIds: string[]): Promise<numbe
             .then(response => {
                 const { data } = response;
                 const sampleIds = [];
-                const rowIds = [];
                 data.forEach(row => {
                     sampleIds.push(row.getIn(['MaterialId', 'value']));
                 });
@@ -396,59 +394,55 @@ function getSamplesIdsNotFound(queryName: string, orderedIds: string[]): Promise
     });
 }
 
-export function getFindSamplesByIdData(): Promise<{ queryName: string; missingIds?: { [key: string]: string[] } }> {
+export function getFindSamplesByIdData(sessionKey: string): Promise<{ queryName: string; ids: string[], missingIds?: { [key: string]: string[] } }> {
     return new Promise((resolve, reject) => {
-        const ids = JSON.parse(sessionStorage.getItem(FIND_IDS_SESSION_STORAGE_KEY));
-        if (ids) {
-            Ajax.request({
-                url: ActionURL.buildURL('experiment', 'saveOrderedSamplesQuery.api'),
-                method: 'POST',
-                jsonData: {
-                    ids,
-                },
-                success: Utils.getCallbackWrapper(response => {
-                    if (response.success) {
-                        const queryName = response.data;
-                        getSamplesIdsNotFound(queryName, ids)
-                            .then(notFound => {
-                                const missingIds = {
-                                    [UNIQUE_ID_FIND_FIELD.label]: notFound
-                                        .filter(id => id.startsWith(UNIQUE_ID_FIND_FIELD.storageKeyPrefix))
-                                        .map(id => id.substring(UNIQUE_ID_FIND_FIELD.storageKeyPrefix.length)),
-                                    [SAMPLE_ID_FIND_FIELD.label]: notFound
-                                        .filter(id => id.startsWith(SAMPLE_ID_FIND_FIELD.storageKeyPrefix))
-                                        .map(id => id.substring(SAMPLE_ID_FIND_FIELD.storageKeyPrefix.length)),
-                                };
-                                resolve({
-                                    queryName,
-                                    missingIds,
-                                });
-                            })
-                            .catch(reason => {
-                                console.error('Problem retrieving data about samples not found', reason);
-                                resolve({
-                                    queryName,
-                                });
+        Ajax.request({
+            url: ActionURL.buildURL('experiment', 'saveOrderedSamplesQuery.api'),
+            method: 'POST',
+            jsonData: {
+                sessionKey
+            },
+            success: Utils.getCallbackWrapper(response => {
+                if (response.success) {
+                    const { queryName, ids } = response.data;
+                    getSamplesIdsNotFound(queryName, ids)
+                        .then(notFound => {
+                            const missingIds = {
+                                [UNIQUE_ID_FIND_FIELD.label]: notFound
+                                    .filter(id => id.startsWith(UNIQUE_ID_FIND_FIELD.storageKeyPrefix))
+                                    .map(id => id.substring(UNIQUE_ID_FIND_FIELD.storageKeyPrefix.length)),
+                                [SAMPLE_ID_FIND_FIELD.label]: notFound
+                                    .filter(id => id.startsWith(SAMPLE_ID_FIND_FIELD.storageKeyPrefix))
+                                    .map(id => id.substring(SAMPLE_ID_FIND_FIELD.storageKeyPrefix.length)),
+                            };
+                            resolve({
+                                queryName,
+                                ids,
+                                missingIds,
                             });
-                    } else {
-                        console.error('Unable to create session query');
-                        reject('There was a problem creating the query for the samples. Please try again.');
-                    }
-                }),
-                failure: Utils.getCallbackWrapper(error => {
-                    console.error('There was a problem creating the query for the samples.', error);
-                    reject('There was a problem creating the query for the samples. Please try again.');
-                }),
-            });
-        } else {
-            // we have no ids in storage so we have no query to create
-            resolve(undefined);
-        }
+                        })
+                        .catch(reason => {
+                            console.error('Problem retrieving data about samples not found', reason);
+                            resolve({
+                                queryName,
+                                ids
+                            });
+                        });
+                } else {
+                    console.error('Unable to create session query');
+                    reject('There was a problem creating the query for the samples. Your session may have expired.');
+                }
+            }),
+            failure: Utils.getCallbackWrapper(error => {
+                console.error('There was a problem creating the query for the samples.', error);
+                reject('There was a problem creating the query for the samples. Please try again.');
+            }),
+        });
+
     });
 }
 
-export function saveIdsToFind(fieldType: FindField, ids: string[]): void {
-    const existingIds: string[] = JSON.parse(sessionStorage.getItem(FIND_IDS_SESSION_STORAGE_KEY));
+export function saveIdsToFind(fieldType: FindField, ids: string[], sessionKey: string): Promise<string> {
     // list of ids deduplicated and prefixed with the field type's storage prefix
     const prefixedIds = [];
     ids.map(id => fieldType.storageKeyPrefix + id).forEach(pid => {
@@ -456,17 +450,29 @@ export function saveIdsToFind(fieldType: FindField, ids: string[]): void {
             prefixedIds.push(pid);
         }
     });
-    // deduplicate from existing ids
-    if (existingIds) {
-        sessionStorage.setItem(
-            FIND_IDS_SESSION_STORAGE_KEY,
-            JSON.stringify(existingIds.concat(prefixedIds.filter(id => !existingIds.includes(id))))
-        );
-    } else {
-        sessionStorage.setItem(FIND_IDS_SESSION_STORAGE_KEY, JSON.stringify(prefixedIds));
-    }
-}
 
-export function clearIdsToFind(): void {
-    sessionStorage.removeItem(FIND_IDS_SESSION_STORAGE_KEY);
+    return new Promise((resolve, reject) => {
+        if (prefixedIds.length > 0) {
+            Ajax.request({
+                url: ActionURL.buildURL('experiment', 'saveFindIds.api'),
+                method: 'POST',
+                jsonData: {
+                    ids: prefixedIds,
+                    sessionKey,
+                },
+                success: Utils.getCallbackWrapper(response => {
+                    if (response.success) {
+                        resolve(response.data);
+                    }
+                }),
+                failure: Utils.getCallbackWrapper(error => {
+                    console.error('There was a problem saving the ids.', error);
+                    reject('There was a problem saving the ids. Your session may have expired.');
+                }),
+            })
+        }
+        else {
+            resolve(undefined);
+        }
+    });
 }

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -2,7 +2,7 @@ import { FindField } from './models';
 
 export const SAMPLE_INVENTORY_ITEM_SELECTION_KEY = 'inventoryItems';
 
-export const FIND_IDS_SESSION_STORAGE_KEY = 'find-ids';
+export const FIND_BY_IDS_QUERY_PARAM = 'findByIdsKey';
 
 export const UNIQUE_ID_FIND_FIELD: FindField = {
     nounSingular: 'Barcode',


### PR DESCRIPTION
#### Rationale
Since our Find Samples in Bulk functionality uses Sample IDs or Barcodes as input that could contain identifying data, we'll stash them in the http session instead of the browser sessionStorage so they will go away when the session expires. 

#### Related Pull Requests
#577 

#### Changes
* Save findIds to HTTP session instead of browser session for less exposure
* don't request to `incrementClientSideMetricCount` if user is a guest