### PR TITLE
NavigationBar: adjust "sm" and "xs" layouts

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.60.1",
+  "version": "2.60.1-fb-navbar-align.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.60.1-fb-navbar-align.0",
+  "version": "2.60.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.60.#
+*Released*: ## July 2021
+* NavigationBar: fix "sm" screen size layout
+
 ### version 2.60.1
 *Released*: 26 July 2021
 * AuditQueriesListingPage component conversion to QueryModel

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.60.#
-*Released*: ## July 2021
+### version 2.60.2
+*Released*: 27 July 2021
 * NavigationBar: fix "sm" screen size layout
 
 ### version 2.60.1

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -99,8 +99,8 @@ export const NavigationBar: FC<Props> = memo(props => {
                         )}
                     </div>
                     <div className="navbar-right col-md-7 col-sm-8 col-xs-5">
-                        <div className="navbar-item pull-right">
-                            {!!user && (
+                        {!!user && (
+                            <div className="navbar-item pull-right">
                                 <UserMenu
                                     extraDevItems={extraDevItems}
                                     extraUserItems={extraUserItems}
@@ -110,8 +110,8 @@ export const NavigationBar: FC<Props> = memo(props => {
                                     signOutUrl={signOutUrl}
                                     user={user}
                                 />
-                            )}
-                        </div>
+                            </div>
+                        )}
                         {_showNotifications && (
                             <div className="navbar-item pull-right navbar-item-notification">
                                 <ServerNotifications {...notificationsConfig} />
@@ -122,19 +122,17 @@ export const NavigationBar: FC<Props> = memo(props => {
                                 <ProductNavigation />
                             </div>
                         )}
-                        <div className="navbar-item pull-right hidden-xs">
-                            {showSearchBox && (
-                                <SearchBox
-                                    onSearch={onSearch}
-                                    placeholder={searchPlaceholder}
-                                    onFindByIds={onFindByIds}
-                                    findNounPlural="samples"
-                                />
-                            )}
-                        </div>
-                        <div className="navbar-item pull-right visible-xs">
-                            {showSearchBox && (
-                                <>
+                        {showSearchBox && (
+                            <div className="navbar-item pull-right">
+                                <div className="hidden-sm hidden-xs">
+                                    <SearchBox
+                                        onSearch={onSearch}
+                                        placeholder={searchPlaceholder}
+                                        onFindByIds={onFindByIds}
+                                        findNounPlural="samples"
+                                    />
+                                </div>
+                                <div className="visible-sm visible-xs">
                                     {onFindByIds ? (
                                         <FindAndSearchDropdown
                                             className="navbar__xs-find-dropdown"
@@ -149,9 +147,9 @@ export const NavigationBar: FC<Props> = memo(props => {
                                             onClick={onSearchIconClick}
                                         />
                                     )}
-                                </>
-                            )}
-                        </div>
+                                </div>
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -83,7 +83,7 @@ export const NavigationBar: FC<Props> = memo(props => {
         <nav className="navbar navbar-container test-loc-nav-header">
             <div className="container">
                 <div className="row">
-                    <div className="navbar-left col-md-5 col-sm-4 col-xs-7">
+                    <div className="navbar-left col-md-5 col-sm-4 col-xs-6">
                         <span className="navbar-item pull-left">{brand}</span>
                         <span className="navbar-item-padded">
                             {showNavMenu && !!model && (
@@ -98,7 +98,7 @@ export const NavigationBar: FC<Props> = memo(props => {
                             </span>
                         )}
                     </div>
-                    <div className="navbar-right col-md-7 col-sm-8 col-xs-5">
+                    <div className="navbar-right col-md-7 col-sm-8 col-xs-6">
                         {!!user && (
                             <div className="navbar-item pull-right">
                                 <UserMenu

--- a/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
@@ -22,17 +22,7 @@ exports[`<NavigationBar/> default props 1`] = `
       </div>
       <div
         className="navbar-right col-md-7 col-sm-8 col-xs-5"
-      >
-        <div
-          className="navbar-item pull-right"
-        />
-        <div
-          className="navbar-item pull-right hidden-xs"
-        />
-        <div
-          className="navbar-item pull-right visible-xs"
-        />
-      </div>
+      />
     </div>
   </div>
 </nav>
@@ -63,149 +53,150 @@ exports[`<NavigationBar/> with findByIds 1`] = `
       >
         <div
           className="navbar-item pull-right"
-        />
-        <div
-          className="navbar-item pull-right hidden-xs"
-        >
-          <form
-            className="navbar__search-form"
-            onSubmit={[Function]}
-          >
-            <div
-              className="form-group"
-            >
-              <i
-                className="fa fa-search navbar__search-icon"
-              />
-              <span
-                className="navbar__input-group input-group"
-              >
-                <input
-                  className="form-control navbar__search-input"
-                  onChange={[Function]}
-                  placeholder="Enter Search Terms"
-                  size={34}
-                  type="text"
-                  value=""
-                />
-                <span
-                  className="input-group-btn"
-                >
-                  <div
-                    className="dropdown btn-group"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="navbar__find-and-search-button undefined dropdown-toggle btn btn-default"
-                      disabled={false}
-                      id="find-and-search-menu"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      role="button"
-                      type="button"
-                    >
-                       
-                      <span
-                        className="caret"
-                      />
-                    </button>
-                    <ul
-                      aria-labelledby="find-and-search-menu"
-                      className="dropdown-menu"
-                      role="menu"
-                    >
-                      <li
-                        className=""
-                        role="presentation"
-                      >
-                        <a
-                          href="#"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="menuitem"
-                          tabIndex="-1"
-                        >
-                          <i
-                            className="fa fa-barcode"
-                          />
-                           Find 
-                          Samples
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </span>
-              </span>
-            </div>
-          </form>
-        </div>
-        <div
-          className="navbar-item pull-right visible-xs"
         >
           <div
-            className="dropdown btn-group"
+            className="hidden-sm hidden-xs"
           >
-            <button
-              aria-expanded={false}
-              aria-haspopup={true}
-              className="navbar__find-and-search-button navbar__xs-find-dropdown dropdown-toggle btn btn-default"
-              disabled={false}
-              id="find-and-search-menu"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="button"
-              type="button"
+            <form
+              className="navbar__search-form"
+              onSubmit={[Function]}
             >
-              <i
-                className="fa fa-search navbar__xs-search-icon"
-              />
-               
-              <span
-                className="caret"
-              />
-            </button>
-            <ul
-              aria-labelledby="find-and-search-menu"
-              className="dropdown-menu"
-              role="menu"
+              <div
+                className="form-group"
+              >
+                <i
+                  className="fa fa-search navbar__search-icon"
+                />
+                <span
+                  className="navbar__input-group input-group"
+                >
+                  <input
+                    className="form-control navbar__search-input"
+                    onChange={[Function]}
+                    placeholder="Enter Search Terms"
+                    size={34}
+                    type="text"
+                    value=""
+                  />
+                  <span
+                    className="input-group-btn"
+                  >
+                    <div
+                      className="dropdown btn-group"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        className="navbar__find-and-search-button undefined dropdown-toggle btn btn-default"
+                        disabled={false}
+                        id="find-and-search-menu"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="button"
+                        type="button"
+                      >
+                         
+                        <span
+                          className="caret"
+                        />
+                      </button>
+                      <ul
+                        aria-labelledby="find-and-search-menu"
+                        className="dropdown-menu"
+                        role="menu"
+                      >
+                        <li
+                          className=""
+                          role="presentation"
+                        >
+                          <a
+                            href="#"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                            <i
+                              className="fa fa-barcode"
+                            />
+                             Find 
+                            Samples
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </span>
+                </span>
+              </div>
+            </form>
+          </div>
+          <div
+            className="visible-sm visible-xs"
+          >
+            <div
+              className="dropdown btn-group"
             >
-              <li
-                className=""
-                role="presentation"
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="navbar__find-and-search-button navbar__xs-find-dropdown dropdown-toggle btn btn-default"
+                disabled={false}
+                id="find-and-search-menu"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                type="button"
               >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="menuitem"
-                  tabIndex="-1"
-                >
-                  <i
-                    className="fa fa-search"
-                  />
-                   Search
-                </a>
-              </li>
-              <li
-                className=""
-                role="presentation"
+                <i
+                  className="fa fa-search navbar__xs-search-icon"
+                />
+                 
+                <span
+                  className="caret"
+                />
+              </button>
+              <ul
+                aria-labelledby="find-and-search-menu"
+                className="dropdown-menu"
+                role="menu"
               >
-                <a
-                  href="#"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="menuitem"
-                  tabIndex="-1"
+                <li
+                  className=""
+                  role="presentation"
                 >
-                  <i
-                    className="fa fa-barcode"
-                  />
-                   Find 
-                  Samples
-                </a>
-              </li>
-            </ul>
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    <i
+                      className="fa fa-search"
+                    />
+                     Search
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    <i
+                      className="fa fa-barcode"
+                    />
+                     Find 
+                    Samples
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -239,42 +230,43 @@ exports[`<NavigationBar/> with search box 1`] = `
       >
         <div
           className="navbar-item pull-right"
-        />
-        <div
-          className="navbar-item pull-right hidden-xs"
         >
-          <form
-            className="navbar__search-form"
-            onSubmit={[Function]}
+          <div
+            className="hidden-sm hidden-xs"
           >
-            <div
-              className="form-group"
+            <form
+              className="navbar__search-form"
+              onSubmit={[Function]}
             >
-              <i
-                className="fa fa-search navbar__search-icon"
-              />
-              <span
-                className="navbar__input-group "
+              <div
+                className="form-group"
               >
-                <input
-                  className="form-control navbar__search-input"
-                  onChange={[Function]}
-                  placeholder="Enter Search Terms"
-                  size={34}
-                  type="text"
-                  value=""
+                <i
+                  className="fa fa-search navbar__search-icon"
                 />
-              </span>
-            </div>
-          </form>
-        </div>
-        <div
-          className="navbar-item pull-right visible-xs"
-        >
-          <i
-            className="fa fa-search navbar__xs-search-icon"
-            onClick={[Function]}
-          />
+                <span
+                  className="navbar__input-group "
+                >
+                  <input
+                    className="form-control navbar__search-input"
+                    onChange={[Function]}
+                    placeholder="Enter Search Terms"
+                    size={34}
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </form>
+          </div>
+          <div
+            className="visible-sm visible-xs"
+          >
+            <i
+              className="fa fa-search navbar__xs-search-icon"
+              onClick={[Function]}
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -304,17 +296,7 @@ exports[`<NavigationBar/> without search but with findByIds 1`] = `
       </div>
       <div
         className="navbar-right col-md-7 col-sm-8 col-xs-5"
-      >
-        <div
-          className="navbar-item pull-right"
-        />
-        <div
-          className="navbar-item pull-right hidden-xs"
-        />
-        <div
-          className="navbar-item pull-right visible-xs"
-        />
-      </div>
+      />
     </div>
   </div>
 </nav>

--- a/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`<NavigationBar/> default props 1`] = `
       className="row"
     >
       <div
-        className="navbar-left col-md-5 col-sm-4 col-xs-7"
+        className="navbar-left col-md-5 col-sm-4 col-xs-6"
       >
         <span
           className="navbar-item pull-left"
@@ -21,7 +21,7 @@ exports[`<NavigationBar/> default props 1`] = `
         />
       </div>
       <div
-        className="navbar-right col-md-7 col-sm-8 col-xs-5"
+        className="navbar-right col-md-7 col-sm-8 col-xs-6"
       />
     </div>
   </div>
@@ -39,7 +39,7 @@ exports[`<NavigationBar/> with findByIds 1`] = `
       className="row"
     >
       <div
-        className="navbar-left col-md-5 col-sm-4 col-xs-7"
+        className="navbar-left col-md-5 col-sm-4 col-xs-6"
       >
         <span
           className="navbar-item pull-left"
@@ -49,7 +49,7 @@ exports[`<NavigationBar/> with findByIds 1`] = `
         />
       </div>
       <div
-        className="navbar-right col-md-7 col-sm-8 col-xs-5"
+        className="navbar-right col-md-7 col-sm-8 col-xs-6"
       >
         <div
           className="navbar-item pull-right"
@@ -216,7 +216,7 @@ exports[`<NavigationBar/> with search box 1`] = `
       className="row"
     >
       <div
-        className="navbar-left col-md-5 col-sm-4 col-xs-7"
+        className="navbar-left col-md-5 col-sm-4 col-xs-6"
       >
         <span
           className="navbar-item pull-left"
@@ -226,7 +226,7 @@ exports[`<NavigationBar/> with search box 1`] = `
         />
       </div>
       <div
-        className="navbar-right col-md-7 col-sm-8 col-xs-5"
+        className="navbar-right col-md-7 col-sm-8 col-xs-6"
       >
         <div
           className="navbar-item pull-right"
@@ -285,7 +285,7 @@ exports[`<NavigationBar/> without search but with findByIds 1`] = `
       className="row"
     >
       <div
-        className="navbar-left col-md-5 col-sm-4 col-xs-7"
+        className="navbar-left col-md-5 col-sm-4 col-xs-6"
       >
         <span
           className="navbar-item pull-left"
@@ -295,7 +295,7 @@ exports[`<NavigationBar/> without search but with findByIds 1`] = `
         />
       </div>
       <div
-        className="navbar-right col-md-7 col-sm-8 col-xs-5"
+        className="navbar-right col-md-7 col-sm-8 col-xs-6"
       />
     </div>
   </div>


### PR DESCRIPTION
#### Rationale
I noticed that recently the search bar in the `NavigationBar` would often overflow resulting in an undesirable stacked layout of the controls:

![image](https://user-images.githubusercontent.com/3926239/127066341-c47ca7d3-2679-43ef-beb5-872133b39015.png)

I've elected to fix this by specifying `hidden-sm` and `visible-sm` on the search controls so that it collapses to the smaller search icon starting with the `sm` layout. Previously, this was only used in `xs` layout.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/950
* https://github.com/LabKey/sampleManagement/pull/638
* https://github.com/LabKey/inventory/pull/284

#### Changes
* Adjust `NavigationBar` container elements for search bar to specify `hidden-sm` and `visible-sm` accordingly.
* Simplify DOM construction.
