### PR TITLE
AssayImportPanels.tsx conversion to QueryModel for batch and run properties

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-fb-assayImportPanelQueryModel.3",
+  "version": "2.61.1-fb-assayImportPanelQueryModel.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-fb-assayImportPanelQueryModel.4",
+  "version": "2.61.1-fb-assayImportPanelQueryModel.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1",
+  "version": "2.61.1-fb-assayImportPanelQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-fb-assayImportPanelQueryModel.5",
+  "version": "2.61.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-fb-assayImportPanelQueryModel.1",
+  "version": "2.61.1-fb-assayImportPanelQueryModel.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-fb-assayImportPanelQueryModel.2",
+  "version": "2.61.1-fb-assayImportPanelQueryModel.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.60.3",
+  "version": "2.60.3-fb-assayImportPanelQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1-fb-assayImportPanelQueryModel.0",
+  "version": "2.61.1-fb-assayImportPanelQueryModel.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* AssayImportPanels.tsx conversion to QueryModel for batch and run properties
+
 ### version 2.60.3
 *Released*: 28 July 2021
 * PermissionAssignments.tsx fix to only request root container security policy if user is root admin

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.61.2
+*Released*: 4 August 2021
 * AssayImportPanels.tsx conversion to QueryModel for batch and run properties
 
 ### version 2.61.1

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -332,7 +332,6 @@ import {
     getImportItemsForAssayDefinitions,
     getRunDetailsQueryColumns,
     importAssayRun,
-    RUN_PROPERTIES_GRID_ID,
     RUN_PROPERTIES_REQUIRED_COLUMNS,
 } from './internal/components/assay/actions';
 import { BaseBarChart } from './internal/components/chart/BaseBarChart';
@@ -917,7 +916,6 @@ export {
     AssayLink,
     clearAssayDefinitionCache,
     fetchAllAssays,
-    RUN_PROPERTIES_GRID_ID,
     RUN_PROPERTIES_REQUIRED_COLUMNS,
     GENERAL_ASSAY_PROVIDER_NAME,
     // heatmap

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -101,11 +101,7 @@ interface OwnProps {
     asyncRowSize?: number;
 }
 
-interface BodyProps {
-    runModelId: string;
-}
-
-type Props = OwnProps & WithFormStepsProps & BodyProps & InjectedQueryModels;
+type Props = OwnProps & WithFormStepsProps & InjectedQueryModels;
 
 interface State {
     schemaQuery: SchemaQuery;
@@ -173,8 +169,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
     }
 
     getRunPropsQueryModel(): QueryModel {
-        const { queryModels, runModelId } = this.props;
-        return queryModels[runModelId];
+        return this.props.queryModels.model;
     }
 
     getRunPropertiesMap(): Map<string, any> {
@@ -774,18 +769,18 @@ class AssayImportPanelsBody extends Component<Props, State> {
     }
 }
 
-const AssayImportPanelWithQueryModels = withQueryModels<OwnProps & WithFormStepsProps & BodyProps>(
+const AssayImportPanelWithQueryModels = withQueryModels<OwnProps & WithFormStepsProps>(
     AssayImportPanelsBody
 );
 
 const AssayImportPanelsBodyImpl: FC<OwnProps & WithFormStepsProps> = props => {
     const { assayDefinition, runId } = props;
+    const key = [runId, assayDefinition.protocolSchemaName].join('|');
     const schemaQuery = useMemo(() => SchemaQuery.create(assayDefinition.protocolSchemaName, 'Runs'), [assayDefinition.protocolSchemaName]);
-    const runModelId = useMemo(() => getStateModelId(RUN_PROPERTIES_GRID_ID, schemaQuery, runId), [runId, schemaQuery]);
 
     const queryConfigs: QueryConfigMap = useMemo(
         () => ({
-            [runModelId]: {
+            model: {
                 keyValue: runId,
                 schemaQuery,
                 requiredColumns: RUN_PROPERTIES_REQUIRED_COLUMNS.toArray(),
@@ -796,14 +791,13 @@ const AssayImportPanelsBodyImpl: FC<OwnProps & WithFormStepsProps> = props => {
                 ],
             },
         }),
-        [runModelId]
+        [runId, schemaQuery]
     );
 
     return (
         <AssayImportPanelWithQueryModels
             autoLoad
-            key={runModelId}
-            runModelId={runModelId}
+            key={key}
             queryConfigs={queryConfigs}
             {...props}
         />

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -145,12 +145,15 @@ class AssayImportPanelsBody extends Component<Props, State> {
         const batchId = this.getBatchId();
 
         if (!queryModels[BATCH_PROPERTIES_GRID_ID] && batchId) {
-            actions.addModel({
-                id: BATCH_PROPERTIES_GRID_ID,
-                keyValue: batchId,
-                schemaQuery: SchemaQuery.create(assayDefinition.protocolSchemaName, 'Batches'),
-                requiredColumns: SCHEMAS.CBMB.concat('Name', 'RowId').toArray(),
-            }, true);
+            actions.addModel(
+                {
+                    id: BATCH_PROPERTIES_GRID_ID,
+                    keyValue: batchId,
+                    schemaQuery: SchemaQuery.create(assayDefinition.protocolSchemaName, 'Batches'),
+                    requiredColumns: SCHEMAS.CBMB.concat('Name', 'RowId').toArray(),
+                },
+                true
+            );
         }
     }
 
@@ -768,14 +771,15 @@ class AssayImportPanelsBody extends Component<Props, State> {
     }
 }
 
-const AssayImportPanelWithQueryModels = withQueryModels<OwnProps & WithFormStepsProps>(
-    AssayImportPanelsBody
-);
+const AssayImportPanelWithQueryModels = withQueryModels<OwnProps & WithFormStepsProps>(AssayImportPanelsBody);
 
 const AssayImportPanelsBodyImpl: FC<OwnProps & WithFormStepsProps> = props => {
     const { assayDefinition, runId } = props;
     const key = [runId, assayDefinition.protocolSchemaName].join('|');
-    const schemaQuery = useMemo(() => SchemaQuery.create(assayDefinition.protocolSchemaName, 'Runs'), [assayDefinition.protocolSchemaName]);
+    const schemaQuery = useMemo(
+        () => SchemaQuery.create(assayDefinition.protocolSchemaName, 'Runs'),
+        [assayDefinition.protocolSchemaName]
+    );
 
     const queryConfigs: QueryConfigMap = useMemo(
         () => ({
@@ -793,14 +797,7 @@ const AssayImportPanelsBodyImpl: FC<OwnProps & WithFormStepsProps> = props => {
         [runId, schemaQuery]
     );
 
-    return (
-        <AssayImportPanelWithQueryModels
-            autoLoad
-            key={key}
-            queryConfigs={queryConfigs}
-            {...props}
-        />
-    );
+    return <AssayImportPanelWithQueryModels autoLoad key={key} queryConfigs={queryConfigs} {...props} />;
 };
 
 export const AssayImportPanels = withFormSteps(AssayImportPanelsBodyImpl, {

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -179,7 +179,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
 
     getRunPropertiesMap(): Map<string, any> {
         const model = this.getRunPropsQueryModel();
-        return flattenQueryModelRow(model?.getRow() || {});
+        return flattenQueryModelRow(model?.getRow());
     }
 
     getBatchId(): string {
@@ -193,7 +193,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
 
     getBatchPropertiesMap(): Map<string, any> {
         const model = this.getBatchPropsQueryModel();
-        return flattenQueryModelRow(model?.getRow() || {});
+        return flattenQueryModelRow(model?.getRow());
     }
 
     isRunPropertiesInit(props: Props) {

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -47,10 +47,8 @@ import {
     WizardNavButtons,
     AssayProtocolModel,
     RUN_PROPERTIES_REQUIRED_COLUMNS,
-    RUN_PROPERTIES_GRID_ID,
     SCHEMAS,
     caseInsensitive,
-    getStateModelId,
     QueryConfigMap,
 } from '../../..';
 
@@ -58,7 +56,6 @@ import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { withQueryModels, InjectedQueryModels } from '../../../public/QueryModel/withQueryModels';
 
 import {
-    BATCH_PROPERTIES_GRID_ID,
     checkForDuplicateAssayFiles,
     DuplicateFilesResponse,
     flattenQueryModelRow,
@@ -72,6 +69,8 @@ import { RunPropertiesPanel } from './RunPropertiesPanel';
 import { BatchPropertiesPanel } from './BatchPropertiesPanel';
 import { AssayUploadGridLoader } from './AssayUploadGridLoader';
 import { AssayWizardModel, IAssayUploadOptions } from './AssayWizardModel';
+
+const BATCH_PROPERTIES_GRID_ID = 'assay-batchdetails';
 
 interface OwnProps {
     assayDefinition: AssayDefinitionModel;

--- a/packages/components/src/internal/components/assay/AssayReimportHeader.spec.tsx
+++ b/packages/components/src/internal/components/assay/AssayReimportHeader.spec.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { fromJS } from 'immutable';
-
 import assayDefJSON from '../../../test/data/assayDefinitionModel.json';
 
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
@@ -12,10 +10,11 @@ import { AssayReimportHeader } from './AssayReimportHeader';
 describe('<AssayReimportHeader/>', () => {
     const assay = AssayDefinitionModel.create(assayDefJSON);
 
-    const runData = fromJS({
-        RowId: 10,
-        Name: 'Test Name',
-    });
+    const runData = {
+        RowId: { value: 10 },
+        Name: { value: 'Test Name' },
+    };
+
     test('has batch properties', () => {
         const component = (
             <AssayReimportHeader hasBatchProperties={true} assay={assay} replacedRunProperties={runData} />

--- a/packages/components/src/internal/components/assay/AssayReimportHeader.tsx
+++ b/packages/components/src/internal/components/assay/AssayReimportHeader.tsx
@@ -1,27 +1,28 @@
 import React from 'react';
 import { Panel } from 'react-bootstrap';
-import { Map } from 'immutable';
 
-import { AppURL } from '../../..';
+import { AppURL, caseInsensitive } from '../../..';
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 
 interface Props {
     hasBatchProperties?: boolean;
     assay: AssayDefinitionModel;
-    replacedRunProperties: Map<string, any>;
+    replacedRunProperties: Record<string, any>;
 }
 
 export class AssayReimportHeader extends React.Component<Props> {
     render() {
         const { assay, hasBatchProperties, replacedRunProperties } = this.props;
-        const assayRunUrl = AppURL.create('assays', assay.type, assay.name, 'runs', replacedRunProperties.get('RowId'));
+        const rowId = caseInsensitive(replacedRunProperties, 'RowId').value;
+        const name = caseInsensitive(replacedRunProperties, 'Name').value;
+        const assayRunUrl = AppURL.create('assays', assay.type, assay.name, 'runs', rowId);
         return (
             <Panel>
                 <Panel.Heading>Re-Import Run</Panel.Heading>
                 <Panel.Body>
                     <p>
                         <strong>
-                            Replacing Run: <a href={assayRunUrl.toHref()}>{replacedRunProperties.get('Name')}</a>
+                            Replacing Run: <a href={assayRunUrl.toHref()}>{name}</a>
                         </strong>
                     </p>
                     <p>

--- a/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
@@ -26,6 +26,7 @@ export class BatchPropertiesPanel extends React.Component<AssayPropertiesPanelPr
         const { model } = this.props;
 
         return (
+            !is(model.batchId, nextProps.model.batchId) ||
             !is(model.batchColumns, nextProps.model.batchColumns) ||
             !is(model.batchProperties, nextProps.model.batchProperties)
         );

--- a/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
@@ -27,7 +27,7 @@ export class BatchPropertiesPanel extends React.Component<AssayPropertiesPanelPr
 
         return (
             !is(model.batchColumns, nextProps.model.batchColumns) ||
-            !is(model.batchProperties, nextProps.model.runProperties)
+            !is(model.batchProperties, nextProps.model.batchProperties)
         );
     }
 

--- a/packages/components/src/internal/components/assay/RunDataPanel.spec.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.spec.tsx
@@ -51,7 +51,6 @@ class RunDataPanelWrapperImpl extends React.Component<Props, any> {
             <RunDataPanel
                 currentStep={currentStep}
                 wizardModel={ASSAY_WIZARD_MODEL}
-                runPropertiesRow={{}}
                 queryGridModelForEditor={gridModel}
                 onFileChange={jest.fn}
                 onFileRemoval={jest.fn}
@@ -76,7 +75,6 @@ describe('<RunDataPanel/>', () => {
             <RunDataPanel
                 currentStep={AssayUploadTabs.Files}
                 wizardModel={ASSAY_WIZARD_MODEL}
-                runPropertiesRow={{}}
                 queryGridModelForEditor={getQueryGridModel(MODEL_ID_NOT_LOADED)}
                 onFileChange={jest.fn}
                 onFileRemoval={jest.fn}

--- a/packages/components/src/internal/components/assay/RunDataPanel.spec.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.spec.tsx
@@ -51,7 +51,8 @@ class RunDataPanelWrapperImpl extends React.Component<Props, any> {
             <RunDataPanel
                 currentStep={currentStep}
                 wizardModel={ASSAY_WIZARD_MODEL}
-                gridModel={gridModel}
+                runPropertiesRow={{}}
+                queryGridModelForEditor={gridModel}
                 onFileChange={jest.fn}
                 onFileRemoval={jest.fn}
                 onTextChange={jest.fn}
@@ -75,7 +76,8 @@ describe('<RunDataPanel/>', () => {
             <RunDataPanel
                 currentStep={AssayUploadTabs.Files}
                 wizardModel={ASSAY_WIZARD_MODEL}
-                gridModel={getQueryGridModel(MODEL_ID_NOT_LOADED)}
+                runPropertiesRow={{}}
+                queryGridModelForEditor={getQueryGridModel(MODEL_ID_NOT_LOADED)}
                 onFileChange={jest.fn}
                 onFileRemoval={jest.fn}
                 onTextChange={jest.fn}

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -316,8 +316,7 @@ export class RunDataPanel extends React.Component<Props, State> {
                                             bulkAddText="Bulk Insert"
                                             bulkAddProps={{
                                                 title: 'Bulk Insert Assay Rows',
-                                                header:
-                                                    'Add a batch of assay data rows that will share the properties set below.',
+                                                header: 'Add a batch of assay data rows that will share the properties set below.',
                                             }}
                                             allowBulkUpdate={allowBulkUpdate}
                                             bordered={true}

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -52,7 +52,7 @@ const PREVIEW_ROW_COUNT = 3;
 interface Props {
     currentStep: number;
     wizardModel: AssayWizardModel;
-    runPropertiesRow: Record<string, any>;
+    runPropertiesRow?: Record<string, any>;
     queryGridModelForEditor: QueryGridModel;
     onFileChange: (attachments: Map<string, File>) => any;
     onFileRemoval: (attachmentName: string) => any;

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -43,7 +43,7 @@ import { DATA_IMPORT_TOPIC } from '../../util/helpLinks';
 
 import { getServerFilePreview } from './utils';
 
-import { getRunPropertiesFileName, getRunPropertiesRow } from './actions';
+import { getRunPropertiesFileName } from './actions';
 import { AssayWizardModel } from './AssayWizardModel';
 
 const TABS = ['Upload Files', 'Copy-and-Paste Data', 'Enter Data Into Grid'];
@@ -52,7 +52,8 @@ const PREVIEW_ROW_COUNT = 3;
 interface Props {
     currentStep: number;
     wizardModel: AssayWizardModel;
-    gridModel: QueryGridModel;
+    runPropertiesRow: Record<string, any>;
+    queryGridModelForEditor: QueryGridModel;
     onFileChange: (attachments: Map<string, File>) => any;
     onFileRemoval: (attachmentName: string) => any;
     onTextChange: (inputName: string, value: any) => any;
@@ -121,27 +122,26 @@ export class RunDataPanel extends React.Component<Props, State> {
 
     initPreviewData() {
         const { previousRunData } = this.state;
-        const { wizardModel } = this.props;
+        const { wizardModel, runPropertiesRow } = this.props;
 
         if (!this.isRerun() || !previousRunData || previousRunData.isLoaded || previousRunData.isLoading) {
             return;
         }
 
         if (wizardModel.isInit && wizardModel.usePreviousRunFile) {
-            const row = getRunPropertiesRow(wizardModel.assayDef, wizardModel.runId);
-            if (row.has('DataOutputs')) {
-                const outputFiles = row.get('DataOutputs/DataFileUrl');
-                if (outputFiles && outputFiles.size == 1) {
-                    const outputs = row.get('DataOutputs');
+            if (runPropertiesRow && runPropertiesRow['DataOutputs']) {
+                const outputFiles = runPropertiesRow['DataOutputs/DataFileUrl'];
+                if (outputFiles?.length === 1) {
+                    const outputs = runPropertiesRow['DataOutputs'];
                     this.setState(() => ({ previousRunData: { isLoading: true, isLoaded: false } }));
 
-                    getServerFilePreview(outputs.getIn([0, 'value']), PREVIEW_ROW_COUNT)
+                    getServerFilePreview(outputs[0].value, PREVIEW_ROW_COUNT)
                         .then(response => {
                             this.setState(() => ({
                                 previousRunData: {
                                     isLoaded: true,
                                     data: response,
-                                    fileName: getRunPropertiesFileName(row),
+                                    fileName: getRunPropertiesFileName(runPropertiesRow),
                                 },
                             }));
                         })
@@ -210,8 +210,8 @@ export class RunDataPanel extends React.Component<Props, State> {
     };
 
     onRowCountChange = (rowCount: number) => {
-        const { gridModel } = this.props;
-        const editorModel = getEditorModel(gridModel.getId());
+        const { queryGridModelForEditor } = this.props;
+        const editorModel = getEditorModel(queryGridModelForEditor.getId());
         if (this.props.onGridDataChange) {
             this.props.onGridDataChange(editorModel && editorModel.rowCount > 0, IMPORT_DATA_FORM_TYPES.GRID);
         }
@@ -220,7 +220,7 @@ export class RunDataPanel extends React.Component<Props, State> {
     render() {
         const {
             currentStep,
-            gridModel,
+            queryGridModelForEditor,
             wizardModel,
             onTextChange,
             acceptedPreviewFileFormats,
@@ -234,7 +234,7 @@ export class RunDataPanel extends React.Component<Props, State> {
             maxEditableGridRowMsg,
         } = this.props;
         const { message, messageStyle, previousRunData } = this.state;
-        const isLoading = !wizardModel.isInit || !gridModel || !gridModel.isLoaded;
+        const isLoading = !wizardModel.isInit || !queryGridModelForEditor || !queryGridModelForEditor.isLoaded;
         const isLoadingPreview = previousRunData && !previousRunData.isLoaded;
 
         let cutPastePlaceholder = 'Paste in a tab-separated set of values (including column headers).';
@@ -308,7 +308,7 @@ export class RunDataPanel extends React.Component<Props, State> {
                                     </FormStep>
                                     <FormStep stepIndex={AssayUploadTabs.Grid} trackActive={false}>
                                         <EditableGridPanel
-                                            model={gridModel}
+                                            model={queryGridModelForEditor}
                                             isSubmitting={wizardModel.isSubmitting}
                                             disabled={currentStep !== AssayUploadTabs.Grid}
                                             allowBulkRemove={allowBulkRemove}

--- a/packages/components/src/internal/components/assay/actions.spec.ts
+++ b/packages/components/src/internal/components/assay/actions.spec.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fromJS } from 'immutable';
-
 import { AssayStateModel, GENERAL_ASSAY_PROVIDER_NAME, QueryInfo, SchemaQuery } from '../../..';
 import { getStateQueryGridModel } from '../../models';
 import { initQueryGridState } from '../../global';
@@ -65,11 +63,11 @@ describe('getImportItemsForAssayDefinitions', () => {
 describe('getRunPropertiesFileName', () => {
     test('abc', () => {
         expect(getRunPropertiesFileName(undefined)).toBe(undefined);
-        expect(getRunPropertiesFileName(fromJS({}))).toBe(undefined);
-        expect(getRunPropertiesFileName(fromJS({ DataOutputs: [] }))).toBe(undefined);
-        expect(
-            getRunPropertiesFileName(fromJS({ DataOutputs: [{ displayValue: 'test1' }, { displayValue: 'test2' }] }))
-        ).toBe(undefined);
-        expect(getRunPropertiesFileName(fromJS({ DataOutputs: [{ displayValue: 'test1' }] }))).toBe('test1');
+        expect(getRunPropertiesFileName({})).toBe(undefined);
+        expect(getRunPropertiesFileName({ DataOutputs: [] })).toBe(undefined);
+        expect(getRunPropertiesFileName({ DataOutputs: [{ displayValue: 'test1' }, { displayValue: 'test2' }] })).toBe(
+            undefined
+        );
+        expect(getRunPropertiesFileName({ DataOutputs: [{ displayValue: 'test1' }] })).toBe('test1');
     });
 });

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -376,7 +376,7 @@ export function flattenQueryModelRow(rowData: Record<string, any>): Map<string, 
                 }
                 valueMap = v[v.length - 1];
             }
-            if (valueMap && valueMap['value'] !== undefined) {
+            if (valueMap && valueMap['value'] !== undefined && valueMap['value'] !== null) {
                 map = map.set(k, valueMap['value']);
             }
         });

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -35,9 +35,6 @@ import { IAssayUploadOptions } from './AssayWizardModel';
 
 export const GENERAL_ASSAY_PROVIDER_NAME = 'General';
 
-export const BATCH_PROPERTIES_GRID_ID = 'assay-batchdetails';
-export const RUN_PROPERTIES_GRID_ID = 'assay-run-details';
-
 export const RUN_PROPERTIES_REQUIRED_COLUMNS = SCHEMAS.CBMB.concat(
     'Name',
     'RowId',


### PR DESCRIPTION
#### Rationale
The AssayImportPanels.tsx component was using QueryGridModel/gridInit/etc. for the run and batch properties info for the assay re-import case. This PR converts those usages to QueryModel.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/596
* https://github.com/LabKey/platform/pull/2515
* https://github.com/LabKey/sampleManagement/pull/648
* https://github.com/LabKey/biologics/pull/960

#### Changes
* AssayImportPanels.tsx conversion to QueryModel for batch and run properties model
* AssayImportPanels.tsx usages of runId as key prop to prevent re-init on URL param changes
* AssayImportPanels.tsx fix to account for replaced runs in re-import baseFilter 
* AssayReimportHeader.tsx convert to run props as JS object instead of immutable Map
* RunDataPanel.tsx to take in run properties row as prop instead of relying on it being in global state and rename model prop to `queryGridModelForEditor` for clarity
* remove unused run and batch props getters for QueryGridModels
