### PR TITLE
SelectInput, UserSelectInput Fixes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.4-fb-lp-assays-samples.0",
+  "version": "2.77.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.4",
+  "version": "2.77.4-fb-lp-assays-samples.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.77.#
+*Released*: ## September 2021
+* Process the user `input` in `UserSelectInput` and compare it against user displayNames to support type-ahead filtering.
+* Prevent processing of "selectedOptions" for asynchronous `SelectInput` configurations during `componentDidUpdate`.
+* Update some internal typings for `SelectInput`.
+* Add unit tests for `initOptions`.
+
 ### version 2.77.4
 *Released*: 23 September 2021
 * Initial API wrapper for actions to allow for jest test overrides, currently only a single action in the "samples" area

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,13 +1,6 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.77.#
-*Released*: ## September 2021
-* Process the user `input` in `UserSelectInput` and compare it against user displayNames to support type-ahead filtering.
-* Prevent processing of "selectedOptions" for asynchronous `SelectInput` configurations during `componentDidUpdate`.
-* Update some internal typings for `SelectInput`.
-* Add unit tests for `initOptions`.
-
 ### version 2.77.5
 *Released*: 27 September 2021
 * Process the user `input` in `UserSelectInput` and compare it against user displayNames to support type-ahead filtering.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -8,6 +8,13 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Update some internal typings for `SelectInput`.
 * Add unit tests for `initOptions`.
 
+### version 2.77.5
+*Released*: 27 September 2021
+* Process the user `input` in `UserSelectInput` and compare it against user displayNames to support type-ahead filtering.
+* Prevent processing of "selectedOptions" for asynchronous `SelectInput` configurations during `componentDidUpdate`.
+* Update some internal typings for `SelectInput`.
+* Add unit tests for `initOptions`.
+
 ### version 2.77.4
 *Released*: 23 September 2021
 * Initial API wrapper for actions to allow for jest test overrides, currently only a single action in the "samples" area

--- a/packages/components/src/internal/components/forms/input/SelectInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.spec.tsx
@@ -20,7 +20,7 @@ import { FieldLabel } from '../FieldLabel';
 
 import { waitForLifecycle } from '../../../testHelpers';
 
-import { SelectInputImpl, SelectInputProps } from './SelectInput';
+import { initOptions, SelectInputImpl, SelectInputProps } from './SelectInput';
 import { blurSelectInputInput, setSelectInputText } from './SelectInputTestUtils';
 
 describe('SelectInput', () => {
@@ -98,5 +98,50 @@ describe('SelectInput', () => {
 
         component.setProps({ showLabel: false });
         validateFieldLabel(component, false);
+    });
+
+    describe('initOptions', () => {
+        test('empty values', () => {
+            expect(initOptions({ value: undefined })).toBeUndefined();
+            expect(initOptions({ value: null })).toBeUndefined();
+            expect(initOptions({ value: '' })).toBeUndefined();
+            expect(initOptions({ value: [] })).toHaveLength(0);
+        });
+        test('primitive values', () => {
+            expect(initOptions({ value: 5 })).toEqual({ label: 5, value: 5 });
+            expect(initOptions({ value: 'word' })).toEqual({ label: 'word', value: 'word' });
+            expect(initOptions({ value: [5, 'word'] })).toEqual([
+                { label: 5, value: 5 },
+                { label: 'word', value: 'word' },
+            ]);
+
+            // labelKey / valueKey
+            expect(initOptions({ labelKey: 'display', value: 5, valueKey: 'key' })).toEqual({ display: 5, key: 5 });
+            expect(initOptions({ labelKey: 'display', value: 'word', valueKey: 'key' })).toEqual({
+                display: 'word',
+                key: 'word',
+            });
+        });
+        test('options', () => {
+            const option1 = { label: 'Five', value: 5 };
+            const option2 = { label: 'Word', value: 'word' };
+            const options = [option1, option2];
+
+            expect(initOptions({ options, value: 5 })).toEqual(option1);
+            expect(initOptions({ options, value: 'word' })).toEqual(option2);
+            expect(initOptions({ options, value: 99 })).toEqual({ label: 99, value: 99 });
+
+            // labelKey / valueKey
+            const option3 = { name: 'Jackie Robinson', number: 42 };
+            const option4 = { name: 'Ken Griffey Jr', number: 24 };
+            const customOptions = [option3, option4];
+            expect(initOptions({ labelKey: 'name', options: customOptions, value: 42, valueKey: 'number' })).toEqual(
+                option3
+            );
+            expect(initOptions({ labelKey: 'name', options: customOptions, value: 99, valueKey: 'number' })).toEqual({
+                name: 99,
+                number: 99,
+            });
+        });
     });
 });

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -98,7 +98,7 @@ export type FilterOption = ((option: SelectInputOption, rawInput: string) => boo
 
 export const DELIMITER = ',';
 
-function initOptionFromPrimitive(value: string | number, props: SelectInputProps): any {
+function initOptionFromPrimitive(value: string | number, props: SelectInputProps): SelectInputOption {
     const { labelKey = 'label', options, valueKey = 'value' } = props;
     return options?.find(o => o[valueKey] === value) ?? { [labelKey]: value, [valueKey]: value };
 }
@@ -106,7 +106,7 @@ function initOptionFromPrimitive(value: string | number, props: SelectInputProps
 // Used to initialize the selected options in `state` when `autoValue` is enabled.
 // This will accept a primitive value (e.g. 5) and resolve it to an option (e.g. { label: 'Awesome', value: 5 })
 // if the option is available. Supports mapping single or multiple values.
-export function initOptions(props: SelectInputProps): any {
+export function initOptions(props: SelectInputProps): SelectInputOption | SelectInputOption[] {
     const { value } = props;
     let options;
 
@@ -195,8 +195,8 @@ interface State {
     asyncKey: number;
     initialLoad: boolean;
     isDisabled: boolean;
-    originalOptions: SelectInputOption[];
-    selectedOptions: SelectInputOption[];
+    originalOptions: SelectInputOption | SelectInputOption[];
+    selectedOptions: SelectInputOption | SelectInputOption[];
 }
 
 // Implementation exported only for tests
@@ -240,7 +240,9 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
     };
 
     componentDidUpdate(prevProps: SelectInputProps): void {
-        if (!this.CHANGE_LOCK && this.props.autoValue && prevProps.value !== this.props.value) {
+        if (!this.CHANGE_LOCK && this.props.autoValue && !this.isAsync() && prevProps.value !== this.props.value) {
+            // If "autoValue" is enabled and the value has changed for a non-async configuration, then we need
+            // to reinitialize "selectedOptions" from the latest props. The async case is handled in this.loadOptions().
             const selectedOptions = initOptions(this.props);
             this.setState({ originalOptions: selectedOptions, selectedOptions });
         }

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -20,15 +20,15 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
 
     const loadOptions = useCallback(
         async (input: string) => {
-            let options_;
-            const input_ = input?.trim().toLowerCase();
+            let options;
+            const sanitizedInput = input?.trim().toLowerCase();
 
             try {
                 const users = await getUsersWithPermissions(permissions);
-                options_ = users
+                options = users
                     .filter(v => {
-                        if (input_) {
-                            return v.displayName?.toLowerCase().indexOf(input_) > -1;
+                        if (sanitizedInput) {
+                            return v.displayName?.toLowerCase().indexOf(sanitizedInput) > -1;
                         }
 
                         return true;
@@ -42,7 +42,7 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
                 console.error(error);
             }
 
-            return options_;
+            return options;
         },
         [notifyList, permissions, useEmail]
     );

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -18,23 +18,34 @@ interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loa
 export const UserSelectInput: FC<UserSelectInputProps> = props => {
     const { notifyList, permissions, useEmail, ...selectInputProps } = props;
 
-    const loadOptions = useCallback(async () => {
-        let options_;
+    const loadOptions = useCallback(
+        async (input: string) => {
+            let options_;
+            const input_ = input?.trim().toLowerCase();
 
-        try {
-            const users = await getUsersWithPermissions(permissions);
-            options_ = users
-                .map(v => ({
-                    label: v.displayName,
-                    value: notifyList ? v.displayName : useEmail ? v.email : v.userId,
-                }))
-                .toArray();
-        } catch (error) {
-            console.error(error);
-        }
+            try {
+                const users = await getUsersWithPermissions(permissions);
+                options_ = users
+                    .filter(v => {
+                        if (input_) {
+                            return v.displayName?.toLowerCase().indexOf(input_) > -1;
+                        }
 
-        return options_;
-    }, [notifyList, permissions, useEmail]);
+                        return true;
+                    })
+                    .map(v => ({
+                        label: v.displayName,
+                        value: notifyList ? v.displayName : useEmail ? v.email : v.userId,
+                    }))
+                    .toArray();
+            } catch (error) {
+                console.error(error);
+            }
+
+            return options_;
+        },
+        [notifyList, permissions, useEmail]
+    );
 
     return <SelectInput {...selectInputProps} delimiter={notifyList ? ';' : ','} loadOptions={loadOptions} />;
 };


### PR DESCRIPTION
#### Rationale
This addresses a couple of issues that were recently discovered with the `SelectInput` and `UserSelectInput`.

- [43997](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43997): This issue identifies how `UserSelectInput` does not support type-ahead filtering. The fix for this is to process the user `input` in `UserSelectInput` and compare it against user displayNames.
- Another issue was identified by @labkey-alan where upon changing values in a multi-value async SelectInput the labels would all switch to the underlying value effectively losing the label:

![image](https://user-images.githubusercontent.com/3926239/134724697-d9b5ad67-0bc0-4550-825d-d5dd253fc2e8.png)

This has been addressed by not attempting to process the "selectedOptions" for async configurations during `componentDidUpdate`.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1000
* https://github.com/LabKey/sampleManagement/pull/697

#### Changes
* Process the user `input` in `UserSelectInput` and compare it against user displayNames to support type-ahead filtering.
* Prevent processing of "selectedOptions" for asynchronous `SelectInput` configurations during `componentDidUpdate`.
* Update some internal typings for `SelectInput`.
* Add unit tests for `initOptions`.
