### PR TITLE
Initial API wrapper for actions to allow for jest test overrides

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.3",
+  "version": "2.77.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* Initial API wrapper for actions to allow for jest test overrides
+* Initial API wrapper for actions to allow for jest test overrides, currently only a single action in the "samples" area
+* Jest test for EntityLineageEditModal which use the test API wrapper and overrides
 
 ### version 2.77.2
 *Released*: 21 September 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Initial API wrapper for actions to allow for jest test overrides
+
 ### version 2.77.1
 *Released*: 21 September 2021
 * EntityLineageEditMenuItem and related updates to support selenium tests for Source Samples grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.77.4
+*Released*: 23 September 2021
 * Initial API wrapper for actions to allow for jest test overrides, currently only a single action in the "samples" area
 * Jest test for EntityLineageEditModal which use the test API wrapper and overrides
 

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -1,0 +1,25 @@
+import { List } from 'immutable';
+import { ISelectRowsResult } from './query/api';
+
+import { getSampleSelectionLineageData } from './components/samples/actions';
+
+export interface ComponentsAPIWrapper {
+    getSampleSelectionLineageData: (
+        selection: List<any>,
+        sampleType: string,
+        columns?: string[]
+    ) => Promise<ISelectRowsResult>;
+}
+
+export class ServerAPIWrapper implements ComponentsAPIWrapper {
+    getSampleSelectionLineageData = getSampleSelectionLineageData; // TODO see if this implementation should just move here
+}
+
+export const getDefaultAPIWrapper = (): ComponentsAPIWrapper => new ServerAPIWrapper();
+
+export function getTestAPIWrapper(overrides: Partial<ComponentsAPIWrapper> = {}): ComponentsAPIWrapper {
+    return {
+        getSampleSelectionLineageData: jest.fn(),
+        ...overrides,
+    };
+}

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -1,25 +1,19 @@
-import { List } from 'immutable';
-import { ISelectRowsResult } from './query/api';
-
-import { getSampleSelectionLineageData } from './components/samples/actions';
+import { SamplesAPIWrapper, SamplesServerAPIWrapper, getSamplesTestAPIWrapper } from './components/samples/APIWrapper';
 
 export interface ComponentsAPIWrapper {
-    getSampleSelectionLineageData: (
-        selection: List<any>,
-        sampleType: string,
-        columns?: string[]
-    ) => Promise<ISelectRowsResult>;
+    // TODO add more wrappers for other functional areas of this package
+    samples: SamplesAPIWrapper;
 }
 
-export class ServerAPIWrapper implements ComponentsAPIWrapper {
-    getSampleSelectionLineageData = getSampleSelectionLineageData; // TODO see if this implementation should just move here
+export function getDefaultAPIWrapper(): ComponentsAPIWrapper {
+    return {
+        samples: new SamplesServerAPIWrapper(),
+    };
 }
-
-export const getDefaultAPIWrapper = (): ComponentsAPIWrapper => new ServerAPIWrapper();
 
 export function getTestAPIWrapper(overrides: Partial<ComponentsAPIWrapper> = {}): ComponentsAPIWrapper {
     return {
-        getSampleSelectionLineageData: jest.fn(),
+        samples: getSamplesTestAPIWrapper(overrides.samples),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
@@ -6,12 +6,15 @@ import { mount, ReactWrapper } from 'enzyme';
 import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 
+import { getTestAPIWrapper } from '../../APIWrapper';
+
+import { waitForLifecycle } from '../../testHelpers';
+
+import { Progress } from '../base/Progress';
+
 import { EntityLineageEditModal } from './EntityLineageEditModal';
 import { DataClassDataType, SampleTypeDataType } from './constants';
 import { ParentEntityEditPanel } from './ParentEntityEditPanel';
-import { getTestAPIWrapper } from '../../APIWrapper';
-import { waitForLifecycle } from '../../testHelpers';
-import { Progress } from '../base/Progress';
 
 const SQ = SchemaQuery.create('schema', 'query');
 const MODEL = makeTestQueryModel(SQ).mutate({
@@ -106,7 +109,9 @@ describe('EntityLineageEditModal', () => {
         validate(wrapper, true, true);
         expect(wrapper.find(Modal.Title).text()).toBe('Edit samples for 1 Selected Sample');
         expect(wrapper.find(Button).last().text()).toBe('Update samples');
-        expect(wrapper.find('.has-aliquots-alert').hostNodes().text()).toBe(' 2 aliquots were among the selections. Lineage for aliquots cannot be changed.');
+        expect(wrapper.find('.has-aliquots-alert').hostNodes().text()).toBe(
+            ' 2 aliquots were among the selections. Lineage for aliquots cannot be changed.'
+        );
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
@@ -64,7 +64,7 @@ const DEFAULT_PROPS = {
     childEntityDataType: SampleTypeDataType,
     parentEntityDataTypes: [SampleTypeDataType, DataClassDataType],
     api: getTestAPIWrapper({
-        getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS),
+        samples: { getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS) },
     }),
 };
 
@@ -98,7 +98,7 @@ describe('EntityLineageEditModal', () => {
                 {...DEFAULT_PROPS}
                 queryModel={MODEL}
                 api={getTestAPIWrapper({
-                    getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITH_ALIQUOTS),
+                    samples: { getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITH_ALIQUOTS) },
                 })}
             />
         );
@@ -116,7 +116,7 @@ describe('EntityLineageEditModal', () => {
                 {...DEFAULT_PROPS}
                 queryModel={MODEL}
                 api={getTestAPIWrapper({
-                    getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS),
+                    samples: { getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS) },
                 })}
             />
         );

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+import { List } from 'immutable';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
+import { SchemaQuery } from '../../../public/SchemaQuery';
+
+import { EntityLineageEditModal } from './EntityLineageEditModal';
+import { DataClassDataType, SampleTypeDataType } from './constants';
+import { ParentEntityEditPanel } from './ParentEntityEditPanel';
+import { getTestAPIWrapper } from '../../APIWrapper';
+import { waitForLifecycle } from '../../testHelpers';
+import { Progress } from '../base/Progress';
+
+const SQ = SchemaQuery.create('schema', 'query');
+const MODEL = makeTestQueryModel(SQ).mutate({
+    selections: new Set(['1', '2', '3']),
+});
+
+const LINEAGE_DATA_WITHOUT_ALIQUOTS = {
+    key: 'schema/query',
+    models: {
+        'schema/query': {
+            1: { IsAliquot: { value: false } },
+            2: { IsAliquot: { value: false } },
+            3: { IsAliquot: { value: false } },
+        },
+    },
+    orderedModels: List(['schema/query']),
+    queries: { 'schema/query': undefined },
+    totalRows: 3,
+};
+const LINEAGE_DATA_WITH_ALIQUOTS = {
+    key: 'schema/query',
+    models: {
+        'schema/query': {
+            1: { IsAliquot: { value: true } },
+            2: { IsAliquot: { value: true } },
+            3: { IsAliquot: { value: false } },
+        },
+    },
+    orderedModels: List(['schema/query']),
+    queries: { 'schema/query': undefined },
+    totalRows: 3,
+};
+const LINEAGE_DATA_ALL_ALIQUOTS = {
+    key: 'schema/query',
+    models: {
+        'schema/query': {
+            1: { IsAliquot: { value: true } },
+            2: { IsAliquot: { value: true } },
+            3: { IsAliquot: { value: true } },
+        },
+    },
+    orderedModels: List(['schema/query']),
+    queries: { 'schema/query': undefined },
+    totalRows: 3,
+};
+
+const DEFAULT_PROPS = {
+    onCancel: jest.fn,
+    onSuccess: jest.fn,
+    childEntityDataType: SampleTypeDataType,
+    parentEntityDataTypes: [SampleTypeDataType, DataClassDataType],
+    api: getTestAPIWrapper({
+        getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS),
+    }),
+};
+
+describe('EntityLineageEditModal', () => {
+    function validate(wrapper: ReactWrapper, hasModel = true, hasAliquots = false, aliquotsOnly = false): void {
+        expect(wrapper.find(Modal)).toHaveLength(hasModel ? 1 : 0);
+        expect(wrapper.find('.has-aliquots-alert').hostNodes()).toHaveLength(hasAliquots ? 1 : 0);
+        expect(wrapper.find(Button)).toHaveLength(hasModel ? (aliquotsOnly ? 1 : 2) : 0);
+        expect(wrapper.find(ParentEntityEditPanel)).toHaveLength(hasModel && !aliquotsOnly ? 1 : 0);
+        expect(wrapper.find(Progress)).toHaveLength(hasModel && !aliquotsOnly ? 1 : 0);
+    }
+
+    test('without queryModel', () => {
+        const wrapper = mount(<EntityLineageEditModal {...DEFAULT_PROPS} queryModel={undefined} />);
+        validate(wrapper, false);
+        wrapper.unmount();
+    });
+
+    test('without aliquots', async () => {
+        const wrapper = mount(<EntityLineageEditModal {...DEFAULT_PROPS} queryModel={MODEL} />);
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(Modal.Title).text()).toBe('Edit samples for 3 Selected Samples');
+        expect(wrapper.find(Button).last().text()).toBe('Update samples');
+        wrapper.unmount();
+    });
+
+    test('with some aliquots', async () => {
+        const wrapper = mount(
+            <EntityLineageEditModal
+                {...DEFAULT_PROPS}
+                queryModel={MODEL}
+                api={getTestAPIWrapper({
+                    getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITH_ALIQUOTS),
+                })}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper, true, true);
+        expect(wrapper.find(Modal.Title).text()).toBe('Edit samples for 1 Selected Sample');
+        expect(wrapper.find(Button).last().text()).toBe('Update samples');
+        expect(wrapper.find('.has-aliquots-alert').hostNodes().text()).toBe(' 2 aliquots were among the selections. Lineage for aliquots cannot be changed.');
+        wrapper.unmount();
+    });
+
+    test('with only aliquots', async () => {
+        const wrapper = mount(
+            <EntityLineageEditModal
+                {...DEFAULT_PROPS}
+                queryModel={MODEL}
+                api={getTestAPIWrapper({
+                    getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS),
+                })}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper, true, false, true);
+        expect(wrapper.find(Modal.Title).text()).toBe('Cannot Edit samples');
+        expect(wrapper.find(Modal.Body).text()).toBe('The samples for aliquots cannot be changed.');
+        expect(wrapper.find(Button).text()).toBe('Dismiss');
+        wrapper.unmount();
+    });
+
+    test('parent noun based on first parentEntityDataTypes', async () => {
+        const wrapper = mount(
+            <EntityLineageEditModal
+                {...DEFAULT_PROPS}
+                queryModel={MODEL}
+                parentEntityDataTypes={[DataClassDataType, SampleTypeDataType]}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(Modal.Title).text()).toBe('Edit data for 3 Selected Samples');
+        expect(wrapper.find(Button).last().text()).toBe('Update data');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -19,12 +19,13 @@ import {
     updateRows,
 } from '../../..';
 
-import { getOriginalParentsFromSampleLineage, getSampleSelectionLineageData } from '../samples/actions';
+import { getOriginalParentsFromSampleLineage } from '../samples/actions';
 
 import { EntityChoice, EntityDataType } from './models';
 import { getEntityNoun, getUpdatedLineageRowsForBulkEdit } from './utils';
 
 import { ParentEntityLineageColumns } from './constants';
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface Props {
     queryModel: QueryModel;
@@ -33,10 +34,11 @@ interface Props {
     childEntityDataType: EntityDataType;
     auditBehavior?: AuditBehaviorTypes;
     parentEntityDataTypes: EntityDataType[];
+    api?: ComponentsAPIWrapper;
 }
 
 export const EntityLineageEditModal: FC<Props> = memo(props => {
-    const { auditBehavior, queryModel, onCancel, childEntityDataType, onSuccess, parentEntityDataTypes } = props;
+    const { api, auditBehavior, queryModel, onCancel, childEntityDataType, onSuccess, parentEntityDataTypes } = props;
     const [submitting, setSubmitting] = useState(false);
     const [numAliquots, setNumAliquots] = useState<number>(undefined);
     const [nonAliquots, setNonAliquots] = useState<Record<string, any>>(undefined);
@@ -48,7 +50,9 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
     const [selectedParents, setSelectedParents] = useState<List<EntityChoice>>(List<EntityChoice>());
 
     useEffect(() => {
-        getSampleSelectionLineageData(
+        if (!queryModel) return;
+
+        api.getSampleSelectionLineageData(
             List.of(...queryModel.selections),
             queryModel.queryName,
             List.of('RowId', 'Name', 'LSID', 'IsAliquot').concat(ParentEntityLineageColumns).toArray()
@@ -216,3 +220,9 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
         </Modal>
     );
 });
+
+EntityLineageEditModal.defaultProps = {
+    api: getDefaultAPIWrapper(),
+};
+
+EntityLineageEditModal.displayName = 'EntityLineageEditModal';

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -171,7 +171,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                             </p>
                         </div>
                         {numAliquots > 0 && !submitting && (
-                            <Alert bsStyle="info">
+                            <Alert bsStyle="info" className="has-aliquots-alert">
                                 {' '}
                                 {Utils.pluralize(numAliquots, 'aliquot was', 'aliquots were')} among the selections.
                                 Lineage for aliquots cannot be changed.

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -52,7 +52,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
     useEffect(() => {
         if (!queryModel) return;
 
-        api.getSampleSelectionLineageData(
+        api.samples.getSampleSelectionLineageData(
             List.of(...queryModel.selections),
             queryModel.queryName,
             List.of('RowId', 'Name', 'LSID', 'IsAliquot').concat(ParentEntityLineageColumns).toArray()

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -21,11 +21,12 @@ import {
 
 import { getOriginalParentsFromSampleLineage } from '../samples/actions';
 
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
 import { EntityChoice, EntityDataType } from './models';
 import { getEntityNoun, getUpdatedLineageRowsForBulkEdit } from './utils';
 
 import { ParentEntityLineageColumns } from './constants';
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface Props {
     queryModel: QueryModel;
@@ -52,11 +53,12 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
     useEffect(() => {
         if (!queryModel) return;
 
-        api.samples.getSampleSelectionLineageData(
-            List.of(...queryModel.selections),
-            queryModel.queryName,
-            List.of('RowId', 'Name', 'LSID', 'IsAliquot').concat(ParentEntityLineageColumns).toArray()
-        )
+        api.samples
+            .getSampleSelectionLineageData(
+                List.of(...queryModel.selections),
+                queryModel.queryName,
+                List.of('RowId', 'Name', 'LSID', 'IsAliquot').concat(ParentEntityLineageColumns).toArray()
+            )
             .then(async response => {
                 const { key, models } = response;
                 const nonAliquots = {};

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -1,5 +1,7 @@
 import { List } from 'immutable';
+
 import { ISelectRowsResult } from '../../query/api';
+
 import { getSampleSelectionLineageData } from './actions';
 
 export interface SamplesAPIWrapper {

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -1,0 +1,22 @@
+import { List } from 'immutable';
+import { ISelectRowsResult } from '../../query/api';
+import { getSampleSelectionLineageData } from './actions';
+
+export interface SamplesAPIWrapper {
+    getSampleSelectionLineageData: (
+        selection: List<any>,
+        sampleType: string,
+        columns?: string[]
+    ) => Promise<ISelectRowsResult>;
+}
+
+export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
+    getSampleSelectionLineageData = getSampleSelectionLineageData;
+}
+
+export function getSamplesTestAPIWrapper(overrides: Partial<SamplesAPIWrapper> = {}): SamplesAPIWrapper {
+    return {
+        getSampleSelectionLineageData: jest.fn(),
+        ...overrides,
+    };
+}


### PR DESCRIPTION
#### Rationale
This PR adds an initial implementation for an API wrapper in the components package. As discussed with the frontend team, the ComponentsAPIWrapper with be a combination of API wrappers from the various functional areas. This initial implementation just adds a first "samples" implementation which has one function: getSampleSelectionLineageData.

This PR also then makes use of this API wrapper in the EntityLineageEditModal.tsx and adds jest tests that override this wrapper with test implementations to verify certain scenarios which might be returned by the getSampleSelectionLineageData() function.

#### Changes
* Add initial ComponentsAPIWrapper and SamplesAPIWrapper
* Add jest tests for EntityLineageEditModal component, which use the overrides to the getTestAPIWrapper()
