### PR TITLE
Issue 43647: SM: creating aliquots for a sample type with a required field gives an error

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.62.1-fb-issue43647.1",
+  "version": "2.62.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.2",
+  "version": "2.61.3-fb-issue43647.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Issue 43647: SM: creating aliquots for a sample type with a required field gives an error
+    * Add required sample properties to insertRows data for aliquot creation
+
 ### version 2.61.2
 *Released*: 4 August 2021
 * AssayImportPanels.tsx conversion to QueryModel for batch and run properties

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 2.62.1
+*Released*: 9 August 2021
 * Issue 43647: SM: creating aliquots for a sample type with a required field gives an error
     * Add required sample properties to insertRows data for aliquot creation
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -730,8 +730,24 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         this.setState({ isSubmitting });
     };
 
+    getAliquotCreationExtraColumns = (): QueryColumn[] => {
+        const { originalQueryInfo } = this.state;
+
+        let requiredProperties = [];
+        originalQueryInfo.columns.forEach((column, key) => {
+            if (column.required
+                && column.shownInInsertView
+                && !column.hidden
+                && ALIQUOT_FIELD_COLS.indexOf(column.fieldKey.toLowerCase()) === -1) {
+                requiredProperties.push(column);
+            }
+        });
+
+        return requiredProperties;
+    };
+
     insertRowsFromGrid = async (): Promise<void> => {
-        const { insertModel } = this.state;
+        const { insertModel, creationType } = this.state;
         const { entityDataType } = this.props;
         const queryGridModel = this.getQueryGridModel();
         const editorModel = getEditorModel(queryGridModel.getId());
@@ -750,8 +766,12 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
         this.setSubmitting(true);
 
+        let extraColumnsToInclude : QueryColumn[] = undefined;
+        if (creationType === SampleCreationType.Aliquots)
+            extraColumnsToInclude = this.getAliquotCreationExtraColumns(); // include required sample property fields in post
+
         try {
-            const response = await insertModel.postEntityGrid(queryGridModel);
+            const response = await insertModel.postEntityGrid(queryGridModel, extraColumnsToInclude);
 
             this.setSubmitting(false);
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -733,12 +733,14 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     getAliquotCreationExtraColumns = (): QueryColumn[] => {
         const { originalQueryInfo } = this.state;
 
-        let requiredProperties = [];
+        const requiredProperties = [];
         originalQueryInfo.columns.forEach((column, key) => {
-            if (column.required
-                && column.shownInInsertView
-                && !column.hidden
-                && ALIQUOT_FIELD_COLS.indexOf(column.fieldKey.toLowerCase()) === -1) {
+            if (
+                column.required &&
+                column.shownInInsertView &&
+                !column.hidden &&
+                ALIQUOT_FIELD_COLS.indexOf(column.fieldKey.toLowerCase()) === -1
+            ) {
                 requiredProperties.push(column);
             }
         });
@@ -766,9 +768,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
         this.setSubmitting(true);
 
-        let extraColumnsToInclude : QueryColumn[] = undefined;
-        if (creationType === SampleCreationType.Aliquots)
-            extraColumnsToInclude = this.getAliquotCreationExtraColumns(); // include required sample property fields in post
+        let extraColumnsToInclude: QueryColumn[];
+        if (creationType === SampleCreationType.Aliquots) extraColumnsToInclude = this.getAliquotCreationExtraColumns(); // include required sample property fields in post
 
         try {
             const response = await insertModel.postEntityGrid(queryGridModel, extraColumnsToInclude);

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -509,11 +509,10 @@ export class EntityIdCreationModel extends Record({
             .valueSeq()
             .reduce((rows, row) => {
                 let map = row.toMap();
-                if (extraColumnsToInclude && extraColumnsToInclude.length > 0)
-                {
+                if (extraColumnsToInclude && extraColumnsToInclude.length > 0) {
                     extraColumnsToInclude.forEach(col => {
                         map = map.set(col.name, undefined);
-                    })
+                    });
                 }
                 rows = rows.push(map);
                 return rows;


### PR DESCRIPTION
#### Rationale
When creating aliquots, the insertRows cmd doesn't include sample type's required columns, which cause the columns validation to fail. We will add those required columns to the post data, and make the change so that the data iterator will bypass absent value check for aliquots at a later time. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/597
* https://github.com/LabKey/platform/pull/2524
* https://github.com/LabKey/sampleManagement/pull/653

#### Changes
* add required column to insertRows post data