### PR TITLE
Issue 43830: EntityLineageEditMenuItem update to add an optional onSuccess callback prop

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.75.1",
+  "version": "2.75.1-fb-sourceSamplesEdit43830.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.75.0",
+  "version": "2.75.0-fb-sourceSamplesEdit43830.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.75.0-fb-sourceSamplesEdit43830.0",
+  "version": "2.75.0-fb-sourceSamplesEdit43830.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.75.1-fb-sourceSamplesEdit43830.0",
+  "version": "2.76.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* EntityLineageEditMenuItem update to add an optional onSuccess callback prop
+
 ### version 2.75.0
 *Released*: 9 September 2021
 * Add "Aliquot Naming Pattern" to sample designer

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.76.0
+*Released*: 16 September 2021
 * EntityLineageEditMenuItem update to add an optional onSuccess callback prop
 
 ### version 2.75.1

--- a/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.tsx
@@ -13,10 +13,11 @@ interface Props {
     childEntityDataType: EntityDataType;
     parentEntityDataTypes: EntityDataType[];
     auditBehavior?: AuditBehaviorTypes;
+    onSuccess?: () => void;
 }
 
 export const EntityLineageEditMenuItem: FC<Props> = memo(props => {
-    const { childEntityDataType, parentEntityDataTypes, queryModel, auditBehavior } = props;
+    const { childEntityDataType, parentEntityDataTypes, queryModel, auditBehavior, onSuccess } = props;
     const parentNounPlural = parentEntityDataTypes[0].nounPlural;
     const itemText =
         'Edit ' +
@@ -31,9 +32,14 @@ export const EntityLineageEditMenuItem: FC<Props> = memo(props => {
         }
     }, [queryModel]);
 
-    const onClose = useCallback(() => {
+    const onCancel = useCallback(() => {
         setShowEditModal(false);
     }, []);
+
+    const _onSuccess = useCallback(() => {
+        setShowEditModal(false);
+        onSuccess?.();
+    }, [onSuccess]);
 
     return (
         <>
@@ -53,11 +59,11 @@ export const EntityLineageEditMenuItem: FC<Props> = memo(props => {
             {showEditModal && (
                 <EntityLineageEditModal
                     queryModel={queryModel}
-                    onCancel={onClose}
+                    onCancel={onCancel}
                     childEntityDataType={childEntityDataType}
                     auditBehavior={auditBehavior}
                     parentEntityDataTypes={parentEntityDataTypes}
-                    onSuccess={onClose}
+                    onSuccess={_onSuccess}
                 />
             )}
         </>

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -96,12 +96,12 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                     rows,
                     auditBehavior,
                 });
+                onSuccess();
                 createNotification(
                     `Successfully updated ${lcParentNounPlural} for ${rows.length} ${capitalizeFirstChar(
                         getEntityNoun(childEntityDataType, rows.length)
                     )}`
                 );
-                onSuccess();
             } catch (e) {
                 setSubmitting(false);
                 setErrorMessage(
@@ -109,8 +109,8 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                 );
             }
         } else {
-            createNotification(`No ${childEntityDataType.nounPlural} updated since no ${lcParentNounPlural} changed.`);
             onSuccess();
+            createNotification(`No ${childEntityDataType.nounPlural} updated since no ${lcParentNounPlural} changed.`);
         }
     }, [selectedParents, auditBehavior, childEntityDataType, queryModel, nonAliquots]);
 


### PR DESCRIPTION
#### Rationale
To support sharing the sample manage options for "edit via grid or in bulk" between the LKSM sample type grids and the source samples grids, this PR adds an optional 'onSuccess' property to the `EntityLineageEditMenuItem` shared component. This allows for the user of this component to reload the model/grid after the lineage change is complete.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/630
* https://github.com/LabKey/sampleManagement/pull/692

#### Changes
* EntityLineageEditMenuItem update to add an optional onSuccess callback prop
