### PR TITLE
Issue 42628: Hide Biologics details view override in view menu

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.67.0-fb-fix-42628.0",
+  "version": "2.67.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.67.0",
+  "version": "2.67.0-fb-fix-42628.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+#### version 2.67.#
+*Release*: ## August 2021
+* Issue 42628: Hide Biologics details view override in view menu
+
 #### version 2.67.0
 *Release*: 25 August 2021
 * Issue 43029: Support File/Attachment Fields

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-#### version 2.67.#
-*Release*: ## August 2021
+#### version 2.67.1
+*Release*: 26 August 2021
 * Issue 42628: Hide Biologics details view override in view menu
 
 #### version 2.67.0

--- a/packages/components/src/internal/components/gridbar/ViewSelector.tsx
+++ b/packages/components/src/internal/components/gridbar/ViewSelector.tsx
@@ -60,7 +60,9 @@ export class ViewSelector extends Component<Props> {
             const items = List<ReactNode>().asMutable();
 
             const valid = model.queryInfo.views.filter(
-                view => view && !view.isDefault && view.name.indexOf('~~') !== 0
+                view =>
+                    // Issue 42628: Hide Biologics details view override in view menu
+                    view && !view.isDefault && view.name.indexOf('~~') !== 0 && view.name !== ViewInfo.BIO_DETAIL_NAME
             );
 
             const publicViews = valid.filter(view => view.shared).sortBy(v => v.label, naturalSort);

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -8,7 +8,7 @@ import { getQueryMetadata } from '../../internal/global';
 interface ViewMenuProps {
     hideEmptyViewMenu: boolean;
     model: QueryModel;
-    onViewSelect: (viewName) => void;
+    onViewSelect: (viewName: string) => void;
 }
 
 export class ViewMenu extends PureComponent<ViewMenuProps> {
@@ -17,7 +17,10 @@ export class ViewMenu extends PureComponent<ViewMenuProps> {
         const { isLoading, views, viewName } = model;
         const activeViewName = viewName ?? ViewInfo.DEFAULT_NAME;
         const defaultView = views.find(view => view.isDefault);
-        const validViews = views.filter(viewInfo => viewInfo.name.indexOf('~~') !== 0);
+        const validViews = views.filter(
+            // Issue 42628: Hide Biologics details view override in view menu
+            view => view.name.indexOf('~~') !== 0 && view.name !== ViewInfo.BIO_DETAIL_NAME
+        );
         const publicViews = validViews.filter(view => !view.isDefault && view.shared);
         const privateViews = validViews.filter(view => !view.isDefault && !view.shared);
         const noViews = publicViews.length === 0 && privateViews.length === 0;


### PR DESCRIPTION
#### Rationale
Addresses [Issue 42628](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42628) by filtering out the "BiologicsDetails" view from the view menu/selector.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/974

#### Changes
* Filter out `ViewInfo.BIO_DETAIL_NAME` at the component level in `ViewSelector` and `ViewMenu`.
