### PR TITLE
EntityLineageEditMenuItem and related updates to support selenium tests for Source Samples grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.0-fb-smSourceSampleEditTest.0",
+  "version": "2.77.0-fb-smSourceSampleEditTest.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.0-fb-smSourceSampleEditTest.1",
+  "version": "2.77.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.0",
+  "version": "2.77.0-fb-smSourceSampleEditTest.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.77.1
+*Released*: 21 September 2021
 * EntityLineageEditMenuItem and related updates to support selenium tests for Source Samples grid
 
 ### version 2.77.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,14 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* EntityLineageEditMenuItem and related updates to support selenium tests for Source Samples grid
+
 ### version 2.77.0
 *Released*: 17 September 2021
 * Move Sample Aliquots panel UI and utils here from LKSM
 * Issue 43833: update aliquot detail panel
-
-### version TBD
-*Released*: TBD
-* EntityLineageEditMenuItem and related updates to support selenium tests for Source Samples grid
 
 ### version 2.76.0
 *Released*: 16 September 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Move Sample Aliquots panel UI and utils here from LKSM
 * Issue 43833: update aliquot detail panel
 
+### version TBD
+*Released*: TBD
+* EntityLineageEditMenuItem and related updates to support selenium tests for Source Samples grid
+
 ### version 2.76.0
 *Released*: 16 September 2021
 * EntityLineageEditMenuItem update to add an optional onSuccess callback prop

--- a/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.spec.tsx
@@ -24,6 +24,7 @@ describe('EntityLineageEditMenuItem', () => {
         expect(wrapper.find(SelectionMenuItem)).toHaveLength(0);
         expect(wrapper.find(MenuItem)).toHaveLength(1);
         expect(wrapper.find(MenuItem).text()).toBe('Edit Cells for Selected Samples in Bulk');
+        wrapper.unmount();
     });
 
     test('multiple selections', () => {
@@ -38,6 +39,7 @@ describe('EntityLineageEditMenuItem', () => {
         );
         expect(wrapper.find(SelectionMenuItem)).toHaveLength(1);
         expect(wrapper.find(SelectionMenuItem).text()).toBe('Edit Cells for Selected Samples in Bulk');
+        wrapper.unmount();
     });
 
     test('single selection', () => {
@@ -51,6 +53,7 @@ describe('EntityLineageEditMenuItem', () => {
             />
         );
         expect(wrapper.find(SelectionMenuItem)).toHaveLength(1);
-        expect(wrapper.find(SelectionMenuItem).text()).toBe('Edit Cells for Selected Sample in Bulk');
+        expect(wrapper.find(SelectionMenuItem).text()).toBe('Edit Cells for Selected Samples in Bulk');
+        wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.tsx
@@ -6,7 +6,6 @@ import { AuditBehaviorTypes } from '@labkey/api';
 import { capitalizeFirstChar, EntityDataType, QueryModel, SelectionMenuItem } from '../../..';
 
 import { EntityLineageEditModal } from './EntityLineageEditModal';
-import { getEntityNoun } from './utils';
 
 interface Props {
     queryModel: QueryModel;
@@ -23,7 +22,8 @@ export const EntityLineageEditMenuItem: FC<Props> = memo(props => {
         'Edit ' +
         parentNounPlural +
         ' for Selected ' +
-        capitalizeFirstChar(getEntityNoun(childEntityDataType, queryModel?.selections?.size) + ' in Bulk');
+        capitalizeFirstChar(childEntityDataType.nounPlural) +
+        ' in Bulk';
     const [showEditModal, setShowEditModal] = useState<boolean>(false);
 
     const onClick = useCallback(() => {

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -100,7 +100,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                 createNotification(
                     `Successfully updated ${lcParentNounPlural} for ${rows.length} ${capitalizeFirstChar(
                         getEntityNoun(childEntityDataType, rows.length)
-                    )}`
+                    )}.`
                 );
             } catch (e) {
                 setSubmitting(false);
@@ -200,13 +200,17 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
 
             <Modal.Footer>
                 {onCancel && (
-                    <Button className="pull-left" onClick={onCancel}>
+                    <Button
+                        className="pull-left test-loc-cancel-button"
+                        onClick={onCancel}
+                    >
                         Cancel
                     </Button>
                 )}
 
                 <Button
-                    bsClass="btn btn-success"
+                    className="test-loc-submit-button"
+                    bsStyle="success"
                     onClick={onConfirm}
                     disabled={submitting || !numNonAliquots || !hasParentUpdates}
                 >

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -200,16 +200,12 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
 
             <Modal.Footer>
                 {onCancel && (
-                    <Button
-                        className="pull-left test-loc-cancel-button"
-                        onClick={onCancel}
-                    >
+                    <Button className="pull-left" onClick={onCancel}>
                         Cancel
                     </Button>
                 )}
 
                 <Button
-                    className="test-loc-submit-button"
                     bsStyle="success"
                     onClick={onConfirm}
                     disabled={submitting || !numNonAliquots || !hasParentUpdates}

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -177,18 +177,20 @@ export function getUpdatedLineageRowsForBulkEdit(
         // Find the types that are included and use those for change comparison.
         // Types that are not represented in the selected parents won't be changed.
         selectedParents.forEach(selected => {
-            let originalValue = null;
-            const possibleChange = originalParents[rowId].find(p => p.type.lsid == selected.type.lsid);
-            if (possibleChange) {
-                originalValue = possibleChange.gridValues
-                    .map(gridValue => gridValue.displayValue)
-                    .sort(naturalSort)
-                    .join(',');
-            }
-            const selValue = selected.value ? selected.value.split(',').sort(naturalSort).join(',') : null;
-            if (originalValue !== selValue) {
-                updatedValues[selected.type.entityDataType.insertColumnNamePrefix + selected.type.label] = selValue;
-                haveUpdate = true;
+            if (selected.type) {
+                let originalValue = null;
+                const possibleChange = originalParents[rowId].find(p => p.type.lsid == selected.type.lsid);
+                if (possibleChange) {
+                    originalValue = possibleChange.gridValues
+                        .map(gridValue => gridValue.displayValue)
+                        .sort(naturalSort)
+                        .join(',');
+                }
+                const selValue = selected.value ? selected.value.split(',').sort(naturalSort).join(',') : null;
+                if (originalValue !== selValue) {
+                    updatedValues[selected.type.entityDataType.insertColumnNamePrefix + selected.type.label] = selValue;
+                    haveUpdate = true;
+                }
             }
         });
         if (haveUpdate) {


### PR DESCRIPTION
#### Rationale
See related PR for more details. This is just a small PR update for some test locator helpers. It also includes one small changes in EntityLineageEditMenuItem to just always use the plural noun in the menu item text, to be consistent with other manage menu item text values.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/696

#### Changes
* EntityLineageEditMenuItem menu item text update to use plural noun
* getUpdatedLineageRowsForBulkEdit() null check
