### PR TITLE
Link to Study Dataset Category Assignment

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.61.1",
+  "version": "2.61.1-fb-autolinktostudycategory-1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.0-fb-autolinktostudycategory-1.0",
+  "version": "2.63.0-fb-autolinktostudycategory-1.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.64.0-fb-autolinktostudycategory-1.0",
+  "version": "2.65.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Create Assay Designer 'Linked Dataset Category' field as part of Link to Study dataset category assignment
+
 ### version 2.63.0
 *Released*: 11 August 2021
 * Issue 43672: Add "referrer" param to the help link URLs

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.65.0
+*Released*: 18 August 2021
 * Create Assay Designer 'Linked Dataset Category' field as part of Link to Study dataset category assignment
 
 ### version 2.64.0

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -328,6 +328,26 @@ export class AutoLinkDataInput extends React.PureComponent<InputProps, AutoLinkD
     }
 }
 
+export class AutoLinkCategoryInput extends React.PureComponent<InputProps> {
+    render() {
+        const { model, onChange } = this.props;
+
+        return (
+            <AssayPropertiesInput
+                label="Linked Dataset Category"
+                helpTipBody={<p> ROSALINE TODO </p>}
+            >
+                <FormControl
+                    id={FORM_IDS.AUTO_LINK_CATEGORY}
+                    type="text"
+                    value={model.autoLinkCategory}
+                    onChange={onChange}
+                />
+            </AssayPropertiesInput>
+        );
+    }
+}
+
 interface ModuleProvidedScriptsInputProps {
     model: AssayProtocolModel;
 }

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -328,25 +328,30 @@ export class AutoLinkDataInput extends React.PureComponent<InputProps, AutoLinkD
     }
 }
 
-export class AutoLinkCategoryInput extends React.PureComponent<InputProps> {
-    render() {
-        const { model, onChange } = this.props;
+export const AutoLinkCategoryInput: FC<InputProps> = memo(props => {
+    const { model, onChange } = props;
 
-        return (
-            <AssayPropertiesInput
-                label="Linked Dataset Category"
-                helpTipBody={<p> ROSALINE TODO </p>}
-            >
-                <FormControl
-                    id={FORM_IDS.AUTO_LINK_CATEGORY}
-                    type="text"
-                    value={model.autoLinkCategory}
-                    onChange={onChange}
-                />
-            </AssayPropertiesInput>
-        );
-    }
-}
+    return (
+        <AssayPropertiesInput
+            label="Linked Dataset Category"
+            helpTipBody={
+                <p>
+                    Specify the desired category for the Assay Dataset that will be created (or appended to) in the
+                    target study when rows are linked. If the category you specify does not exist, it will be created.
+                    If the Assay Dataset already exists, this setting will not overwrite a previously assigned category.
+                    Leave blank to use the default category of "Uncategorized".
+                </p>
+            }
+        >
+            <FormControl
+                id={FORM_IDS.AUTO_LINK_CATEGORY}
+                type="text"
+                value={model.autoLinkCategory}
+                onChange={onChange}
+            />
+        </AssayPropertiesInput>
+    );
+});
 
 interface ModuleProvidedScriptsInputProps {
     model: AssayProtocolModel;

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
@@ -9,6 +9,7 @@ import { AssayProtocolModel } from './models';
 
 import {
     AutoLinkDataInput,
+    AutoLinkCategoryInput,
     BackgroundUploadInput,
     DescriptionInput,
     DetectionMethodsInput,
@@ -128,6 +129,7 @@ describe('AssayPropertiesPanel', () => {
         expect(simpleModelWrapper.find(SaveScriptDataInput)).toHaveLength(0);
         expect(simpleModelWrapper.find(ModuleProvidedScriptsInput)).toHaveLength(0);
         expect(simpleModelWrapper.find(AutoLinkDataInput)).toHaveLength(1);
+        expect(simpleModelWrapper.find(AutoLinkCategoryInput)).toHaveLength(1);
         simpleModelWrapper.unmount();
     });
 
@@ -160,6 +162,7 @@ describe('AssayPropertiesPanel', () => {
         expect(simpleModelWrapper.find(SaveScriptDataInput)).toHaveLength(1);
         expect(simpleModelWrapper.find(ModuleProvidedScriptsInput)).toHaveLength(1);
         expect(simpleModelWrapper.find(AutoLinkDataInput)).toHaveLength(1);
+        expect(simpleModelWrapper.find(AutoLinkCategoryInput)).toHaveLength(1);
         simpleModelWrapper.unmount();
     });
 
@@ -192,6 +195,7 @@ describe('AssayPropertiesPanel', () => {
         expect(simpleModelWrapper.find(SaveScriptDataInput)).toHaveLength(0);
         expect(simpleModelWrapper.find(ModuleProvidedScriptsInput)).toHaveLength(0);
         expect(simpleModelWrapper.find(AutoLinkDataInput)).toHaveLength(0);
+        expect(simpleModelWrapper.find(AutoLinkCategoryInput)).toHaveLength(0);
         simpleModelWrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -201,13 +201,11 @@ class AssayPropertiesPanelImpl extends React.PureComponent<Props & InjectedDomai
         const { model } = this.props;
 
         return (
-            <>
-                <div className="domain-field-padding-bottom">
-                    <SectionHeading title="Link to Study Settings" />
-                    <AutoLinkDataInput model={model} onChange={this.onInputChange} />
-                    <AutoLinkCategoryInput model={model} onChange={this.onInputChange} />
-                </div>
-            </>
+            <div className="domain-field-padding-bottom">
+                <SectionHeading title="Link to Study Settings" />
+                <AutoLinkDataInput model={model} onChange={this.onInputChange} />
+                <AutoLinkCategoryInput model={model} onChange={this.onInputChange} />
+            </div>
         );
     }
 

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -13,6 +13,7 @@ import { BasePropertiesPanel, BasePropertiesPanelProps } from '../BaseProperties
 
 import { AssayProtocolModel } from './models';
 import {
+    AutoLinkCategoryInput,
     AutoLinkDataInput,
     BackgroundUploadInput,
     DescriptionInput,
@@ -35,6 +36,7 @@ export const FORM_IDS = {
     ASSAY_NAME: FORM_ID_PREFIX + 'name',
     ASSAY_DESCRIPTION: FORM_ID_PREFIX + 'description',
     AUTO_LINK_TARGET: FORM_ID_PREFIX + 'autoCopyTargetContainerId',
+    AUTO_LINK_CATEGORY: FORM_ID_PREFIX + 'autoLinkCategory',
     BACKGROUND_UPLOAD: FORM_ID_PREFIX + 'backgroundUpload',
     DETECTION_METHOD: FORM_ID_PREFIX + 'selectedDetectionMethod',
     EDITABLE_RUNS: FORM_ID_PREFIX + 'editableRuns',
@@ -178,7 +180,6 @@ class AssayPropertiesPanelImpl extends React.PureComponent<Props & InjectedDomai
             <>
                 <div className="domain-field-padding-bottom">
                     <SectionHeading title="Import Settings" />
-                    <AutoLinkDataInput model={model} onChange={this.onInputChange} />
                     {model.allowBackgroundUpload && (
                         <BackgroundUploadInput model={model} onChange={this.onInputChange} />
                     )}
@@ -191,6 +192,20 @@ class AssayPropertiesPanelImpl extends React.PureComponent<Props & InjectedDomai
                     {model.moduleTransformScripts && model.moduleTransformScripts.size > 0 && (
                         <ModuleProvidedScriptsInput model={model} />
                     )}
+                </div>
+            </>
+        );
+    }
+
+    renderLinkToStudySettings() {
+        const { model } = this.props;
+
+        return (
+            <>
+                <div className="domain-field-padding-bottom">
+                    <SectionHeading title="Link to Study Settings" />
+                    <AutoLinkDataInput model={model} onChange={this.onInputChange} />
+                    <AutoLinkCategoryInput model={model} onChange={this.onInputChange} />
                 </div>
             </>
         );
@@ -234,8 +249,13 @@ class AssayPropertiesPanelImpl extends React.PureComponent<Props & InjectedDomai
                     {this.renderBasicProperties()}
                     {this.renderEditSettings()}
                 </Col>
+
                 <Col xs={12} lg={6}>
                     {!appPropertiesOnly && this.renderImportSettings()}
+                </Col>
+
+                <Col xs={12} lg={6}>
+                    {!appPropertiesOnly && this.renderLinkToStudySettings()}
                 </Col>
             </Form>
         );

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -252,6 +252,7 @@ class AssayPropertiesPanelImpl extends React.PureComponent<Props & InjectedDomai
                     {!appPropertiesOnly && this.renderImportSettings()}
                 </Col>
 
+                {/* TODO: As one can run LKS without the study module, we should add a relevant check (i.e. 'hasModule('Study')) to this conditional'*/}
                 <Col xs={12} lg={6}>
                     {!appPropertiesOnly && this.renderLinkToStudySettings()}
                 </Col>

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
@@ -18,6 +18,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
       "allowPlateMetadata": false,
       "autoCopyTargetContainer": undefined,
       "autoCopyTargetContainerId": undefined,
+      "autoLinkCategory": undefined,
       "availableDetectionMethods": undefined,
       "availableMetadataInputFormats": undefined,
       "availablePlateTemplates": undefined,
@@ -130,6 +131,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
         "allowPlateMetadata": false,
         "autoCopyTargetContainer": undefined,
         "autoCopyTargetContainerId": undefined,
+        "autoLinkCategory": undefined,
         "availableDetectionMethods": undefined,
         "availableMetadataInputFormats": undefined,
         "availablePlateTemplates": undefined,
@@ -269,6 +271,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                     "allowPlateMetadata": false,
                     "autoCopyTargetContainer": undefined,
                     "autoCopyTargetContainerId": undefined,
+                    "autoLinkCategory": undefined,
                     "availableDetectionMethods": undefined,
                     "availableMetadataInputFormats": undefined,
                     "availablePlateTemplates": undefined,
@@ -532,6 +535,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                     "allowPlateMetadata": false,
                     "autoCopyTargetContainer": undefined,
                     "autoCopyTargetContainerId": undefined,
+                    "autoLinkCategory": undefined,
                     "availableDetectionMethods": undefined,
                     "availableMetadataInputFormats": undefined,
                     "availablePlateTemplates": undefined,
@@ -790,6 +794,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                     "allowPlateMetadata": false,
                     "autoCopyTargetContainer": undefined,
                     "autoCopyTargetContainerId": undefined,
+                    "autoLinkCategory": undefined,
                     "availableDetectionMethods": undefined,
                     "availableMetadataInputFormats": undefined,
                     "availablePlateTemplates": undefined,
@@ -1037,6 +1042,16 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
             className="col-lg-6 col-xs-12"
           />
         </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          lg={6}
+          xs={12}
+        >
+          <div
+            className="col-lg-6 col-xs-12"
+          />
+        </Col>
       </form>
     </Form>
   </AssayPropertiesPanelImpl>
@@ -1058,6 +1073,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
       "allowPlateMetadata": false,
       "autoCopyTargetContainer": undefined,
       "autoCopyTargetContainerId": undefined,
+      "autoLinkCategory": undefined,
       "availableDetectionMethods": undefined,
       "availableMetadataInputFormats": undefined,
       "availablePlateTemplates": undefined,
@@ -1170,6 +1186,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
         "allowPlateMetadata": false,
         "autoCopyTargetContainer": undefined,
         "autoCopyTargetContainerId": undefined,
+        "autoLinkCategory": undefined,
         "availableDetectionMethods": undefined,
         "availableMetadataInputFormats": undefined,
         "availablePlateTemplates": undefined,
@@ -1285,6 +1302,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
           "allowPlateMetadata": false,
           "autoCopyTargetContainer": undefined,
           "autoCopyTargetContainerId": undefined,
+          "autoLinkCategory": undefined,
           "availableDetectionMethods": undefined,
           "availableMetadataInputFormats": undefined,
           "availablePlateTemplates": undefined,
@@ -1516,6 +1534,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -1779,6 +1798,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -2037,6 +2057,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -2295,6 +2316,30 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 Import Settings
                               </div>
                             </SectionHeading>
+                          </div>
+                        </div>
+                      </Col>
+                      <Col
+                        bsClass="col"
+                        componentClass="div"
+                        lg={6}
+                        xs={12}
+                      >
+                        <div
+                          className="col-lg-6 col-xs-12"
+                        >
+                          <div
+                            className="domain-field-padding-bottom"
+                          >
+                            <SectionHeading
+                              title="Link to Study Settings"
+                            >
+                              <div
+                                className="domain-field-section-heading"
+                              >
+                                Link to Study Settings
+                              </div>
+                            </SectionHeading>
                             <AutoLinkDataInput
                               model={
                                 Immutable.Record {
@@ -2306,6 +2351,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -2563,6 +2609,259 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 </Row>
                               </Component>
                             </AutoLinkDataInput>
+                            <AutoLinkCategoryInput
+                              model={
+                                Immutable.Record {
+                                  "allowBackgroundUpload": false,
+                                  "allowEditableResults": false,
+                                  "allowQCStates": false,
+                                  "allowSpacesInPath": false,
+                                  "allowTransformationScript": false,
+                                  "allowPlateMetadata": false,
+                                  "autoCopyTargetContainer": undefined,
+                                  "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
+                                  "availableDetectionMethods": undefined,
+                                  "availableMetadataInputFormats": undefined,
+                                  "availablePlateTemplates": undefined,
+                                  "backgroundUpload": false,
+                                  "description": undefined,
+                                  "domains": Immutable.List [
+                                    Immutable.Record {
+                                      "name": "Batch Fields",
+                                      "container": undefined,
+                                      "description": undefined,
+                                      "domainURI": undefined,
+                                      "domainId": null,
+                                      "allowFileLinkProperties": false,
+                                      "allowAttachmentProperties": false,
+                                      "allowFlagProperties": true,
+                                      "allowTimepointProperties": false,
+                                      "showDefaultValueSettings": false,
+                                      "defaultDefaultValueType": undefined,
+                                      "defaultValueOptions": Immutable.List [],
+                                      "fields": Immutable.List [],
+                                      "indices": Immutable.List [],
+                                      "domainException": undefined,
+                                      "mandatoryFieldNames": Immutable.List [],
+                                      "reservedFieldNames": Immutable.List [],
+                                      "newDesignFields": undefined,
+                                      "instructions": undefined,
+                                      "domainKindName": undefined,
+                                    },
+                                    Immutable.Record {
+                                      "name": "Run Fields",
+                                      "container": undefined,
+                                      "description": undefined,
+                                      "domainURI": undefined,
+                                      "domainId": null,
+                                      "allowFileLinkProperties": false,
+                                      "allowAttachmentProperties": false,
+                                      "allowFlagProperties": true,
+                                      "allowTimepointProperties": false,
+                                      "showDefaultValueSettings": false,
+                                      "defaultDefaultValueType": undefined,
+                                      "defaultValueOptions": Immutable.List [],
+                                      "fields": Immutable.List [],
+                                      "indices": Immutable.List [],
+                                      "domainException": undefined,
+                                      "mandatoryFieldNames": Immutable.List [],
+                                      "reservedFieldNames": Immutable.List [],
+                                      "newDesignFields": undefined,
+                                      "instructions": undefined,
+                                      "domainKindName": undefined,
+                                    },
+                                    Immutable.Record {
+                                      "name": "Data Fields",
+                                      "container": undefined,
+                                      "description": undefined,
+                                      "domainURI": undefined,
+                                      "domainId": null,
+                                      "allowFileLinkProperties": false,
+                                      "allowAttachmentProperties": false,
+                                      "allowFlagProperties": true,
+                                      "allowTimepointProperties": false,
+                                      "showDefaultValueSettings": false,
+                                      "defaultDefaultValueType": undefined,
+                                      "defaultValueOptions": Immutable.List [],
+                                      "fields": Immutable.List [],
+                                      "indices": Immutable.List [],
+                                      "domainException": undefined,
+                                      "mandatoryFieldNames": Immutable.List [],
+                                      "reservedFieldNames": Immutable.List [],
+                                      "newDesignFields": undefined,
+                                      "instructions": undefined,
+                                      "domainKindName": undefined,
+                                    },
+                                  ],
+                                  "editableResults": false,
+                                  "editableRuns": false,
+                                  "exception": undefined,
+                                  "metadataInputFormatHelp": undefined,
+                                  "moduleTransformScripts": undefined,
+                                  "name": undefined,
+                                  "plateMetadata": undefined,
+                                  "protocolId": undefined,
+                                  "protocolParameters": undefined,
+                                  "protocolTransformScripts": undefined,
+                                  "providerName": "General",
+                                  "saveScriptFiles": false,
+                                  "selectedDetectionMethod": undefined,
+                                  "selectedMetadataInputFormat": undefined,
+                                  "selectedPlateTemplate": undefined,
+                                  "qcEnabled": undefined,
+                                }
+                              }
+                              onChange={[Function]}
+                            >
+                              <Component
+                                colSize={9}
+                                helpTipBody={
+                                  <p>
+                                     ROSALINE TODO 
+                                  </p>
+                                }
+                                label="Linked Dataset Category"
+                              >
+                                <Row
+                                  bsClass="row"
+                                  className="margin-top"
+                                  componentClass="div"
+                                >
+                                  <div
+                                    className="margin-top row"
+                                  >
+                                    <Col
+                                      bsClass="col"
+                                      componentClass="div"
+                                      lg={4}
+                                      xs={3}
+                                    >
+                                      <div
+                                        className="col-lg-4 col-xs-3"
+                                      >
+                                        <DomainFieldLabel
+                                          helpTipBody={
+                                            <p>
+                                               ROSALINE TODO 
+                                            </p>
+                                          }
+                                          label="Linked Dataset Category"
+                                        >
+                                          Linked Dataset 
+                                          <span
+                                            className="domain-no-wrap"
+                                          >
+                                            Category
+                                            <Component
+                                              customStyle={Object {}}
+                                              id="tooltip"
+                                              size="1x"
+                                              title="Linked Dataset Category"
+                                            >
+                                              <span
+                                                className="label-help-target"
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <FontAwesomeIcon
+                                                  border={false}
+                                                  className="label-help-icon"
+                                                  fixedWidth={false}
+                                                  flip={null}
+                                                  icon={
+                                                    Object {
+                                                      "icon": Array [
+                                                        512,
+                                                        512,
+                                                        Array [],
+                                                        "f059",
+                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                      ],
+                                                      "iconName": "question-circle",
+                                                      "prefix": "fas",
+                                                    }
+                                                  }
+                                                  inverse={false}
+                                                  listItem={false}
+                                                  mask={null}
+                                                  pull={null}
+                                                  pulse={false}
+                                                  rotation={null}
+                                                  size="1x"
+                                                  spin={false}
+                                                  style={Object {}}
+                                                  swapOpacity={false}
+                                                  symbol={false}
+                                                  title=""
+                                                  transform={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden="true"
+                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                    data-icon="question-circle"
+                                                    data-prefix="fas"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={Object {}}
+                                                    viewBox="0 0 512 512"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                      fill="currentColor"
+                                                      style={Object {}}
+                                                    />
+                                                  </svg>
+                                                </FontAwesomeIcon>
+                                                <Overlay
+                                                  animation={[Function]}
+                                                  placement="right"
+                                                  rootClose={false}
+                                                  show={false}
+                                                >
+                                                  <Overlay
+                                                    placement="right"
+                                                    rootClose={false}
+                                                    show={false}
+                                                    transition={[Function]}
+                                                  />
+                                                </Overlay>
+                                              </span>
+                                            </Component>
+                                          </span>
+                                        </DomainFieldLabel>
+                                      </div>
+                                    </Col>
+                                    <Col
+                                      bsClass="col"
+                                      componentClass="div"
+                                      lg={8}
+                                      xs={9}
+                                    >
+                                      <div
+                                        className="col-lg-8 col-xs-9"
+                                      >
+                                        <FormControl
+                                          bsClass="form-control"
+                                          componentClass="input"
+                                          id="assay-design-autoLinkCategory"
+                                          onChange={[Function]}
+                                          type="text"
+                                        >
+                                          <input
+                                            className="form-control"
+                                            id="assay-design-autoLinkCategory"
+                                            onChange={[Function]}
+                                            type="text"
+                                          />
+                                        </FormControl>
+                                      </div>
+                                    </Col>
+                                  </div>
+                                </Row>
+                              </Component>
+                            </AutoLinkCategoryInput>
                           </div>
                         </div>
                       </Col>
@@ -2594,6 +2893,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
       "allowPlateMetadata": false,
       "autoCopyTargetContainer": undefined,
       "autoCopyTargetContainerId": undefined,
+      "autoLinkCategory": undefined,
       "availableDetectionMethods": undefined,
       "availableMetadataInputFormats": undefined,
       "availablePlateTemplates": undefined,
@@ -2706,6 +3006,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
         "allowPlateMetadata": false,
         "autoCopyTargetContainer": undefined,
         "autoCopyTargetContainerId": undefined,
+        "autoLinkCategory": undefined,
         "availableDetectionMethods": undefined,
         "availableMetadataInputFormats": undefined,
         "availablePlateTemplates": undefined,
@@ -2821,6 +3122,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
           "allowPlateMetadata": false,
           "autoCopyTargetContainer": undefined,
           "autoCopyTargetContainerId": undefined,
+          "autoLinkCategory": undefined,
           "availableDetectionMethods": undefined,
           "availableMetadataInputFormats": undefined,
           "availablePlateTemplates": undefined,
@@ -3052,6 +3354,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -3315,6 +3618,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -3573,6 +3877,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -3831,6 +4136,30 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 Import Settings
                               </div>
                             </SectionHeading>
+                          </div>
+                        </div>
+                      </Col>
+                      <Col
+                        bsClass="col"
+                        componentClass="div"
+                        lg={6}
+                        xs={12}
+                      >
+                        <div
+                          className="col-lg-6 col-xs-12"
+                        >
+                          <div
+                            className="domain-field-padding-bottom"
+                          >
+                            <SectionHeading
+                              title="Link to Study Settings"
+                            >
+                              <div
+                                className="domain-field-section-heading"
+                              >
+                                Link to Study Settings
+                              </div>
+                            </SectionHeading>
                             <AutoLinkDataInput
                               model={
                                 Immutable.Record {
@@ -3842,6 +4171,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -4099,6 +4429,259 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 </Row>
                               </Component>
                             </AutoLinkDataInput>
+                            <AutoLinkCategoryInput
+                              model={
+                                Immutable.Record {
+                                  "allowBackgroundUpload": false,
+                                  "allowEditableResults": false,
+                                  "allowQCStates": false,
+                                  "allowSpacesInPath": false,
+                                  "allowTransformationScript": false,
+                                  "allowPlateMetadata": false,
+                                  "autoCopyTargetContainer": undefined,
+                                  "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
+                                  "availableDetectionMethods": undefined,
+                                  "availableMetadataInputFormats": undefined,
+                                  "availablePlateTemplates": undefined,
+                                  "backgroundUpload": false,
+                                  "description": undefined,
+                                  "domains": Immutable.List [
+                                    Immutable.Record {
+                                      "name": "Batch Fields",
+                                      "container": undefined,
+                                      "description": undefined,
+                                      "domainURI": undefined,
+                                      "domainId": null,
+                                      "allowFileLinkProperties": false,
+                                      "allowAttachmentProperties": false,
+                                      "allowFlagProperties": true,
+                                      "allowTimepointProperties": false,
+                                      "showDefaultValueSettings": false,
+                                      "defaultDefaultValueType": undefined,
+                                      "defaultValueOptions": Immutable.List [],
+                                      "fields": Immutable.List [],
+                                      "indices": Immutable.List [],
+                                      "domainException": undefined,
+                                      "mandatoryFieldNames": Immutable.List [],
+                                      "reservedFieldNames": Immutable.List [],
+                                      "newDesignFields": undefined,
+                                      "instructions": undefined,
+                                      "domainKindName": undefined,
+                                    },
+                                    Immutable.Record {
+                                      "name": "Run Fields",
+                                      "container": undefined,
+                                      "description": undefined,
+                                      "domainURI": undefined,
+                                      "domainId": null,
+                                      "allowFileLinkProperties": false,
+                                      "allowAttachmentProperties": false,
+                                      "allowFlagProperties": true,
+                                      "allowTimepointProperties": false,
+                                      "showDefaultValueSettings": false,
+                                      "defaultDefaultValueType": undefined,
+                                      "defaultValueOptions": Immutable.List [],
+                                      "fields": Immutable.List [],
+                                      "indices": Immutable.List [],
+                                      "domainException": undefined,
+                                      "mandatoryFieldNames": Immutable.List [],
+                                      "reservedFieldNames": Immutable.List [],
+                                      "newDesignFields": undefined,
+                                      "instructions": undefined,
+                                      "domainKindName": undefined,
+                                    },
+                                    Immutable.Record {
+                                      "name": "Data Fields",
+                                      "container": undefined,
+                                      "description": undefined,
+                                      "domainURI": undefined,
+                                      "domainId": null,
+                                      "allowFileLinkProperties": false,
+                                      "allowAttachmentProperties": false,
+                                      "allowFlagProperties": true,
+                                      "allowTimepointProperties": false,
+                                      "showDefaultValueSettings": false,
+                                      "defaultDefaultValueType": undefined,
+                                      "defaultValueOptions": Immutable.List [],
+                                      "fields": Immutable.List [],
+                                      "indices": Immutable.List [],
+                                      "domainException": undefined,
+                                      "mandatoryFieldNames": Immutable.List [],
+                                      "reservedFieldNames": Immutable.List [],
+                                      "newDesignFields": undefined,
+                                      "instructions": undefined,
+                                      "domainKindName": undefined,
+                                    },
+                                  ],
+                                  "editableResults": false,
+                                  "editableRuns": false,
+                                  "exception": undefined,
+                                  "metadataInputFormatHelp": undefined,
+                                  "moduleTransformScripts": undefined,
+                                  "name": undefined,
+                                  "plateMetadata": undefined,
+                                  "protocolId": undefined,
+                                  "protocolParameters": undefined,
+                                  "protocolTransformScripts": undefined,
+                                  "providerName": "General",
+                                  "saveScriptFiles": false,
+                                  "selectedDetectionMethod": undefined,
+                                  "selectedMetadataInputFormat": undefined,
+                                  "selectedPlateTemplate": undefined,
+                                  "qcEnabled": undefined,
+                                }
+                              }
+                              onChange={[Function]}
+                            >
+                              <Component
+                                colSize={9}
+                                helpTipBody={
+                                  <p>
+                                     ROSALINE TODO 
+                                  </p>
+                                }
+                                label="Linked Dataset Category"
+                              >
+                                <Row
+                                  bsClass="row"
+                                  className="margin-top"
+                                  componentClass="div"
+                                >
+                                  <div
+                                    className="margin-top row"
+                                  >
+                                    <Col
+                                      bsClass="col"
+                                      componentClass="div"
+                                      lg={4}
+                                      xs={3}
+                                    >
+                                      <div
+                                        className="col-lg-4 col-xs-3"
+                                      >
+                                        <DomainFieldLabel
+                                          helpTipBody={
+                                            <p>
+                                               ROSALINE TODO 
+                                            </p>
+                                          }
+                                          label="Linked Dataset Category"
+                                        >
+                                          Linked Dataset 
+                                          <span
+                                            className="domain-no-wrap"
+                                          >
+                                            Category
+                                            <Component
+                                              customStyle={Object {}}
+                                              id="tooltip"
+                                              size="1x"
+                                              title="Linked Dataset Category"
+                                            >
+                                              <span
+                                                className="label-help-target"
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <FontAwesomeIcon
+                                                  border={false}
+                                                  className="label-help-icon"
+                                                  fixedWidth={false}
+                                                  flip={null}
+                                                  icon={
+                                                    Object {
+                                                      "icon": Array [
+                                                        512,
+                                                        512,
+                                                        Array [],
+                                                        "f059",
+                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                      ],
+                                                      "iconName": "question-circle",
+                                                      "prefix": "fas",
+                                                    }
+                                                  }
+                                                  inverse={false}
+                                                  listItem={false}
+                                                  mask={null}
+                                                  pull={null}
+                                                  pulse={false}
+                                                  rotation={null}
+                                                  size="1x"
+                                                  spin={false}
+                                                  style={Object {}}
+                                                  swapOpacity={false}
+                                                  symbol={false}
+                                                  title=""
+                                                  transform={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden="true"
+                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                    data-icon="question-circle"
+                                                    data-prefix="fas"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={Object {}}
+                                                    viewBox="0 0 512 512"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                      fill="currentColor"
+                                                      style={Object {}}
+                                                    />
+                                                  </svg>
+                                                </FontAwesomeIcon>
+                                                <Overlay
+                                                  animation={[Function]}
+                                                  placement="right"
+                                                  rootClose={false}
+                                                  show={false}
+                                                >
+                                                  <Overlay
+                                                    placement="right"
+                                                    rootClose={false}
+                                                    show={false}
+                                                    transition={[Function]}
+                                                  />
+                                                </Overlay>
+                                              </span>
+                                            </Component>
+                                          </span>
+                                        </DomainFieldLabel>
+                                      </div>
+                                    </Col>
+                                    <Col
+                                      bsClass="col"
+                                      componentClass="div"
+                                      lg={8}
+                                      xs={9}
+                                    >
+                                      <div
+                                        className="col-lg-8 col-xs-9"
+                                      >
+                                        <FormControl
+                                          bsClass="form-control"
+                                          componentClass="input"
+                                          id="assay-design-autoLinkCategory"
+                                          onChange={[Function]}
+                                          type="text"
+                                        >
+                                          <input
+                                            className="form-control"
+                                            id="assay-design-autoLinkCategory"
+                                            onChange={[Function]}
+                                            type="text"
+                                          />
+                                        </FormControl>
+                                      </div>
+                                    </Col>
+                                  </div>
+                                </Row>
+                              </Component>
+                            </AutoLinkCategoryInput>
                           </div>
                         </div>
                       </Col>
@@ -4130,6 +4713,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
       "allowPlateMetadata": false,
       "autoCopyTargetContainer": undefined,
       "autoCopyTargetContainerId": undefined,
+      "autoLinkCategory": undefined,
       "availableDetectionMethods": undefined,
       "availableMetadataInputFormats": undefined,
       "availablePlateTemplates": undefined,
@@ -4175,6 +4759,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
         "allowPlateMetadata": false,
         "autoCopyTargetContainer": undefined,
         "autoCopyTargetContainerId": undefined,
+        "autoLinkCategory": undefined,
         "availableDetectionMethods": undefined,
         "availableMetadataInputFormats": undefined,
         "availablePlateTemplates": undefined,
@@ -4223,6 +4808,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
           "allowPlateMetadata": false,
           "autoCopyTargetContainer": undefined,
           "autoCopyTargetContainerId": undefined,
+          "autoLinkCategory": undefined,
           "availableDetectionMethods": undefined,
           "availableMetadataInputFormats": undefined,
           "availablePlateTemplates": undefined,
@@ -4389,6 +4975,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -4585,6 +5172,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -4776,6 +5364,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -4967,6 +5556,30 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 Import Settings
                               </div>
                             </SectionHeading>
+                          </div>
+                        </div>
+                      </Col>
+                      <Col
+                        bsClass="col"
+                        componentClass="div"
+                        lg={6}
+                        xs={12}
+                      >
+                        <div
+                          className="col-lg-6 col-xs-12"
+                        >
+                          <div
+                            className="domain-field-padding-bottom"
+                          >
+                            <SectionHeading
+                              title="Link to Study Settings"
+                            >
+                              <div
+                                className="domain-field-section-heading"
+                              >
+                                Link to Study Settings
+                              </div>
+                            </SectionHeading>
                             <AutoLinkDataInput
                               model={
                                 Immutable.Record {
@@ -4978,6 +5591,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -5168,6 +5782,192 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 </Row>
                               </Component>
                             </AutoLinkDataInput>
+                            <AutoLinkCategoryInput
+                              model={
+                                Immutable.Record {
+                                  "allowBackgroundUpload": false,
+                                  "allowEditableResults": false,
+                                  "allowQCStates": false,
+                                  "allowSpacesInPath": false,
+                                  "allowTransformationScript": false,
+                                  "allowPlateMetadata": false,
+                                  "autoCopyTargetContainer": undefined,
+                                  "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
+                                  "availableDetectionMethods": undefined,
+                                  "availableMetadataInputFormats": undefined,
+                                  "availablePlateTemplates": undefined,
+                                  "backgroundUpload": false,
+                                  "description": "test description for this assay",
+                                  "domains": Immutable.List [],
+                                  "editableResults": true,
+                                  "editableRuns": true,
+                                  "exception": undefined,
+                                  "metadataInputFormatHelp": undefined,
+                                  "moduleTransformScripts": undefined,
+                                  "name": "name should not be editable",
+                                  "plateMetadata": undefined,
+                                  "protocolId": 1,
+                                  "protocolParameters": undefined,
+                                  "protocolTransformScripts": undefined,
+                                  "providerName": undefined,
+                                  "saveScriptFiles": false,
+                                  "selectedDetectionMethod": undefined,
+                                  "selectedMetadataInputFormat": undefined,
+                                  "selectedPlateTemplate": undefined,
+                                  "qcEnabled": undefined,
+                                }
+                              }
+                              onChange={[Function]}
+                            >
+                              <Component
+                                colSize={9}
+                                helpTipBody={
+                                  <p>
+                                     ROSALINE TODO 
+                                  </p>
+                                }
+                                label="Linked Dataset Category"
+                              >
+                                <Row
+                                  bsClass="row"
+                                  className="margin-top"
+                                  componentClass="div"
+                                >
+                                  <div
+                                    className="margin-top row"
+                                  >
+                                    <Col
+                                      bsClass="col"
+                                      componentClass="div"
+                                      lg={4}
+                                      xs={3}
+                                    >
+                                      <div
+                                        className="col-lg-4 col-xs-3"
+                                      >
+                                        <DomainFieldLabel
+                                          helpTipBody={
+                                            <p>
+                                               ROSALINE TODO 
+                                            </p>
+                                          }
+                                          label="Linked Dataset Category"
+                                        >
+                                          Linked Dataset 
+                                          <span
+                                            className="domain-no-wrap"
+                                          >
+                                            Category
+                                            <Component
+                                              customStyle={Object {}}
+                                              id="tooltip"
+                                              size="1x"
+                                              title="Linked Dataset Category"
+                                            >
+                                              <span
+                                                className="label-help-target"
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <FontAwesomeIcon
+                                                  border={false}
+                                                  className="label-help-icon"
+                                                  fixedWidth={false}
+                                                  flip={null}
+                                                  icon={
+                                                    Object {
+                                                      "icon": Array [
+                                                        512,
+                                                        512,
+                                                        Array [],
+                                                        "f059",
+                                                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
+                                                      ],
+                                                      "iconName": "question-circle",
+                                                      "prefix": "fas",
+                                                    }
+                                                  }
+                                                  inverse={false}
+                                                  listItem={false}
+                                                  mask={null}
+                                                  pull={null}
+                                                  pulse={false}
+                                                  rotation={null}
+                                                  size="1x"
+                                                  spin={false}
+                                                  style={Object {}}
+                                                  swapOpacity={false}
+                                                  symbol={false}
+                                                  title=""
+                                                  transform={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden="true"
+                                                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                                                    data-icon="question-circle"
+                                                    data-prefix="fas"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={Object {}}
+                                                    viewBox="0 0 512 512"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                                                      fill="currentColor"
+                                                      style={Object {}}
+                                                    />
+                                                  </svg>
+                                                </FontAwesomeIcon>
+                                                <Overlay
+                                                  animation={[Function]}
+                                                  placement="right"
+                                                  rootClose={false}
+                                                  show={false}
+                                                >
+                                                  <Overlay
+                                                    placement="right"
+                                                    rootClose={false}
+                                                    show={false}
+                                                    transition={[Function]}
+                                                  />
+                                                </Overlay>
+                                              </span>
+                                            </Component>
+                                          </span>
+                                        </DomainFieldLabel>
+                                      </div>
+                                    </Col>
+                                    <Col
+                                      bsClass="col"
+                                      componentClass="div"
+                                      lg={8}
+                                      xs={9}
+                                    >
+                                      <div
+                                        className="col-lg-8 col-xs-9"
+                                      >
+                                        <FormControl
+                                          bsClass="form-control"
+                                          componentClass="input"
+                                          id="assay-design-autoLinkCategory"
+                                          onChange={[Function]}
+                                          type="text"
+                                        >
+                                          <input
+                                            className="form-control"
+                                            id="assay-design-autoLinkCategory"
+                                            onChange={[Function]}
+                                            type="text"
+                                          />
+                                        </FormControl>
+                                      </div>
+                                    </Col>
+                                  </div>
+                                </Row>
+                              </Component>
+                            </AutoLinkCategoryInput>
                           </div>
                         </div>
                       </Col>
@@ -5201,6 +6001,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
       "allowPlateMetadata": false,
       "autoCopyTargetContainer": undefined,
       "autoCopyTargetContainerId": undefined,
+      "autoLinkCategory": undefined,
       "availableDetectionMethods": undefined,
       "availableMetadataInputFormats": undefined,
       "availablePlateTemplates": undefined,
@@ -5313,6 +6114,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
         "allowPlateMetadata": false,
         "autoCopyTargetContainer": undefined,
         "autoCopyTargetContainerId": undefined,
+        "autoLinkCategory": undefined,
         "availableDetectionMethods": undefined,
         "availableMetadataInputFormats": undefined,
         "availablePlateTemplates": undefined,
@@ -5428,6 +6230,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
           "allowPlateMetadata": false,
           "autoCopyTargetContainer": undefined,
           "autoCopyTargetContainerId": undefined,
+          "autoLinkCategory": undefined,
           "availableDetectionMethods": undefined,
           "availableMetadataInputFormats": undefined,
           "availablePlateTemplates": undefined,
@@ -5628,6 +6431,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -5891,6 +6695,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -6149,6 +6954,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                   "allowPlateMetadata": false,
                                   "autoCopyTargetContainer": undefined,
                                   "autoCopyTargetContainerId": undefined,
+                                  "autoLinkCategory": undefined,
                                   "availableDetectionMethods": undefined,
                                   "availableMetadataInputFormats": undefined,
                                   "availablePlateTemplates": undefined,
@@ -6385,6 +7191,16 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                             </EditableRunsInput>
                           </div>
                         </div>
+                      </Col>
+                      <Col
+                        bsClass="col"
+                        componentClass="div"
+                        lg={6}
+                        xs={12}
+                      >
+                        <div
+                          className="col-lg-6 col-xs-12"
+                        />
                       </Col>
                       <Col
                         bsClass="col"

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
@@ -2615,7 +2615,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 </Row>
                               </Component>
                             </AutoLinkDataInput>
-                            <AutoLinkCategoryInput
+                            <Memo()
                               model={
                                 Immutable.Record {
                                   "allowBackgroundUpload": false,
@@ -2724,7 +2724,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 colSize={9}
                                 helpTipBody={
                                   <p>
-                                     ROSALINE TODO 
+                                    Specify the desired category for the Assay Dataset that will be created (or appended to) in the target study when rows are linked. If the category you specify does not exist, it will be created. If the Assay Dataset already exists, this setting will not overwrite a previously assigned category. Leave blank to use the default category of "Uncategorized".
                                   </p>
                                 }
                                 label="Linked Dataset Category"
@@ -2749,7 +2749,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                         <DomainFieldLabel
                                           helpTipBody={
                                             <p>
-                                               ROSALINE TODO 
+                                              Specify the desired category for the Assay Dataset that will be created (or appended to) in the target study when rows are linked. If the category you specify does not exist, it will be created. If the Assay Dataset already exists, this setting will not overwrite a previously assigned category. Leave blank to use the default category of "Uncategorized".
                                             </p>
                                           }
                                           label="Linked Dataset Category"
@@ -2867,7 +2867,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                   </div>
                                 </Row>
                               </Component>
-                            </AutoLinkCategoryInput>
+                            </Memo()>
                           </div>
                         </div>
                       </Col>
@@ -4441,7 +4441,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 </Row>
                               </Component>
                             </AutoLinkDataInput>
-                            <AutoLinkCategoryInput
+                            <Memo()
                               model={
                                 Immutable.Record {
                                   "allowBackgroundUpload": false,
@@ -4550,7 +4550,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 colSize={9}
                                 helpTipBody={
                                   <p>
-                                     ROSALINE TODO 
+                                    Specify the desired category for the Assay Dataset that will be created (or appended to) in the target study when rows are linked. If the category you specify does not exist, it will be created. If the Assay Dataset already exists, this setting will not overwrite a previously assigned category. Leave blank to use the default category of "Uncategorized".
                                   </p>
                                 }
                                 label="Linked Dataset Category"
@@ -4575,7 +4575,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                         <DomainFieldLabel
                                           helpTipBody={
                                             <p>
-                                               ROSALINE TODO 
+                                              Specify the desired category for the Assay Dataset that will be created (or appended to) in the target study when rows are linked. If the category you specify does not exist, it will be created. If the Assay Dataset already exists, this setting will not overwrite a previously assigned category. Leave blank to use the default category of "Uncategorized".
                                             </p>
                                           }
                                           label="Linked Dataset Category"
@@ -4693,7 +4693,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                   </div>
                                 </Row>
                               </Component>
-                            </AutoLinkCategoryInput>
+                            </Memo()>
                           </div>
                         </div>
                       </Col>
@@ -5800,7 +5800,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 </Row>
                               </Component>
                             </AutoLinkDataInput>
-                            <AutoLinkCategoryInput
+                            <Memo()
                               model={
                                 Immutable.Record {
                                   "allowBackgroundUpload": false,
@@ -5842,7 +5842,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 colSize={9}
                                 helpTipBody={
                                   <p>
-                                     ROSALINE TODO 
+                                    Specify the desired category for the Assay Dataset that will be created (or appended to) in the target study when rows are linked. If the category you specify does not exist, it will be created. If the Assay Dataset already exists, this setting will not overwrite a previously assigned category. Leave blank to use the default category of "Uncategorized".
                                   </p>
                                 }
                                 label="Linked Dataset Category"
@@ -5867,7 +5867,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                         <DomainFieldLabel
                                           helpTipBody={
                                             <p>
-                                               ROSALINE TODO 
+                                              Specify the desired category for the Assay Dataset that will be created (or appended to) in the target study when rows are linked. If the category you specify does not exist, it will be created. If the Assay Dataset already exists, this setting will not overwrite a previously assigned category. Leave blank to use the default category of "Uncategorized".
                                             </p>
                                           }
                                           label="Linked Dataset Category"
@@ -5985,7 +5985,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                   </div>
                                 </Row>
                               </Component>
-                            </AutoLinkCategoryInput>
+                            </Memo()>
                           </div>
                         </div>
                       </Col>

--- a/packages/components/src/internal/components/domainproperties/assay/models.ts
+++ b/packages/components/src/internal/components/domainproperties/assay/models.ts
@@ -28,6 +28,7 @@ export class AssayProtocolModel extends Record({
     allowPlateMetadata: false,
     autoCopyTargetContainer: undefined,
     autoCopyTargetContainerId: undefined,
+    autoLinkCategory: undefined,
     availableDetectionMethods: undefined,
     availableMetadataInputFormats: undefined,
     availablePlateTemplates: undefined,
@@ -59,6 +60,7 @@ export class AssayProtocolModel extends Record({
     declare allowPlateMetadata: boolean;
     declare autoCopyTargetContainer: {};
     declare autoCopyTargetContainerId: string;
+    declare autoLinkCategory: string;
     declare availableDetectionMethods: [];
     declare availableMetadataInputFormats: {};
     declare availablePlateTemplates: [];

--- a/packages/components/src/test/data/assay-getProtocolELISpot.json
+++ b/packages/components/src/test/data/assay-getProtocolELISpot.json
@@ -1466,6 +1466,7 @@
     "qcEnabled" : false,
     "protocolTransformScripts" : [ ],
     "autoCopyTargetContainer" : null,
+    "autoLinkCategory": "",
     "allowTransformationScript" : true,
     "allowBackgroundUpload" : false,
     "allowEditableResults" : false,

--- a/packages/components/src/test/data/assay-getProtocolELISpotTemplate.json
+++ b/packages/components/src/test/data/assay-getProtocolELISpotTemplate.json
@@ -1301,6 +1301,7 @@
     "qcEnabled" : false,
     "protocolTransformScripts" : [ ],
     "autoCopyTargetContainer" : null,
+    "autoLinkCategory": "",
     "allowTransformationScript" : true,
     "allowBackgroundUpload" : false,
     "allowEditableResults" : false,

--- a/packages/components/src/test/data/assay-getProtocolGeneral.json
+++ b/packages/components/src/test/data/assay-getProtocolGeneral.json
@@ -448,6 +448,7 @@
     "qcEnabled" : true,
     "protocolTransformScripts" : ["/path/to/transform.R", "/path/to/anotherTransform.pl"],
     "autoCopyTargetContainerId" : "DDFDA233-F0C8-1036-95AB-F5B7057CFF74",
+    "autoLinkCategory": "aCategoryName",
     "allowTransformationScript" : true,
     "allowBackgroundUpload" : true,
     "allowEditableResults" : true,

--- a/packages/components/src/test/data/assay-getProtocolGeneralDuplicateFields.json
+++ b/packages/components/src/test/data/assay-getProtocolGeneralDuplicateFields.json
@@ -491,6 +491,7 @@
     "qcEnabled" : true,
     "protocolTransformScripts" : ["/path/to/transform.R", "/path/to/anotherTransform.pl"],
     "autoCopyTargetContainerId" : "DDFDA233-F0C8-1036-95AB-F5B7057CFF74",
+    "autoLinkCategory": "aCategoryName",
     "allowTransformationScript" : true,
     "allowBackgroundUpload" : true,
     "allowEditableResults" : true,

--- a/packages/components/src/test/data/assay-getProtocolGeneralTemplate.json
+++ b/packages/components/src/test/data/assay-getProtocolGeneralTemplate.json
@@ -264,6 +264,7 @@
     "qcEnabled" : false,
     "protocolTransformScripts" : [ ],
     "autoCopyTargetContainer" : null,
+    "autoLinkCategory": "",
     "allowTransformationScript" : true,
     "allowBackgroundUpload" : true,
     "allowEditableResults" : true,


### PR DESCRIPTION
#### Rationale
To support changes that allow for predefinition of dataset category, we have added a 'Link to Study Settings' header within the Assay Properties panel, and a new text field, 'Linked Dataset Category'.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2540

#### Changes
* Add new 'Link to Study Settings' header section
* Add new 'Linked Dataset Category' text field
* Round trip 'autoLinkCategory' property
* Update tests
