### PR TITLE
Issue 43911: Add ability to use a custom key on UserSelectInput to facilitate clearing (rerendering) in containing component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.78.0",
+  "version": "2.78.1-clearAllSelectInput.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add optional `keySuffix` property to `UserSelectInput` to facilitate manual clearing of (actually rerendering of) the component from a containing component
+
 ### version 2.78.0
 *Released*: 28 September 2021
 * Update `EntityDeleteConfirmModalDisplay` to add message about sample status preventing deletion

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -13,10 +13,11 @@ interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loa
     notifyList?: boolean;
     permissions?: string | string[];
     useEmail?: boolean;
+    keySuffix?: number;
 }
 
 export const UserSelectInput: FC<UserSelectInputProps> = props => {
-    const { notifyList, permissions, useEmail, ...selectInputProps } = props;
+    const { keySuffix, notifyList, permissions, useEmail, ...selectInputProps } = props;
 
     const loadOptions = useCallback(
         async (input: string) => {
@@ -47,7 +48,7 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
         [notifyList, permissions, useEmail]
     );
 
-    return <SelectInput {...selectInputProps} delimiter={notifyList ? ';' : ','} loadOptions={loadOptions} />;
+    return <SelectInput key={selectInputProps.name + (keySuffix ? ('-' + keySuffix) : '')} {...selectInputProps} delimiter={notifyList ? ';' : ','} loadOptions={loadOptions} />;
 };
 
 UserSelectInput.defaultProps = {


### PR DESCRIPTION
#### Rationale
In various places in our applications (job samples search UI, Storage samples search UI) we provide the user with a number of custom filter inputs and then also a single link that is meant to clear all of these filter inputs.  When the `SelectInput` in use loads its option asynchronously (that is, has the property `loadOptions` provided instead of `options`), the value of the Input selector is under the control of the SelectInput, so clearing it is not possible from the containing component by just supplying it an undefined value.  To achieve the effect of clearing (or, actually resetting), we will cause the component to re-render by providing a key that can be controlled in the container and updated as clearing occurs.  It's not beautiful, but it seems to work.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1012
* https://github.com/LabKey/sampleManagement/pull/712
* https://github.com/LabKey/inventory/pull/314


#### Changes
* Add optional `keySuffix` property to `UserSelectInput` to facilitate manual clearing of (actually re-rendering of) the component from a containing component
