### PR TITLE
43771: Show Folder title on Application home pages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.69.0",
+  "version": "2.69.0-fb-nick-fix-219.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.69.0-fb-nick-fix-219.0",
+  "version": "2.69.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.69.#
-*Released*: ## August 2021
+### version 2.69.1
+*Released*: 31 August 2021
 * Issue 43771: Show Folder title on Application home pages.
 * Issue 43474: Prevent text wrapping for date columns.
 * Introduce `useUserProperties` for retrieving user properties based on current user.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.69.#
+*Released*: ## August 2021
+* Issue 43771: Show Folder title on Application home pages.
+* Issue 43474: Prevent text wrapping for date columns.
+* Introduce `useUserProperties` for retrieving user properties based on current user.
+
 ### version 2.69.0
 *Released*: 31 August 2021
 * Parameterize verb in DetailPanelHeader.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -370,7 +370,7 @@ import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
 import { SiteUsersGridPanel } from './internal/components/user/SiteUsersGridPanel';
-import { UserProvider } from './internal/components/user/UserProvider';
+import { UserProvider, useUserProperties } from './internal/components/user/UserProvider';
 import { FieldEditorOverlay } from './internal/components/forms/FieldEditorOverlay';
 import {
     DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
@@ -815,6 +815,7 @@ export {
     SecurityRole,
     Principal,
     UserProvider,
+    useUserProperties,
     // sample picklist items
     AddToPicklistMenuItem,
     PicklistButton,

--- a/packages/components/src/internal/components/__snapshots__/QueryGridPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/__snapshots__/QueryGridPanel.spec.tsx.snap
@@ -3116,7 +3116,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
                 <td
@@ -3127,7 +3127,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
                 <td
@@ -3138,6 +3138,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <a
+                    className="ws-pre-wrap"
                     href="#/rd/assayrun/650"
                   >
                     GPAT 1_2019-08-07_13-18-06
@@ -3151,7 +3152,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-no-wrap"
                   >
                     2019-08-07 13:18
                   </span>
@@ -3164,6 +3165,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <a
+                    className="ws-pre-wrap"
                     href="#/q/core/siteusers/1005"
                   >
                     susanh
@@ -3177,7 +3179,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
                 <td
@@ -3188,7 +3190,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   >
                     reimport run 2
                   </span>
@@ -3201,7 +3203,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
                 <td
@@ -3212,7 +3214,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
                 <td
@@ -3223,7 +3225,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
                 <td
@@ -3234,7 +3236,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
                 <td
@@ -3245,7 +3247,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-no-wrap"
                   />
                 </td>
                 <td
@@ -3256,7 +3258,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                   }
                 >
                   <span
-                    className="detail-display"
+                    className="ws-pre-wrap"
                   />
                 </td>
               </tr>

--- a/packages/components/src/internal/components/auditlog/TimelineView.tsx
+++ b/packages/components/src/internal/components/auditlog/TimelineView.tsx
@@ -159,7 +159,7 @@ export class TimelineView extends React.Component<Props, any> {
                 placement="bottom"
                 title="Comment"
             >
-                <div className="detail-display">{comment}</div>
+                <div className="ws-pre-wrap">{comment}</div>
             </LabelHelpTip>
         );
     }
@@ -176,7 +176,7 @@ export class TimelineView extends React.Component<Props, any> {
                         placement="bottom"
                         title={info.title}
                     >
-                        <div className="detail-display">{info.content}</div>
+                        <div className="ws-pre-wrap">{info.content}</div>
                     </LabelHelpTip>
                 );
             }

--- a/packages/components/src/internal/components/auditlog/__snapshots__/TimelineView.spec.tsx.snap
+++ b/packages/components/src/internal/components/auditlog/__snapshots__/TimelineView.spec.tsx.snap
@@ -559,7 +559,7 @@ exports[`<TimelineView /> Disable selection 1`] = `
             title="Comment"
           >
             <div
-              className="detail-display"
+              className="ws-pre-wrap"
             >
               This is why I checked it out.
             </div>
@@ -1098,7 +1098,7 @@ exports[`<TimelineView /> Hide user link 1`] = `
             title="Comment"
           >
             <div
-              className="detail-display"
+              className="ws-pre-wrap"
             >
               This is why I checked it out.
             </div>
@@ -1681,7 +1681,7 @@ exports[`<TimelineView /> with selection, completed entity 1`] = `
             title="Comment"
           >
             <div
-              className="detail-display"
+              className="ws-pre-wrap"
             >
               This is why I checked it out.
             </div>
@@ -2264,7 +2264,7 @@ exports[`<TimelineView /> with selection, open entity 1`] = `
             title="Comment"
           >
             <div
-              className="detail-display"
+              className="ws-pre-wrap"
             >
               This is why I checked it out.
             </div>

--- a/packages/components/src/internal/components/forms/FieldEditorOverlay.tsx
+++ b/packages/components/src/internal/components/forms/FieldEditorOverlay.tsx
@@ -235,7 +235,7 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
                         <span className={haveValues ? 'field__set' : 'field__unset'}>
                             <span title={'Edit ' + caption} className="field-edit__icon fa fa-pencil-square-o" />
                             {showIconText && (
-                                <span className="detail-display" title={fieldValue}>
+                                <span className="ws-pre-wrap" title={fieldValue}>
                                     {haveValues
                                         ? fieldValue
                                             ? fieldValue
@@ -247,7 +247,7 @@ export class FieldEditorOverlay extends React.PureComponent<Props, State> {
                     </OverlayTrigger>
                 )}
                 {!canUpdate && showValueOnNotAllowed && (
-                    <span className="detail-display" title={fieldValue}>
+                    <span className="ws-pre-wrap" title={fieldValue}>
                         {fieldValue}
                     </span>
                 )}

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { FC, memo, ReactNode, useMemo } from 'react';
-import { List, Map, OrderedMap } from 'immutable';
+import { List, OrderedMap } from 'immutable';
 import { Panel } from 'react-bootstrap';
 
 import { DefaultRenderer, QueryColumn } from '../../../..';
@@ -28,33 +28,26 @@ export type DetailRenderer = (
 
 export type TitleRenderer = (column: QueryColumn) => ReactNode;
 
-export const _defaultRenderer: Renderer = d => <DefaultRenderer data={d} />;
+export const _defaultRenderer = (col: QueryColumn): Renderer => {
+    return data => <DefaultRenderer col={col} data={data} />;
+};
 
 function processFields(
     queryColumns: List<QueryColumn>,
-    detailRenderer: DetailRenderer,
-    titleRenderer: TitleRenderer,
+    detailRenderer?: DetailRenderer,
+    titleRenderer?: TitleRenderer,
     options?: RenderOptions,
     fileInputRenderer?: (col: QueryColumn, data: any) => ReactNode
-): Map<string, DetailField> {
+): OrderedMap<string, DetailField> {
     return queryColumns.reduce((fields, c) => {
         const fieldKey = c.fieldKey.toLowerCase();
-        let renderer;
-
-        if (detailRenderer) {
-            renderer = detailRenderer(c, options, fileInputRenderer);
-        }
-
-        if (!renderer) {
-            renderer = _defaultRenderer;
-        }
 
         return fields.set(
             fieldKey,
             new DetailField({
                 fieldKey,
                 title: c.caption,
-                renderer,
+                renderer: detailRenderer?.(c, options, fileInputRenderer) ?? _defaultRenderer(c),
                 titleRenderer: titleRenderer ? titleRenderer(c) : <span title={c.fieldKey}>{c.caption}</span>,
             })
         );

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -49,7 +49,7 @@ export function titleRenderer(col: QueryColumn): React.ReactNode {
 }
 
 function detailNonEditableRenderer(col: QueryColumn, data: any): ReactNode {
-    return <div className="field__un-editable">{_defaultRenderer(data)}</div>;
+    return <div className="field__un-editable">{_defaultRenderer(col)(data)}</div>;
 }
 
 // TODO: Merge this functionality with <QueryFormInputs />

--- a/packages/components/src/internal/components/forms/detail/__snapshots__/Detail.spec.tsx.snap
+++ b/packages/components/src/internal/components/forms/detail/__snapshots__/Detail.spec.tsx.snap
@@ -31,7 +31,7 @@ exports[`<Detail/> asPanel 1`] = `
               data-fieldkey="flag"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 
               </span>
@@ -51,7 +51,7 @@ exports[`<Detail/> asPanel 1`] = `
               data-fieldkey="for set 3"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 abc
               </span>
@@ -71,7 +71,7 @@ exports[`<Detail/> asPanel 1`] = `
               data-fieldkey="again for set 3"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 false
               </span>
@@ -91,7 +91,7 @@ exports[`<Detail/> asPanel 1`] = `
               data-fieldkey="another"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 test test
               </span>
@@ -111,6 +111,7 @@ exports[`<Detail/> asPanel 1`] = `
               data-fieldkey="lookupfield"
             >
               <a
+                className="ws-pre-wrap"
                 href="/labkey/Sample%20Management%202/list-details.view?listId=1&pk=test2"
               >
                 test2
@@ -157,7 +158,7 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-fieldkey="flag"
         >
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             
           </span>
@@ -177,7 +178,7 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-fieldkey="for set 3"
         >
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             abc
           </span>
@@ -197,7 +198,7 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-fieldkey="again for set 3"
         >
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             false
           </span>
@@ -217,7 +218,7 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-fieldkey="another"
         >
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             test test
           </span>
@@ -237,6 +238,7 @@ exports[`<Detail/> with QueryGridModel 1`] = `
           data-fieldkey="lookupfield"
         >
           <a
+            className="ws-pre-wrap"
             href="/labkey/Sample%20Management%202/list-details.view?listId=1&pk=test2"
           >
             test2

--- a/packages/components/src/internal/components/forms/detail/__snapshots__/DetailEditing.spec.tsx.snap
+++ b/packages/components/src/internal/components/forms/detail/__snapshots__/DetailEditing.spec.tsx.snap
@@ -35,7 +35,7 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-fieldkey="flag"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 
               </span>
@@ -55,7 +55,7 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-fieldkey="for set 3"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 abc
               </span>
@@ -75,7 +75,7 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-fieldkey="again for set 3"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 false
               </span>
@@ -95,7 +95,7 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-fieldkey="another"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 test test
               </span>
@@ -115,6 +115,7 @@ exports[`<DetailEditing/> canUpdate false 1`] = `
               data-fieldkey="lookupfield"
             >
               <a
+                className="ws-pre-wrap"
                 href="/labkey/Sample%20Management%202/list-details.view?listId=1&pk=test2"
               >
                 test2
@@ -174,7 +175,7 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-fieldkey="flag"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 
               </span>
@@ -194,7 +195,7 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-fieldkey="for set 3"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 abc
               </span>
@@ -214,7 +215,7 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-fieldkey="again for set 3"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 false
               </span>
@@ -234,7 +235,7 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-fieldkey="another"
             >
               <span
-                className="detail-display"
+                className="ws-pre-wrap"
               >
                 test test
               </span>
@@ -254,6 +255,7 @@ exports[`<DetailEditing/> canUpdate true 1`] = `
               data-fieldkey="lookupfield"
             >
               <a
+                className="ws-pre-wrap"
                 href="/labkey/Sample%20Management%202/list-details.view?listId=1&pk=test2"
               >
                 test2

--- a/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.tsx
@@ -80,16 +80,8 @@ interface ProductNavigationMenuImplProps extends ProductNavigationMenuProps {
 
 // exported for jest testing
 export const ProductNavigationMenuImpl: FC<ProductNavigationMenuImplProps> = memo(props => {
-    const {
-        error,
-        products,
-        homeVisible,
-        disableLKSContainerLink,
-        tabs,
-        onCloseMenu,
-        selectedProductId,
-        onSelection,
-    } = props;
+    const { error, products, homeVisible, disableLKSContainerLink, tabs, onCloseMenu, selectedProductId, onSelection } =
+        props;
 
     if (error) {
         return <Alert>{error}</Alert>;
@@ -105,7 +97,7 @@ export const ProductNavigationMenuImpl: FC<ProductNavigationMenuImplProps> = mem
     const showSectionsDrawer = selectedProduct !== undefined;
     const { user } = getServerContext();
     const showMenuSettings = useMemo(() => {
-        return hasPremiumModule() && user.isRootAdmin
+        return hasPremiumModule() && user.isRootAdmin;
     }, [user, hasPremiumModule]);
 
     return (
@@ -124,12 +116,7 @@ export const ProductNavigationMenuImpl: FC<ProductNavigationMenuImplProps> = mem
                         tabs={tabs}
                     />
                 )}
-                {showSectionsDrawer && (
-                    <ProductSectionsDrawer
-                        product={selectedProduct}
-                        onCloseMenu={onCloseMenu}
-                    />
-                )}
+                {showSectionsDrawer && <ProductSectionsDrawer product={selectedProduct} onCloseMenu={onCloseMenu} />}
             </ul>
             {selectedProductId === undefined && (
                 <div className="product-navigation-footer">

--- a/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { getServerContext, Security } from '@labkey/api';
 
-import { Alert, Container, LoadingSpinner, naturalSortByProperty, useServerContext } from '../../..';
+import { Alert, LoadingSpinner, naturalSortByProperty } from '../../..';
 import { LKS_PRODUCT_ID } from '../../app/constants';
 
 import { hasPremiumModule } from '../../app/utils';

--- a/packages/components/src/internal/components/samples/__snapshots__/SampleAliquotDetailHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/samples/__snapshots__/SampleAliquotDetailHeader.spec.tsx.snap
@@ -19,6 +19,7 @@ Array [
         </td>
         <td>
           <a
+            className="ws-pre-wrap"
             href="#/rd/samples/2"
           >
             S-1-1
@@ -31,6 +32,7 @@ Array [
         </td>
         <td>
           <a
+            className="ws-pre-wrap"
             href="#/q/core/siteusers/1005"
           >
             xyang
@@ -43,7 +45,7 @@ Array [
         </td>
         <td>
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             2021-03-02 14:49
           </span>
@@ -55,7 +57,7 @@ Array [
         </td>
         <td>
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             this is a sub-aliquot - 3
           </span>
@@ -67,7 +69,7 @@ Array [
         </td>
         <td>
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             ali-1-1 - child4
           </span>
@@ -92,6 +94,7 @@ Array [
         </td>
         <td>
           <a
+            className="ws-pre-wrap"
             href="#/rd/samples/1"
           >
             S-1
@@ -104,7 +107,7 @@ Array [
         </td>
         <td>
           <span
-            className="detail-display"
+            className="ws-pre-wrap"
           >
             4
           </span>

--- a/packages/components/src/internal/components/user/UserDetailHeader.spec.tsx
+++ b/packages/components/src/internal/components/user/UserDetailHeader.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { fromJS } from 'immutable';
 
 import { Button } from 'react-bootstrap';
 
@@ -10,7 +9,7 @@ import { UserDetailHeader } from './UserDetailHeader';
 
 describe('<UserDetailHeader/>', () => {
     test('default properties', () => {
-        const component = <UserDetailHeader dateFormat="YYYY-MM-DD" title="Title" user={TEST_USER_READER} />;
+        const component = <UserDetailHeader title="Title" user={TEST_USER_READER} />;
         const tree = renderer.create(component);
         expect(tree).toMatchSnapshot();
     });
@@ -24,7 +23,7 @@ describe('<UserDetailHeader/>', () => {
                 renderButtons={<Button>Test</Button>}
                 title="Title (Custom)"
                 user={TEST_USER_ASSAY_DESIGNER}
-                userProperties={fromJS({ lastLogin: '2019-11-15 13:50:17.987' })}
+                userProperties={{ lastLogin: '2019-11-15 13:50:17.987' }}
             />
         );
         const tree = renderer.create(component);

--- a/packages/components/src/internal/components/user/UserDetailHeader.spec.tsx
+++ b/packages/components/src/internal/components/user/UserDetailHeader.spec.tsx
@@ -10,40 +10,21 @@ import { UserDetailHeader } from './UserDetailHeader';
 
 describe('<UserDetailHeader/>', () => {
     test('default properties', () => {
-        const component = (
-            <UserDetailHeader
-                title="Title"
-                user={TEST_USER_READER}
-                userProperties={fromJS({})}
-                dateFormat={undefined}
-            />
-        );
+        const component = <UserDetailHeader dateFormat="YYYY-MM-DD" title="Title" user={TEST_USER_READER} />;
         const tree = renderer.create(component);
         expect(tree).toMatchSnapshot();
     });
 
-    test('custom properties', () => {
+    test('optional properties', () => {
         const component = (
             <UserDetailHeader
+                container={{ title: 'Container Title' }}
+                dateFormat="YYYY-MM-DD"
+                description="My custom description"
+                renderButtons={<Button>Test</Button>}
                 title="Title (Custom)"
                 user={TEST_USER_ASSAY_DESIGNER}
                 userProperties={fromJS({ lastLogin: '2019-11-15 13:50:17.987' })}
-                dateFormat="YYYY-MM-DD"
-                renderButtons={<Button>Test</Button>}
-            />
-        );
-        const tree = renderer.create(component);
-        expect(tree).toMatchSnapshot();
-    });
-
-    test('custom description', () => {
-        const component = (
-            <UserDetailHeader
-                title="Title"
-                user={TEST_USER_ASSAY_DESIGNER}
-                userProperties={fromJS({})}
-                dateFormat={undefined}
-                description="My custom description"
             />
         );
         const tree = renderer.create(component);

--- a/packages/components/src/internal/components/user/UserDetailHeader.tsx
+++ b/packages/components/src/internal/components/user/UserDetailHeader.tsx
@@ -1,40 +1,45 @@
 import React, { FC, ReactNode, useMemo } from 'react';
 import { Map } from 'immutable';
 
-import { PageDetailHeader, User } from '../../..';
+import { Container, PageDetailHeader, User } from '../../..';
 
 import { getUserLastLogin, getUserPermissionsDisplay } from './actions';
 
-interface HeaderProps {
+interface Props {
+    container?: Partial<Container>;
     dateFormat: string;
     description?: string;
     renderButtons?: ReactNode;
+    showFolderTitle?: boolean;
     title: string;
     user: User;
     userProperties?: Map<string, any>;
 }
 
-export const UserDetailHeader: FC<HeaderProps> = props => {
-    const { user, userProperties, title, dateFormat, renderButtons, description } = props;
+export const UserDetailHeader: FC<Props> = props => {
+    const { container, dateFormat, description, renderButtons, showFolderTitle, title, user, userProperties } = props;
     const lastLogin = useMemo(() => getUserLastLogin(userProperties, dateFormat), [dateFormat, userProperties]);
     const userDescription = useMemo(() => {
         return description || getUserPermissionsDisplay(user).join(', ');
     }, [description, user]);
 
     return (
-        <PageDetailHeader
-            user={user}
-            iconUrl={user.avatar}
-            title={title}
-            description={userDescription}
-            leftColumns={10}
-        >
-            {lastLogin && <div className="detail__header--desc">Last Login: {lastLogin}</div>}
+        <PageDetailHeader user={user} iconUrl={user.avatar} title={title} description={userDescription} leftColumns={9}>
+            {showFolderTitle && !!container?.title && (
+                <div className="detail__header--desc">
+                    <i className="fa fa-folder-open" />
+                    &nbsp;{container.title}
+                </div>
+            )}
+            {lastLogin && <div className="detail__header--desc pull-right">Last Login: {lastLogin}</div>}
             {renderButtons && <div className={lastLogin ? 'detail__header--buttons' : ''}>{renderButtons}</div>}
         </PageDetailHeader>
     );
 };
 
+UserDetailHeader.displayName = 'UserDetailHeader';
+
 UserDetailHeader.defaultProps = {
+    showFolderTitle: true,
     userProperties: Map<string, any>(),
 };

--- a/packages/components/src/internal/components/user/UserDetailHeader.tsx
+++ b/packages/components/src/internal/components/user/UserDetailHeader.tsx
@@ -1,5 +1,4 @@
 import React, { FC, ReactNode, useMemo } from 'react';
-import { Map } from 'immutable';
 
 import { Container, PageDetailHeader, User } from '../../..';
 
@@ -7,13 +6,13 @@ import { getUserLastLogin, getUserPermissionsDisplay } from './actions';
 
 interface Props {
     container?: Partial<Container>;
-    dateFormat: string;
+    dateFormat?: string;
     description?: string;
     renderButtons?: ReactNode;
     showFolderTitle?: boolean;
     title: string;
     user: User;
-    userProperties?: Map<string, any>;
+    userProperties?: Record<string, any>;
 }
 
 export const UserDetailHeader: FC<Props> = props => {
@@ -41,5 +40,4 @@ UserDetailHeader.displayName = 'UserDetailHeader';
 
 UserDetailHeader.defaultProps = {
     showFolderTitle: true,
-    userProperties: Map<string, any>(),
 };

--- a/packages/components/src/internal/components/user/UserProfile.spec.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { fromJS } from 'immutable';
 import { mount } from 'enzyme';
 import { Button } from 'react-bootstrap';
 
@@ -17,12 +16,7 @@ describe('<UserProfile/>', () => {
     test('without state, except queryInfo', () => {
         return getQueryDetails(SCHEMAS.CORE_TABLES.USERS).then(queryInfo => {
             const wrapper = mount(
-                <UserProfile
-                    user={TEST_USER_READER}
-                    userProperties={fromJS({})}
-                    onSuccess={jest.fn()}
-                    onCancel={jest.fn()}
-                />
+                <UserProfile user={TEST_USER_READER} userProperties={{}} onSuccess={jest.fn()} onCancel={jest.fn()} />
             );
 
             wrapper.setState({ queryInfo });

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -80,7 +80,7 @@ export class UserProfile extends PureComponent<Props, State> {
 
     columnFilter = (col: QueryColumn): boolean => {
         // make sure all columns are set as shownInInsertView and those that are marked as editable are not also readOnly
-        const _col = col.merge({'shownInInsertView': true, 'readOnly': !col.get('userEditable')}) as QueryColumn;
+        const _col = col.merge({ shownInInsertView: true, readOnly: !col.get('userEditable') }) as QueryColumn;
         return insertColumnFilter(_col) && !FIELDS_TO_EXCLUDE.contains(_col.fieldKey.toLowerCase());
     };
 

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -3,7 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import React, { PureComponent } from 'react';
-import { List, Map, OrderedMap } from 'immutable';
+import { List, OrderedMap } from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 import { ActionURL } from '@labkey/api';
 
@@ -49,7 +49,7 @@ interface State {
 
 interface Props {
     user: User;
-    userProperties: Map<string, any>;
+    userProperties: Record<string, any>;
     onSuccess: (result: {}, shouldReload: boolean) => void;
     onCancel: () => void;
 }
@@ -162,7 +162,7 @@ export class UserProfile extends PureComponent<Props, State> {
                 <QueryInfoForm
                     columnFilter={this.columnFilter}
                     queryInfo={queryInfo}
-                    fieldValues={userProperties.toJS()}
+                    fieldValues={userProperties}
                     includeCountField={false}
                     submitText="Save"
                     isSubmittedText="Saving..."

--- a/packages/components/src/internal/components/user/__snapshots__/UserDetailHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/user/__snapshots__/UserDetailHeader.spec.tsx.snap
@@ -1,107 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<UserDetailHeader/> custom description 1`] = `
-<div
-  className="page-header"
->
-  <div
-    className="col-md-10 detail__header--container"
-  >
-    <div
-      className="detail__header--image-container"
-    >
-      <img
-        className="detail__header-icon"
-        src="/labkey/_images/defaultavatar.png"
-      />
-    </div>
-    <div
-      className="detail__header-icon--body-container"
-    >
-      <h2
-        className="no-margin-top detail__header--name"
-      >
-        Title
-      </h2>
-      <span
-        className="detail__header--desc"
-      >
-        My custom description
-      </span>
-    </div>
-  </div>
-  <div
-    className="pull-right"
-  />
-  <div
-    className="clearfix"
-  />
-</div>
-`;
-
-exports[`<UserDetailHeader/> custom properties 1`] = `
-<div
-  className="page-header"
->
-  <div
-    className="col-md-10 detail__header--container"
-  >
-    <div
-      className="detail__header--image-container"
-    >
-      <img
-        className="detail__header-icon"
-        src="/labkey/_images/defaultavatar.png"
-      />
-    </div>
-    <div
-      className="detail__header-icon--body-container"
-    >
-      <h2
-        className="no-margin-top detail__header--name"
-      >
-        Title (Custom)
-      </h2>
-      <span
-        className="detail__header--desc"
-      >
-        Assay Designer, Reader
-      </span>
-    </div>
-  </div>
-  <div
-    className="pull-right"
-  >
-    <div
-      className="detail__header--desc"
-    >
-      Last Login: 
-      2019-11-15
-    </div>
-    <div
-      className="detail__header--buttons"
-    >
-      <button
-        className="btn btn-default"
-        disabled={false}
-        type="button"
-      >
-        Test
-      </button>
-    </div>
-  </div>
-  <div
-    className="clearfix"
-  />
-</div>
-`;
-
 exports[`<UserDetailHeader/> default properties 1`] = `
 <div
   className="page-header"
 >
   <div
-    className="col-md-10 detail__header--container"
+    className="col-md-9 detail__header--container"
   >
     <div
       className="detail__header--image-container"
@@ -129,6 +33,72 @@ exports[`<UserDetailHeader/> default properties 1`] = `
   <div
     className="pull-right"
   />
+  <div
+    className="clearfix"
+  />
+</div>
+`;
+
+exports[`<UserDetailHeader/> optional properties 1`] = `
+<div
+  className="page-header"
+>
+  <div
+    className="col-md-9 detail__header--container"
+  >
+    <div
+      className="detail__header--image-container"
+    >
+      <img
+        className="detail__header-icon"
+        src="/labkey/_images/defaultavatar.png"
+      />
+    </div>
+    <div
+      className="detail__header-icon--body-container"
+    >
+      <h2
+        className="no-margin-top detail__header--name"
+      >
+        Title (Custom)
+      </h2>
+      <span
+        className="detail__header--desc"
+      >
+        My custom description
+      </span>
+    </div>
+  </div>
+  <div
+    className="pull-right"
+  >
+    <div
+      className="detail__header--desc"
+    >
+      <i
+        className="fa fa-folder-open"
+      />
+       
+      Container Title
+    </div>
+    <div
+      className="detail__header--desc pull-right"
+    >
+      Last Login: 
+      2019-11-15
+    </div>
+    <div
+      className="detail__header--buttons"
+    >
+      <button
+        className="btn btn-default"
+        disabled={false}
+        type="button"
+      >
+        Test
+      </button>
+    </div>
+  </div>
   <div
     className="clearfix"
   />

--- a/packages/components/src/internal/components/user/actions.spec.ts
+++ b/packages/components/src/internal/components/user/actions.spec.ts
@@ -2,8 +2,6 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { fromJS } from 'immutable';
-
 import {
     TEST_USER_APP_ADMIN,
     TEST_USER_ASSAY_DESIGNER,
@@ -60,10 +58,10 @@ describe('User actions', () => {
 
     test('getUserLastLogin', () => {
         const lastLogin = '2019-11-15 13:50:17.987';
-        expect(getUserLastLogin(fromJS({ lastlogin: lastLogin }), undefined).indexOf('2019-11-15T')).toBe(0);
-        expect(getUserLastLogin(fromJS({ lastlogin: lastLogin }), 'YYYY-MM-DD')).toBe('2019-11-15');
-        expect(getUserLastLogin(fromJS({ lastLogin }), 'YYYY-MM-DD')).toBe('2019-11-15');
-        expect(getUserLastLogin(fromJS({ LastLogin: lastLogin }), 'YYYY-MM-DD')).toBe('2019-11-15');
+        expect(getUserLastLogin({ lastlogin: lastLogin }).indexOf('2019-11-15T')).toBe(0);
+        expect(getUserLastLogin({ lastlogin: lastLogin }, 'YYYY-MM-DD')).toBe('2019-11-15');
+        expect(getUserLastLogin({ lastLogin }, 'YYYY-MM-DD')).toBe('2019-11-15');
+        expect(getUserLastLogin({ LastLogin: lastLogin }, 'YYYY-MM-DD')).toBe('2019-11-15');
     });
 
     test('getUserRoleDisplay', () => {

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -72,8 +72,8 @@ export function getUserRoleDisplay(user: User): string {
     return 'Unknown Role';
 }
 
-export function getUserLastLogin(userProperties: Map<string, any>, dateFormat: string): string {
-    const lastLogin = caseInsensitive(userProperties.toObject(), 'lastlogin');
+export function getUserLastLogin(userProperties: Record<string, any>, dateFormat?: string): string {
+    const lastLogin = caseInsensitive(userProperties, 'lastlogin');
     return lastLogin ? moment(lastLogin).format(dateFormat) : undefined;
 }
 

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -16,13 +16,24 @@
 import React, { FC, memo } from 'react';
 import { List } from 'immutable';
 
+import { QueryColumn } from '../../public/QueryColumn';
+
 import { MultiValueRenderer } from './MultiValueRenderer';
+
+interface Props {
+    col?: QueryColumn;
+    data: any;
+}
 
 /**
  * This is the default cell renderer for Details/Grids using a QueryGridModel.
  */
-export const DefaultRenderer: FC<any> = memo(({ data }) => {
+export const DefaultRenderer: FC<Props> = memo(({ col, data }) => {
     let display = null;
+    // Issue 43474: Prevent text wrapping for date columns
+    const noWrap = col?.jsonType === 'date';
+    // Issue 36941: when using the default renderer, add css so that line breaks as preserved
+    const className = noWrap ? 'ws-no-wrap' : 'ws-pre-wrap';
 
     if (data) {
         if (typeof data === 'string') {
@@ -41,11 +52,16 @@ export const DefaultRenderer: FC<any> = memo(({ data }) => {
             }
 
             if (data.get('url')) {
-                return <a href={data.get('url')}>{display}</a>;
+                return (
+                    <a className={className} href={data.get('url')}>
+                        {display}
+                    </a>
+                );
             }
         }
     }
 
-    // Issue 36941: when using the default renderer, add css so that line breaks as preserved
-    return <span className="detail-display">{display}</span>;
+    return <span className={className}>{display}</span>;
 });
+
+DefaultRenderer.displayName = 'DefaultRenderer';

--- a/packages/components/src/internal/renderers/__snapshots__/DefaultRenderer.spec.tsx.snap
+++ b/packages/components/src/internal/renderers/__snapshots__/DefaultRenderer.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DefaultRenderer boolean 1`] = `
 <span
-  className="detail-display"
+  className="ws-pre-wrap"
 >
   true
 </span>
@@ -10,7 +10,7 @@ exports[`DefaultRenderer boolean 1`] = `
 
 exports[`DefaultRenderer displayValue 1`] = `
 <span
-  className="detail-display"
+  className="ws-pre-wrap"
 >
   Value 1
 </span>
@@ -18,7 +18,7 @@ exports[`DefaultRenderer displayValue 1`] = `
 
 exports[`DefaultRenderer formattedValue 1`] = `
 <span
-  className="detail-display"
+  className="ws-pre-wrap"
 >
   Value 1.00
 </span>
@@ -26,7 +26,7 @@ exports[`DefaultRenderer formattedValue 1`] = `
 
 exports[`DefaultRenderer new line 1`] = `
 <span
-  className="detail-display"
+  className="ws-pre-wrap"
 >
   test1
 test2
@@ -35,7 +35,7 @@ test2
 
 exports[`DefaultRenderer string 1`] = `
 <span
-  className="detail-display"
+  className="ws-pre-wrap"
 >
   test string
 </span>
@@ -43,12 +43,13 @@ exports[`DefaultRenderer string 1`] = `
 
 exports[`DefaultRenderer undefined 1`] = `
 <span
-  className="detail-display"
+  className="ws-pre-wrap"
 />
 `;
 
 exports[`DefaultRenderer url 1`] = `
 <a
+  className="ws-pre-wrap"
   href="labkey.com"
 >
   Value 1
@@ -57,7 +58,7 @@ exports[`DefaultRenderer url 1`] = `
 
 exports[`DefaultRenderer value 1`] = `
 <span
-  className="detail-display"
+  className="ws-pre-wrap"
 >
   1
 </span>

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -56,8 +56,12 @@
   padding-left: 5px;
 }
 
-.detail-display {
-    white-space: pre-wrap;
+.ws-pre-wrap {
+  white-space: pre-wrap;
+}
+
+.ws-no-wrap {
+  white-space: nowrap;
 }
 
 .component-detail--child {

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -168,6 +168,7 @@
 .detail__header--desc {
   color: grey;
   font-style: $font-size-small;
+  margin-bottom: 3px;
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
#### Rationale
This PR addresses:
* [Issue 43771](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43771): Show Folder title on Application home pages.
* [Issue 43474](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43474): Prevent text wrapping for date columns

_43771: Here you can see the folder title in the upper right-hand corner of the page._
![image](https://user-images.githubusercontent.com/3926239/131404704-f57b4983-dd74-4918-8957-ce8451539c51.png)

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/980
* https://github.com/LabKey/sampleManagement/pull/681
* https://github.com/LabKey/inventory/pull/296

#### Changes
* Pass `QueryColumn` metadata to `<DefaultRenderer/>` to allow for processing of type.
* Add optional `container` and `showFolderTitle` flags to `<UserDetailHeader/>`.
* Replace `detail-display` with specific white-space declaration classes `ws-pre-wrap` and `ws-no-wrap`.
