### PR TITLE
43561: Support fields with nameExpression

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.2",
+  "version": "2.61.2-fb-data-class-names.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.2-fb-data-class-names.0",
+  "version": "2.62.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.3",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.6.3",
+    "@labkey/api": "1.6.5",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.62.0
+*Released*: 5 August 2021
+* Add `help` guidance for user when a `nameExpression` is present on the `QueryColumn`.
+* Mark field as required in when updating if a `nameExpression` is present.
+* GridPanel: allow multiple filters on same column in OmniBox.
+
 ### version 2.61.2
 *Released*: 4 August 2021
 * AssayImportPanels.tsx conversion to QueryModel for batch and run properties

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -50,7 +50,6 @@ export const getFieldEnabledFieldName = function (column: QueryColumn, fieldName
 interface QueryFormInputsProps {
     columnFilter?: (col?: QueryColumn) => boolean;
     componentKey?: string; // unique key to add to QuerySelect to avoid duplication w/ transpose
-    destroyOnDismount?: boolean;
     fieldValues?: any;
     fireQSChangeOnInit?: boolean;
     checkRequiredFields?: boolean;

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -187,7 +187,12 @@ export function resolveDetailEditRenderer(
                         validations={validations}
                         validationError={validationError}
                         value={value}
-                        required={col.required}
+                        // Issue 43561: Support name expression fields
+                        // NK: If a name expression is applied, then the server does not mark the field as required as
+                        // it will be generated. This is OK for the insert scenario, however, for update a value is
+                        // still required as the name expression won't be run upon update. Here we mark the input as
+                        // required if the nameExpression is not defined to force the form to require a value.
+                        required={col.required || col.nameExpression !== undefined}
                         elementWrapperClassName={[{ 'col-sm-9': false }, 'col-sm-12']}
                     />
                 );

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -145,7 +145,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
 
         let help: string;
         if (queryColumn.nameExpression) {
-            help = `A ${queryColumn.caption.toLowerCase()} will be generated if one is not given.`;
+            help = `A ${queryColumn.caption} will be generated if one is not given.`;
         }
 
         return (

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -143,11 +143,17 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
             }
         }
 
+        let help: string;
+        if (queryColumn.nameExpression) {
+            help = `A ${queryColumn.caption.toLowerCase()} will be generated if one is not given.`;
+        }
+
         return (
             <Input
                 disabled={this.state.isDisabled}
                 changeDebounceInterval={changeDebounceInterval}
                 elementWrapperClassName={elementWrapperClassName}
+                help={help}
                 id={queryColumn.fieldKey}
                 label={this.renderLabel()}
                 labelClassName={labelClassName}

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -77,6 +77,7 @@ export class QueryColumn extends Record({
     multiValue: false,
     // mvEnabled: undefined,
     name: undefined,
+    nameExpression: undefined,
     // nullable: undefined,
     phiProtected: undefined,
     protected: undefined,
@@ -141,6 +142,7 @@ export class QueryColumn extends Record({
     declare multiValue: boolean;
     // declare mvEnabled: boolean;
     declare name: string;
+    declare nameExpression: string;
     // declare nullable: boolean;
     declare phiProtected: boolean;
     declare 'protected': boolean;

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -436,7 +436,7 @@ describe('GridPanel', () => {
         // You should be able to add multiple filters if they're on different columns.
         testAddOmniBoxValue(wrapper, filterAction1, [filter1]);
         testAddOmniBoxValue(wrapper, filterAction2, [filter1, filter2]);
-        // Adding another filter on the same column as the second should replace the second filter.
+        // Adding another filter on the same column and sample filter type as the second should replace the second filter.
         testAddOmniBoxValue(wrapper, filterAction3, [filter1, filter3]);
         // Modifying the second filter should replace the filter on the model, and not touch the first filter.
         testModifyOmniBoxValue(wrapper, filterAction4, 1, [filter1, filter4]);

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -379,19 +379,23 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         if (change.type === ChangeType.add || change.type === ChangeType.modify) {
             const newValue = actionValues[actionValues.length - 1].valueObject;
             const newColumnName = newValue.getColumnName();
-            // Remove any filters on the same column, and append the new filter.
-            newFilters = newFilters.filter(filter => filter.getColumnName() !== newColumnName).concat(newValue);
+            const newFilterTypeSuffix = newValue.getFilterType().getURLSuffix();
+
+            // Remove any filters on the same column with the same filter type. Append the new filter.
+            newFilters = newFilters
+                .filter(
+                    f => f.getColumnName() !== newColumnName || f.getFilterType().getURLSuffix() !== newFilterTypeSuffix
+                )
+                .concat(newValue);
+
             // Remove any filter ActionValues with the same columnName as well.
-            actionValues = actionValues.filter(actionValue => {
-                const { action, valueObject } = actionValue;
-
-                if (action.keyword !== 'filter') {
-                    return true;
-                }
-
-                // Keep the new value, and any ActionValues on different columns.
-                return valueObject === newValue || valueObject.getColumnName() !== newColumnName;
-            });
+            actionValues = actionValues.filter(
+                ({ action, valueObject }) =>
+                    action.keyword !== 'filter' ||
+                    valueObject === newValue ||
+                    valueObject.getColumnName() !== newColumnName ||
+                    valueObject.getFilterType().getURLSuffix() !== newFilterTypeSuffix
+            );
         }
 
         // Defer model updates after localState is updated so we don't unnecessarily repopulate the omnibox.

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -771,10 +771,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.3":
-  version "1.6.3"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.3.tgz#4c3bdf94a58b33d8d46f8dbb241d1b2c8b95404b"
-  integrity sha1-TDvflKWLM9jUb427JB0bLIuVQEs=
+"@labkey/api@1.6.5":
+  version "1.6.5"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.5.tgz#4d41526aebd016f356f6e22836b3f08df325542d"
+  integrity sha1-TUFSauvQFvNW9uIoNrPwjfMlVC0=
 
 "@labkey/eslint-config-base@0.0.10":
   version "0.0.10"


### PR DESCRIPTION
#### Rationale
Respect presence of `nameExpression` on `QueryColumn` in text inputs. When present a help message is displayed to the user.

![image](https://user-images.githubusercontent.com/3926239/128062885-21192c95-ffdb-4a0f-a3c7-85e3d7597cd9.png)

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/959
* https://github.com/LabKey/platform/pull/2510
* https://github.com/LabKey/recipe/pull/56
* https://github.com/LabKey/labkey-api-js/pull/107
* https://github.com/LabKey/labkey-ui-components/pull/593

#### Changes
* Add `help` guidance for user when a `nameExpression` is present on the `QueryColumn`.
* Mark field as required in when updating if a `nameExpression` is present.
