### PR TITLE
Additional ConfirmModal props, export parseDate

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.80.1
+*Released*: 4 October 2021
+* Expose additional `Modal` props via `ConfirmModal`.
+* Export `parseDate`.
+
 ### version 2.80.0
 *Released*: 4 October 2021
 * Add announcements components (Discussions, Thread, ThreadBlock, and more)

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -120,7 +120,7 @@ import {
     initNotificationsState,
 } from './internal/components/notifications/global';
 import { ConfirmModal } from './internal/components/base/ConfirmModal';
-import { formatDate, formatDateTime, getDateFormat } from './internal/util/Date';
+import { formatDate, formatDateTime, getDateFormat, parseDate } from './internal/util/Date';
 import { SVGIcon, Theme } from './internal/components/base/SVGIcon';
 import { CreatedModified } from './internal/components/base/CreatedModified';
 import {
@@ -1075,6 +1075,7 @@ export {
     getDisambiguatedSelectInputOptions,
     formatDate,
     formatDateTime,
+    parseDate,
     blurActiveElement,
     caseInsensitive,
     capitalizeFirstChar,

--- a/packages/components/src/internal/components/base/ConfirmModal.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.tsx
@@ -18,6 +18,7 @@ import { Button, Modal, Sizes } from 'react-bootstrap';
 import classNames from 'classnames';
 
 interface Props {
+    backdrop?: string;
     cancelButtonText?: string;
     confirmButtonText?: string;
     confirmVariant?: string;
@@ -40,6 +41,7 @@ export class ConfirmModal extends React.PureComponent<Props> {
 
     render(): ReactNode {
         const {
+            backdrop,
             children,
             show,
             title,
@@ -53,7 +55,7 @@ export class ConfirmModal extends React.PureComponent<Props> {
         } = this.props;
         const cancelBtnClass = classNames({ 'pull-left': onConfirm !== undefined });
         return (
-            <Modal bsSize={size} show={show} onHide={onCancel}>
+            <Modal backdrop={backdrop} bsSize={size} show={show} onHide={onCancel}>
                 <Modal.Header closeButton={!!onCancel}>
                     <Modal.Title>{title}</Modal.Title>
                 </Modal.Header>

--- a/packages/components/src/internal/components/base/ConfirmModal.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.tsx
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 import React, { ReactNode } from 'react';
-import { Button, Modal } from 'react-bootstrap';
+import { Button, Modal, Sizes } from 'react-bootstrap';
 import classNames from 'classnames';
 
 interface Props {
-    show?: boolean;
-    title?: string;
-    onConfirm?: () => void;
-    onCancel?: () => void;
-    confirmButtonText?: string;
     cancelButtonText?: string;
+    confirmButtonText?: string;
     confirmVariant?: string;
+    onCancel?: () => void;
+    onConfirm?: () => void;
+    show?: boolean;
+    size?: Sizes;
     submitting?: boolean;
+    title?: string;
 }
 
 export class ConfirmModal extends React.PureComponent<Props> {
@@ -47,12 +48,13 @@ export class ConfirmModal extends React.PureComponent<Props> {
             confirmButtonText,
             cancelButtonText,
             confirmVariant,
+            size,
             submitting,
         } = this.props;
         const cancelBtnClass = classNames({ 'pull-left': onConfirm !== undefined });
         return (
-            <Modal show={show} onHide={onCancel}>
-                <Modal.Header closeButton={onCancel !== undefined}>
+            <Modal bsSize={size} show={show} onHide={onCancel}>
+                <Modal.Header closeButton={!!onCancel}>
                     <Modal.Title>{title}</Modal.Title>
                 </Modal.Header>
 


### PR DESCRIPTION
#### Rationale
A few minor updates that were necessary for Lab Processes development.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/715
* https://github.com/LabKey/labkey-ui-components/pull/647
* https://github.com/LabKey/biologics/pull/1015
* <https://github.com/LabKey/platform/pull/2657

#### Changes
* Expose additional `Modal` props via `ConfirmModal`.
* Export `parseDate`.
