### PR TITLE
Item 9368: Misc fixes for file field behavior in apps

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.1-fb-sm219Cory.1",
+  "version": "2.63.1-fb-sm219Cory.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.1-fb-sm219Cory.0",
+  "version": "2.63.1-fb-sm219Cory.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.1",
+  "version": "2.63.1-fb-sm219Cory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.2-fb-sm219Cory.0",
+  "version": "2.63.2-fb-sm219Cory.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.2-fb-sm219Cory.1",
+  "version": "2.64.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.2",
+  "version": "2.63.2-fb-sm219Cory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD August 2021
 * Issue 43728: bulk insert for samples is broken when a file field is present
 * Issue 43725: account for both forward and back slash in FileColumnRenderer.getAttachmentTitleFromName
+* Issue 43703: show warning on sample creation editable grid if required fields are included
 
 ### version 2.63.1
 *Released*: 13 August 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD August 2021
 * Issue 43728: bulk insert for samples is broken when a file field is present
+* Issue 43725: account for both forward and back slash in FileColumnRenderer.getAttachmentTitleFromName
 
 ### version 2.63.1
 *Released*: 13 August 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD August 2021
+* Issue 43728: bulk insert for samples is broken when a file field is present
+
 ### version 2.63.1
 *Released*: 13 August 2021
 * Item 8561: Add some sample type designer element class names for testing

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD August 2021
+### version 2.64.0
+*Released*: 18 August 2021
 * Issue 43728: bulk insert for samples is broken when a file field is present
 * Issue 43725: account for both forward and back slash in FileColumnRenderer.getAttachmentTitleFromName
 * Issue 43703: show warning on sample creation editable grid if required fields are included

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -3093,10 +3093,7 @@ export function removeRows(model: QueryGridModel, dataIdIndexes: List<number>): 
 }
 
 export function removeRow(model: QueryGridModel, dataId: any, rowIdx: number): void {
-    removeRows(
-        model,
-        List<number>([rowIdx])
-    );
+    removeRows(model, List<number>([rowIdx]));
 }
 
 /**

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -540,9 +540,7 @@ function loadDataForEditor(model: QueryGridModel, response?: any): void {
     const rows: Map<any, Map<string, any>> = response ? response.data : Map<string, Map<string, any>>();
     const ids = response ? response.dataIds : List();
     const columns = model.queryInfo.columns.toList().filter(column => {
-        return (
-            (insertColumnFilter(column) || model.requiredColumns?.indexOf(column.fieldKey) > -1) && !column.isFileInput
-        );
+        return insertColumnFilter(column, false) || model.requiredColumns?.indexOf(column.fieldKey) > -1;
     });
 
     const getLookup = (col: QueryColumn) => getLookupStore(col);

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { List } from 'immutable';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { EntityInsertGridRequiredFieldAlert, getFieldKeysOfRequiredCols } from './EntityInsertGridRequiredFieldAlert';
 import { QueryColumn } from '../../../public/QueryColumn';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { Alert } from '../base/Alert';
+
+import { EntityInsertGridRequiredFieldAlert, getFieldKeysOfRequiredCols } from './EntityInsertGridRequiredFieldAlert';
 
 const DEFAULT_PROPS = {
     type: 'Sample Type',
@@ -25,10 +26,8 @@ describe('EntityInsertGridRequiredFieldAlert', () => {
 
     test('queryInfo isLoading', () => {
         const wrapper = mount(
-            <EntityInsertGridRequiredFieldAlert
-                {...DEFAULT_PROPS}
-                queryInfo={QueryInfo.create({ isLoading: true })}
-            />);
+            <EntityInsertGridRequiredFieldAlert {...DEFAULT_PROPS} queryInfo={QueryInfo.create({ isLoading: true })} />
+        );
         validate(wrapper);
         wrapper.unmount();
     });
@@ -51,7 +50,8 @@ describe('EntityInsertGridRequiredFieldAlert', () => {
                         },
                     ],
                 })}
-            />);
+            />
+        );
         validate(wrapper, false);
         wrapper.unmount();
     });
@@ -74,7 +74,8 @@ describe('EntityInsertGridRequiredFieldAlert', () => {
                         },
                     ],
                 })}
-            />);
+            />
+        );
         validate(wrapper, false, true);
         const alertText = wrapper.find(Alert).text();
         expect(alertText).toContain('the selected Sample Type has required fields');
@@ -85,30 +86,80 @@ describe('EntityInsertGridRequiredFieldAlert', () => {
 
 describe('getFieldKeysOfRequiredCols', () => {
     test('editable and required', () => {
-        expect(getFieldKeysOfRequiredCols(List.of(
-            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: true, shownInUpdateView: true, required: true })
-        )).length).toBe(1);
+        expect(
+            getFieldKeysOfRequiredCols(
+                List.of(
+                    QueryColumn.create({
+                        fieldKey: 'col1',
+                        readOnly: false,
+                        userEditable: true,
+                        shownInUpdateView: true,
+                        required: true,
+                    })
+                )
+            ).length
+        ).toBe(1);
 
-        expect(getFieldKeysOfRequiredCols(List.of(
-            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: true, shownInUpdateView: true, required: true })
-        ))[0]).toBe('col1');
+        expect(
+            getFieldKeysOfRequiredCols(
+                List.of(
+                    QueryColumn.create({
+                        fieldKey: 'col1',
+                        readOnly: false,
+                        userEditable: true,
+                        shownInUpdateView: true,
+                        required: true,
+                    })
+                )
+            )[0]
+        ).toBe('col1');
     });
 
     test('editable and not required', () => {
-        expect(getFieldKeysOfRequiredCols(List.of(
-            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: true, shownInUpdateView: true, required: false })
-        )).length).toBe(0);
+        expect(
+            getFieldKeysOfRequiredCols(
+                List.of(
+                    QueryColumn.create({
+                        fieldKey: 'col1',
+                        readOnly: false,
+                        userEditable: true,
+                        shownInUpdateView: true,
+                        required: false,
+                    })
+                )
+            ).length
+        ).toBe(0);
     });
 
     test('not editable and required', () => {
-        expect(getFieldKeysOfRequiredCols(List.of(
-            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: false, shownInUpdateView: true, required: true })
-        )).length).toBe(0);
+        expect(
+            getFieldKeysOfRequiredCols(
+                List.of(
+                    QueryColumn.create({
+                        fieldKey: 'col1',
+                        readOnly: false,
+                        userEditable: false,
+                        shownInUpdateView: true,
+                        required: true,
+                    })
+                )
+            ).length
+        ).toBe(0);
     });
 
     test('not editable and not required', () => {
-        expect(getFieldKeysOfRequiredCols(List.of(
-            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: false, shownInUpdateView: true, required: false })
-        )).length).toBe(0);
+        expect(
+            getFieldKeysOfRequiredCols(
+                List.of(
+                    QueryColumn.create({
+                        fieldKey: 'col1',
+                        readOnly: false,
+                        userEditable: false,
+                        shownInUpdateView: true,
+                        required: false,
+                    })
+                )
+            ).length
+        ).toBe(0);
     });
 });

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { List } from 'immutable';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { EntityInsertGridRequiredFieldAlert, getFieldKeysOfRequiredCols } from './EntityInsertGridRequiredFieldAlert';
+import { QueryColumn } from '../../../public/QueryColumn';
+import { QueryInfo } from '../../../public/QueryInfo';
+import { Alert } from '../base/Alert';
+
+const DEFAULT_PROPS = {
+    type: 'Sample Type',
+    queryInfo: undefined,
+};
+
+describe('EntityInsertGridRequiredFieldAlert', () => {
+    function validate(wrapper: ReactWrapper, isLoading = true, hasMissing = false): void {
+        expect(wrapper.find(Alert)).toHaveLength(isLoading || !hasMissing ? 0 : 1);
+    }
+
+    test('without queryInfo', () => {
+        const wrapper = mount(<EntityInsertGridRequiredFieldAlert {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('queryInfo isLoading', () => {
+        const wrapper = mount(
+            <EntityInsertGridRequiredFieldAlert
+                {...DEFAULT_PROPS}
+                queryInfo={QueryInfo.create({ isLoading: true })}
+            />);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('without missing required cols', () => {
+        const wrapper = mount(
+            <EntityInsertGridRequiredFieldAlert
+                {...DEFAULT_PROPS}
+                queryInfo={QueryInfo.fromJSON({
+                    columns: [
+                        {
+                            fieldKey: 'a',
+                            fieldKeyArray: ['a'],
+                            caption: 'FieldA',
+                            shownInInsertView: true,
+                            shownInUpdateView: true,
+                            userEditable: true,
+                            required: true,
+                            inputType: 'text',
+                        },
+                    ],
+                })}
+            />);
+        validate(wrapper, false);
+        wrapper.unmount();
+    });
+
+    test('with missing required cols', () => {
+        const wrapper = mount(
+            <EntityInsertGridRequiredFieldAlert
+                {...DEFAULT_PROPS}
+                queryInfo={QueryInfo.fromJSON({
+                    columns: [
+                        {
+                            fieldKey: 'a',
+                            fieldKeyArray: ['a'],
+                            caption: 'FieldA',
+                            shownInInsertView: false,
+                            shownInUpdateView: true,
+                            userEditable: true,
+                            required: true,
+                            inputType: 'text',
+                        },
+                    ],
+                })}
+            />);
+        validate(wrapper, false, true);
+        const alertText = wrapper.find(Alert).text();
+        expect(alertText).toContain('the selected Sample Type has required fields');
+        expect(alertText).toContain(': FieldA');
+        wrapper.unmount();
+    });
+});
+
+describe('getFieldKeysOfRequiredCols', () => {
+    test('editable and required', () => {
+        expect(getFieldKeysOfRequiredCols(List.of(
+            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: true, shownInUpdateView: true, required: true })
+        )).length).toBe(1);
+
+        expect(getFieldKeysOfRequiredCols(List.of(
+            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: true, shownInUpdateView: true, required: true })
+        ))[0]).toBe('col1');
+    });
+
+    test('editable and not required', () => {
+        expect(getFieldKeysOfRequiredCols(List.of(
+            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: true, shownInUpdateView: true, required: false })
+        )).length).toBe(0);
+    });
+
+    test('not editable and required', () => {
+        expect(getFieldKeysOfRequiredCols(List.of(
+            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: false, shownInUpdateView: true, required: true })
+        )).length).toBe(0);
+    });
+
+    test('not editable and not required', () => {
+        expect(getFieldKeysOfRequiredCols(List.of(
+            QueryColumn.create({ fieldKey: 'col1', readOnly: false, userEditable: false, shownInUpdateView: true, required: false })
+        )).length).toBe(0);
+    });
+});

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
@@ -36,7 +36,8 @@ export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
     );
 });
 
-function getFieldKeysOfRequiredCols(cols: List<QueryColumn>): string[] {
+// exported for jest testing
+export function getFieldKeysOfRequiredCols(cols: List<QueryColumn>): string[] {
     return cols
         .filter(col => col.isEditable() && col.required)
         .map(col => col.fieldKey)

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
@@ -30,7 +30,7 @@ export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
 
     return (
         <Alert bsStyle="warning">
-            <b>Warning: </b> the selected {type} has required fields which are not included in the grid below:{' '}
+            <b>Warning: </b> the selected {type} has required fields that are not included in the grid below:{' '}
             {missingReqColLabels.join(', ')}.
         </Alert>
     );

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
@@ -1,0 +1,44 @@
+import React, { FC, memo, useMemo } from 'react';
+import { List } from 'immutable';
+
+import { QueryInfo } from '../../../public/QueryInfo';
+import { QueryColumn } from '../../../public/QueryColumn';
+import { Alert } from '../base/Alert';
+
+interface Props {
+    type: string;
+    queryInfo: QueryInfo;
+}
+
+export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
+    const { type, queryInfo } = props;
+    if (!queryInfo || queryInfo.isLoading) {
+        return null;
+    }
+
+    const allRequiredCols = useMemo(() => getFieldKeysOfRequiredCols(queryInfo.getAllColumns()), [queryInfo]);
+    const insertRequiredCols = useMemo(() => getFieldKeysOfRequiredCols(queryInfo.getInsertColumns()), [queryInfo]);
+    if (allRequiredCols.length === insertRequiredCols.length) {
+        return null;
+    }
+
+    const missingReqColLabels = useMemo(() => {
+        return allRequiredCols
+            .filter(fieldKey => insertRequiredCols.indexOf(fieldKey) === -1)
+            .map(fieldKey => queryInfo.getColumn(fieldKey).caption);
+    }, [queryInfo]);
+
+    return (
+        <Alert bsStyle="warning">
+            <b>Warning: </b> the selected {type} has required fields which are not included in the grid below:{' '}
+            {missingReqColLabels.join(', ')}.
+        </Alert>
+    );
+});
+
+function getFieldKeysOfRequiredCols(cols: List<QueryColumn>): string[] {
+    return cols
+        .filter(col => col.isEditable() && col.required)
+        .map(col => col.fieldKey)
+        .toArray();
+}

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -892,7 +892,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
     columnFilter = (col: QueryColumn): boolean => {
         return (
-            insertColumnFilter(col) &&
+            insertColumnFilter(col, false) &&
             col.fieldKey !== this.props.entityDataType.uniqueFieldKey &&
             col.derivationDataScope !== DERIVATION_DATA_SCOPE_CHILD_ONLY
         );

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -957,45 +957,45 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                         <LoadingSpinner wrapperClassName="loading-data-message" />
                     )}
                     {isLoaded && (
-                        <EntityInsertGridRequiredFieldAlert
-                            type={this.capTypeTextSingular}
-                            queryInfo={queryGridModel?.queryInfo}
-                        />
-                    )}
-                    {isLoaded && (
-                        <EditableGridPanel
-                            addControlProps={{
-                                nounSingular: gridNounSingularCap,
-                                nounPlural: gridNounPluralCap,
-                                placement: 'top' as PlacementType,
-                                wrapperClass: 'pull-left',
-                                maxCount: MAX_EDITABLE_GRID_ROWS,
-                            }}
-                            allowBulkRemove
-                            allowBulkAdd
-                            allowBulkUpdate
-                            bordered
-                            striped
-                            bulkAddText="Bulk Insert"
-                            bulkAddProps={{
-                                title: `Bulk Creation of ${gridNounPluralCap}`,
-                                header: `Add a batch of ${gridNounPlural} that will share the properties set below.`,
-                                columnFilter: this.columnFilter,
-                                fieldValues: this.getBulkAddFormValues(),
-                                creationTypeOptions: bulkCreationTypeOptions,
-                                countText: `New ${gridNounPlural}`,
-                            }}
-                            onBulkAdd={onBulkAdd}
-                            bulkUpdateProps={{ columnFilter: this.columnFilter }}
-                            bulkRemoveText={'Remove ' + gridNounPluralCap}
-                            columnMetadata={columnMetadata}
-                            onRowCountChange={this.onRowCountChange}
-                            model={queryGridModel}
-                            initialEmptyRowCount={0}
-                            emptyGridMsg={`Start by adding the quantity of ${gridNounPlural} you want to create.`}
-                            maxTotalRows={this.props.maxEntities}
-                            getInsertColumns={this.getInsertColumns}
-                        />
+                        <>
+                            <EntityInsertGridRequiredFieldAlert
+                                type={this.capTypeTextSingular}
+                                queryInfo={queryGridModel?.queryInfo}
+                            />
+                            <EditableGridPanel
+                                addControlProps={{
+                                    nounSingular: gridNounSingularCap,
+                                    nounPlural: gridNounPluralCap,
+                                    placement: 'top' as PlacementType,
+                                    wrapperClass: 'pull-left',
+                                    maxCount: MAX_EDITABLE_GRID_ROWS,
+                                }}
+                                allowBulkRemove
+                                allowBulkAdd
+                                allowBulkUpdate
+                                bordered
+                                striped
+                                bulkAddText="Bulk Insert"
+                                bulkAddProps={{
+                                    title: `Bulk Creation of ${gridNounPluralCap}`,
+                                    header: `Add a batch of ${gridNounPlural} that will share the properties set below.`,
+                                    columnFilter: this.columnFilter,
+                                    fieldValues: this.getBulkAddFormValues(),
+                                    creationTypeOptions: bulkCreationTypeOptions,
+                                    countText: `New ${gridNounPlural}`,
+                                }}
+                                onBulkAdd={onBulkAdd}
+                                bulkUpdateProps={{ columnFilter: this.columnFilter }}
+                                bulkRemoveText={'Remove ' + gridNounPluralCap}
+                                columnMetadata={columnMetadata}
+                                onRowCountChange={this.onRowCountChange}
+                                model={queryGridModel}
+                                initialEmptyRowCount={0}
+                                emptyGridMsg={`Start by adding the quantity of ${gridNounPlural} you want to create.`}
+                                maxTotalRows={this.props.maxEntities}
+                                getInsertColumns={this.getInsertColumns}
+                            />
+                        </>
                     )}
                 </div>
             </>

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -98,6 +98,7 @@ import {
 
 import { getUniqueIdColumnMetadata } from './utils';
 import { getEntityTypeData, handleEntityFileImport } from './actions';
+import { EntityInsertGridRequiredFieldAlert } from './EntityInsertGridRequiredFieldAlert';
 
 const ALIQUOT_FIELD_COLS = ['aliquotedfrom', 'name', 'description'];
 const ALIQUOT_NOUN_SINGULAR = 'Aliquot';
@@ -954,6 +955,12 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                 <div className="top-spacing">
                     {!isLoaded && !insertModel.isError && !!insertModel.targetEntityType?.value && (
                         <LoadingSpinner wrapperClassName="loading-data-message" />
+                    )}
+                    {isLoaded && (
+                        <EntityInsertGridRequiredFieldAlert
+                            type={this.capTypeTextSingular}
+                            queryInfo={queryGridModel?.queryInfo}
+                        />
                     )}
                     {isLoaded && (
                         <EditableGridPanel

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -186,7 +186,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
         // QueryFormInputs to be a rendering factory for the columns that are in the set.
         if (columns) {
             return columns
-                .filter(filter)
+                .filter(col => filter(col))
                 .valueSeq()
                 .map((col, i) => {
                     const shouldDisableField =

--- a/packages/components/src/internal/renderers/FileColumnRenderer.spec.tsx
+++ b/packages/components/src/internal/renderers/FileColumnRenderer.spec.tsx
@@ -74,4 +74,10 @@ describe('getAttachmentTitleFromName', () => {
         expect(getAttachmentTitleFromName('sampletype/test.tsv')).toBe('test.tsv');
         expect(getAttachmentTitleFromName('sampleset/test.tsv')).toBe('test.tsv');
     });
+
+    test('with backslash dir prefix', () => {
+        expect(getAttachmentTitleFromName('something\\test.tsv')).toBe('test.tsv');
+        expect(getAttachmentTitleFromName('sampletype\\test.tsv')).toBe('test.tsv');
+        expect(getAttachmentTitleFromName('sampleset\\test.tsv')).toBe('test.tsv');
+    });
 });

--- a/packages/components/src/internal/renderers/FileColumnRenderer.tsx
+++ b/packages/components/src/internal/renderers/FileColumnRenderer.tsx
@@ -81,5 +81,10 @@ export function getAttachmentTitleFromName(name: string): string {
     if (name.indexOf('/') > -1) {
         return name.substr(name.lastIndexOf('/') + 1);
     }
+    // Issue 43725: Windows file name comes through with backslash instead
+    else if (name.indexOf('\\') > -1) {
+        return name.substr(name.lastIndexOf('\\') + 1);
+    }
+
     return name;
 }

--- a/packages/components/src/public/QueryColumn.spec.ts
+++ b/packages/components/src/public/QueryColumn.spec.ts
@@ -442,7 +442,6 @@ describe('insertColumnFilter', () => {
                 })
             )
         ).toBeFalsy();
-
         expect(
             insertColumnFilter(
                 new QueryColumn({
@@ -451,6 +450,53 @@ describe('insertColumnFilter', () => {
                     userEditable: true,
                     fieldKeyArray: ['test1', 'test2'],
                 })
+            )
+        ).toBeFalsy();
+    });
+
+    test('includeFileInputs', () => {
+        expect(
+            insertColumnFilter(
+                new QueryColumn({
+                    shownInInsertView: true,
+                    userEditable: true,
+                    fieldKeyArray: ['test'],
+                    inputType: 'text',
+                }),
+                true
+            )
+        ).toBeTruthy();
+        expect(
+            insertColumnFilter(
+                new QueryColumn({
+                    shownInInsertView: true,
+                    userEditable: true,
+                    fieldKeyArray: ['test'],
+                    inputType: 'text',
+                }),
+                false
+            )
+        ).toBeTruthy();
+        expect(
+            insertColumnFilter(
+                new QueryColumn({
+                    shownInInsertView: true,
+                    userEditable: true,
+                    fieldKeyArray: ['test'],
+                    inputType: 'file',
+                }),
+                true
+            )
+        ).toBeTruthy();
+        expect(
+            insertColumnFilter(
+                new QueryColumn({
+                    shownInInsertView: true,
+                    userEditable: true,
+                    fieldKeyArray: ['test'],
+                    inputType: 'file',
+                }),
+                false
             )
         ).toBeFalsy();
     });

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -292,12 +292,13 @@ export class QueryColumn extends Record({
     }
 }
 
-export function insertColumnFilter(col: QueryColumn): boolean {
+export function insertColumnFilter(col: QueryColumn, includeFileInputs = true): boolean {
     return (
         col &&
         col.removeFromViews !== true &&
         col.shownInInsertView === true &&
         col.userEditable === true &&
-        col.fieldKeyArray.length === 1
+        col.fieldKeyArray.length === 1 &&
+        (includeFileInputs || !col.isFileInput)
     );
 }

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -114,9 +114,7 @@ describe('QueryInfo', () => {
         });
 
         test('with readOnly columns', () => {
-            const columns = queryInfo.getUpdateColumns(
-                List<string>(['Name'])
-            );
+            const columns = queryInfo.getUpdateColumns(List<string>(['Name']));
             expect(columns.size).toBe(4);
             expect(columns.get(0).fieldKey).toBe('Name');
             expect(columns.get(1).fieldKey).toBe('Description');

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -163,6 +163,31 @@ describe('QueryInfo', () => {
         });
     });
 
+    describe('getInsertColumns', () => {
+        test('includeFileInputs false', () => {
+            const insertCol1 = QueryInfo.fromJSON({
+                columns: [
+                    {
+                        fieldKey: 'test1',
+                        fieldKeyArray: ['test1'],
+                        shownInInsertView: true,
+                        userEditable: true,
+                        inputType: 'text',
+                    },
+                    {
+                        fieldKey: 'test2',
+                        fieldKeyArray: ['test2'],
+                        shownInInsertView: true,
+                        userEditable: true,
+                        inputType: 'file',
+                    },
+                ],
+            }).getInsertColumns();
+            expect(insertCol1.size).toBe(1);
+            expect(insertCol1.get(0).fieldKey).toBe('test1');
+        });
+    });
+
     describe('getFileColumnFieldKeys', () => {
         test('default', () => {
             const fieldKeys = QueryInfo.fromJSON({

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -226,7 +226,7 @@ export class QueryInfo extends Record({
 
     getInsertColumns(): List<QueryColumn> {
         // CONSIDER: use the columns in ~~INSERT~~ view to determine this set
-        return this.columns.filter(insertColumnFilter).toList();
+        return this.columns.filter(col => insertColumnFilter(col, false)).toList();
     }
 
     getUpdateColumns(readOnlyColumns?: List<string>): List<QueryColumn> {


### PR DESCRIPTION
#### Rationale
Issue [43728](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43728): Sample Manager: bulk insert for samples is broken when a file field is present
Issue [43725](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43725): Sample Manager: sample type file field is not displaying the correct filename on Windows
Issue [43703](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43703): Sample Manager: unable to create samples when a sample type contains a File field that's marked as required

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/966
* https://github.com/LabKey/sampleManagement/pull/660

#### Changes
* EntityInsertGridRequiredFieldAlert for warning display on EntityInsertPanel
* insertColumnFilter update to optionally filter out file fields from column list
* getAttachmentTitleFromName update to account for both forward and back slash in file path/name
