### PR TITLE
43029: Support File/Attachment Fields

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.3",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.6.6-fb-fix-43029.0",
+    "@labkey/api": "1.6.6-fb-fix-43029.1",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.3",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.6.5",
+    "@labkey/api": "1.6.6-fb-fix-43029.0",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.3",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@labkey/api": "1.6.6-fb-fix-43029.1",
+    "@labkey/api": "1.6.7",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.66.1",
+  "version": "2.67.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,11 +1,16 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-#### versionn 2.66.1
+#### version 2.67.0
+*Release*: 25 August 2021
+* Issue 43029: Support File/Attachment Fields
+    * See https://github.com/LabKey/labkey-ui-components/pull/610 for more details.
+
+#### version 2.66.1
 *Release*: 25 August 2021
 * Issue 43782: Omnibox - Filtering on a field pulled into a lookup shows lookup field instead of the pulled in field
 
-#### versionn 2.66.0
+#### version 2.66.0
 *Release*: 23 August 2021
 * Issue 43693: Indicate the depth of the lineage graphs and grids
 * Issue 43692: expose LineageGroupingOptions for ease of overriding defaults; update default depth to 5

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -387,6 +387,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
     };
 
     handleBatchChange = (fieldValues: any, isChanged?: boolean): void => {
+        // TODO: Ensure this works
+        console.log('handleBatchChange', fieldValues, isChanged);
         // Here we have to merge incoming values with model.batchProperties because of the way Formsy works.
         // FileInput fields are not Formsy components, so when they send updates they only send the value for their
         // field. When formsy sends updates it sends the entire form (but not file fields). So we need to merge
@@ -404,6 +406,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
     };
 
     handleRunChange = (fieldValues: any, isChanged?: boolean): void => {
+        // TODO: Ensure this works
+        console.log('handleRunChange', fieldValues, isChanged);
         // See the note in handleBatchChange for why this method exists.
         const values = {
             ...this.state.model.runProperties.toObject(),

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -386,7 +386,9 @@ class AssayImportPanelsBody extends Component<Props, State> {
         }));
     };
 
-    handleBatchChange = (values: any, isChanged?: boolean): void => {
+    handleBatchChange = (fieldValues: any, isChanged?: boolean): void => {
+        const values = { ...this.state.model.batchProperties.toObject(), ...fieldValues };
+
         if (isChanged) {
             this.props.onDataChange?.(true, IMPORT_DATA_FORM_TYPES.OTHER);
         }
@@ -394,7 +396,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
         this.handleChange('batchProperties', Map<string, any>(values ? values : {}));
     };
 
-    handleRunChange = (values: any, isChanged?: boolean): void => {
+    handleRunChange = (fieldValues: any, isChanged?: boolean): void => {
+        const values = { ...this.state.model.runProperties.toObject(), ...fieldValues };
         let { comment, runName } = this.state.model;
 
         const cleanedValues = Object.keys(values).reduce((result, key) => {

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -386,18 +386,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
         }));
     };
 
-    handleBatchChange = (fieldValues: any, isChanged?: boolean): void => {
-        // TODO: Ensure this works
-        console.log('handleBatchChange', fieldValues, isChanged);
-        // Here we have to merge incoming values with model.batchProperties because of the way Formsy works.
-        // FileInput fields are not Formsy components, so when they send updates they only send the value for their
-        // field. When formsy sends updates it sends the entire form (but not file fields). So we need to merge
-        // with the known values and then both Formsy and FileInput fields can work together.
-        const values = {
-            ...this.state.model.batchProperties.toObject(),
-            ...fieldValues,
-        };
-
+    handleBatchChange = (values: any, isChanged?: boolean): void => {
         if (isChanged) {
             this.props.onDataChange?.(true, IMPORT_DATA_FORM_TYPES.OTHER);
         }
@@ -405,15 +394,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
         this.handleChange('batchProperties', Map<string, any>(values ? values : {}));
     };
 
-    handleRunChange = (fieldValues: any, isChanged?: boolean): void => {
-        // TODO: Ensure this works
-        console.log('handleRunChange', fieldValues, isChanged);
-        // See the note in handleBatchChange for why this method exists.
-        const values = {
-            ...this.state.model.runProperties.toObject(),
-            ...fieldValues,
-        };
-
+    handleRunChange = (values: any, isChanged?: boolean): void => {
         let { comment, runName } = this.state.model;
 
         const cleanedValues = Object.keys(values).reduce((result, key) => {
@@ -540,9 +521,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                     const jobDescription = getJobDescription ? getJobDescription(data) : undefined;
                     importAssayRun({ ...processedData, forceAsync, jobDescription, jobNotificationProvider })
                         .then((response: AssayUploadResultModel) => {
-                            if (this.props.onDataChange) {
-                                this.props.onDataChange(false);
-                            }
+                            this.props.onDataChange?.(false);
                             if (importAgain && onSave) {
                                 this.onSuccessContinue(response, backgroundUpload || forceAsync);
                             } else {

--- a/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
@@ -13,51 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { FC, memo } from 'react';
 import Formsy from 'formsy-react';
-import { is } from 'immutable';
 
 import { QueryFormInputs } from '../../..';
 
 import { AssayPropertiesPanelProps } from './models';
 
-export class BatchPropertiesPanel extends React.Component<AssayPropertiesPanelProps, any> {
-    shouldComponentUpdate(nextProps: AssayPropertiesPanelProps) {
-        const { model } = this.props;
+export const BatchPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
+    const { model, onChange, title = 'Batch Details', showQuerySelectPreviewOptions } = props;
 
-        return (
-            !is(model.batchId, nextProps.model.batchId) ||
-            !is(model.batchColumns, nextProps.model.batchColumns) ||
-            !is(model.batchProperties, nextProps.model.batchProperties)
-        );
-    }
-
-    render() {
-        const { model, onChange, title, showQuerySelectPreviewOptions } = this.props;
-        const panelTitle = title || 'Batch Details';
-
-        if (model.batchColumns.size) {
-            const disabled = model.batchId !== undefined;
-
-            return (
-                <div className="panel panel-default">
-                    <div className="panel-heading">{panelTitle}</div>
-
-                    <div className="panel-body">
-                        <Formsy className="form-horizontal" onChange={onChange} disabled={disabled}>
-                            <QueryFormInputs
-                                renderFileInputs={true}
-                                queryColumns={model.batchColumns}
-                                fieldValues={model.batchProperties.toObject()}
-                                onChange={onChange}
-                                showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
-                            />
-                        </Formsy>
-                    </div>
-                </div>
-            );
-        }
-
+    if (model.batchColumns.size === 0) {
         return null;
     }
-}
+
+    const disabled = model.batchId !== undefined;
+
+    return (
+        <div className="panel panel-default">
+            <div className="panel-heading">{title}</div>
+
+            <div className="panel-body">
+                <Formsy className="form-horizontal" onChange={onChange} disabled={disabled}>
+                    <QueryFormInputs
+                        fieldValues={model.batchProperties.toObject()}
+                        queryColumns={model.batchColumns}
+                        renderFileInputs
+                        showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
+                    />
+                </Formsy>
+            </div>
+        </div>
+    );
+});
+
+BatchPropertiesPanel.displayName = 'BatchPropertiesPanel';

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -13,75 +13,63 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { FC, memo } from 'react';
 import Formsy from 'formsy-react';
 import { Input, Textarea } from 'formsy-react-components';
-import { is } from 'immutable';
 
 import { QueryFormInputs, LabelOverlay } from '../../..';
 
 import { AssayPropertiesPanelProps } from './models';
 
-const ASSAY_ID_LABEL = (
-    <LabelOverlay
-        label="Assay ID"
-        description="The assay/experiment ID that uniquely identifies this assay run."
-        type="Text (String)"
-    />
-);
+export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
+    const { model, onChange, title = 'Run Details', showQuerySelectPreviewOptions } = props;
 
-const COMMENT_LABEL = (
-    <LabelOverlay label="Comments" description="Contains comments about this run" type="Text (String)" />
-);
-
-export class RunPropertiesPanel extends React.Component<AssayPropertiesPanelProps, any> {
-    shouldComponentUpdate(nextProps: AssayPropertiesPanelProps) {
-        return (
-            this.props.model.comment !== nextProps.model.comment ||
-            this.props.model.runName !== nextProps.model.runName ||
-            !is(this.props.model.runColumns, nextProps.model.runColumns) ||
-            !is(this.props.model.runProperties, nextProps.model.runProperties)
-        );
-    }
-
-    render() {
-        const { model, onChange, title, showQuerySelectPreviewOptions } = this.props;
-        const panelTitle = title || 'Run Details';
-
-        return (
-            <div className="panel panel-default">
-                <div className="panel-heading">{panelTitle}</div>
-                <div className="panel-body">
-                    <Formsy className="form-horizontal" onChange={onChange}>
-                        <Input
-                            changeDebounceInterval={0}
-                            label={ASSAY_ID_LABEL}
-                            labelClassName="text-left"
-                            name="runname"
-                            type="text"
-                            value={model.runName}
-                        />
-                        <Textarea
-                            changeDebounceInterval={0}
-                            cols={60}
-                            label={COMMENT_LABEL}
-                            labelClassName="text-left"
-                            name="comment"
-                            rows={2}
-                            value={model.comment}
-                        />
-                        {model.runColumns.size !== 0 && (
-                            <QueryFormInputs
-                                renderFileInputs={true}
-                                queryColumns={model.runColumns}
-                                fieldValues={model.runProperties.toObject()}
-                                onChange={onChange}
-                                showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
+    return (
+        <div className="panel panel-default">
+            <div className="panel-heading">{title}</div>
+            <div className="panel-body">
+                <Formsy className="form-horizontal" onChange={onChange}>
+                    <Input
+                        changeDebounceInterval={0}
+                        label={
+                            <LabelOverlay
+                                description="The assay/experiment ID that uniquely identifies this assay run."
+                                label="Assay ID"
+                                type="Text (String)"
                             />
-                        )}
-                    </Formsy>
-                </div>
+                        }
+                        labelClassName="text-left"
+                        name="runname"
+                        type="text"
+                        value={model.runName}
+                    />
+                    <Textarea
+                        changeDebounceInterval={0}
+                        cols={60}
+                        label={
+                            <LabelOverlay
+                                description="Contains comments about this run"
+                                label="Comments"
+                                type="Text (String)"
+                            />
+                        }
+                        labelClassName="text-left"
+                        name="comment"
+                        rows={2}
+                        value={model.comment}
+                    />
+                    {model.runColumns.size !== 0 && (
+                        <QueryFormInputs
+                            fieldValues={model.runProperties.toObject()}
+                            queryColumns={model.runColumns}
+                            renderFileInputs
+                            showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
+                        />
+                    )}
+                </Formsy>
             </div>
-        );
-    }
-}
+        </div>
+    );
+});
+
+RunPropertiesPanel.displayName = 'RunPropertiesPanel';

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -21,6 +21,18 @@ import { QueryFormInputs, LabelOverlay } from '../../..';
 
 import { AssayPropertiesPanelProps } from './models';
 
+const ASSAY_ID_LABEL = (
+    <LabelOverlay
+        description="The assay/experiment ID that uniquely identifies this assay run."
+        label="Assay ID"
+        type="Text (String)"
+    />
+);
+
+const COMMENT_LABEL = (
+    <LabelOverlay description="Contains comments about this run" label="Comments" type="Text (String)" />
+);
+
 export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
     const { model, onChange, title = 'Run Details', showQuerySelectPreviewOptions } = props;
 
@@ -31,13 +43,7 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                 <Formsy className="form-horizontal" onChange={onChange}>
                     <Input
                         changeDebounceInterval={0}
-                        label={
-                            <LabelOverlay
-                                description="The assay/experiment ID that uniquely identifies this assay run."
-                                label="Assay ID"
-                                type="Text (String)"
-                            />
-                        }
+                        label={ASSAY_ID_LABEL}
                         labelClassName="text-left"
                         name="runname"
                         type="text"
@@ -46,13 +52,7 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                     <Textarea
                         changeDebounceInterval={0}
                         cols={60}
-                        label={
-                            <LabelOverlay
-                                description="Contains comments about this run"
-                                label="Comments"
-                                type="Text (String)"
-                            />
-                        }
+                        label={COMMENT_LABEL}
                         labelClassName="text-left"
                         name="comment"
                         rows={2}

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -92,10 +92,8 @@ export function importAssayRun(config: Partial<AssayDOM.IImportRunOptions>): Pro
 
 export function uploadAssayRunFiles(data: IAssayUploadOptions): Promise<IAssayUploadOptions> {
     return new Promise((resolve, reject) => {
-        const batchProperties = data.batchProperties;
-        const runProperties = data.properties;
-        const batchFiles = collectFiles(batchProperties);
-        const runFiles = collectFiles(runProperties);
+        const batchFiles = collectFiles(data.batchProperties);
+        const runFiles = collectFiles(data.properties);
         let maxFileSize = 0; // return the largest file size, used to determine if async mode should be used
 
         const maxRowCount = Array.isArray(data.dataRows) ? data.dataRows.length : undefined;
@@ -205,7 +203,7 @@ interface FileMap {
     [s: string]: File;
 }
 
-function collectFiles(source): FileMap {
+function collectFiles(source: Record<string, any>): FileMap {
     return Object.keys(source).reduce((files, key) => {
         const item = source[key];
 

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { QueryColumn, QueryInfo, SchemaQuery } from '../../..';
 
@@ -50,19 +50,30 @@ const DEFAULT_PROPS = {
 
 describe('BulkUpdateForm', () => {
     // TODO missing test cases for main functionality of component
+    describe('columnFilter', () => {
+        test('filters without uniqueKeyField', () => {
+            // Arrange
+            const wrapper = shallow(<BulkUpdateForm {...DEFAULT_PROPS} />);
+            const columnFilter = wrapper.find(QueryInfoForm).prop('columnFilter');
 
-    test('getUpdateQueryInfo without uniqueFieldKey', () => {
-        const wrapper = mount(<BulkUpdateForm {...DEFAULT_PROPS} />);
-        const queryInfo = wrapper.find(QueryInfoForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(1);
-        expect(queryInfo.columns.get('update')).toBe(COLUMN_CAN_UPDATE);
-        wrapper.unmount();
-    });
+            // Act
+            const filteredColumns = QUERY_INFO.columns.filter(c => columnFilter(c)).toMap();
 
-    test('getUpdateQueryInfo with uniqueFieldKey', () => {
-        const wrapper = mount(<BulkUpdateForm {...DEFAULT_PROPS} uniqueFieldKey="update" />);
-        const queryInfo = wrapper.find(QueryInfoForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(0);
-        wrapper.unmount();
+            // Assert
+            expect(filteredColumns.size).toEqual(1);
+            expect(filteredColumns.get('update')).toEqual(COLUMN_CAN_UPDATE);
+        });
+
+        test('filters with uniqueFieldKey', () => {
+            // Arrange
+            const wrapper = shallow(<BulkUpdateForm {...DEFAULT_PROPS} uniqueFieldKey="update" />);
+            const columnFilter = wrapper.find(QueryInfoForm).prop('columnFilter');
+
+            // Act
+            const filteredColumns = QUERY_INFO.columns.filter(c => columnFilter(c)).toMap();
+
+            // Assert
+            expect(filteredColumns.size).toEqual(0);
+        });
     });
 });

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
@@ -60,8 +60,9 @@ describe('BulkUpdateForm', () => {
             const filteredColumns = QUERY_INFO.columns.filter(c => columnFilter(c)).toMap();
 
             // Assert
-            expect(filteredColumns.size).toEqual(1);
+            expect(filteredColumns.size).toEqual(2);
             expect(filteredColumns.get('update')).toEqual(COLUMN_CAN_UPDATE);
+            expect(filteredColumns.get('fileinput')).toEqual(COLUMN_FILE_INPUT);
         });
 
         test('filters with uniqueFieldKey', () => {
@@ -73,7 +74,8 @@ describe('BulkUpdateForm', () => {
             const filteredColumns = QUERY_INFO.columns.filter(c => columnFilter(c)).toMap();
 
             // Assert
-            expect(filteredColumns.size).toEqual(0);
+            expect(filteredColumns.size).toEqual(1);
+            expect(filteredColumns.get('fileinput')).toEqual(COLUMN_FILE_INPUT);
         });
     });
 });

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -99,11 +99,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
 
     columnFilter = (col: QueryColumn): boolean => {
         const lcUniqueFieldKey = this.props.uniqueFieldKey?.toLowerCase();
-        return (
-            col.shownInUpdateView === true &&
-            (!lcUniqueFieldKey || col.name.toLowerCase() !== lcUniqueFieldKey) &&
-            !col.isFileInput
-        );
+        return col.isUpdateColumn && (!lcUniqueFieldKey || col.name.toLowerCase() !== lcUniqueFieldKey);
     };
 
     onSubmit = (data): Promise<any> => {
@@ -162,6 +158,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                 onSubmitForEdit={this.onSubmitForEdit}
                 onSubmit={this.onSubmit}
                 onSuccess={onComplete}
+                renderFileInputs
                 queryInfo={queryInfo}
                 showLabelAsterisk
                 submitForEditText="Edit with Grid"

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { PureComponent, ReactNode } from 'react';
 import { List, Map, OrderedMap } from 'immutable';
 import { Utils } from '@labkey/api';
 
@@ -35,63 +35,53 @@ interface Props {
 }
 
 interface State {
-    isLoadingDataForSelection: boolean;
     dataForSelection: Map<string, any>;
     dataIdsForSelection: List<any>;
     errorMsg: string;
+    isLoadingDataForSelection: boolean;
 }
 
-export class BulkUpdateForm extends React.Component<Props, State> {
+export class BulkUpdateForm extends PureComponent<Props, State> {
     static defaultProps = {
-        singularNoun: 'row',
-        pluralNoun: 'rows',
         itemLabel: 'table',
+        pluralNoun: 'rows',
+        singularNoun: 'row',
     };
 
     constructor(props) {
         super(props);
 
         this.state = {
-            isLoadingDataForSelection: true,
             dataForSelection: undefined,
             dataIdsForSelection: undefined,
             errorMsg: undefined,
+            isLoadingDataForSelection: true,
         };
     }
 
-    componentDidMount(): void {
-        const {
-            onCancel,
-            pluralNoun,
-            queryInfo,
-            readOnlyColumns,
-            selectedIds,
-            shownInUpdateColumns,
-            sortString,
-        } = this.props;
+    componentDidMount = async (): Promise<void> => {
+        const { onCancel, pluralNoun, queryInfo, readOnlyColumns, selectedIds, shownInUpdateColumns, sortString } =
+            this.props;
         // Get all shownInUpdateView columns or undefined
         const columns = shownInUpdateColumns
             ? (queryInfo.getPkCols().concat(queryInfo.getUpdateColumns(readOnlyColumns)) as List<QueryColumn>)
             : undefined;
         const columnString = columns?.map(c => c.fieldKey).join(',');
         const { schemaName, name } = queryInfo;
-        getSelectedData(schemaName, name, selectedIds, columnString, sortString)
-            .then(response => {
-                const { data, dataIds } = response;
-                this.setState(() => ({
-                    isLoadingDataForSelection: false,
-                    dataForSelection: data,
-                    dataIdsForSelection: dataIds,
-                }));
-            })
-            .catch(reason => {
-                console.error(reason);
-                if (this.props.onError) {
-                    this.props.onError('There was a problem loading the data for the selected ' + pluralNoun + '.');
-                }
-                onCancel();
+
+        try {
+            const { data, dataIds } = await getSelectedData(schemaName, name, selectedIds, columnString, sortString);
+            this.setState({
+                dataForSelection: data,
+                dataIdsForSelection: dataIds,
+                isLoadingDataForSelection: false,
             });
-    }
+        } catch (reason) {
+            console.error(reason);
+            this.props.onError?.('There was a problem loading the data for the selected ' + pluralNoun + '.');
+            onCancel();
+        }
+    };
 
     getSelectionCount(): number {
         return this.props.selectedIds.length;
@@ -107,29 +97,25 @@ export class BulkUpdateForm extends React.Component<Props, State> {
         return prefix + " selected from '" + this.props.itemLabel + "'";
     }
 
-    getUpdateQueryInfo(): QueryInfo {
-        const { queryInfo, uniqueFieldKey } = this.props;
-        const lcUniqueFieldKey = uniqueFieldKey ? uniqueFieldKey.toLowerCase() : undefined;
-        const updateColumns = queryInfo.columns.filter(
-            column =>
-                column.shownInUpdateView &&
-                (!lcUniqueFieldKey || column.name.toLowerCase() !== lcUniqueFieldKey) &&
-                !column.isFileInput
+    columnFilter = (col: QueryColumn): boolean => {
+        const lcUniqueFieldKey = this.props.uniqueFieldKey?.toLowerCase();
+        return (
+            col.shownInUpdateView === true &&
+            (!lcUniqueFieldKey || col.name.toLowerCase() !== lcUniqueFieldKey) &&
+            !col.isFileInput
         );
-        return queryInfo.set('columns', updateColumns) as QueryInfo;
-    }
+    };
 
-    bulkUpdateSelectedRows = (data): Promise<any> => {
+    onSubmit = (data): Promise<any> => {
         const { queryInfo, updateRows } = this.props;
         const rows = !Utils.isEmptyObj(data) ? getUpdatedData(this.state.dataForSelection, data, queryInfo.pkCols) : [];
 
         return updateRows(queryInfo.schemaQuery, rows);
     };
 
-    onEditWithGrid = (updateData: OrderedMap<string, any>) => {
-        const { onSubmitForEdit } = this.props;
+    onSubmitForEdit = (updateData: OrderedMap<string, any>) => {
         const { dataForSelection, dataIdsForSelection } = this.state;
-        return onSubmitForEdit(updateData, dataForSelection, dataIdsForSelection);
+        return this.props.onSubmitForEdit(updateData, dataForSelection, dataIdsForSelection);
     };
 
     renderBulkUpdateHeader() {
@@ -160,27 +146,27 @@ export class BulkUpdateForm extends React.Component<Props, State> {
 
         return (
             <QueryInfoForm
-                allowFieldDisable={true}
+                allowFieldDisable
+                asModal
                 canSubmitForEdit={canSubmitForEdit}
-                disableSubmitForEditMsg={'At most ' + MAX_EDITABLE_GRID_ROWS + ' can be edited with the grid.'}
-                initiallyDisableFields={true}
-                isLoading={isLoadingDataForSelection}
-                fieldValues={fieldValues}
-                onSubmitForEdit={this.onEditWithGrid}
-                onSubmit={this.bulkUpdateSelectedRows}
-                onSuccess={onComplete}
-                asModal={true}
-                includeCountField={false}
                 checkRequiredFields={false}
-                showLabelAsterisk={true}
+                columnFilter={this.columnFilter}
+                disableSubmitForEditMsg={'At most ' + MAX_EDITABLE_GRID_ROWS + ' can be edited with the grid.'}
+                fieldValues={fieldValues}
+                header={this.renderBulkUpdateHeader()}
+                includeCountField={false}
+                initiallyDisableFields
+                isLoading={isLoadingDataForSelection}
+                onCancel={onCancel}
+                onHide={onCancel}
+                onSubmitForEdit={this.onSubmitForEdit}
+                onSubmit={this.onSubmit}
+                onSuccess={onComplete}
+                queryInfo={queryInfo}
+                showLabelAsterisk
                 submitForEditText="Edit with Grid"
                 submitText={`Update ${capitalizeFirstChar(pluralNoun)}`}
-                onHide={onCancel}
-                onCancel={onCancel}
-                queryInfo={this.getUpdateQueryInfo()}
-                schemaQuery={queryInfo.schemaQuery}
                 title={this.getTitle()}
-                header={this.renderBulkUpdateHeader()}
             />
         );
     }

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -33,11 +33,11 @@ export interface LabelOverlayProps {
     canMouseOverTooltip?: boolean;
 }
 
-export class LabelOverlay extends React.Component<LabelOverlayProps, any> {
+export class LabelOverlay extends React.Component<LabelOverlayProps> {
     static defaultProps = {
         isFormsy: true,
         addLabelAsterisk: false,
-        labelClass: 'control-label col-md-3 col-xs-12 text-left',
+        labelClass: 'control-label col-sm-3 col-xs-12 text-left',
         canMouseOverTooltip: false,
     };
 

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -289,7 +289,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 formsy
                                 key={i}
                                 queryColumn={col}
-                                value={value}
+                                initialValue={value}
                                 name={col.fieldKey}
                                 allowDisable={allowFieldDisable}
                                 initiallyDisabled={shouldDisableField}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -48,26 +48,25 @@ export const getFieldEnabledFieldName = function (column: QueryColumn, fieldName
 };
 
 interface QueryFormInputsProps {
+    allowFieldDisable?: boolean;
+    checkRequiredFields?: boolean;
     columnFilter?: (col?: QueryColumn) => boolean;
     componentKey?: string; // unique key to add to QuerySelect to avoid duplication w/ transpose
+    disabledFields?: List<string>;
     fieldValues?: any;
     fireQSChangeOnInit?: boolean;
-    checkRequiredFields?: boolean;
-    showLabelAsterisk?: boolean; // only used if checkRequiredFields is false, to show * for fields that are originally required
     includeLabelField?: boolean;
+    initiallyDisableFields?: boolean;
+    lookups?: Map<string, number>;
+    onFieldsEnabledChange?: (numEnabled: number) => void;
     onQSChange?: (name: string, value: string | any[], items: any) => any;
     queryColumns?: OrderedMap<string, QueryColumn>;
     queryInfo?: QueryInfo;
-    lookups?: Map<string, number>;
-    onFileChange?: (fileMap: Record<string, File>) => void;
     renderFileInputs?: boolean;
-    allowFieldDisable?: boolean;
-    onFieldsEnabledChange?: (numEnabled: number) => void;
-    initiallyDisableFields?: boolean;
-    useDatePicker?: boolean;
-    disabledFields?: List<string>;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
+    showLabelAsterisk?: boolean; // only used if checkRequiredFields is false, to show * for fields that are originally required
     showQuerySelectPreviewOptions?: boolean;
+    useDatePicker?: boolean;
 }
 
 interface State {
@@ -170,7 +169,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             lookups,
             queryColumns,
             queryInfo,
-            onFileChange,
             renderFileInputs,
             allowFieldDisable,
             disabledFields,
@@ -292,7 +290,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 key={i}
                                 queryColumn={col}
                                 value={value}
-                                onChange={onFileChange}
                                 name={col.fieldKey}
                                 allowDisable={allowFieldDisable}
                                 initiallyDisabled={shouldDisableField}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -59,7 +59,7 @@ interface QueryFormInputsProps {
     queryColumns?: OrderedMap<string, QueryColumn>;
     queryInfo?: QueryInfo;
     lookups?: Map<string, number>;
-    onChange?: Function;
+    onFileChange?: (fileMap: Record<string, File>) => void;
     renderFileInputs?: boolean;
     allowFieldDisable?: boolean;
     onFieldsEnabledChange?: (numEnabled: number) => void;
@@ -170,7 +170,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             lookups,
             queryColumns,
             queryInfo,
-            onChange,
+            onFileChange,
             renderFileInputs,
             allowFieldDisable,
             disabledFields,
@@ -288,15 +288,18 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     } else if (col.inputType === 'file' && renderFileInputs) {
                         return (
                             <FileInput
+                                formsy
                                 key={i}
                                 queryColumn={col}
                                 value={value}
-                                onChange={onChange}
+                                onChange={onFileChange}
+                                name={col.fieldKey}
                                 allowDisable={allowFieldDisable}
                                 initiallyDisabled={shouldDisableField}
                                 onToggleDisable={this.onToggleDisable}
                                 addLabelAsterisk={showAsteriskSymbol}
                                 renderFieldLabel={renderFieldLabel}
+                                showLabel
                             />
                         );
                     }

--- a/packages/components/src/internal/components/forms/QueryInfoForm.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.spec.tsx
@@ -40,9 +40,7 @@ describe('QueryInfoForm', () => {
     test('default props', () => {
         expect.hasAssertions();
         return getQueryDetails(schemaQuery).then(queryInfo => {
-            const formWrapper = shallow(
-                <QueryInfoForm schemaQuery={schemaQuery} queryInfo={queryInfo} onSubmit={jest.fn()} />
-            );
+            const formWrapper = shallow(<QueryInfoForm queryInfo={queryInfo} onSubmit={jest.fn()} />);
             expect(formWrapper.find(QueryFormInputs)).toHaveLength(1);
             expect(formWrapper.find(Button)).toHaveLength(2);
         });
@@ -52,9 +50,7 @@ describe('QueryInfoForm', () => {
         expect.hasAssertions();
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const header = <span className="header-info">Header info here</span>;
-            const formWrapper = shallow(
-                <QueryInfoForm header={header} schemaQuery={schemaQuery} queryInfo={queryInfo} onSubmit={jest.fn()} />
-            );
+            const formWrapper = shallow(<QueryInfoForm header={header} queryInfo={queryInfo} onSubmit={jest.fn()} />);
 
             expect(formWrapper.find('.header-info')).toHaveLength(1);
         });
@@ -63,9 +59,7 @@ describe('QueryInfoForm', () => {
     test('as modal', () => {
         expect.hasAssertions();
         return getQueryDetails(schemaQuery).then(queryInfo => {
-            const formWrapper = shallow(
-                <QueryInfoForm asModal={true} schemaQuery={schemaQuery} queryInfo={queryInfo} onSubmit={jest.fn()} />
-            );
+            const formWrapper = shallow(<QueryInfoForm asModal={true} queryInfo={queryInfo} onSubmit={jest.fn()} />);
             expect(formWrapper.find(Modal)).toHaveLength(1);
             expect(formWrapper.find(ModalTitle)).toHaveLength(0);
         });
@@ -75,13 +69,7 @@ describe('QueryInfoForm', () => {
         expect.hasAssertions();
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const formWrapper = shallow(
-                <QueryInfoForm
-                    asModal={true}
-                    title="Test modal title"
-                    schemaQuery={schemaQuery}
-                    queryInfo={queryInfo}
-                    onSubmit={jest.fn()}
-                />
+                <QueryInfoForm asModal={true} title="Test modal title" queryInfo={queryInfo} onSubmit={jest.fn()} />
             );
             expect(formWrapper.find(Modal)).toHaveLength(1);
             const modalTitle = formWrapper.find(ModalTitle);
@@ -94,12 +82,7 @@ describe('QueryInfoForm', () => {
         expect.hasAssertions();
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const formWrapper = shallow(
-                <QueryInfoForm
-                    includeCountField={false}
-                    schemaQuery={schemaQuery}
-                    queryInfo={queryInfo}
-                    onSubmit={jest.fn()}
-                />
+                <QueryInfoForm includeCountField={false} queryInfo={queryInfo} onSubmit={jest.fn()} />
             );
             expect(formWrapper.find('input#numItems')).toHaveLength(0);
         });
@@ -115,7 +98,6 @@ describe('QueryInfoForm', () => {
                     cancelText={cancelText}
                     countText={countText}
                     submitText={submitText}
-                    schemaQuery={schemaQuery}
                     queryInfo={queryInfo}
                     onSubmit={jest.fn()}
                 />
@@ -133,9 +115,7 @@ describe('QueryInfoForm', () => {
         expect.hasAssertions();
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const footer = <span className="footer-info">Footer info here</span>;
-            const formWrapper = shallow(
-                <QueryInfoForm footer={footer} schemaQuery={schemaQuery} queryInfo={queryInfo} onSubmit={jest.fn()} />
-            );
+            const formWrapper = shallow(<QueryInfoForm footer={footer} queryInfo={queryInfo} onSubmit={jest.fn()} />);
 
             expect(formWrapper.find('.footer-info')).toHaveLength(1);
         });
@@ -148,7 +128,6 @@ describe('QueryInfoForm', () => {
                 <QueryInfoForm
                     includeCountField={false}
                     checkRequiredFields={false}
-                    schemaQuery={schemaQuery}
                     queryInfo={queryInfo}
                     submitForEditText={submitForEditText}
                     onSubmitForEdit={jest.fn()}
@@ -167,7 +146,6 @@ describe('QueryInfoForm', () => {
                 <QueryInfoForm
                     includeCountField={false}
                     checkRequiredFields={false}
-                    schemaQuery={schemaQuery}
                     queryInfo={queryInfo}
                     onSubmitForEdit={jest.fn()}
                     onSubmit={jest.fn()}
@@ -186,7 +164,6 @@ describe('QueryInfoForm', () => {
             const formWrapper = shallow(
                 <QueryInfoForm
                     includeCountField={true}
-                    schemaQuery={schemaQuery}
                     queryInfo={queryInfo}
                     onSubmitForEdit={jest.fn()}
                     onSubmit={jest.fn()}
@@ -206,7 +183,6 @@ describe('QueryInfoForm', () => {
                 <QueryInfoForm
                     includeCountField={false}
                     checkRequiredFields={false}
-                    schemaQuery={schemaQuery}
                     queryInfo={queryInfo}
                     onSubmit={jest.fn()}
                     canSubmitNotDirty={false}
@@ -225,12 +201,7 @@ describe('QueryInfoForm', () => {
 
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const formWrapper = mount(
-                <QueryInfoForm
-                    schemaQuery={schemaQuery}
-                    queryInfo={queryInfo}
-                    columnFilter={filter}
-                    onSubmit={jest.fn()}
-                />
+                <QueryInfoForm queryInfo={queryInfo} columnFilter={filter} onSubmit={jest.fn()} />
             );
 
             expect(formWrapper.find(TextInput)).toHaveLength(1);
@@ -241,12 +212,7 @@ describe('QueryInfoForm', () => {
     test('skip required check', () => {
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const formWrapper = mount(
-                <QueryInfoForm
-                    schemaQuery={schemaQuery}
-                    queryInfo={queryInfo}
-                    checkRequiredFields={false}
-                    onSubmit={jest.fn()}
-                />
+                <QueryInfoForm queryInfo={queryInfo} checkRequiredFields={false} onSubmit={jest.fn()} />
             );
 
             expect(formWrapper.text()).toContain('Extra Test Column Cancel');
@@ -258,7 +224,6 @@ describe('QueryInfoForm', () => {
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const formWrapper = mount(
                 <QueryInfoForm
-                    schemaQuery={schemaQuery}
                     queryInfo={queryInfo}
                     checkRequiredFields={false}
                     showLabelAsterisk={true}
@@ -274,12 +239,7 @@ describe('QueryInfoForm', () => {
     test('all fields disabled', () => {
         return getQueryDetails(schemaQuery).then(queryInfo => {
             const formWrapper = mount(
-                <QueryInfoForm
-                    schemaQuery={schemaQuery}
-                    queryInfo={queryInfo}
-                    initiallyDisableFields={true}
-                    onSubmit={jest.fn()}
-                />
+                <QueryInfoForm queryInfo={queryInfo} initiallyDisableFields={true} onSubmit={jest.fn()} />
             );
             expect(formWrapper.find('Button[type="submit"]').prop('disabled')).toBeTruthy();
             formWrapper.unmount();

--- a/packages/components/src/internal/components/forms/QueryInfoQuantity.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoQuantity.tsx
@@ -1,20 +1,23 @@
-import React, { PureComponent } from "react";
+import React, { PureComponent } from 'react';
 import { Input } from 'formsy-react-components';
-import { RadioGroupInput } from "./input/RadioGroupInput";
+
 import { addValidationRule } from 'formsy-react';
-import { SampleCreationType, SampleCreationTypeModel } from "../samples/models";
+
+import { SampleCreationType, SampleCreationTypeModel } from '../samples/models';
+
+import { RadioGroupInput } from './input/RadioGroupInput';
 
 interface Props {
-    creationTypeOptions: Array<SampleCreationTypeModel>
+    creationTypeOptions: SampleCreationTypeModel[];
     includeCountField: boolean;
     maxCount: number;
     countText: string;
-    onCountChange?: (count: number) => void
+    onCountChange?: (count: number) => void;
 }
 
 interface State {
-    count: number
-    selectedCreationType: SampleCreationType
+    count: number;
+    selectedCreationType: SampleCreationType;
 }
 
 addValidationRule('isPositiveLt', (vs, v, smax) => {
@@ -22,23 +25,22 @@ addValidationRule('isPositiveLt', (vs, v, smax) => {
         return true;
     }
 
-    const max = parseInt(smax);
-    const i = parseInt(v);
+    const max = parseInt(smax, 10);
+    const i = parseInt(v, 10);
 
     if (!isNaN(i) && i >= 1 && i <= max) return true;
-    return max == 1 ? 'Only 1 allowed' : `Value must be between 1 and ${max}.`;
+    return max === 1 ? 'Only 1 allowed' : `Value must be between 1 and ${max}.`;
 });
 
 export class QueryInfoQuantity extends PureComponent<Props, State> {
-
     constructor(props: Props) {
         super(props);
 
-        const selectedOption = props.creationTypeOptions?.find(option => (option.selected));
+        const selectedOption = props.creationTypeOptions?.find(option => option.selected);
         this.state = {
             count: undefined,
-            selectedCreationType: selectedOption?.type
-        }
+            selectedCreationType: selectedOption?.type,
+        };
     }
 
     onCountChange = (field, value): void => {
@@ -46,26 +48,25 @@ export class QueryInfoQuantity extends PureComponent<Props, State> {
         this.props.onCountChange?.(value);
     };
 
-    onOptionChange = (value)  => {
-        this.setState(() => ({selectedCreationType: value}));
-    }
+    onOptionChange = value => {
+        this.setState(() => ({ selectedCreationType: value }));
+    };
 
     render() {
         const { creationTypeOptions, includeCountField, maxCount } = this.props;
         const { count, selectedCreationType } = this.state;
         let text = this.props.countText;
 
-        let options = [];
+        const options = [];
 
-        if (creationTypeOptions)
-        {
+        if (creationTypeOptions) {
             creationTypeOptions.forEach(option => {
                 const selected = selectedCreationType === option.type;
-                if (selected)
-                    text = option.quantityLabel;
+                if (selected) text = option.quantityLabel;
                 options.push({
                     value: option.type,
-                    description: option.disabled && option.disabledDescription ? option.disabledDescription : option.description,
+                    description:
+                        option.disabled && option.disabledDescription ? option.disabledDescription : option.description,
                     label: option.type,
                     disabled: option.disabled,
                     selected: option.selected,
@@ -75,12 +76,7 @@ export class QueryInfoQuantity extends PureComponent<Props, State> {
         return (
             <>
                 {options.length > 0 && (
-                    <RadioGroupInput
-                        name={"creationType"}
-                        options={options}
-                        formsy={true}
-                        onValueChange={this.onOptionChange}
-                    />
+                    <RadioGroupInput name="creationType" options={options} formsy onValueChange={this.onOptionChange} />
                 )}
                 {(options.length > 0 || includeCountField) && (
                     <Input
@@ -91,12 +87,12 @@ export class QueryInfoQuantity extends PureComponent<Props, State> {
                         max={maxCount}
                         min={1}
                         onChange={this.onCountChange}
-                        required={true}
+                        required
                         step="1"
                         style={{ width: '125px' }}
                         type="number"
                         validations={`isPositiveLt:${maxCount}`}
-                        value={count ? count.toString() : "1"}
+                        value={count ? count.toString() : '1'}
                     />
                 )}
             </>

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -21,7 +21,7 @@ import { AuditBehaviorTypes } from '@labkey/api';
 
 import { updateRows, Alert, resolveErrorMessage, QueryColumn, QueryGridModel } from '../../../..';
 
-import { fileInputRenderer } from '../renderers';
+import { FileInputRenderer } from '../renderers';
 
 import { Detail } from './Detail';
 import { DetailPanelHeader } from './DetailPanelHeader';
@@ -107,8 +107,14 @@ export class DetailEditing extends Component<Props, State> {
     };
 
     fileInputRenderer = (col: QueryColumn, data: any): ReactNode => {
-        const updatedFile = this.state.fileMap[col.name];
-        return fileInputRenderer(col, data, updatedFile, this.handleFileInputChange);
+        return (
+            <FileInputRenderer
+                column={col}
+                data={data}
+                onChange={this.handleFileInputChange}
+                updatedFile={this.state.fileMap[col.name]}
+            />
+        );
     };
 
     handleSubmit = values => {

--- a/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditing.tsx
@@ -19,16 +19,12 @@ import { List } from 'immutable';
 import Formsy from 'formsy-react';
 import { AuditBehaviorTypes } from '@labkey/api';
 
-import { updateRows, Alert, resolveErrorMessage, QueryColumn, QueryGridModel } from '../../../..';
-
-import { FileInputRenderer } from '../renderers';
+import { updateRows, Alert, FileInput, resolveErrorMessage, QueryColumn, QueryGridModel } from '../../../..';
 
 import { Detail } from './Detail';
 import { DetailPanelHeader } from './DetailPanelHeader';
 import { extractChanges } from './utils';
 import { DetailRenderer } from './DetailDisplay';
-
-const EMPTY_FILE_FOR_DELETE = new File([], '');
 
 interface Props {
     appEditable?: boolean;
@@ -55,7 +51,6 @@ interface State {
     error: ReactNode;
     isSubmitting: boolean;
     warning: string;
-    fileMap: Record<string, File>;
 }
 
 export class DetailEditing extends Component<Props, State> {
@@ -71,7 +66,6 @@ export class DetailEditing extends Component<Props, State> {
         warning: undefined,
         error: undefined,
         isSubmitting: false,
-        fileMap: {},
     };
 
     disableSubmitButton = (): void => {
@@ -99,85 +93,55 @@ export class DetailEditing extends Component<Props, State> {
         }
     };
 
-    handleFileInputChange = (fileMap: Record<string, File>): void => {
-        this.setState(state => ({
-            fileMap: { ...state.fileMap, ...fileMap },
-            canSubmit: true,
-        }));
-    };
-
     fileInputRenderer = (col: QueryColumn, data: any): ReactNode => {
-        return (
-            <FileInputRenderer
-                column={col}
-                data={data}
-                onChange={this.handleFileInputChange}
-                updatedFile={this.state.fileMap[col.name]}
-            />
-        );
+        return <FileInput formsy initialValue={data} name={col.fieldKey} queryColumn={col} />;
     };
 
-    handleSubmit = values => {
-        this.setState(() => ({ isSubmitting: true }));
+    handleSubmit = async (values: Record<string, any>): Promise<void> => {
+        this.setState({ isSubmitting: true });
 
         const { auditBehavior, queryModel, onEditToggle, onUpdate } = this.props;
-        const { fileMap } = this.state;
         const queryData = queryModel.getRow();
         const queryInfo = queryModel.queryInfo;
         const schemaQuery = queryInfo.schemaQuery;
         const updatedValues = extractChanges(queryInfo, queryData, values);
-        const hasFileUpdates = Object.keys(fileMap).length > 0;
 
-        // If form contains new values, proceed to update
-        if (Object.keys(updatedValues).length > 0 || hasFileUpdates) {
-            // iterate the set of pkCols for this QueryInfo -- include value from queryData
-            queryInfo.getPkCols().forEach(pkCol => {
-                const pkVal = queryData.getIn([pkCol.fieldKey, 'value']);
-
-                if (pkVal !== undefined && pkVal !== null) {
-                    updatedValues[pkCol.fieldKey] = pkVal;
-                } else {
-                    console.warn('Unable to find value for pkCol "' + pkCol.fieldKey + '"');
-                }
-            });
-
-            // to support file/attachment columns, we need to pass them in as FormData and updateRows will handle the rest
-            let form;
-            if (hasFileUpdates) {
-                form = new FormData();
-                Object.keys(fileMap).forEach(key => {
-                    form.append(key, fileMap[key] ?? EMPTY_FILE_FOR_DELETE);
-                });
-            }
-
-            return updateRows({
-                schemaQuery,
-                rows: [updatedValues],
-                form,
-                auditBehavior,
-            })
-                .then(() => {
-                    this.setState(
-                        () => ({ isSubmitting: false, editing: false }),
-                        () => {
-                            onUpdate?.();
-                            onEditToggle?.(false);
-                        }
-                    );
-                })
-                .catch(error => {
-                    this.setState(() => ({
-                        warning: undefined,
-                        isSubmitting: false,
-                        error: resolveErrorMessage(error, 'data', undefined, 'update'),
-                    }));
-                });
-        } else {
+        if (Object.keys(updatedValues).length === 0) {
             this.setState({
                 canSubmit: false,
-                warning: 'No changes detected. Please update the form and click save.',
                 error: undefined,
+                warning: 'No changes detected. Please update the form and click save.',
                 isSubmitting: false,
+            });
+            return;
+        }
+
+        // iterate the set of pkCols for this QueryInfo -- include value from queryData
+        queryInfo.getPkCols().forEach(pkCol => {
+            const pkVal = queryData.getIn([pkCol.fieldKey, 'value']);
+
+            if (pkVal !== undefined && pkVal !== null) {
+                updatedValues[pkCol.fieldKey] = pkVal;
+            } else {
+                console.warn('Unable to find value for pkCol "' + pkCol.fieldKey + '"');
+            }
+        });
+
+        try {
+            await updateRows({ auditBehavior, rows: [updatedValues], schemaQuery });
+
+            this.setState(
+                () => ({ isSubmitting: false, editing: false }),
+                () => {
+                    onUpdate?.();
+                    onEditToggle?.(false);
+                }
+            );
+        } catch (error) {
+            this.setState({
+                error: resolveErrorMessage(error, 'data', undefined, 'update'),
+                isSubmitting: false,
+                warning: undefined,
             });
         }
     };

--- a/packages/components/src/internal/components/forms/detail/utils.ts
+++ b/packages/components/src/internal/components/forms/detail/utils.ts
@@ -68,8 +68,7 @@ export function extractChanges(
                 if (newDateValue === origDateValue) {
                     return false;
                 }
-            }
-            else if (column?.jsonType === 'string') {
+            } else if (column?.jsonType === 'string' && column?.inputType !== 'file') {
                 newValue = newValue?.trim();
                 if (currentData.get(field) === newValue) {
                     return false;

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -15,6 +15,7 @@
  */
 import React, { FC, ReactNode, RefObject } from 'react';
 import classNames from 'classnames';
+import { Map } from 'immutable';
 import { withFormsy } from 'formsy-react';
 
 import { FieldLabel } from '../FieldLabel';
@@ -77,7 +78,10 @@ class FileInputImpl extends DisableableInput<Props, State> {
 
         this.fileInput = React.createRef<HTMLInputElement>();
         this.state = {
-            data: props.initialValue,
+            // FileInput only accepts query-shaped row data as the initialValue
+            // as that is what is accepted by FileColumnRenderer. Without this there is likely insufficient
+            // metadata to render and act on the associated file value.
+            data: Map.isMap(props.initialValue) ? props.initialValue : undefined,
             isHover: false,
             file: null,
             error: '',

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -185,7 +185,9 @@ class FileInputImpl extends DisableableInput<Props, State> {
                 </div>
             );
         } else if (data?.get('value')) {
-            body = <FileColumnRenderer col={queryColumn} data={data} onRemove={this.onRemove} />;
+            body = (
+                <FileColumnRenderer col={queryColumn} data={data} onRemove={isDisabled ? undefined : this.onRemove} />
+            );
         } else {
             body = (
                 <>
@@ -202,7 +204,10 @@ class FileInputImpl extends DisableableInput<Props, State> {
 
                     {/* We render a label here so click and drag events propagate to the input above */}
                     <label
-                        className={classNames('file-upload--compact-label', { 'file-upload--is-hover': isHover })}
+                        className={classNames('file-upload--compact-label', {
+                            'file-upload--is-disabled': isDisabled,
+                            'file-upload--is-hover': isHover && !isDisabled,
+                        })}
                         htmlFor={inputId}
                         onDrop={this.onDrop}
                         onDragEnter={this.onDrag}

--- a/packages/components/src/internal/components/forms/renderers.spec.tsx
+++ b/packages/components/src/internal/components/forms/renderers.spec.tsx
@@ -19,7 +19,7 @@ import { fromJS, Map } from 'immutable';
 
 import { FileColumnRenderer, FileInput, QueryColumn } from '../../..';
 
-import { fileInputRenderer, resolveDetailFieldValue } from './renderers';
+import { FileInputRenderer, resolveDetailFieldValue } from './renderers';
 
 describe('resolveDetailFieldValue', () => {
     test('data value undefined', () => {
@@ -82,25 +82,30 @@ describe('resolveDetailFieldValue', () => {
     });
 });
 
-describe('fileInputRenderer', () => {
+describe('FileInputRenderer', () => {
     const column = new QueryColumn({ name: 'test' });
 
     test('without value', () => {
-        const wrapper = mount(<div>{fileInputRenderer(column, Map(), undefined, jest.fn)}</div>);
+        const wrapper = mount(<FileInputRenderer column={column} data={Map()} onChange={jest.fn()} />);
         expect(wrapper.find(FileColumnRenderer)).toHaveLength(0);
         expect(wrapper.find(FileInput)).toHaveLength(1);
         wrapper.unmount();
     });
 
     test('with value', () => {
-        const wrapper = mount(<div>{fileInputRenderer(column, Map({ value: 'test.txt' }), undefined, jest.fn)}</div>);
+        const wrapper = mount(
+            <FileInputRenderer column={column} data={Map({ value: 'test.txt' })} onChange={jest.fn()} />
+        );
         expect(wrapper.find(FileColumnRenderer)).toHaveLength(1);
         expect(wrapper.find(FileInput)).toHaveLength(0);
         wrapper.unmount();
     });
 
     test('updatedFile', () => {
-        const wrapper = mount(<div>{fileInputRenderer(column, Map(), new File([], null), jest.fn)}</div>);
+        const updatedFile = new File([], null);
+        const wrapper = mount(
+            <FileInputRenderer column={column} data={Map()} onChange={jest.fn()} updatedFile={updatedFile} />
+        );
         expect(wrapper.find(FileColumnRenderer)).toHaveLength(0);
         expect(wrapper.find(FileInput)).toHaveLength(1);
         wrapper.unmount();

--- a/packages/components/src/internal/components/forms/renderers.spec.tsx
+++ b/packages/components/src/internal/components/forms/renderers.spec.tsx
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 import React from 'react';
-import { mount } from 'enzyme';
-import { fromJS, Map } from 'immutable';
+import { fromJS } from 'immutable';
 
-import { FileColumnRenderer, FileInput, QueryColumn } from '../../..';
-
-import { FileInputRenderer, resolveDetailFieldValue } from './renderers';
+import { resolveDetailFieldValue } from './renderers';
 
 describe('resolveDetailFieldValue', () => {
     test('data value undefined', () => {
@@ -79,35 +76,5 @@ describe('resolveDetailFieldValue', () => {
                 true
             )
         ).toBe('test1');
-    });
-});
-
-describe('FileInputRenderer', () => {
-    const column = new QueryColumn({ name: 'test' });
-
-    test('without value', () => {
-        const wrapper = mount(<FileInputRenderer column={column} data={Map()} onChange={jest.fn()} />);
-        expect(wrapper.find(FileColumnRenderer)).toHaveLength(0);
-        expect(wrapper.find(FileInput)).toHaveLength(1);
-        wrapper.unmount();
-    });
-
-    test('with value', () => {
-        const wrapper = mount(
-            <FileInputRenderer column={column} data={Map({ value: 'test.txt' })} onChange={jest.fn()} />
-        );
-        expect(wrapper.find(FileColumnRenderer)).toHaveLength(1);
-        expect(wrapper.find(FileInput)).toHaveLength(0);
-        wrapper.unmount();
-    });
-
-    test('updatedFile', () => {
-        const updatedFile = new File([], null);
-        const wrapper = mount(
-            <FileInputRenderer column={column} data={Map()} onChange={jest.fn()} updatedFile={updatedFile} />
-        );
-        expect(wrapper.find(FileColumnRenderer)).toHaveLength(0);
-        expect(wrapper.find(FileInput)).toHaveLength(1);
-        wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode, ReactText } from 'react';
+import React, { FC, ReactNode, ReactText, useCallback } from 'react';
 import { List, Map } from 'immutable';
 import { Input } from 'formsy-react-components';
 import { addValidationRule, validationRules } from 'formsy-react';
@@ -146,18 +146,27 @@ export function resolveDetailFieldValue(
     return undefined;
 }
 
-export function fileInputRenderer(
-    col: QueryColumn,
-    data: any,
-    updatedFile: File,
-    onChange: (fileMap: Record<string, File>) => void
-): ReactNode {
+interface FileColumnRendererProps {
+    column: QueryColumn;
+    data: any;
+    onChange: (fileMap: Record<string, File>) => void;
+    updatedFile?: File;
+}
+
+export const FileInputRenderer: FC<FileColumnRendererProps> = props => {
+    const { column, data, onChange, updatedFile } = props;
     const value = data?.get('value');
+
+    const onRemove = useCallback(() => {
+        onChange({ [column.name]: null });
+    }, [column.name, onChange]);
 
     // check to see if an existing file for this column has been removed / changed
     if (value && updatedFile === undefined) {
-        return <FileColumnRenderer col={col} data={data} onRemove={() => onChange({ [col.name]: null })} />;
+        return <FileColumnRenderer col={column} data={data} onRemove={onRemove} />;
     }
 
-    return <FileInput key={col.fieldKey} queryColumn={col} showLabel={false} onChange={onChange} />;
-}
+    return <FileInput key={column.fieldKey} queryColumn={column} showLabel={false} onChange={onChange} />;
+};
+
+FileInputRenderer.displayName = 'FileInputRenderer';

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, ReactNode, ReactText, useCallback } from 'react';
+import React, { ReactNode, ReactText } from 'react';
 import { List, Map } from 'immutable';
 import { Input } from 'formsy-react-components';
 import { addValidationRule, validationRules } from 'formsy-react';
 
-import { FileColumnRenderer, FileInput, QueryColumn } from '../../..';
+import { QueryColumn } from '../../..';
 
 import { LabelOverlay } from './LabelOverlay';
 import { AliasInput } from './input/AliasInput';
@@ -145,28 +145,3 @@ export function resolveDetailFieldValue(
 
     return undefined;
 }
-
-interface FileColumnRendererProps {
-    column: QueryColumn;
-    data: any;
-    onChange: (fileMap: Record<string, File>) => void;
-    updatedFile?: File;
-}
-
-export const FileInputRenderer: FC<FileColumnRendererProps> = props => {
-    const { column, data, onChange, updatedFile } = props;
-    const value = data?.get('value');
-
-    const onRemove = useCallback(() => {
-        onChange({ [column.name]: null });
-    }, [column.name, onChange]);
-
-    // check to see if an existing file for this column has been removed / changed
-    if (value && updatedFile === undefined) {
-        return <FileColumnRenderer col={column} data={data} onRemove={onRemove} />;
-    }
-
-    return <FileInput key={column.fieldKey} queryColumn={column} showLabel={false} onChange={onChange} />;
-};
-
-FileInputRenderer.displayName = 'FileInputRenderer';

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { List, Map, OrderedMap } from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 import { ActionURL } from '@labkey/api';
@@ -13,6 +13,7 @@ import {
     FileInput,
     getActionErrorMessage,
     getQueryDetails,
+    insertColumnFilter,
     LoadingSpinner,
     QueryInfo,
     QueryColumn,
@@ -49,11 +50,11 @@ interface State {
 interface Props {
     user: User;
     userProperties: Map<string, any>;
-    onSuccess: (result: {}, shouldReload: boolean) => any;
-    onCancel: () => any;
+    onSuccess: (result: {}, shouldReload: boolean) => void;
+    onCancel: () => void;
 }
 
-export class UserProfile extends React.Component<Props, State> {
+export class UserProfile extends PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
 
@@ -66,7 +67,7 @@ export class UserProfile extends React.Component<Props, State> {
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         getQueryDetails(SCHEMAS.CORE_TABLES.USERS)
             .then(queryInfo => {
                 this.setState(() => ({ queryInfo }));
@@ -77,24 +78,18 @@ export class UserProfile extends React.Component<Props, State> {
             });
     }
 
-    getUpdateQueryInfo(): QueryInfo {
-        const { queryInfo } = this.state;
-        let updateColumns = queryInfo.columns.filter(column => {
-            return column.userEditable && !FIELDS_TO_EXCLUDE.contains(column.fieldKey.toLowerCase());
-        });
-
+    columnFilter = (col: QueryColumn): boolean => {
         // make sure all columns are set as shownInInsertView
-        updateColumns = updateColumns.map(col => col.set('shownInInsertView', true) as QueryColumn);
+        const _col = col.set('shownInInsertView', true) as QueryColumn;
+        return insertColumnFilter(_col) && !FIELDS_TO_EXCLUDE.contains(_col.fieldKey.toLowerCase());
+    };
 
-        return queryInfo.set('columns', updateColumns) as QueryInfo;
-    }
-
-    onAvatarFileChange = (files: {}) => {
+    onAvatarFileChange = (files: {}): void => {
         this.setState(() => ({ avatar: files[USER_AVATAR_FILE] }));
     };
 
-    removeCurrentAvatar = () => {
-        this.setState(() => ({ removeCurrentAvatar: true }));
+    removeCurrentAvatar = (): void => {
+        this.setState({ removeCurrentAvatar: true });
     };
 
     submitUserDetails = (data: OrderedMap<string, any>): Promise<any> => {
@@ -115,7 +110,7 @@ export class UserProfile extends React.Component<Props, State> {
         return updateUserDetails(SCHEMAS.CORE_TABLES.USERS, getUserDetailsRowData(user, data, avatar));
     };
 
-    onSuccess = (result: {}) => {
+    onSuccess = (result: {}): void => {
         this.props.onSuccess(result, this.state.reloadRequired);
     };
 
@@ -165,8 +160,8 @@ export class UserProfile extends React.Component<Props, State> {
                 </Row>
                 {this.renderSectionTitle('User Details')}
                 <QueryInfoForm
-                    queryInfo={this.getUpdateQueryInfo()}
-                    schemaQuery={queryInfo.schemaQuery}
+                    columnFilter={this.columnFilter}
+                    queryInfo={queryInfo}
                     fieldValues={userProperties.toJS()}
                     includeCountField={false}
                     submitText="Save"
@@ -175,7 +170,7 @@ export class UserProfile extends React.Component<Props, State> {
                     onSuccess={this.onSuccess}
                     onHide={onCancel}
                     disabledFields={DISABLED_FIELDS}
-                    showErrorsAtBottom={true}
+                    showErrorsAtBottom
                 />
             </>
         );

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -669,6 +669,7 @@ export function insertRows(options: InsertRowsOptions): Promise<InsertRowsRespon
             auditUserComment,
             apiVersion: 13.2,
             form: options.form,
+            autoFormFileData: true,
             success: (response, request) => {
                 if (processRequest(response, request, reject)) return;
 
@@ -751,6 +752,7 @@ export function updateRows(options: IUpdateRowsOptions): Promise<any> {
             auditBehavior: options.auditBehavior,
             auditUserComment: options.auditUserComment,
             form: options.form,
+            autoFormFileData: true,
             success: (response, request) => {
                 if (processRequest(response, request, reject)) return;
 

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -9,11 +9,11 @@ import { DetailRenderer } from '../../internal/components/forms/detail/DetailDis
 import { extractChanges } from '../../internal/components/forms/detail/utils';
 
 import { Alert, DetailPanel, QueryColumn, RequiresModelAndActions, resolveErrorMessage, updateRows } from '../..';
-import { fileInputRenderer } from '../../internal/components/forms/renderers';
+import { FileInputRenderer } from '../../internal/components/forms/renderers';
 
 const EMPTY_FILE_FOR_DELETE = new File([], '');
 
-interface EditableDetailPanelProps extends RequiresModelAndActions {
+interface Props extends RequiresModelAndActions {
     appEditable?: boolean;
     asSubPanel?: boolean;
     auditBehavior?: AuditBehaviorTypes;
@@ -31,7 +31,7 @@ interface EditableDetailPanelProps extends RequiresModelAndActions {
     useEditIcon: boolean;
 }
 
-interface EditableDetailPanelState {
+interface State {
     canSubmit?: boolean;
     editing?: boolean;
     error?: string;
@@ -39,14 +39,14 @@ interface EditableDetailPanelState {
     fileMap: Record<string, File>;
 }
 
-export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps, EditableDetailPanelState> {
+export class EditableDetailPanel extends PureComponent<Props, State> {
     static defaultProps = {
         useEditIcon: true,
         cancelText: 'Cancel',
         submitText: 'Save',
     };
 
-    state: Readonly<EditableDetailPanelState> = {
+    state: Readonly<State> = {
         canSubmit: false,
         editing: false,
         error: undefined,
@@ -83,8 +83,14 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
     };
 
     fileInputRenderer = (col: QueryColumn, data: any): ReactNode => {
-        const updatedFile = this.state.fileMap[col.name];
-        return fileInputRenderer(col, data, updatedFile, this.handleFileInputChange);
+        return (
+            <FileInputRenderer
+                column={col}
+                data={data}
+                onChange={this.handleFileInputChange}
+                updatedFile={this.state.fileMap[col.name]}
+            />
+        );
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -117,6 +123,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
             }
         });
 
+        // TODO: Convert this to use Formsy values rather than persisting File data itself
         // to support file/attachment columns, we need to pass them in as FormData and updateRows will handle the rest
         let form;
         if (hasFileUpdates) {

--- a/packages/components/src/theme/fileupload.scss
+++ b/packages/components/src/theme/fileupload.scss
@@ -98,6 +98,12 @@
   }
 }
 
+.file-upload--is-disabled {
+    background-color: #EEEEEE;
+    color: #555555;
+    cursor: not-allowed;
+}
+
 .file-upload--error-message {
   margin-left: 7px;
   color: $brand-danger;

--- a/packages/components/src/theme/fileupload.scss
+++ b/packages/components/src/theme/fileupload.scss
@@ -99,8 +99,8 @@
 }
 
 .file-upload--is-disabled {
-    background-color: #EEEEEE;
-    color: #555555;
+    background-color: $gray-lighter;
+    color: $gray;
     cursor: not-allowed;
 }
 

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -771,10 +771,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.5":
-  version "1.6.5"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.5.tgz#4d41526aebd016f356f6e22836b3f08df325542d"
-  integrity sha1-TUFSauvQFvNW9uIoNrPwjfMlVC0=
+"@labkey/api@1.6.6-fb-fix-43029.0":
+  version "1.6.6-fb-fix-43029.0"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.6-fb-fix-43029.0.tgz#1968711348450326435a8424f7f8dfab66aa365c"
+  integrity sha1-GWhxE0hFAyZDWoQk9/jfq2aqNlw=
 
 "@labkey/eslint-config-base@0.0.10":
   version "0.0.10"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -771,10 +771,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.6-fb-fix-43029.1":
-  version "1.6.6-fb-fix-43029.1"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.6-fb-fix-43029.1.tgz#a237daa1bfc1e81b0fe3f28ef94ac6010157b565"
-  integrity sha1-ojfaob/B6BsP4/KO+UrGAQFXtWU=
+"@labkey/api@1.6.7":
+  version "1.6.7"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz#20bff29d8be22838bc224d636543dd09ace9afd2"
+  integrity sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I=
 
 "@labkey/eslint-config-base@0.0.10":
   version "0.0.10"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -771,10 +771,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.6-fb-fix-43029.0":
-  version "1.6.6-fb-fix-43029.0"
-  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.6-fb-fix-43029.0.tgz#1968711348450326435a8424f7f8dfab66aa365c"
-  integrity sha1-GWhxE0hFAyZDWoQk9/jfq2aqNlw=
+"@labkey/api@1.6.6-fb-fix-43029.1":
+  version "1.6.6-fb-fix-43029.1"
+  resolved "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.6-fb-fix-43029.1.tgz#a237daa1bfc1e81b0fe3f28ef94ac6010157b565"
+  integrity sha1-ojfaob/B6BsP4/KO+UrGAQFXtWU=
 
 "@labkey/eslint-config-base@0.0.10":
   version "0.0.10"


### PR DESCRIPTION
#### Rationale
This addresses [Issue 43029](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43029) by updating `FileInput` to support binding as a Formsy input into a form. It can then be utilized by `QueryFormInputs` without requiring additional `File` data processing by the component user. Additionally, this updates `insertRows` and `updateRows` wrappers to specify `autoFormFileData` as `true` to allow for the underlying `@labkey/api` endpoint wrappers to handle serialization of `File` data.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/110
* https://github.com/LabKey/labkey-ui-components/pull/610
* https://github.com/LabKey/biologics/pull/971
* https://github.com/LabKey/sampleManagement/pull/672
* https://github.com/LabKey/platform/pull/2563

#### Changes
* Update `FileInput`:
    * Add support for binding Formsy. This allows `File` data to be handled like any other data types.
    * Render `FileColumnRenderer` if data is provided. Allows for `FileInput` to handle displaying/removing previous value.
    * Improve disabled state look & feel.
* Add support for file/attachment fields to `BulkUpdateForm`.
* Update `insertRows` and `updateRows` wrappers to specify `autoFormFileData` as `true`. See related `@labkey/api` PR.
* Update `BulkUpdateForm` and `UserProfile` to utilize `columnFilter` on `QueryInfoForm` rather than instantiate a new `QueryInfo` upon render.
* Refactor `BulkAddUpdateForm` to more succinctly wrap `QueryInfoForm`.
* Remove superfluous call to `selectRows` from `QueryInfoForm`. This is turn removed need for `schemaQuery` parameter.
* Remove explicit file handling from `AssayImportPanel`, `DetailEditing`, and `EditableDetailPanel` and delegate handling to `assayImport` and `updateRows` respectively.
* Remove `fileInputRenderer` as it is no longer necessary due to associated updates to `FileInput`.
