### PR TITLE
Item 9436:  Freezer Management in Biologics - Update sample overview page

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.76.0-fb-lkbFMOverview.1",
+  "version": "2.76.0-fb-lkbFMOverview.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.75.0",
+  "version": "2.76.0-fb-lkbFMOverview.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.76.0",
+  "version": "2.77.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,6 +3,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.75.0
 *Released*: 9 September 2021
+* Move Sample Aliquots panel UI and utils here from LKSM
+* Issue 43833: update aliquot detail panel
+
+### version 2.75.0
+*Released*: 9 September 2021
 * Add "Aliquot Naming Pattern" to sample designer
 
 ### version 2.74.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,8 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 16 September 2021
 * Rehydrate yarn.lock to fix issue with npm run start-link in LKSM module
 
-### version 2.75.0
-*Released*: 9 September 2021
+### version XXX
+*Released*: XXX
 * Move Sample Aliquots panel UI and utils here from LKSM
 * Issue 43833: update aliquot detail panel
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.77.0
+*Released*: 17 September 2021
+* Move Sample Aliquots panel UI and utils here from LKSM
+* Issue 43833: update aliquot detail panel
+
 ### version 2.76.0
 *Released*: 16 September 2021
 * EntityLineageEditMenuItem update to add an optional onSuccess callback prop
@@ -8,11 +13,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.75.1
 *Released*: 16 September 2021
 * Rehydrate yarn.lock to fix issue with npm run start-link in LKSM module
-
-### version XXX
-*Released*: XXX
-* Move Sample Aliquots panel UI and utils here from LKSM
-* Issue 43833: update aliquot detail panel
 
 ### version 2.75.0
 *Released*: 9 September 2021

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -296,6 +296,7 @@ import { CreateSamplesSubMenuBase } from './internal/components/samples/CreateSa
 import { SampleCreationTypeModal } from './internal/components/samples/SampleCreationTypeModal';
 import { SamplesSelectionProvider } from './internal/components/samples/SamplesSelectionContextProvider';
 import { SampleAliquotDetailHeader } from './internal/components/samples/SampleAliquotDetailHeader';
+import { SampleAliquotsSummary } from './internal/components/samples/SampleAliquotsSummary';
 import {
     ALIQUOT_FILTER_MODE,
     SampleAliquotViewSelector,
@@ -875,6 +876,7 @@ export {
     SamplesSelectionProvider,
     SampleAliquotDetailHeader,
     SampleAliquotViewSelector,
+    SampleAliquotsSummary,
     ALIQUOT_FILTER_MODE,
     SampleAssayDetail,
     SharedSampleTypeAdminConfirmModal,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -279,6 +279,7 @@ import {
     getEditSharedSampleTypeUrl,
     getFindSamplesByIdData,
     getSampleAssayQueryConfigs,
+    getSampleAliquotsQueryConfig,
     getSampleSet,
     getSampleTypeDetails,
     getSelectedItemSamples,
@@ -368,6 +369,7 @@ import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
 import { SiteUsersGridPanel } from './internal/components/user/SiteUsersGridPanel';
 import { UserProvider, useUserProperties } from './internal/components/user/UserProvider';
+import { UserLink } from './internal/components/user/UserLink';
 import { FieldEditorOverlay } from './internal/components/forms/FieldEditorOverlay';
 import {
     DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
@@ -806,6 +808,7 @@ export {
     getUserSharedContainerPermissions,
     UserDetailHeader,
     UserProfile,
+    UserLink,
     ChangePasswordModal,
     SiteUsersGridPanel,
     InsufficientPermissionsPage,
@@ -887,6 +890,7 @@ export {
     SAMPLE_INVENTORY_ITEM_SELECTION_KEY,
     getFindSamplesByIdData,
     getSampleAssayQueryConfigs,
+    getSampleAliquotsQueryConfig,
     // entities
     EntityTypeDeleteConfirmModal,
     EntityDeleteConfirmModal,

--- a/packages/components/src/internal/components/samples/SampleAliquotAssaysCount.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotAssaysCount.tsx
@@ -1,0 +1,83 @@
+import React, { FC, memo, useEffect, useMemo } from 'react';
+
+import {
+    InjectedAssayModel,
+    isLoading,
+    LoadingSpinner,
+    getSampleAssayQueryConfigs,
+    SchemaQuery,
+} from "../../..";
+
+// These need to be direct imports from files to avoid circular dependencies in index.ts
+import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
+import { withAssayModels } from '../assay/withAssayModels';
+
+const SampleAliquotAssaysCountBodyImpl: FC<InjectedQueryModels> = memo(props => {
+    const { actions, queryModels } = props;
+    const allModels = Object.values(queryModels);
+    const allLoaded = allModels.every(model => !model.isLoading);
+
+    useEffect(() => {
+        actions.loadAllModels(true);
+    }, []);
+
+    const totalCount = useMemo(() => {
+        let count = 0;
+        allModels.forEach(model => {
+            count += model.rowCount;
+        })
+        return count;
+    }, [allLoaded, queryModels]);
+
+    if (allModels.length === 0)
+        return <>0</>;
+
+    if (!allLoaded) {
+        return <LoadingSpinner/>;
+    }
+
+    return <>{totalCount}</>;
+});
+
+const SampleAliquotAssaysCountBody = withQueryModels<any>(SampleAliquotAssaysCountBodyImpl);
+
+interface Props {
+    sampleId: string;
+    aliquotIds: number[];
+    sampleSchemaQuery: SchemaQuery;
+}
+
+const SampleAliquotAssaysCountImpl: FC<Props & InjectedAssayModel> = props => {
+    const { assayModel, sampleId, sampleSchemaQuery, aliquotIds } = props;
+    const loadingDefinitions = isLoading(assayModel.definitionsLoadingState);
+
+    const queryConfigs = useMemo(() => {
+        if (loadingDefinitions) {
+            return {};
+        }
+
+        const _configs = getSampleAssayQueryConfigs(assayModel, aliquotIds, sampleId + '', 'aliquot-assay', true, sampleSchemaQuery);
+
+        return _configs
+            .reduce((_configs, config) => {
+                const modelId = config.id;
+                _configs[modelId] = config;
+                return _configs;
+            }, {});
+
+    }, [assayModel.definitions, loadingDefinitions, sampleSchemaQuery, sampleId, aliquotIds]);
+
+    if (loadingDefinitions) {
+        return <LoadingSpinner />
+    }
+
+    return (
+        <SampleAliquotAssaysCountBody
+            {...props}
+            key={'aliquot-assay-stats-' + sampleId}
+            queryConfigs={queryConfigs}
+        />
+    );
+};
+
+export const SampleAliquotAssaysCount = withAssayModels(SampleAliquotAssaysCountImpl);

--- a/packages/components/src/internal/components/samples/SampleAliquotAssaysCount.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotAssaysCount.tsx
@@ -13,13 +13,9 @@ import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel
 import { withAssayModels } from '../assay/withAssayModels';
 
 const SampleAliquotAssaysCountBodyImpl: FC<InjectedQueryModels> = memo(props => {
-    const { actions, queryModels } = props;
+    const { queryModels } = props;
     const allModels = Object.values(queryModels);
     const allLoaded = allModels.every(model => !model.isLoading);
-
-    useEffect(() => {
-        actions.loadAllModels(true);
-    }, []);
 
     const totalCount = useMemo(() => {
         let count = 0;
@@ -76,6 +72,7 @@ const SampleAliquotAssaysCountImpl: FC<Props & InjectedAssayModel> = props => {
             {...props}
             key={'aliquot-assay-stats-' + sampleId}
             queryConfigs={queryConfigs}
+            autoLoad={true}
         />
     );
 };

--- a/packages/components/src/internal/components/samples/SampleAliquotAssaysCount.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotAssaysCount.tsx
@@ -1,12 +1,6 @@
 import React, { FC, memo, useEffect, useMemo } from 'react';
 
-import {
-    InjectedAssayModel,
-    isLoading,
-    LoadingSpinner,
-    getSampleAssayQueryConfigs,
-    SchemaQuery,
-} from "../../..";
+import { InjectedAssayModel, isLoading, LoadingSpinner, getSampleAssayQueryConfigs, SchemaQuery } from '../../..';
 
 // These need to be direct imports from files to avoid circular dependencies in index.ts
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
@@ -21,15 +15,14 @@ const SampleAliquotAssaysCountBodyImpl: FC<InjectedQueryModels> = memo(props => 
         let count = 0;
         allModels.forEach(model => {
             count += model.rowCount;
-        })
+        });
         return count;
     }, [allLoaded, queryModels]);
 
-    if (allModels.length === 0)
-        return <>0</>;
+    if (allModels.length === 0) return <>0</>;
 
     if (!allLoaded) {
-        return <LoadingSpinner/>;
+        return <LoadingSpinner />;
     }
 
     return <>{totalCount}</>;
@@ -52,19 +45,24 @@ const SampleAliquotAssaysCountImpl: FC<Props & InjectedAssayModel> = props => {
             return {};
         }
 
-        const _configs = getSampleAssayQueryConfigs(assayModel, aliquotIds, sampleId + '', 'aliquot-assay', true, sampleSchemaQuery);
+        const _configs = getSampleAssayQueryConfigs(
+            assayModel,
+            aliquotIds,
+            sampleId + '',
+            'aliquot-assay',
+            true,
+            sampleSchemaQuery
+        );
 
-        return _configs
-            .reduce((_configs, config) => {
-                const modelId = config.id;
-                _configs[modelId] = config;
-                return _configs;
-            }, {});
-
+        return _configs.reduce((_configs, config) => {
+            const modelId = config.id;
+            _configs[modelId] = config;
+            return _configs;
+        }, {});
     }, [assayModel.definitions, loadingDefinitions, sampleSchemaQuery, sampleId, aliquotIds]);
 
     if (loadingDefinitions) {
-        return <LoadingSpinner />
+        return <LoadingSpinner />;
     }
 
     return (

--- a/packages/components/src/internal/components/samples/SampleAliquotDetailHeader.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotDetailHeader.tsx
@@ -39,14 +39,9 @@ export class SampleAliquotDetailHeader extends PureComponent<SampleAliquotDetail
         const created = newRow.get('created');
         const createdBy = newRow.get('createdby');
         const parent = newRow.get('aliquotedfromlsid/name');
-        const root = newRow.get('rootmateriallsid/name');
-        const rootDescription = newRow.get('rootmateriallsid/description');
-
-        const showRootSampleName = root.get('value') !== parent.get('value');
 
         return (
             <>
-                {this.renderAliquotDetailSubHeader('Aliquot Data')}
                 <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-table">
                     <tbody>
                         {this.renderDetailRow('Aliquoted from', parent, 'aliquotedfrom')}
@@ -60,13 +55,6 @@ export class SampleAliquotDetailHeader extends PureComponent<SampleAliquotDetail
                                 key
                             );
                         })}
-                    </tbody>
-                </table>
-                {this.renderAliquotDetailSubHeader('Original Sample Data')}
-                <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table">
-                    <tbody>
-                        {showRootSampleName && this.renderDetailRow('Original sample', root, 'originalsample')}
-                        {this.renderDetailRow('Sample description', rootDescription, 'sampledescription')}
                     </tbody>
                 </table>
             </>

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
@@ -1,0 +1,319 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { ReactWrapper } from 'enzyme';
+
+import {
+    LoadingSpinner,
+    LoadingState,
+    makeTestActions,
+    makeTestQueryModel,
+    SchemaQuery
+} from "../../..";
+
+import { SampleAliquotsSummaryWithModels } from "./SampleAliquotsSummary";
+
+const DEFAULT_PROPS = {
+    queryModels: {},
+    actions: makeTestActions(),
+    hideAssayData: true,
+    aliquotJobsQueryConfig: {schemaQuery: SchemaQuery.create("test", "query")},
+};
+
+function getQueryModelFromRows(rows) {
+    return makeTestQueryModel(SchemaQuery.create('schema', 'query'), undefined,
+        rows, Object.keys(rows), Object.keys(rows).length, 'id')
+        .mutate({rowsLoadingState: LoadingState.LOADED})
+}
+
+describe("<SampleAliquotsSummaryWithModels/>", () => {
+
+    function validateStats(wrapper: ReactWrapper, loading = false, empty? : boolean, totalAliquots?: number, availableCount?: number, totalVolume?: string, jobsWithAliquots?: number) {
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(loading ? 1 : 0);
+        if (loading)
+            return;
+
+        expect(wrapper.find('.sample-aliquots-stats-empty')).toHaveLength(empty ? 1 : 0);
+        if (empty)
+            return;
+
+        const stats = wrapper.find('.aliquot-stats-value');
+        expect(stats).toHaveLength(4);
+        expect(stats.at(0).text()).toBe(totalAliquots + '');
+        expect(stats.at(1).text()).toBe(availableCount + '/' + totalAliquots);
+        expect(stats.at(2).text()).toBe(totalVolume);
+        expect(stats.at(3).text()).toBe(jobsWithAliquots + '');
+    }
+
+    test('query model not yet created', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={undefined}
+            aliquotsModel={undefined}
+            jobsModel={undefined}
+        />);
+
+        validateStats(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('query loading', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={undefined}
+            aliquotsModel={makeTestQueryModel(SchemaQuery.create('schema', 'query'))}
+            jobsModel={undefined}
+        />);
+
+        validateStats(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('no aliquots present', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={undefined}
+            aliquotsModel={getQueryModelFromRows({})}
+            jobsModel={getQueryModelFromRows({})}
+        />);
+
+        validateStats(wrapper, false, true);
+        wrapper.unmount();
+    });
+
+    test('has single aliquot, not in storage, not added to job', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'0'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'Not in storage'},
+                    StoredAmount: {value: null},
+                    Units: {value: null}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({})}
+        />);
+
+        validateStats(wrapper, false, false, 1, 0, '0', 0);
+        wrapper.unmount();
+    });
+
+    test('has single aliquot, in storage, no volume, added to job', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'0'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: null},
+                    Units: {value: null}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({1:{RowId: {value: 1}}})}
+        />);
+
+        validateStats(wrapper, false, false, 1, 1, '0', 1);
+        wrapper.unmount();
+    });
+
+    test('has single aliquot, in storage, without amount, but with unit', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'0 g'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: null},
+                    Units: {value: 'g'}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({1:{RowId: {value: 1}}})}
+        />);
+
+        validateStats(wrapper, false, false, 1, 1, '0 g', 1);
+        wrapper.unmount();
+
+    });
+
+    test('has single aliquot, in storage, with amount, but without unit', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'100.1'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '100.1'},
+                    Units: {value: null}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({1:{RowId: {value: 1}}})}
+        />);
+
+        validateStats(wrapper, false, false, 1, 1, '100.1', 1);
+        wrapper.unmount();
+    });
+
+    test('has multiple aliquots, some storage, without unit, some has jobs', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'150.6'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '100.1'},
+                    Units: {value: null}
+                },
+                2: {
+                    StorageStatus: {value: 'Not in storage'},
+                    StoredAmount: {value: null},
+                    Units: {value: null}
+                },
+                3: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '50.5'},
+                    Units: {value: null}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({
+                1: {
+                    RowId: {value: 1}
+                },
+                3: {
+                    RowId: {value: 3}
+                }
+            })}
+        />);
+
+        validateStats(wrapper, false, false, 3, 2, '150.6', 2);
+        wrapper.unmount();
+
+    });
+
+    test('has multiple aliquots, some storage, with same unit', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'150.6 mL'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '100.1'},
+                    Units: {value: 'mL'}
+                },
+                2: {
+                    StorageStatus: {value: 'Not in storage'},
+                    StoredAmount: {value: null},
+                    Units: {value: null}
+                },
+                3: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '50.5'},
+                    Units: {value: 'mL'}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({})}
+        />);
+
+        validateStats(wrapper, false, false, 3, 2, '150.6 mL', 0);
+        wrapper.unmount();
+
+    });
+
+    test('has multiple aliquots, some storage, with different unit', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'50,600.1 mL'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '100.1'},
+                    Units: {value: 'mL'}
+                },
+                2: {
+                    StorageStatus: {value: 'Not in storage'},
+                    StoredAmount: {value: null},
+                    Units: {value: null}
+                },
+                3: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '50.5'},
+                    Units: {value: 'L'}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({})}
+        />);
+
+        validateStats(wrapper, false, false, 3, 2, '50,600.1 mL', 0);
+        wrapper.unmount();
+
+    });
+
+    test('has multiple aliquots, all in storage, but some are checked out', () => {
+        const wrapper = mount(<SampleAliquotsSummaryWithModels
+            {...DEFAULT_PROPS}
+            sampleId={'86873'}
+            sampleLsid={'S-20200404-1'}
+            sampleSet={'dirt'}
+            totalAliquotVolume={'1,100.1 mL'}
+            aliquotsModel={getQueryModelFromRows({
+                1: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: '100.1'},
+                    Units: {value: 'mL'}
+                },
+                2: {
+                    StorageStatus: {value: 'Checked out'},
+                    StoredAmount: {value: '1'},
+                    Units: {value: 'L'}
+                },
+                3: {
+                    StorageStatus: {value: 'In storage'},
+                    StoredAmount: {value: null},
+                    Units: {value: 'L'}
+                }
+            })}
+            jobsModel={getQueryModelFromRows({
+                1: {
+                    RowId: {value: 1}
+                },
+                3: {
+                    RowId: {value: 3}
+                }
+            })}
+        />);
+
+        validateStats(wrapper, false, false, 3, 2, '1,100.1 mL', 2);
+        wrapper.unmount();
+
+    });
+
+})

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
@@ -1,59 +1,61 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { ReactWrapper } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 
-import {
-    LoadingSpinner,
-    LoadingState,
-    makeTestActions,
-    makeTestQueryModel,
-    SchemaQuery
-} from "../../..";
+import { LoadingSpinner, LoadingState, makeTestActions, makeTestQueryModel, SchemaQuery } from '../../..';
 
-import { SampleAliquotsSummaryWithModels } from "./SampleAliquotsSummary";
+import { SampleAliquotsSummaryWithModels } from './SampleAliquotsSummary';
 
 const DEFAULT_PROPS = {
     queryModels: {},
     actions: makeTestActions(),
     hideAssayData: true,
-    aliquotJobsQueryConfig: {schemaQuery: SchemaQuery.create("test", "query")},
+    aliquotJobsQueryConfig: { schemaQuery: SchemaQuery.create('test', 'query') },
 };
 
 const noAliquotVolume = {
-    'AliquotTotalVolume' : {
-        displayValue: null
+    AliquotTotalVolume: {
+        displayValue: null,
     },
-    'Units' : {
-        displayValue: null
-    }
-}
+    Units: {
+        displayValue: null,
+    },
+};
 
 const zeroAliquotVolume = {
-    'AliquotTotalVolume' : {
-        displayValue: 0
+    AliquotTotalVolume: {
+        displayValue: 0,
     },
-    'Units' : {
-        displayValue: null
-    }
-}
-
+    Units: {
+        displayValue: null,
+    },
+};
 
 function getQueryModelFromRows(rows) {
-    return makeTestQueryModel(SchemaQuery.create('schema', 'query'), undefined,
-        rows, Object.keys(rows), Object.keys(rows).length, 'id')
-        .mutate({rowsLoadingState: LoadingState.LOADED})
+    return makeTestQueryModel(
+        SchemaQuery.create('schema', 'query'),
+        undefined,
+        rows,
+        Object.keys(rows),
+        Object.keys(rows).length,
+        'id'
+    ).mutate({ rowsLoadingState: LoadingState.LOADED });
 }
 
-describe("<SampleAliquotsSummaryWithModels/>", () => {
-
-    function validateStats(wrapper: ReactWrapper, loading = false, empty? : boolean, totalAliquots?: number, availableCount?: number, totalVolume?: string, jobsWithAliquots?: number) {
+describe('<SampleAliquotsSummaryWithModels/>', () => {
+    function validateStats(
+        wrapper: ReactWrapper,
+        loading = false,
+        empty?: boolean,
+        totalAliquots?: number,
+        availableCount?: number,
+        totalVolume?: string,
+        jobsWithAliquots?: number
+    ) {
         expect(wrapper.find(LoadingSpinner)).toHaveLength(loading ? 1 : 0);
-        if (loading)
-            return;
+        if (loading) return;
 
         expect(wrapper.find('.sample-aliquots-stats-empty')).toHaveLength(empty ? 1 : 0);
-        if (empty)
-            return;
+        if (empty) return;
 
         const stats = wrapper.find('.aliquot-stats-value');
         expect(stats).toHaveLength(4);
@@ -64,317 +66,333 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
     }
 
     test('query model not yet created', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={noAliquotVolume}
-            aliquotsModel={undefined}
-            jobsModel={undefined}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={noAliquotVolume}
+                aliquotsModel={undefined}
+                jobsModel={undefined}
+            />
+        );
 
         validateStats(wrapper, true);
         wrapper.unmount();
     });
 
     test('query loading', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={noAliquotVolume}
-            aliquotsModel={makeTestQueryModel(SchemaQuery.create('schema', 'query'))}
-            jobsModel={undefined}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={noAliquotVolume}
+                aliquotsModel={makeTestQueryModel(SchemaQuery.create('schema', 'query'))}
+                jobsModel={undefined}
+            />
+        );
 
         validateStats(wrapper, true);
         wrapper.unmount();
     });
 
     test('no aliquots present', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={noAliquotVolume}
-            aliquotsModel={getQueryModelFromRows({})}
-            jobsModel={getQueryModelFromRows({})}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={noAliquotVolume}
+                aliquotsModel={getQueryModelFromRows({})}
+                jobsModel={getQueryModelFromRows({})}
+            />
+        );
 
         validateStats(wrapper, false, true);
         wrapper.unmount();
     });
 
     test('has single aliquot, not in storage, not added to job', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={zeroAliquotVolume}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'Not in storage'},
-                    StoredAmount: {value: null},
-                    Units: {value: null}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({})}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={zeroAliquotVolume}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'Not in storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: null },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({})}
+            />
+        );
 
         validateStats(wrapper, false, false, 1, 0, '0', 0);
         wrapper.unmount();
     });
 
     test('has single aliquot, in storage, no volume, added to job', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={zeroAliquotVolume}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: null},
-                    Units: {value: null}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({1:{RowId: {value: 1}}})}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={zeroAliquotVolume}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: null },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({ 1: { RowId: { value: 1 } } })}
+            />
+        );
 
         validateStats(wrapper, false, false, 1, 1, '0', 1);
         wrapper.unmount();
     });
 
     test('has single aliquot, in storage, without amount, but with unit', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={{
-                'AliquotTotalVolume' : {
-                    displayValue: 0
-                },
-                'Units' : {
-                    displayValue: 'g'
-                }
-            }}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: null},
-                    Units: {value: 'g'}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({1:{RowId: {value: 1}}})}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={{
+                    AliquotTotalVolume: {
+                        displayValue: 0,
+                    },
+                    Units: {
+                        displayValue: 'g',
+                    },
+                }}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: 'g' },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({ 1: { RowId: { value: 1 } } })}
+            />
+        );
 
         validateStats(wrapper, false, false, 1, 1, '0 g', 1);
         wrapper.unmount();
-
     });
 
     test('has single aliquot, in storage, with amount, but without unit', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={{
-                'AliquotTotalVolume' : {
-                    displayValue: 100.1
-                },
-                'Units' : {
-                    displayValue: null
-                }
-            }}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '100.1'},
-                    Units: {value: null}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({1:{RowId: {value: 1}}})}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={{
+                    AliquotTotalVolume: {
+                        displayValue: 100.1,
+                    },
+                    Units: {
+                        displayValue: null,
+                    },
+                }}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '100.1' },
+                        Units: { value: null },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({ 1: { RowId: { value: 1 } } })}
+            />
+        );
 
         validateStats(wrapper, false, false, 1, 1, '100.1', 1);
         wrapper.unmount();
     });
 
     test('has multiple aliquots, some storage, without unit, some has jobs', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={{
-                'AliquotTotalVolume' : {
-                    displayValue: 150.6
-                },
-                'Units' : {
-                    displayValue: null
-                }
-            }}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '100.1'},
-                    Units: {value: null}
-                },
-                2: {
-                    StorageStatus: {value: 'Not in storage'},
-                    StoredAmount: {value: null},
-                    Units: {value: null}
-                },
-                3: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '50.5'},
-                    Units: {value: null}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({
-                1: {
-                    RowId: {value: 1}
-                },
-                3: {
-                    RowId: {value: 3}
-                }
-            })}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={{
+                    AliquotTotalVolume: {
+                        displayValue: 150.6,
+                    },
+                    Units: {
+                        displayValue: null,
+                    },
+                }}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '100.1' },
+                        Units: { value: null },
+                    },
+                    2: {
+                        StorageStatus: { value: 'Not in storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: null },
+                    },
+                    3: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '50.5' },
+                        Units: { value: null },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({
+                    1: {
+                        RowId: { value: 1 },
+                    },
+                    3: {
+                        RowId: { value: 3 },
+                    },
+                })}
+            />
+        );
 
         validateStats(wrapper, false, false, 3, 2, '150.6', 2);
         wrapper.unmount();
-
     });
 
     test('has multiple aliquots, some storage, with same unit', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={{
-                'AliquotTotalVolume' : {
-                    displayValue: 150.6
-                },
-                'Units' : {
-                    displayValue: 'mL'
-                }
-            }}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '100.1'},
-                    Units: {value: 'mL'}
-                },
-                2: {
-                    StorageStatus: {value: 'Not in storage'},
-                    StoredAmount: {value: null},
-                    Units: {value: null}
-                },
-                3: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '50.5'},
-                    Units: {value: 'mL'}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({})}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={{
+                    AliquotTotalVolume: {
+                        displayValue: 150.6,
+                    },
+                    Units: {
+                        displayValue: 'mL',
+                    },
+                }}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '100.1' },
+                        Units: { value: 'mL' },
+                    },
+                    2: {
+                        StorageStatus: { value: 'Not in storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: null },
+                    },
+                    3: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '50.5' },
+                        Units: { value: 'mL' },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({})}
+            />
+        );
 
         validateStats(wrapper, false, false, 3, 2, '150.6 mL', 0);
         wrapper.unmount();
-
     });
 
     test('has multiple aliquots, some storage, with different unit', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={{
-                'AliquotTotalVolume' : {
-                    displayValue: 50600.1
-                },
-                'Units' : {
-                    displayValue: 'mL'
-                }
-            }}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '100.1'},
-                    Units: {value: 'mL'}
-                },
-                2: {
-                    StorageStatus: {value: 'Not in storage'},
-                    StoredAmount: {value: null},
-                    Units: {value: null}
-                },
-                3: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '50.5'},
-                    Units: {value: 'L'}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({})}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={{
+                    AliquotTotalVolume: {
+                        displayValue: 50600.1,
+                    },
+                    Units: {
+                        displayValue: 'mL',
+                    },
+                }}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '100.1' },
+                        Units: { value: 'mL' },
+                    },
+                    2: {
+                        StorageStatus: { value: 'Not in storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: null },
+                    },
+                    3: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '50.5' },
+                        Units: { value: 'L' },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({})}
+            />
+        );
 
         validateStats(wrapper, false, false, 3, 2, '50,600.1 mL', 0);
         wrapper.unmount();
-
     });
 
     test('has multiple aliquots, all in storage, but some are checked out', () => {
-        const wrapper = mount(<SampleAliquotsSummaryWithModels
-            {...DEFAULT_PROPS}
-            sampleId={'86873'}
-            sampleLsid={'S-20200404-1'}
-            sampleSet={'dirt'}
-            sampleRow={{
-                'AliquotTotalVolume' : {
-                    displayValue: 1100.1
-                },
-                'Units' : {
-                    displayValue: 'mL'
-                }
-            }}
-            aliquotsModel={getQueryModelFromRows({
-                1: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: '100.1'},
-                    Units: {value: 'mL'}
-                },
-                2: {
-                    StorageStatus: {value: 'Checked out'},
-                    StoredAmount: {value: '1'},
-                    Units: {value: 'L'}
-                },
-                3: {
-                    StorageStatus: {value: 'In storage'},
-                    StoredAmount: {value: null},
-                    Units: {value: 'L'}
-                }
-            })}
-            jobsModel={getQueryModelFromRows({
-                1: {
-                    RowId: {value: 1}
-                },
-                3: {
-                    RowId: {value: 3}
-                }
-            })}
-        />);
+        const wrapper = mount(
+            <SampleAliquotsSummaryWithModels
+                {...DEFAULT_PROPS}
+                sampleId="86873"
+                sampleLsid="S-20200404-1"
+                sampleSet="dirt"
+                sampleRow={{
+                    AliquotTotalVolume: {
+                        displayValue: 1100.1,
+                    },
+                    Units: {
+                        displayValue: 'mL',
+                    },
+                }}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: '100.1' },
+                        Units: { value: 'mL' },
+                    },
+                    2: {
+                        StorageStatus: { value: 'Checked out' },
+                        StoredAmount: { value: '1' },
+                        Units: { value: 'L' },
+                    },
+                    3: {
+                        StorageStatus: { value: 'In storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: 'L' },
+                    },
+                })}
+                jobsModel={getQueryModelFromRows({
+                    1: {
+                        RowId: { value: 1 },
+                    },
+                    3: {
+                        RowId: { value: 3 },
+                    },
+                })}
+            />
+        );
 
         validateStats(wrapper, false, false, 3, 2, '1,100.1 mL', 2);
         wrapper.unmount();
-
     });
-
-})
+});

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
@@ -19,6 +19,25 @@ const DEFAULT_PROPS = {
     aliquotJobsQueryConfig: {schemaQuery: SchemaQuery.create("test", "query")},
 };
 
+const noAliquotVolume = {
+    'AliquotTotalVolume' : {
+        displayValue: null
+    },
+    'Units' : {
+        displayValue: null
+    }
+}
+
+const zeroAliquotVolume = {
+    'AliquotTotalVolume' : {
+        displayValue: 0
+    },
+    'Units' : {
+        displayValue: null
+    }
+}
+
+
 function getQueryModelFromRows(rows) {
     return makeTestQueryModel(SchemaQuery.create('schema', 'query'), undefined,
         rows, Object.keys(rows), Object.keys(rows).length, 'id')
@@ -50,7 +69,7 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={undefined}
+            sampleRow={noAliquotVolume}
             aliquotsModel={undefined}
             jobsModel={undefined}
         />);
@@ -65,7 +84,7 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={undefined}
+            sampleRow={noAliquotVolume}
             aliquotsModel={makeTestQueryModel(SchemaQuery.create('schema', 'query'))}
             jobsModel={undefined}
         />);
@@ -80,7 +99,7 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={undefined}
+            sampleRow={noAliquotVolume}
             aliquotsModel={getQueryModelFromRows({})}
             jobsModel={getQueryModelFromRows({})}
         />);
@@ -95,7 +114,7 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'0'}
+            sampleRow={zeroAliquotVolume}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'Not in storage'},
@@ -116,7 +135,7 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'0'}
+            sampleRow={zeroAliquotVolume}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'In storage'},
@@ -137,7 +156,14 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'0 g'}
+            sampleRow={{
+                'AliquotTotalVolume' : {
+                    displayValue: 0
+                },
+                'Units' : {
+                    displayValue: 'g'
+                }
+            }}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'In storage'},
@@ -159,7 +185,14 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'100.1'}
+            sampleRow={{
+                'AliquotTotalVolume' : {
+                    displayValue: 100.1
+                },
+                'Units' : {
+                    displayValue: null
+                }
+            }}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'In storage'},
@@ -180,7 +213,14 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'150.6'}
+            sampleRow={{
+                'AliquotTotalVolume' : {
+                    displayValue: 150.6
+                },
+                'Units' : {
+                    displayValue: null
+                }
+            }}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'In storage'},
@@ -219,7 +259,14 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'150.6 mL'}
+            sampleRow={{
+                'AliquotTotalVolume' : {
+                    displayValue: 150.6
+                },
+                'Units' : {
+                    displayValue: 'mL'
+                }
+            }}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'In storage'},
@@ -251,7 +298,14 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'50,600.1 mL'}
+            sampleRow={{
+                'AliquotTotalVolume' : {
+                    displayValue: 50600.1
+                },
+                'Units' : {
+                    displayValue: 'mL'
+                }
+            }}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'In storage'},
@@ -283,7 +337,14 @@ describe("<SampleAliquotsSummaryWithModels/>", () => {
             sampleId={'86873'}
             sampleLsid={'S-20200404-1'}
             sampleSet={'dirt'}
-            totalAliquotVolume={'1,100.1 mL'}
+            sampleRow={{
+                'AliquotTotalVolume' : {
+                    displayValue: 1100.1
+                },
+                'Units' : {
+                    displayValue: 'mL'
+                }
+            }}
             aliquotsModel={getQueryModelFromRows({
                 1: {
                     StorageStatus: {value: 'In storage'},

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
@@ -13,7 +13,7 @@ import {
     App,
     AppURL,
     ALIQUOT_FILTER_MODE,
-    SchemaQuery
+    SchemaQuery, caseInsensitive
 } from '../../..';
 
 import { getSampleAliquotsQueryConfig, getSampleAliquotsStats } from './actions';
@@ -24,8 +24,8 @@ interface OwnProps {
     sampleLsid: string;
     sampleId: string;
     sampleSet: string;
-    totalAliquotVolume: string;
     aliquotJobsQueryConfig: QueryConfig;
+    sampleRow: any;
     sampleSchemaQuery?: SchemaQuery;
 }
 
@@ -41,10 +41,14 @@ interface SampleAliquotsSummaryWithModelsProps {
 export class SampleAliquotsSummaryWithModels extends PureComponent<Props & SampleAliquotsSummaryWithModelsProps> {
 
     renderStats(stats: SampleAliquotsStats, hideAssayData?: boolean) {
-        const { sampleSet, sampleId, totalAliquotVolume, sampleSchemaQuery, aliquotJobsQueryConfig } = this.props;
+        const { sampleSet, sampleId, sampleRow, sampleSchemaQuery, aliquotJobsQueryConfig } = this.props;
         let aliquotUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Aliquots');
         const jobUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Jobs').addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots).toHref();
         const assayDataUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Assays').addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots).toHref();
+
+        const totalAliquotVolume = caseInsensitive(sampleRow, 'AliquotTotalVolume')?.displayValue?.toLocaleString();
+        const units = caseInsensitive(sampleRow, 'Units')?.displayValue ?? caseInsensitive(sampleRow, 'Units')?.value;
+        const totalAliquotVolumeDisplay = totalAliquotVolume != null ? (totalAliquotVolume + (units ? ' ' + units : '')) : undefined;
 
         return (
             <>
@@ -62,7 +66,7 @@ export class SampleAliquotsSummaryWithModels extends PureComponent<Props & Sampl
                 </tr>
                 <tr>
                     <td>Current available amount:</td>
-                    <td className={'aliquot-stats-value'}>{totalAliquotVolume ? totalAliquotVolume : 'Not available'}</td>
+                    <td className={'aliquot-stats-value'}>{totalAliquotVolumeDisplay ? totalAliquotVolumeDisplay : 'Not available'}</td>
                 </tr>
                 <tr>
                     <td>Jobs with aliquots:</td>

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
@@ -13,12 +13,13 @@ import {
     App,
     AppURL,
     ALIQUOT_FILTER_MODE,
-    SchemaQuery, caseInsensitive
+    SchemaQuery,
+    caseInsensitive,
 } from '../../..';
 
 import { getSampleAliquotsQueryConfig, getSampleAliquotsStats } from './actions';
 import { SampleAliquotsStats } from './models';
-import { SampleAliquotAssaysCount } from "./SampleAliquotAssaysCount";
+import { SampleAliquotAssaysCount } from './SampleAliquotAssaysCount';
 
 interface OwnProps {
     sampleLsid: string;
@@ -39,78 +40,100 @@ interface SampleAliquotsSummaryWithModelsProps {
 
 // exported for jest testing
 export class SampleAliquotsSummaryWithModels extends PureComponent<Props & SampleAliquotsSummaryWithModelsProps> {
-
     renderStats(stats: SampleAliquotsStats, hideAssayData?: boolean) {
         const { sampleSet, sampleId, sampleRow, sampleSchemaQuery, aliquotJobsQueryConfig } = this.props;
-        let aliquotUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Aliquots');
-        const jobUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Jobs').addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots).toHref();
-        const assayDataUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Assays').addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots).toHref();
+        const aliquotUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Aliquots');
+        const jobUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Jobs')
+            .addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots)
+            .toHref();
+        const assayDataUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Assays')
+            .addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots)
+            .toHref();
 
         const totalAliquotVolume = caseInsensitive(sampleRow, 'AliquotTotalVolume')?.displayValue?.toLocaleString();
         const units = caseInsensitive(sampleRow, 'Units')?.displayValue ?? caseInsensitive(sampleRow, 'Units')?.value;
-        const totalAliquotVolumeDisplay = totalAliquotVolume != null ? (totalAliquotVolume + (units ? ' ' + units : '')) : undefined;
+        const totalAliquotVolumeDisplay =
+            totalAliquotVolume != null ? totalAliquotVolume + (units ? ' ' + units : '') : undefined;
 
         return (
             <>
                 <tr>
                     <td>Total aliquots created:</td>
-                    <td className={'aliquot-stats-value'}>
+                    <td className="aliquot-stats-value">
                         <a href={aliquotUrl.toHref()}>{stats.aliquotCount}</a>
                     </td>
                 </tr>
                 <tr>
                     <td>Available aliquots:</td>
-                    <td className={'aliquot-stats-value'}>
-                        <a href={aliquotUrl.addFilters(Filter.create('StorageStatus', 'In storage')).toHref()}>{stats.inStorageCount + '/' + stats.aliquotCount}</a>
+                    <td className="aliquot-stats-value">
+                        <a href={aliquotUrl.addFilters(Filter.create('StorageStatus', 'In storage')).toHref()}>
+                            {stats.inStorageCount + '/' + stats.aliquotCount}
+                        </a>
                     </td>
                 </tr>
                 <tr>
                     <td>Current available amount:</td>
-                    <td className={'aliquot-stats-value'}>{totalAliquotVolumeDisplay ? totalAliquotVolumeDisplay : 'Not available'}</td>
+                    <td className="aliquot-stats-value">
+                        {totalAliquotVolumeDisplay ? totalAliquotVolumeDisplay : 'Not available'}
+                    </td>
                 </tr>
                 <tr>
                     <td>Jobs with aliquots:</td>
-                    <td className={'aliquot-stats-value'}>
+                    <td className="aliquot-stats-value">
                         <a href={jobUrl}>{stats.jobsCount}</a>
                     </td>
                 </tr>
-                {!hideAssayData &&
-                <tr>
-                    <td>Assay data with aliquots:</td>
-                    <td className={'aliquot-stats-value'}>
-                        <a href={assayDataUrl}>
-                            <SampleAliquotAssaysCount
-                                sampleId={sampleId}
-                                aliquotIds={stats.aliquotIds}
-                                sampleSchemaQuery={sampleSchemaQuery}
-                            />
-                        </a>
-                    </td>
-                </tr>
-                }
+                {!hideAssayData && (
+                    <tr>
+                        <td>Assay data with aliquots:</td>
+                        <td className="aliquot-stats-value">
+                            <a href={assayDataUrl}>
+                                <SampleAliquotAssaysCount
+                                    sampleId={sampleId}
+                                    aliquotIds={stats.aliquotIds}
+                                    sampleSchemaQuery={sampleSchemaQuery}
+                                />
+                            </a>
+                        </td>
+                    </tr>
+                )}
             </>
-        )
+        );
     }
 
     render() {
         const { aliquotsModel, jobsModel, hideAssayData, aliquotJobsQueryConfig } = this.props;
 
-        if (!aliquotsModel || isLoading(aliquotsModel.rowsLoadingState)
-            || !jobsModel || isLoading(jobsModel.rowsLoadingState)) {
+        if (
+            !aliquotsModel ||
+            isLoading(aliquotsModel.rowsLoadingState) ||
+            !jobsModel ||
+            isLoading(jobsModel.rowsLoadingState)
+        ) {
             return <LoadingSpinner />;
         }
 
-        const stats : SampleAliquotsStats = aliquotsModel.rowCount === 0 ? null : getSampleAliquotsStats(aliquotsModel.rows);
-        if (stats)
-            stats.jobsCount = jobsModel.rowCount;
+        const stats: SampleAliquotsStats =
+            aliquotsModel.rowCount === 0 ? null : getSampleAliquotsStats(aliquotsModel.rows);
+        if (stats) stats.jobsCount = jobsModel.rowCount;
 
         return (
             <Panel>
                 <Panel.Heading>Aliquots</Panel.Heading>
                 <Panel.Body>
-                    <table className={'table table-responsive table-condensed detail-component--table__fixed sample-aliquots-stats-table'}>
+                    <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-stats-table">
                         <tbody>
-                        {stats ? this.renderStats(stats, hideAssayData) : <tr><td><span className={'sample-aliquots-stats-empty'}>This sample has no aliquots.</span></td></tr>}
+                            {stats ? (
+                                this.renderStats(stats, hideAssayData)
+                            ) : (
+                                <tr>
+                                    <td>
+                                        <span className="sample-aliquots-stats-empty">
+                                            This sample has no aliquots.
+                                        </span>
+                                    </td>
+                                </tr>
+                            )}
                         </tbody>
                     </table>
                 </Panel.Body>

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
@@ -1,0 +1,164 @@
+import React, { PureComponent } from 'react';
+import { Panel } from 'react-bootstrap';
+import { Filter } from '@labkey/api';
+
+// These need to be direct imports from files to avoid circular dependencies in index.ts
+import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
+
+import {
+    QueryModel,
+    QueryConfig,
+    isLoading,
+    LoadingSpinner,
+    App,
+    AppURL,
+    ALIQUOT_FILTER_MODE,
+    SchemaQuery
+} from '../../..';
+
+import { getSampleAliquotsQueryConfig, getSampleAliquotsStats } from './actions';
+import { SampleAliquotsStats } from './models';
+import { SampleAliquotAssaysCount } from "./SampleAliquotAssaysCount";
+
+interface OwnProps {
+    sampleLsid: string;
+    sampleId: string;
+    sampleSet: string;
+    totalAliquotVolume: string;
+    aliquotJobsQueryConfig: QueryConfig;
+    sampleSchemaQuery?: SchemaQuery;
+}
+
+type Props = OwnProps & InjectedQueryModels;
+
+interface SampleAliquotsSummaryWithModelsProps {
+    aliquotsModel: QueryModel;
+    jobsModel?: QueryModel;
+    hideAssayData?: boolean;
+}
+
+// exported for jest testing
+export class SampleAliquotsSummaryWithModels extends PureComponent<Props & SampleAliquotsSummaryWithModelsProps> {
+
+    renderStats(stats: SampleAliquotsStats, hideAssayData?: boolean) {
+        const { sampleSet, sampleId, totalAliquotVolume, sampleSchemaQuery, aliquotJobsQueryConfig } = this.props;
+        let aliquotUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Aliquots');
+        const jobUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Jobs').addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots).toHref();
+        const assayDataUrl = AppURL.create(App.SAMPLES_KEY, sampleSet, sampleId, 'Assays').addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots).toHref();
+
+        return (
+            <>
+                <tr>
+                    <td>Total aliquots created:</td>
+                    <td className={'aliquot-stats-value'}>
+                        <a href={aliquotUrl.toHref()}>{stats.aliquotCount}</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Available aliquots:</td>
+                    <td className={'aliquot-stats-value'}>
+                        <a href={aliquotUrl.addFilters(Filter.create('StorageStatus', 'In storage')).toHref()}>{stats.inStorageCount + '/' + stats.aliquotCount}</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Current available amount:</td>
+                    <td className={'aliquot-stats-value'}>{totalAliquotVolume ? totalAliquotVolume : 'Not available'}</td>
+                </tr>
+                <tr>
+                    <td>Jobs with aliquots:</td>
+                    <td className={'aliquot-stats-value'}>
+                        <a href={jobUrl}>{stats.jobsCount}</a>
+                    </td>
+                </tr>
+                {!hideAssayData &&
+                <tr>
+                    <td>Assay data with aliquots:</td>
+                    <td className={'aliquot-stats-value'}>
+                        <a href={assayDataUrl}>
+                            <SampleAliquotAssaysCount
+                                sampleId={sampleId}
+                                aliquotIds={stats.aliquotIds}
+                                sampleSchemaQuery={sampleSchemaQuery}
+                            />
+                        </a>
+                    </td>
+                </tr>
+                }
+            </>
+        )
+    }
+
+    render() {
+        const { aliquotsModel, jobsModel, hideAssayData, aliquotJobsQueryConfig } = this.props;
+
+        if (!aliquotsModel || isLoading(aliquotsModel.rowsLoadingState)
+            || !jobsModel || isLoading(jobsModel.rowsLoadingState)) {
+            return <LoadingSpinner />;
+        }
+
+        const stats : SampleAliquotsStats = aliquotsModel.rowCount === 0 ? null : getSampleAliquotsStats(aliquotsModel.rows);
+        if (stats)
+            stats.jobsCount = jobsModel.rowCount;
+
+        return (
+            <Panel>
+                <Panel.Heading>Aliquots</Panel.Heading>
+                <Panel.Body>
+                    <table className={'table table-responsive table-condensed detail-component--table__fixed sample-aliquots-stats-table'}>
+                        <tbody>
+                        {stats ? this.renderStats(stats, hideAssayData) : <tr><td><span className={'sample-aliquots-stats-empty'}>This sample has no aliquots.</span></td></tr>}
+                        </tbody>
+                    </table>
+                </Panel.Body>
+            </Panel>
+        );
+    }
+}
+
+class SampleAliquotsSummaryImpl extends PureComponent<Props> {
+    componentDidMount(): void {
+        this.initModel();
+    }
+
+    componentDidUpdate(prevProps: Readonly<Props>): void {
+        if (this.props.sampleId !== prevProps.sampleId) {
+            this.initModel();
+        }
+    }
+
+    initModel(): void {
+        const { actions, aliquotJobsQueryConfig } = this.props;
+
+        actions.addModel(this.getAliquotQueryConfig(), true);
+        actions.addModel(aliquotJobsQueryConfig, true);
+    }
+
+    getAliquotQueryConfig(): QueryConfig {
+        const { sampleSet, sampleLsid } = this.props;
+        return getSampleAliquotsQueryConfig(sampleSet, sampleLsid, false);
+    }
+
+    getQueryModel(index: number): QueryModel {
+        return Object.values(this.props.queryModels)[index];
+    }
+
+    getAliquotQueryModel(): QueryModel {
+        return this.getQueryModel(0);
+    }
+
+    getAliquotJobsQueryModel(): QueryModel {
+        return this.getQueryModel(1);
+    }
+
+    render() {
+        return (
+            <SampleAliquotsSummaryWithModels
+                {...this.props}
+                aliquotsModel={this.getAliquotQueryModel()}
+                jobsModel={this.getAliquotJobsQueryModel()}
+            />
+        );
+    }
+}
+
+export const SampleAliquotsSummary = withQueryModels<OwnProps>(SampleAliquotsSummaryImpl);

--- a/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
+++ b/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
@@ -35,8 +35,6 @@ interface Props {
     sampleSet: string;
     title: string;
     queryModel?: QueryModel;
-    isAliquot?: boolean;
-    aliquotRootLsid?: string;
 }
 
 interface State {
@@ -133,7 +131,6 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
             onUpdate,
             queryModel,
             title,
-            aliquotRootLsid,
         } = this.props;
         const { hasError, sampleTypeDomainFields } = this.state;
 
@@ -201,7 +198,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
                         <Panel.Body>
                             {parentDetailHeader}
                             <DetailPanelWithModel
-                                key={aliquotRootLsid}
+                                key={root?.value}
                                 queryConfig={this.getAliquotRootSampleQueryConfig()}
                             />
                         </Panel.Body>

--- a/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
+++ b/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
@@ -106,7 +106,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
         return getGroupedSampleDisplayColumns(detailColumns, updateColumns, sampleTypeDomainFields, isAliquot);
     };
 
-    getAliquotRootSampleQueryConfig = () : QueryConfig => {
+    getAliquotRootSampleQueryConfig = (): QueryConfig => {
         const { sampleSet } = this.props;
 
         const row = this.getRow();
@@ -114,7 +114,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
 
         return {
             schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet),
-            baseFilters: [Filter.create("lsid", rootLsid)],
+            baseFilters: [Filter.create('lsid', rootLsid)],
             requiredColumns: ['Name', 'Description'],
             omittedColumns: ['IsAliquot'],
         };
@@ -166,7 +166,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
         const parentDetailHeader = showRootSampleName ? (
             <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table">
                 <tbody>
-                    <tr key='originalSample'>
+                    <tr key="originalSample">
                         <td>Original sample</td>
                         <td>
                             <DefaultRenderer data={fromJS(root)} />
@@ -192,7 +192,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
                     queryColumns={displayColumns}
                     title={isAliquot ? 'Aliquot Details' : undefined}
                 />
-                {isAliquot &&
+                {isAliquot && (
                     <Panel>
                         <Panel.Heading>Original Sample Details</Panel.Heading>
                         <Panel.Body>
@@ -203,7 +203,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
                             />
                         </Panel.Body>
                     </Panel>
-                }
+                )}
             </>
         );
     }

--- a/packages/components/src/internal/components/samples/__snapshots__/SampleAliquotDetailHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/samples/__snapshots__/SampleAliquotDetailHeader.spec.tsx.snap
@@ -1,119 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SampleAliquotDetailHeader/> aliquot detail header 1`] = `
-Array [
-  <div
-    className="bottom-spacing"
-  >
-    <b>
-      Aliquot Data
-    </b>
-  </div>,
-  <table
-    className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-table"
-  >
-    <tbody>
-      <tr>
-        <td>
-          Aliquoted from
-        </td>
-        <td>
-          <a
-            className="ws-pre-wrap"
-            href="#/rd/samples/2"
-          >
-            S-1-1
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Aliquoted by
-        </td>
-        <td>
-          <a
-            className="ws-pre-wrap"
-            href="#/q/core/siteusers/1005"
-          >
-            xyang
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Aliquot date
-        </td>
-        <td>
-          <span
-            className="ws-pre-wrap"
-          >
-            2021-03-02 14:49
-          </span>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Aliquot description
-        </td>
-        <td>
-          <span
-            className="ws-pre-wrap"
-          >
-            this is a sub-aliquot - 3
-          </span>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Aliquot Specific
-        </td>
-        <td>
-          <span
-            className="ws-pre-wrap"
-          >
-            ali-1-1 - child4
-          </span>
-        </td>
-      </tr>
-    </tbody>
-  </table>,
-  <div
-    className="bottom-spacing"
-  >
-    <b>
-      Original Sample Data
-    </b>
-  </div>,
-  <table
-    className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table"
-  >
-    <tbody>
-      <tr>
-        <td>
-          Original sample
-        </td>
-        <td>
-          <a
-            className="ws-pre-wrap"
-            href="#/rd/samples/1"
-          >
-            S-1
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Sample description
-        </td>
-        <td>
-          <span
-            className="ws-pre-wrap"
-          >
-            4
-          </span>
-        </td>
-      </tr>
-    </tbody>
-  </table>,
-]
+<table
+  className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-table"
+>
+  <tbody>
+    <tr>
+      <td>
+        Aliquoted from
+      </td>
+      <td>
+        <a
+          className="ws-pre-wrap"
+          href="#/rd/samples/2"
+        >
+          S-1-1
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Aliquoted by
+      </td>
+      <td>
+        <a
+          className="ws-pre-wrap"
+          href="#/q/core/siteusers/1005"
+        >
+          xyang
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Aliquot date
+      </td>
+      <td>
+        <span
+          className="ws-pre-wrap"
+        >
+          2021-03-02 14:49
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Aliquot description
+      </td>
+      <td>
+        <span
+          className="ws-pre-wrap"
+        >
+          this is a sub-aliquot - 3
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Aliquot Specific
+      </td>
+      <td>
+        <span
+          className="ws-pre-wrap"
+        >
+          ali-1-1 - child4
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -28,6 +28,7 @@ import {
     FindField,
     getSelectedData,
     getSelection,
+    getStateModelId,
     ISelectRowsResult,
     naturalSortByProperty,
     QueryColumn,
@@ -49,7 +50,8 @@ import { getInitialParentChoices } from '../entities/utils';
 
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../domainproperties/constants';
 
-import { GroupedSampleFields } from './models';
+import { GroupedSampleFields, SampleAliquotsStats } from './models';
+import { IS_ALIQUOT_FIELD } from "./constants";
 
 export function initSampleSetSelects(isUpdate: boolean, ssName: string, includeDataClasses: boolean): Promise<any[]> {
     const promises = [];
@@ -443,8 +445,6 @@ export function getGroupedSampleDisplayColumns(
             // barcodes belong to the individual sample or aliquot (but not both)
             if (col.conceptURI === STORAGE_UNIQUE_ID_CONCEPT_URI) {
                 aliquotHeaderDisplayColumns.push(col);
-            } else if (sampleTypeDomainFields.metaFields.indexOf(colName) > -1) {
-                displayColumns.push(col);
             }
             // display parent meta for aliquot
             else if (sampleTypeDomainFields.aliquotFields.indexOf(colName) > -1) {
@@ -464,10 +464,6 @@ export function getGroupedSampleDisplayColumns(
                 editColumns.push(col);
             } else if (colName === 'description') {
                 editColumns.push(col);
-            } else {
-                if (sampleTypeDomainFields.metaFields.indexOf(colName) === -1) {
-                    editColumns.push(col);
-                }
             }
         } else {
             if (sampleTypeDomainFields.aliquotFields.indexOf(colName) === -1) {
@@ -685,4 +681,47 @@ export function getSampleAssayQueryConfigs(
 
             return _configs;
         }, []);
+}
+
+
+export function getSampleAliquotsStats(rows: Record<string, any>): SampleAliquotsStats {
+    let inStorageCount = 0, aliquotCount = 0, aliquotIds = [];
+    for (let ind in rows) {
+        const row = rows[ind];
+        const storageStatus = caseInsensitive(row, 'StorageStatus')?.value
+
+        const inStorage = storageStatus === 'In storage';
+        inStorageCount += inStorage ? 1 : 0;
+        aliquotCount++;
+
+        aliquotIds.push(caseInsensitive(row, 'RowId')?.value);
+    }
+
+    return {
+        aliquotCount,
+        inStorageCount,
+        aliquotIds
+    }
+}
+
+export function getSampleAliquotsQueryConfig(
+    sampleSet: string,
+    sampleLsid: string,
+    forGridView?: boolean,
+    aliquotRootLsid?: string,
+    omitCols?: List<string>
+): QueryConfig {
+    const omitCol = IS_ALIQUOT_FIELD;
+
+    return {
+        id: getStateModelId("sample-aliquots", SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet)),
+        schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet),
+        bindURL: forGridView,
+        maxRows: forGridView ? undefined : -1,
+        omittedColumns: omitCols ? [...omitCols.toArray(), omitCol] : [omitCol],
+        baseFilters: [
+            Filter.create('RootMaterialLSID', aliquotRootLsid ?? sampleLsid),
+            Filter.create('Lsid', sampleLsid, Filter.Types.EXP_CHILD_OF)
+        ]
+    };
 }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -51,7 +51,7 @@ import { getInitialParentChoices } from '../entities/utils';
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../domainproperties/constants';
 
 import { GroupedSampleFields, SampleAliquotsStats } from './models';
-import { IS_ALIQUOT_FIELD } from "./constants";
+import { IS_ALIQUOT_FIELD } from './constants';
 
 export function initSampleSetSelects(isUpdate: boolean, ssName: string, includeDataClasses: boolean): Promise<any[]> {
     const promises = [];
@@ -683,12 +683,13 @@ export function getSampleAssayQueryConfigs(
         }, []);
 }
 
-
 export function getSampleAliquotsStats(rows: Record<string, any>): SampleAliquotsStats {
-    let inStorageCount = 0, aliquotCount = 0, aliquotIds = [];
-    for (let ind in rows) {
+    let inStorageCount = 0,
+        aliquotCount = 0,
+        aliquotIds = [];
+    for (const ind in rows) {
         const row = rows[ind];
-        const storageStatus = caseInsensitive(row, 'StorageStatus')?.value
+        const storageStatus = caseInsensitive(row, 'StorageStatus')?.value;
 
         const inStorage = storageStatus === 'In storage';
         inStorageCount += inStorage ? 1 : 0;
@@ -700,8 +701,8 @@ export function getSampleAliquotsStats(rows: Record<string, any>): SampleAliquot
     return {
         aliquotCount,
         inStorageCount,
-        aliquotIds
-    }
+        aliquotIds,
+    };
 }
 
 export function getSampleAliquotsQueryConfig(
@@ -714,14 +715,14 @@ export function getSampleAliquotsQueryConfig(
     const omitCol = IS_ALIQUOT_FIELD;
 
     return {
-        id: getStateModelId("sample-aliquots", SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet)),
+        id: getStateModelId('sample-aliquots', SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet)),
         schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet),
         bindURL: forGridView,
         maxRows: forGridView ? undefined : -1,
         omittedColumns: omitCols ? [...omitCols.toArray(), omitCol] : [omitCol],
         baseFilters: [
             Filter.create('RootMaterialLSID', aliquotRootLsid ?? sampleLsid),
-            Filter.create('Lsid', sampleLsid, Filter.Types.EXP_CHILD_OF)
-        ]
+            Filter.create('Lsid', sampleLsid, Filter.Types.EXP_CHILD_OF),
+        ],
     };
 }

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -21,3 +21,5 @@ export const SAMPLE_ID_FIND_FIELD: FindField = {
     label: 'Sample IDs',
     storageKeyPrefix: 's:',
 };
+
+export const IS_ALIQUOT_FIELD = 'isAliquot';

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -99,6 +99,6 @@ export interface FindField {
 export interface SampleAliquotsStats {
     aliquotCount: number;
     inStorageCount: number;
-    jobsCount?: number
-    aliquotIds?: number[]
+    jobsCount?: number;
+    aliquotIds?: number[];
 }

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -95,3 +95,10 @@ export interface FindField {
     label: string;
     storageKeyPrefix: string;
 }
+
+export interface SampleAliquotsStats {
+    aliquotCount: number;
+    inStorageCount: number;
+    jobsCount?: number
+    aliquotIds?: number[]
+}

--- a/packages/components/src/internal/components/user/UserLink.tsx
+++ b/packages/components/src/internal/components/user/UserLink.tsx
@@ -10,7 +10,7 @@ interface Props {
     userId: string
 }
 
-export class UserLink extends React.PureComponent<Props, any> {
+export class UserLink extends React.PureComponent<Props> {
 
     render() {
         const { allUsers, currentUser, userId } = this.props;

--- a/packages/components/src/internal/components/user/UserLink.tsx
+++ b/packages/components/src/internal/components/user/UserLink.tsx
@@ -1,30 +1,28 @@
 import React from 'react';
 import { List } from 'immutable';
-import { User as IUser } from '@labkey/api'
+import { User as IUser } from '@labkey/api';
 
 import { AppURL, User } from '../../..';
 
 interface Props {
-    currentUser: User
-    allUsers: List<IUser>
-    userId: string
+    currentUser: User;
+    allUsers: List<IUser>;
+    userId: string;
 }
 
 export class UserLink extends React.PureComponent<Props> {
-
     render() {
         const { allUsers, currentUser, userId } = this.props;
-        if (!allUsers || !userId)
-            return null;
+        if (!allUsers || !userId) return null;
 
         let targetUser: IUser = null;
         if (allUsers) {
-            targetUser = allUsers.find((user) => (user.userId === parseInt(userId)));
+            targetUser = allUsers.find(user => user.userId === parseInt(userId));
         }
 
         if (targetUser) {
             const link = AppURL.create('q', 'core', 'siteusers', userId).toHref();
-            return currentUser.isAdmin ? <a href={link}>{targetUser.displayName}</a> : targetUser.displayName
+            return currentUser.isAdmin ? <a href={link}>{targetUser.displayName}</a> : targetUser.displayName;
         }
         return null;
     }

--- a/packages/components/src/internal/components/user/UserLink.tsx
+++ b/packages/components/src/internal/components/user/UserLink.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { List } from 'immutable';
+import { User as IUser } from '@labkey/api'
+
+import { AppURL, User } from '../../..';
+
+interface Props {
+    currentUser: User
+    allUsers: List<IUser>
+    userId: string
+}
+
+export class UserLink extends React.PureComponent<Props, any> {
+
+    render() {
+        const { allUsers, currentUser, userId } = this.props;
+        if (!allUsers || !userId)
+            return null;
+
+        let targetUser: IUser = null;
+        if (allUsers) {
+            targetUser = allUsers.find((user) => (user.userId === parseInt(userId)));
+        }
+
+        if (targetUser) {
+            const link = AppURL.create('q', 'core', 'siteusers', userId).toHref();
+            return currentUser.isAdmin ? <a href={link}>{targetUser.displayName}</a> : targetUser.displayName
+        }
+        return null;
+    }
+}

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -192,7 +192,7 @@ export class QueryModel {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly keyValue?: any;
     /**
-     * The maximum number of rows to return from the server (defaults to 100000).
+     * The maximum number of rows to return from the server (defaults to 20).
      * If you want to return all possible rows, set this config property to -1.
      */
     readonly maxRows: number;

--- a/packages/components/src/theme/samples.scss
+++ b/packages/components/src/theme/samples.scss
@@ -93,3 +93,7 @@
 .edit-parent-danger {
     color: $brand-danger;
 }
+
+.sample-aliquots-details-meta-table {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
#### Rationale
As part of the epic to enable FM for LKB, Storage Location and Aliquots panels will be added to LKB sample's overview page, to be consistent with LKSM sample's overview page. Aliquots related components will be moved from LKSM to ui-components in this PR, so they can be used by LKB. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/631
* https://github.com/LabKey/inventory/pull/301
* https://github.com/LabKey/sampleManagement/pull/693
* https://github.com/LabKey/biologics/pull/997

#### Changes
* Move Sample Aliquots panel UI and utils here from LKSM
* Issue 43833: update aliquot detail panel
