### PR TITLE
Samples grid performance

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.4",
+  "version": "2.77.5-fb-smPerf21.10.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.79.1-fb-smPerf21.10.1",
+  "version": "2.79.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Support filterable prop for QueryColumn
+
 ### version 2.77.4
 *Released*: 23 September 2021
 * Initial API wrapper for actions to allow for jest test overrides, currently only a single action in the "samples" area

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 2.79.1
+*Released*: 1 October 2021
 * Support filterable prop for QueryColumn
 
 ### version 2.79.0

--- a/packages/components/src/internal/components/omnibox/actions/Filter.ts
+++ b/packages/components/src/internal/components/omnibox/actions/Filter.ts
@@ -303,7 +303,10 @@ export class FilterAction implements Action {
                         .filter(c => c.name.toLowerCase().indexOf(columnName.toLowerCase()) === 0)
                         .toList();
                 }
-                columnSet = columnSet.filter(c => !c.multiValue).toList();
+                columnSet = columnSet
+                    .filter(c => !c.multiValue)
+                    .filter(c => c.filterable)
+                    .toList();
 
                 columnSet.forEach(c => {
                     actionOptions.push({

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -253,11 +253,7 @@ export class QueryColumn extends Record({
     }
 
     get isUpdateColumn(): boolean {
-        return (
-            this.removeFromViews !== true &&
-            this.isEditable() &&
-            this.fieldKeyArray.length === 1
-        );
+        return this.removeFromViews !== true && this.isEditable() && this.fieldKeyArray.length === 1;
     }
 
     get isUniqueIdColumn(): boolean {

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -57,6 +57,7 @@ export class QueryColumn extends Record({
     fieldKey: undefined,
     fieldKeyArray: undefined,
     // fieldKeyPath: undefined,
+    filterable: true,
     format: undefined,
     // friendlyType: undefined,
     hidden: undefined,
@@ -92,7 +93,6 @@ export class QueryColumn extends Record({
     shownInInsertView: undefined,
     shownInUpdateView: undefined,
     sortable: true,
-    filterable: true,
     // sqlType: undefined,
     type: undefined,
     userEditable: undefined,
@@ -123,6 +123,7 @@ export class QueryColumn extends Record({
     declare fieldKey: string;
     declare fieldKeyArray: string[];
     // declare fieldKeyPath: string;
+    declare filterable: boolean;
     declare format: string;
     // declare friendlyType: string;
     declare hidden: boolean;
@@ -158,7 +159,6 @@ export class QueryColumn extends Record({
     declare shownInInsertView: boolean;
     declare shownInUpdateView: boolean;
     declare sortable: boolean;
-    declare filterable: boolean;
     // declare sqlType: string;
     declare type: string;
     declare userEditable: boolean;

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -92,6 +92,7 @@ export class QueryColumn extends Record({
     shownInInsertView: undefined,
     shownInUpdateView: undefined,
     sortable: true,
+    filterable: true,
     // sqlType: undefined,
     type: undefined,
     userEditable: undefined,
@@ -157,6 +158,7 @@ export class QueryColumn extends Record({
     declare shownInInsertView: boolean;
     declare shownInUpdateView: boolean;
     declare sortable: boolean;
+    declare filterable: boolean;
     // declare sqlType: string;
     declare type: string;
     declare userEditable: boolean;


### PR DESCRIPTION
#### Rationale
QueryColumn has a sortable property, which can be used to enable/disable sort for a column. We want to enable similar control for filtering a column. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/642
* https://github.com/LabKey/platform/pull/2642
* https://github.com/LabKey/inventory/pull/309
* https://github.com/LabKey/sampleManagement/pull/706
* https://github.com/LabKey/biologics/pull/1008

#### Changes
* Support filterable for QueryColumn
