### PR TITLE
Item 8959: PermissionAssignments.tsx fix to only request root container security policy if user is root admin

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.60.2",
+  "version": "2.60.2-fb-smPermUpdatesTests.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.60.1",
+  "version": "2.60.1-fb-smPermUpdatesTests.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.60.2-fb-smPermUpdatesTests.0",
+  "version": "2.60.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.60.3
+*Released*: 28 July 2021
 * PermissionAssignments.tsx fix to only request root container security policy if user is root admin
 
 ### version 2.60.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* PermissionAssignments.tsx fix to only request root container security policy if user is root admin
+
 ### version 2.60.1
 *Released*: 26 July 2021
 * AuditQueriesListingPage component conversion to QueryModel

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -55,8 +55,9 @@ export class PermissionAssignments extends React.PureComponent<Props, State> {
     }
 
     componentDidMount(): void {
-        const rootId = getServerContext().project.rootId;
-        if (this.props.containerId !== rootId) {
+        const { project, user } = getServerContext();
+        const rootId = project.rootId;
+        if (this.props.containerId !== rootId && user.isRootAdmin) {
             fetchContainerSecurityPolicy(rootId, this.props.principalsById, this.props.inactiveUsersById).then(
                 rootPolicy => {
                     this.setState(() => ({ rootPolicy }));


### PR DESCRIPTION
#### Rationale
While adding some SM test cases for the user / permissions management app changes, one of the tests failed when impersonating a project admin because it was trying to request the root container security policy and the user doesn't have perm to do that. This PR adds a check so we don't even make that request if the user is not a root admin.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/590
* https://github.com/LabKey/testAutomation/pull/817
* https://github.com/LabKey/sampleManagement/pull/639

#### Changes
* PermissionAssignments.tsx fix to only request root container security policy if user is root admin
