### PR TITLE
Make sure picklist listing is updated after a picklist is added from the listing page

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-picklistsSeleniumTests.1",
+  "version": "2.61.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-picklistsSeleniumTests.0",
+  "version": "2.61.1-picklistsSeleniumTests.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.60.3",
+  "version": "2.60.4-picklistsSeleniumTests.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add after-creation callback property to PicklistCreationMenuItem
+
 ### version 2.60.3
 *Released*: 28 July 2021
 * PermissionAssignments.tsx fix to only request root container security policy if user is root admin

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.61.1
+*Released*: 3 August 2021
 * Add after-creation callback property to PicklistCreationMenuItem
 
 ### version 2.61.0

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -20,14 +20,16 @@ interface Props {
     currentProductId?: string;
     picklistProductId?: string;
     metricFeatureArea?: string;
+    onCreatePicklist?: () => void;
 }
 
 export const PicklistCreationMenuItem: FC<Props> = props => {
-    const { key, itemText, user } = props;
+    const { key, itemText, user, onCreatePicklist } = props;
     const [showModal, setShowModal] = useState<boolean>(false);
 
     const onFinish = (picklist: Picklist) => {
         setShowModal(false);
+        onCreatePicklist?.();
     };
 
     const onCancel = () => {

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -74,9 +74,16 @@ export const PicklistEditModal: FC<Props> = memo(props => {
         finishingVerb = 'Creating';
     }
 
-    const onHide = useCallback(() => {
+    const reset = () => {
         setPicklistError(undefined);
         setIsSubmitting(false);
+        setName(undefined);
+        setDescription(undefined);
+        setShared(false);
+    }
+
+    const onHide = useCallback(() => {
+        reset();
         onCancel();
     }, []);
 
@@ -117,7 +124,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                 updatedList = await createPicklist(trimmedName, description, shared, selectionKey, sampleIds);
                 incrementClientSideMetricCount(metricFeatureArea, 'createPicklist');
             }
-            setIsSubmitting(false);
+            reset();
             if (showNotification) {
                 createSuccessNotification(updatedList);
             }


### PR DESCRIPTION
#### Rationale
When a picklist is created from a picklist listing page, we stay on the page, so we need to make sure we'll refresh the grid of picklists after creation happens.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/644

#### Changes
* Add after-creation callback property to PicklistCreationMenuItem
