### PR TITLE
Fix confirm modal classnames

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.77.5",
+  "version": "2.77.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+# version 2.77.6
+*Released*: ?? September 2021
+* Generate correct classNames for ConfirmModal cancel and confirm buttons
+* Add margin-left to .required-symbol, users no longer need to add a trailing space to form labels
+
 ### version 2.77.5
 *Released*: 27 September 2021
 * Process the user `input` in `UserSelectInput` and compare it against user displayNames to support type-ahead filtering.

--- a/packages/components/src/internal/components/base/ConfirmModal.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.tsx
@@ -49,10 +49,7 @@ export class ConfirmModal extends React.PureComponent<Props> {
             confirmVariant,
             submitting,
         } = this.props;
-        const cancelBtnClass = classNames('btn btn-default', {
-            'pull-left': onConfirm !== undefined,
-        });
-
+        const cancelBtnClass = classNames({ 'pull-left': onConfirm !== undefined });
         return (
             <Modal show={show} onHide={onCancel}>
                 <Modal.Header closeButton={onCancel !== undefined}>
@@ -63,12 +60,12 @@ export class ConfirmModal extends React.PureComponent<Props> {
 
                 <Modal.Footer>
                     {onCancel && (
-                        <Button bsClass={cancelBtnClass} onClick={onCancel}>
+                        <Button className={cancelBtnClass} onClick={onCancel}>
                             {cancelButtonText}
                         </Button>
                     )}
                     {onConfirm && (
-                        <Button bsClass={'btn btn-' + confirmVariant} onClick={onConfirm} disabled={submitting}>
+                        <Button bsStyle={confirmVariant} onClick={onConfirm} disabled={submitting}>
                             {confirmButtonText}
                         </Button>
                     )}

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -280,3 +280,7 @@ div.react-datepicker__current-month {
         font-weight: normal;
     }
 }
+
+.required-symbol {
+    margin-left: 4px;
+}


### PR DESCRIPTION
#### Rationale
The ConfirmModal generates incorrect classNames for the confirm and cancel buttons.


![Screen Shot 2021-09-27 at 4 06 11 PM](https://user-images.githubusercontent.com/5341647/134985475-f17126c2-a1ef-4499-94a0-3d5b6c2f71e6.png)

#### Related Pull Requests
* n/a

#### Changes
* Generate correct classNames for ConfirmModal cancel and confirm buttons
* Add margin-left to .required-symbol, users no longer need to add a trailing space to form labels
