### PR TITLE
getDateFormat / getDateTimeFormat: support container parameter

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.62.1-fb-lp-job-overview.0",
+  "version": "2.62.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.62.1",
+  "version": "2.62.1-fb-lp-job-overview.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.6#.#
-*Released*: # August 2021
+### version 2.62.2
+*Released*: 10 August 2021
 * getDateFormat / getDateTimeFormat: support container parameter
 
 ### version 2.62.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.6#.#
+*Released*: # August 2021
+* getDateFormat / getDateTimeFormat: support container parameter
+
 ### version 2.62.1
 *Released*: 9 August 2021
 * Issue 43647: SM: creating aliquots for a sample type with a required field gives an error

--- a/packages/components/src/internal/components/DateInput.tsx
+++ b/packages/components/src/internal/components/DateInput.tsx
@@ -7,6 +7,10 @@ export class DateInput extends PureComponent<ReactDatePickerProps> {
     static defaultProps = {
         autoComplete: 'off',
         className: 'form-control',
+        // TODO: Support server-specified date formats.
+        // DatePicker utilizes `date-fns` (https://date-fns.org/) for handling date formatting. Currently, LabKey
+        // utilizes `moment` for handling date formats on the client and Java date formatting on the server. This
+        // mix of different formats is problematic for providing consistent date formatting to users in all cases.
         dateFormat: 'MM/dd/yyyy', // different format than Moment.
         wrapperClassName: 'form-control',
         showTimeSelect: false,

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -6,11 +6,11 @@ import { getDateFormat } from '../util/Date';
 import { Key, useEnterEscape } from '../../public/useEnterEscape';
 
 import { DateInput } from './DateInput';
+import { useServerContext } from './base/ServerContext';
 
-interface EditInlineField {
+interface Props {
     allowBlank?: boolean;
     allowEdit?: boolean;
-    dateFormat?: string; // Moment date format
     emptyText?: string;
     label?: string;
     name: string;
@@ -20,9 +20,10 @@ interface EditInlineField {
     value: any;
 }
 
-export const EditInlineField: FC<EditInlineField> = memo(props => {
+export const EditInlineField: FC<Props> = memo(props => {
     const { allowBlank, allowEdit, emptyText, label, name, onChange, placeholder, type, value } = props;
-    const dateFormat = props.dateFormat ? props.dateFormat : getDateFormat();
+    const { container } = useServerContext();
+    const dateFormat = getDateFormat(container);
     const isDate = type === 'date';
     const isText = type === 'text';
     const isTextArea = type === 'textarea';
@@ -110,6 +111,8 @@ export const EditInlineField: FC<EditInlineField> = memo(props => {
         }
     }, []);
 
+    // TODO: Pass through the dateFormat to the <DateInput/> so the format is consistent between viewing and editing.
+    // See note on <DateInput/> regarding supporting date formats.
     return (
         <div className="edit-inline-field">
             {state.editing && isDate && (

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -16,7 +16,7 @@
 import moment from 'moment-jdateformatparser';
 import momentTZ from 'moment-timezone';
 import numeral from 'numeral';
-import { getServerContext } from '@labkey/api';
+import { Container, getServerContext } from '@labkey/api';
 
 import { QueryColumn } from '../..';
 
@@ -55,12 +55,12 @@ export function isDateTimeCol(col: QueryColumn): boolean {
 }
 
 // 30834: get look and feel display formats
-export function getDateFormat(): string {
-    return moment().toMomentFormatString(getServerContext().container.formats.dateFormat);
+export function getDateFormat(container?: Partial<Container>): string {
+    return moment().toMomentFormatString((container ?? getServerContext().container).formats.dateFormat);
 }
 
-export function getDateTimeFormat(): string {
-    return moment().toMomentFormatString(getServerContext().container.formats.dateTimeFormat);
+export function getDateTimeFormat(container?: Partial<Container>): string {
+    return moment().toMomentFormatString((container ?? getServerContext().container).formats.dateTimeFormat);
 }
 
 export function parseDate(dateStr: string, dateFormat?: string): Date {


### PR DESCRIPTION
#### Rationale
Support passing in a `container` for `getDateFormat` and `getDateTimeFormat`. This reduces dependency on `getServerContext()` and makes it usable with callers of `useServerContext()`.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/939
* https://github.com/LabKey/sampleManagement/pull/627

#### Changes
* `getDateFormat` / `getDateTimeFormat`: support container parameter