### PR TITLE
Item 9448:  Remove media sample types from samples for freezers

### DIFF
--- a/packages/components/src/test/data/product-getRegisteredProducts.json
+++ b/packages/components/src/test/data/product-getRegisteredProducts.json
@@ -1,6 +1,6 @@
 [ {
   "moduleName" : "Biologics",
-  "sectionNames" : [ "Registry", "NonMediaSampleTypes", "Media", "Experiments", "Workflow" ],
+  "sectionNames" : [ "Registry", "Sample Types", "Media", "Experiments", "Workflow" ],
   "documentationUrl" : "https://www.labkey.org/Documentation/wiki-page.view?name=biologics",
   "productId" : "Biologics",
   "productName" : "Biologics",


### PR DESCRIPTION
#### Rationale
Biologics sample types menu sections has been updated to use the same section from LKSM without override. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2664
* https://github.com/LabKey/inventory/pull/315
* https://github.com/LabKey/sampleManagement/pull/718
* https://github.com/LabKey/biologics/pull/1018
* https://github.com/LabKey/labkey-ui-components/pull/648

#### Changes
* update test data
