### PR TITLE
Issue 43782: Omnibox - Filtering on a field pulled into a lookup shows lookup field instead of the pulled in field

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.66.0",
+  "version": "2.66.0-fb-43782-omnibox-lookup.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.66.0-fb-43782-omnibox-lookup.0",
+  "version": "2.66.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+#### versionn 2.66.1
+*Release*: 25 August 2021
+* Issue 43782: Omnibox - Filtering on a field pulled into a lookup shows lookup field instead of the pulled in field
+
 #### versionn 2.66.0
 *Release*: 23 August 2021
 * Issue 43693: Indicate the depth of the lineage graphs and grids

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -595,16 +595,20 @@ export class QueryModel {
         const isLookup = lowered.indexOf('/') > -1;
         const allColumns = this.allColumns;
 
-        // First attempt to find by name/lookup
-        const column = allColumns.find(queryColumn => {
+        // First find all possible matches by name/lookup
+        const columns = allColumns.filter(queryColumn => {
             if (isLookup && queryColumn.isLookup()) {
                 return lowered.split('/')[0] === queryColumn.name.toLowerCase();
-            } else if (isLookup && !queryColumn.isLookup()) {
-                return false;
             }
 
             return queryColumn.name.toLowerCase() === lowered;
         });
+
+        // Use exact match first, else first possible match
+        let column = columns.find(c => c.name.toLowerCase() === lowered);
+        if (column === undefined && columns.length > 0) {
+            column = columns[0];
+        }
 
         if (column !== undefined) {
             return column;


### PR DESCRIPTION
#### Rationale
See [ticket](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43782)

#### Changes
* Update lookup handling to find more specific full lookup name match before falling back to the lookup column name
