### PR TITLE
Update scss for form has-error display of updated react-select component to match other form inputs

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.62.2-fb-reactSelectHasError.0",
+  "version": "2.62.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.62.2",
+  "version": "2.62.2-fb-reactSelectHasError.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.62.1-fb-reactSelectHasError.0",
+  "version": "2.62.1-fb-reactSelectHasError.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.62.1",
+  "version": "2.62.1-fb-reactSelectHasError.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD August 2021
+* Update scss for form has-error display of updated react-select component to match other form inputs
+
 ### version 2.62.1
 *Released*: 9 August 2021
 * Issue 43647: SM: creating aliquots for a sample type with a required field gives an error

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD August 2021
+### version 2.62.3
+*Released*: 11 August 2021
 * Update scss for form has-error display of updated react-select component to match other form inputs
 
 ### version 2.62.2

--- a/packages/components/src/theme/entities.scss
+++ b/packages/components/src/theme/entities.scss
@@ -16,8 +16,7 @@
   padding-top: 7px;
 }
 
-.has-error .Select-control, .has-error .select-input__control,
-.has-error .form-control, .has-error .form-control:focus {
+.has-error .select-input__control, .has-error .form-control, .has-error .form-control:focus {
   border-color: $red-border;
   box-shadow: inset 0 0 3px 0 $red-shadow, 0 0 3px 0 $red-shadow;
 }

--- a/packages/components/src/theme/entities.scss
+++ b/packages/components/src/theme/entities.scss
@@ -16,7 +16,8 @@
   padding-top: 7px;
 }
 
-.has-error .Select-control, .has-error .form-control, .has-error .form-control:focus {
+.has-error .Select-control, .has-error .select-input__control,
+.has-error .form-control, .has-error .form-control:focus {
   border-color: $red-border;
   box-shadow: inset 0 0 3px 0 $red-shadow, 0 0 3px 0 $red-shadow;
 }


### PR DESCRIPTION
#### Rationale
To make the error display for required form inputs consistent between form input types (i.e. text input vs selects), we are adding the updated react-select component class to the entities.scss "has-error" rule definition to make it match the previous error validation display for the react-select component.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add `.has-error .select-input__control` to scss rule
