### PR TITLE
Item 8561: Selenium test cases for Unique ID fields in sample type

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.0",
+  "version": "2.63.0-fb-uniqueIdTestCases.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.0-fb-uniqueIdTestCases.0",
+  "version": "2.63.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD August 2021
+* Item 8561: Add some sample type designer element class names for testing
+
 ### version 2.63.0
 *Released*: 11 August 2021
 * Issue 43672: Add "referrer" param to the help link URLs

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD August 2021
+### version 2.63.1
+*Released*: 13 August 2021
 * Item 8561: Add some sample type designer element class names for testing
 
 ### version 2.63.0

--- a/packages/components/src/internal/components/domainproperties/samples/UniqueIdBanner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/UniqueIdBanner.tsx
@@ -33,11 +33,11 @@ export const UniqueIdBanner: FC<Props> = memo(({ model, isFieldsPanel, onAddFiel
 
     const uniqueIdFields = model.domain?.fields?.filter(field => field.isUniqueIdField()).toArray();
     if (model.isNew() && !isFieldsPanel && !uniqueIdFields?.length) {
-        return <div>{NEW_TYPE_NO_BARCODE_FIELDS_MSG}</div>;
+        return <div className="uniqueid-msg">{NEW_TYPE_NO_BARCODE_FIELDS_MSG}</div>;
     } else {
         if (!uniqueIdFields?.length) {
             return (
-                <Alert bsStyle="info">
+                <Alert bsStyle="info" className="uniqueid-alert">
                     {ADD_NEW_UNIQUE_ID_MSG}
                     <Button className="pull-right alert-button" bsStyle="info" onClick={onClick}>
                         Yes, Add Unique ID Field
@@ -46,7 +46,7 @@ export const UniqueIdBanner: FC<Props> = memo(({ model, isFieldsPanel, onAddFiel
             );
         } else if (!isFieldsPanel) {
             return (
-                <div>
+                <div className="uniqueid-msg">
                     <i className="fa fa-check-circle domain-panel-status-icon-green" />
                     <span className="left-spacing">
                         {uniqueIdFields?.length === 1


### PR DESCRIPTION
#### Rationale
To make selenium testing easier, this PR adds some css class names to the UniqueIdBanner component.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/605
* https://github.com/LabKey/testAutomation/pull/836
* https://github.com/LabKey/sampleManagement/pull/658
* https://github.com/LabKey/platform/pull/2542
* https://github.com/LabKey/premium/pull/262

#### Changes
* adds some css class names to the UniqueIdBanner component
