### PR TITLE
Issue 43734: SM: Aliquot overview details panel shows some aliquot values under the 'originating sample data' section

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.2",
+  "version": "2.63.3-fb-sm219X.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.63.3-fb-sm219X.1",
+  "version": "2.63.3-fb-sm219X.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.65.0",
+  "version": "2.65.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Issue 43734: SM: Aliquot overview details panel shows some aliquot values under the 'originating sample data' section
+  * Hide extra exp.material fields from aliquot detail view
+
 ### version 2.63.2
 *Released*: 13 August 2021
 * Fix capitalization in FindByIdsModal button

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -302,10 +302,10 @@ export function getGroupedSampleDisplayColumns(
             // display parent meta for aliquot
             else if (sampleTypeDomainFields.aliquotFields.indexOf(colName) > -1) {
                 aliquotHeaderDisplayColumns = aliquotHeaderDisplayColumns.push(col);
-            } else {
-                if (sampleTypeDomainFields.metaFields.indexOf(colName) === -1) {
+            }
+            else if (sampleTypeDomainFields.metaFields.indexOf(colName) === -1) {
+                if ("created" === colName || "createdby" === colName)
                     displayColumns.push(col);
-                }
             }
         } else {
             if (sampleTypeDomainFields.aliquotFields.indexOf(colName) === -1) {

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -303,10 +303,6 @@ export function getGroupedSampleDisplayColumns(
             else if (sampleTypeDomainFields.aliquotFields.indexOf(colName) > -1) {
                 aliquotHeaderDisplayColumns = aliquotHeaderDisplayColumns.push(col);
             }
-            else if (sampleTypeDomainFields.metaFields.indexOf(colName) === -1) {
-                if ("created" === colName || "createdby" === colName)
-                    displayColumns.push(col);
-            }
         } else {
             if (sampleTypeDomainFields.aliquotFields.indexOf(colName) === -1) {
                 displayColumns.push(col);


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* skip exp.materials columns fields for aliquots
