### PR TITLE
Issue 43923: LKSM: Unable to go back to page 1 for Source/Samples grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.0",
+  "version": "2.77.1-fb-issue43923.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.2",
+  "version": "2.77.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.1-fb-issue43923.1",
+  "version": "2.77.1-fb-issue43923.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Issue 43923: LKSM: Unable to go back to page 1 for Source/Samples grid
+  * Allow GridAliquotViewSelector to update queryModel's aliquot filter
+
 ### version 2.77.0
 *Released*: 17 September 2021
 * Move Sample Aliquots panel UI and utils here from LKSM

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -253,6 +253,7 @@ import {
     useUsersWithPermissions,
 } from './internal/components/forms/actions';
 import { FormStep, FormTabs, withFormSteps } from './internal/components/forms/FormStep';
+import { GridAliquotViewSelector } from './internal/components/gridbar/GridAliquotViewSelector';
 import { SchemaListing } from './internal/components/listing/SchemaListing';
 import { QueriesListing } from './internal/components/listing/QueriesListing';
 import { QueriesListingPage } from './internal/components/listing/pages/QueriesListingPage';
@@ -879,6 +880,7 @@ export {
     SamplesSelectionProvider,
     SampleAliquotDetailHeader,
     SampleAliquotViewSelector,
+    GridAliquotViewSelector,
     SampleAliquotsSummary,
     ALIQUOT_FILTER_MODE,
     SampleAssayDetail,

--- a/packages/components/src/internal/components/gridbar/GridAliquotViewSelector.tsx
+++ b/packages/components/src/internal/components/gridbar/GridAliquotViewSelector.tsx
@@ -29,14 +29,14 @@ interface Props {
 }
 
 interface State {
-    initAliquotModeSynced: boolean
+    initAliquotModeSynced: boolean;
 }
 
 const IS_ALIQUOT_COL = 'IsAliquot';
 
 export class GridAliquotViewSelector extends Component<Props, State> {
     state: Readonly<State> = {
-        initAliquotModeSynced: false
+        initAliquotModeSynced: false,
     };
 
     componentDidMount(): void {
@@ -53,11 +53,10 @@ export class GridAliquotViewSelector extends Component<Props, State> {
         // if bindURL = true, rely on url param to set aliquot filter and ignore the initAliquotMode prop
         if (!initAliquotModeSynced && initAliquotMode && !queryModel.bindURL && !queryModel?.isLoading) {
             const currentMode = this.getAliquotFilterMode();
-            if (initAliquotMode != currentMode)
-                this.updateAliquotFilter(initAliquotMode);
+            if (initAliquotMode != currentMode) this.updateAliquotFilter(initAliquotMode);
             this.setState(() => ({ initAliquotModeSynced: true }));
         }
-    }
+    };
 
     updateAliquotFilter = (newMode: ALIQUOT_FILTER_MODE) => {
         const { queryGridModel, updateFilter } = this.props;

--- a/packages/components/src/internal/components/gridbar/GridAliquotViewSelector.tsx
+++ b/packages/components/src/internal/components/gridbar/GridAliquotViewSelector.tsx
@@ -50,7 +50,8 @@ export class GridAliquotViewSelector extends Component<Props, State> {
     syncInitMode = () => {
         const { initAliquotMode, queryModel } = this.props;
         const { initAliquotModeSynced } = this.state;
-        if (!initAliquotModeSynced && initAliquotMode && !queryModel?.isLoading) {
+        // if bindURL = true, rely on url param to set aliquot filter and ignore the initAliquotMode prop
+        if (!initAliquotModeSynced && initAliquotMode && !queryModel.bindURL && !queryModel?.isLoading) {
             const currentMode = this.getAliquotFilterMode();
             if (initAliquotMode != currentMode)
                 this.updateAliquotFilter(initAliquotMode);


### PR DESCRIPTION
#### Rationale
Aliquot view selector initialization currently depend on url param to initialize to the correct selection. To work around a issue related to bindURL for source/samples, this PR modifies the view selector so it doesn't have to rely on url param for correct initialization

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/698

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
