### PR TITLE
Item 9533: App support for module defined sample assay results view configs to show in sample assays tabbed grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.81.0-fb-smPanorama.0",
+  "version": "2.81.0-fb-smPanorama.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.81.0",
+  "version": "2.81.0-fb-smPanorama.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.81.0-fb-smPanorama.3",
+  "version": "2.81.0-fb-smPanorama.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.81.0-fb-smPanorama.2",
+  "version": "2.81.0-fb-smPanorama.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.80.1",
+  "version": "2.80.1-fb-smPanorama.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.81.0-fb-smPanorama.1",
+  "version": "2.81.0-fb-smPanorama.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.81.0-fb-smPanorama.4",
+  "version": "2.81.0-fb-smPanorama.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.81.0-fb-smPanorama.5",
+  "version": "2.82.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.82.0
+*Released*: 12 October 2021
 * Item 9533: SampleAssayDetail support for module defined sample assay results view configs
 
 ### version 2.81.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 9533: SampleAssayDetail support for module defined sample assay results view configs
+
 ### version 2.80.1
 *Released*: 4 October 2021
 * Expose additional `Modal` props via `ConfirmModal`.

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
@@ -15,6 +15,7 @@ import { Progress } from '../base/Progress';
 import { EntityLineageEditModal } from './EntityLineageEditModal';
 import { DataClassDataType, SampleTypeDataType } from './constants';
 import { ParentEntityEditPanel } from './ParentEntityEditPanel';
+import { getSamplesTestAPIWrapper } from '../samples/APIWrapper';
 
 const SQ = SchemaQuery.create('schema', 'query');
 const MODEL = makeTestQueryModel(SQ).mutate({
@@ -67,7 +68,9 @@ const DEFAULT_PROPS = {
     childEntityDataType: SampleTypeDataType,
     parentEntityDataTypes: [SampleTypeDataType, DataClassDataType],
     api: getTestAPIWrapper({
-        samples: { getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS) },
+        samples: getSamplesTestAPIWrapper({
+            getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS)
+        }),
     }),
 };
 
@@ -101,7 +104,9 @@ describe('EntityLineageEditModal', () => {
                 {...DEFAULT_PROPS}
                 queryModel={MODEL}
                 api={getTestAPIWrapper({
-                    samples: { getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITH_ALIQUOTS) },
+                    samples: getSamplesTestAPIWrapper({
+                        getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITH_ALIQUOTS),
+                    }),
                 })}
             />
         );
@@ -121,7 +126,9 @@ describe('EntityLineageEditModal', () => {
                 {...DEFAULT_PROPS}
                 queryModel={MODEL}
                 api={getTestAPIWrapper({
-                    samples: { getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS) },
+                    samples: getSamplesTestAPIWrapper({
+                        getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS)
+                    }),
                 })}
             />
         );

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
@@ -12,10 +12,11 @@ import { waitForLifecycle } from '../../testHelpers';
 
 import { Progress } from '../base/Progress';
 
+import { getSamplesTestAPIWrapper } from '../samples/APIWrapper';
+
 import { EntityLineageEditModal } from './EntityLineageEditModal';
 import { DataClassDataType, SampleTypeDataType } from './constants';
 import { ParentEntityEditPanel } from './ParentEntityEditPanel';
-import { getSamplesTestAPIWrapper } from '../samples/APIWrapper';
 
 const SQ = SchemaQuery.create('schema', 'query');
 const MODEL = makeTestQueryModel(SQ).mutate({
@@ -69,7 +70,7 @@ const DEFAULT_PROPS = {
     parentEntityDataTypes: [SampleTypeDataType, DataClassDataType],
     api: getTestAPIWrapper({
         samples: getSamplesTestAPIWrapper({
-            getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS)
+            getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS),
         }),
     }),
 };
@@ -127,7 +128,7 @@ describe('EntityLineageEditModal', () => {
                 queryModel={MODEL}
                 api={getTestAPIWrapper({
                     samples: getSamplesTestAPIWrapper({
-                        getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS)
+                        getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS),
                     }),
                 })}
             />

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -2,9 +2,18 @@ import { List } from 'immutable';
 
 import { ISelectRowsResult } from '../../query/api';
 
-import { getSampleSelectionLineageData } from './actions';
+import {
+    getSampleAliquotRows,
+    getSampleAssayResultViewConfigs,
+    getSampleSelectionLineageData,
+    SampleAssayResultViewConfig,
+} from './actions';
 
 export interface SamplesAPIWrapper {
+    getSampleAliquotRows: (sampleId: number | string) => Promise<Record<string, any>[]>;
+
+    getSampleAssayResultViewConfigs: () => Promise<SampleAssayResultViewConfig[]>;
+
     getSampleSelectionLineageData: (
         selection: List<any>,
         sampleType: string,
@@ -13,11 +22,15 @@ export interface SamplesAPIWrapper {
 }
 
 export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
+    getSampleAliquotRows = getSampleAliquotRows;
+    getSampleAssayResultViewConfigs = getSampleAssayResultViewConfigs;
     getSampleSelectionLineageData = getSampleSelectionLineageData;
 }
 
 export function getSamplesTestAPIWrapper(overrides: Partial<SamplesAPIWrapper> = {}): SamplesAPIWrapper {
     return {
+        getSampleAliquotRows: jest.fn(),
+        getSampleAssayResultViewConfigs: jest.fn(),
         getSampleSelectionLineageData: jest.fn(),
         ...overrides,
     };

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { ReactWrapper } from 'enzyme';
+import { fromJS } from 'immutable';
+import { Button, SplitButton } from 'react-bootstrap';
+
+import { makeTestActions, makeTestQueryModel } from '../../../public/QueryModel/testUtils';
+import { SchemaQuery } from '../../../public/SchemaQuery';
+import { AssayStateModel } from '../assay/models';
+import { AssayDefinitionModel } from '../../AssayDefinitionModel';
+import { LoadingState } from '../../../public/LoadingState';
+
+import { SampleAssayDetailButtons, SampleAssayDetailButtonsRight } from './SampleAssayDetail';
+import { mountWithServerContext } from '../../testHelpers';
+import { TEST_USER_AUTHOR, TEST_USER_READER } from '../../../test/data/users';
+import { SampleAliquotViewSelector } from './SampleAliquotViewSelector';
+
+const assayModel = new AssayStateModel({
+    definitions: [
+        new AssayDefinitionModel({ id: 17, name: 'First Assay', type: 'General', links: fromJS({ 'import': 'test1' }) }),
+        new AssayDefinitionModel({ id: 41, name: 'NAb Assay', type: 'NAb', links: fromJS({ 'import': 'test2' }) }),
+    ],
+    definitionsLoadingState: LoadingState.LOADED,
+});
+const sampleModel = makeTestQueryModel(SchemaQuery.create('schema', 'query'));
+const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'First Assay' });
+const DEFAULT_PROPS = {
+    assayModel,
+    sampleModel,
+    model,
+    actions: makeTestActions(),
+};
+
+describe('SampleAssayDetailButtons', () => {
+    function validate(wrapper: ReactWrapper, buttonCount = 0): void {
+        expect(wrapper.find(SplitButton)).toHaveLength(buttonCount > 1 ? 1 : 0);
+        expect(wrapper.find(Button)).toHaveLength(buttonCount);
+    }
+
+    test('without insert perm', () => {
+        const wrapper = mountWithServerContext(
+            <SampleAssayDetailButtons {...DEFAULT_PROPS} />,
+            { user: TEST_USER_READER }
+        );
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('currentAssayHref undefined', () => {
+        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'Other Assay' });
+        const wrapper = mountWithServerContext(
+            <SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />,
+            { user: TEST_USER_AUTHOR }
+        );
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('multiple menu items', () => {
+        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'NAb Assay' });
+        const wrapper = mountWithServerContext(
+            <SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />,
+            { user: TEST_USER_AUTHOR }
+        );
+        validate(wrapper, 2);
+        expect(wrapper.find(SplitButton).prop('href')).toBe('test2');
+        wrapper.unmount();
+    });
+
+    test('one menu item', () => {
+        const assayModel = new AssayStateModel({
+            definitions: [
+                new AssayDefinitionModel({ id: 17, name: 'First Assay', type: 'General', links: fromJS({ 'import': 'test1' }) }),
+            ],
+            definitionsLoadingState: LoadingState.LOADED,
+        });
+
+        const wrapper = mountWithServerContext(
+            <SampleAssayDetailButtons {...DEFAULT_PROPS} assayModel={assayModel} />,
+            { user: TEST_USER_AUTHOR }
+        );
+        validate(wrapper, 1);
+        expect(wrapper.find(Button).prop('href')).toBe('test1');
+        wrapper.unmount();
+    });
+});
+
+describe('SampleAssayDetailButtonsRight', () => {
+    test('isSourceSampleAssayGrid false', () => {
+        const wrapper = mountWithServerContext(
+            <SampleAssayDetailButtonsRight {...DEFAULT_PROPS} isSourceSampleAssayGrid={false} />,
+            { user: TEST_USER_READER }
+        );
+        expect(wrapper.find(SampleAliquotViewSelector)).toHaveLength(1);
+        expect(wrapper.find(SampleAliquotViewSelector).prop('headerLabel')).toBe('Show Assay Data with Samples');
+        expect(wrapper.find(SampleAliquotViewSelector).prop('samplesLabel')).toBe('Sample Only');
+        expect(wrapper.find(SampleAliquotViewSelector).prop('allLabel')).toBe('Sample or Aliquots');
+        wrapper.unmount();
+    });
+
+    test('isSourceSampleAssayGrid true', () => {
+        const wrapper = mountWithServerContext(
+            <SampleAssayDetailButtonsRight {...DEFAULT_PROPS} isSourceSampleAssayGrid={true} />,
+            { user: TEST_USER_READER }
+        );
+        expect(wrapper.find(SampleAliquotViewSelector)).toHaveLength(1);
+        expect(wrapper.find(SampleAliquotViewSelector).prop('headerLabel')).toBe('Show Assay Data with Source Samples');
+        expect(wrapper.find(SampleAliquotViewSelector).prop('samplesLabel')).toBe('Derived Samples Only');
+        expect(wrapper.find(SampleAliquotViewSelector).prop('allLabel')).toBe('Derived Samples or Aliquots');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
@@ -13,6 +13,11 @@ import { LoadingState } from '../../../public/LoadingState';
 import { TabbedGridPanel } from '../../../public/QueryModel/TabbedGridPanel';
 import { QueryInfo } from '../../../public/QueryInfo';
 
+import { mountWithServerContext, waitForLifecycle } from '../../testHelpers';
+import { TEST_USER_AUTHOR, TEST_USER_READER } from '../../../test/data/users';
+import { getTestAPIWrapper } from '../../APIWrapper';
+
+import { ALIQUOT_FILTER_MODE, SampleAliquotViewSelector } from './SampleAliquotViewSelector';
 import {
     AssayResultPanel,
     getSampleAssayDetailEmptyText,
@@ -22,23 +27,31 @@ import {
     SampleAssayDetailButtonsRight,
     SampleAssayDetailImpl,
 } from './SampleAssayDetail';
-import { ALIQUOT_FILTER_MODE, SampleAliquotViewSelector } from './SampleAliquotViewSelector';
-import { mountWithServerContext, waitForLifecycle } from '../../testHelpers';
-import { TEST_USER_AUTHOR, TEST_USER_READER } from '../../../test/data/users';
-import { getTestAPIWrapper } from '../../APIWrapper';
 import { getSamplesTestAPIWrapper } from './APIWrapper';
 
 const assayModel = new AssayStateModel({
     definitions: [
-        new AssayDefinitionModel({ id: 17, name: 'First Assay', type: 'General', links: fromJS({ 'import': 'test1' }) }),
-        new AssayDefinitionModel({ id: 41, name: 'NAb Assay', type: 'NAb', links: fromJS({ 'import': 'test2' }) }),
+        new AssayDefinitionModel({ id: 17, name: 'First Assay', type: 'General', links: fromJS({ import: 'test1' }) }),
+        new AssayDefinitionModel({ id: 41, name: 'NAb Assay', type: 'NAb', links: fromJS({ import: 'test2' }) }),
     ],
     definitionsLoadingState: LoadingState.LOADED,
 });
 const SQ = SchemaQuery.create('schema', 'query');
-const modelLoadedNoRows = makeTestQueryModel(SQ, new QueryInfo(), {}, [], 0).mutate({ queryInfoLoadingState: LoadingState.LOADED, rowsLoadingState: LoadingState.LOADED });
-const modelLoadedWithRow = makeTestQueryModel(SQ, new QueryInfo(), {1: { RowId: { value: 1 }, Name: { value: 'Name1' } }}, ['1'], 1).mutate({ queryInfoLoadingState: LoadingState.LOADED, rowsLoadingState: LoadingState.LOADED });
-const modelLoading = makeTestQueryModel(SQ).mutate({ queryInfoLoadingState: LoadingState.LOADED, rowsLoadingState: LoadingState.LOADING });
+const modelLoadedNoRows = makeTestQueryModel(SQ, new QueryInfo(), {}, [], 0).mutate({
+    queryInfoLoadingState: LoadingState.LOADED,
+    rowsLoadingState: LoadingState.LOADED,
+});
+const modelLoadedWithRow = makeTestQueryModel(
+    SQ,
+    new QueryInfo(),
+    { 1: { RowId: { value: 1 }, Name: { value: 'Name1' } } },
+    ['1'],
+    1
+).mutate({ queryInfoLoadingState: LoadingState.LOADED, rowsLoadingState: LoadingState.LOADED });
+const modelLoading = makeTestQueryModel(SQ).mutate({
+    queryInfoLoadingState: LoadingState.LOADED,
+    rowsLoadingState: LoadingState.LOADING,
+});
 const sampleModel = makeTestQueryModel(SQ);
 const model = makeTestQueryModel(SQ).mutate({ title: 'First Assay' });
 const DEFAULT_PROPS = {
@@ -55,30 +68,27 @@ describe('SampleAssayDetailButtons', () => {
     }
 
     test('without insert perm', () => {
-        const wrapper = mountWithServerContext(
-            <SampleAssayDetailButtons {...DEFAULT_PROPS} />,
-            { user: TEST_USER_READER }
-        );
+        const wrapper = mountWithServerContext(<SampleAssayDetailButtons {...DEFAULT_PROPS} />, {
+            user: TEST_USER_READER,
+        });
         validate(wrapper);
         wrapper.unmount();
     });
 
     test('currentAssayHref undefined', () => {
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'Other Assay' });
-        const wrapper = mountWithServerContext(
-            <SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />,
-            { user: TEST_USER_AUTHOR }
-        );
+        const wrapper = mountWithServerContext(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />, {
+            user: TEST_USER_AUTHOR,
+        });
         validate(wrapper);
         wrapper.unmount();
     });
 
     test('multiple menu items', () => {
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'NAb Assay' });
-        const wrapper = mountWithServerContext(
-            <SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />,
-            { user: TEST_USER_AUTHOR }
-        );
+        const wrapper = mountWithServerContext(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />, {
+            user: TEST_USER_AUTHOR,
+        });
         validate(wrapper, 2);
         expect(wrapper.find(SplitButton).prop('href')).toBe('test2');
         wrapper.unmount();
@@ -87,7 +97,12 @@ describe('SampleAssayDetailButtons', () => {
     test('one menu item', () => {
         const assayModel = new AssayStateModel({
             definitions: [
-                new AssayDefinitionModel({ id: 17, name: 'First Assay', type: 'General', links: fromJS({ 'import': 'test1' }) }),
+                new AssayDefinitionModel({
+                    id: 17,
+                    name: 'First Assay',
+                    type: 'General',
+                    links: fromJS({ import: 'test1' }),
+                }),
             ],
             definitionsLoadingState: LoadingState.LOADED,
         });
@@ -347,10 +362,13 @@ describe('SampleAssayDetailImpl', () => {
                 {...IMPL_PROPS}
                 api={getTestAPIWrapper({
                     samples: getSamplesTestAPIWrapper({
-                        getSampleAssayResultViewConfigs: () => Promise.resolve([{
-                            ...moduleAssayConfig,
-                            sampleRowKey: 'Name',
-                        }]),
+                        getSampleAssayResultViewConfigs: () =>
+                            Promise.resolve([
+                                {
+                                    ...moduleAssayConfig,
+                                    sampleRowKey: 'Name',
+                                },
+                            ]),
                     }),
                 })}
             />

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -27,8 +27,9 @@ import { getImportItemsForAssayDefinitions } from '../assay/actions';
 // These need to be direct imports from files to avoid circular dependencies in index.ts
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 
-import { getSampleAssayQueryConfigs, SampleAssayResultViewConfig } from './actions';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
+import { getSampleAssayQueryConfigs, SampleAssayResultViewConfig } from './actions';
 
 interface Props {
     api?: ComponentsAPIWrapper;
@@ -325,26 +326,27 @@ export const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
 
         api.samples
             .getSampleAliquotRows(sampleId)
-                .then(aliquots => {
-                    setAliquotRows(aliquots);
-                })
-                .catch(() => {
-                    createNotification({
-                        alertClass: 'danger',
-                        message: 'Unable to load sample aliquots. Your session may have expired.',
-                    });
+            .then(aliquots => {
+                setAliquotRows(aliquots);
+            })
+            .catch(() => {
+                createNotification({
+                    alertClass: 'danger',
+                    message: 'Unable to load sample aliquots. Your session may have expired.',
                 });
-            }, [sampleId, showAliquotViewSelector]);
+            });
+    }, [sampleId, showAliquotViewSelector]);
 
-    const [sampleAssayResultViewConfigs, setSampleAssayResultViewConfigs] = useState<SampleAssayResultViewConfig[]>(undefined);
+    const [sampleAssayResultViewConfigs, setSampleAssayResultViewConfigs] =
+        useState<SampleAssayResultViewConfig[]>(undefined);
     useEffect(() => {
         api.samples
             .getSampleAssayResultViewConfigs()
-                    .then(setSampleAssayResultViewConfigs)
-                    .catch(() => {
-                        setSampleAssayResultViewConfigs([]);
-                    });
-            }, []);
+            .then(setSampleAssayResultViewConfigs)
+            .catch(() => {
+                setSampleAssayResultViewConfigs([]);
+            });
+    }, []);
 
     const loadingDefinitions =
         isLoading(assayModel.definitionsLoadingState) || sampleAssayResultViewConfigs === undefined;

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -1,5 +1,6 @@
 import React, { FC, memo, useEffect, useMemo, useState, useCallback, ReactNode } from 'react';
 import { Button, MenuItem, Panel, SplitButton } from 'react-bootstrap';
+import { Filter, getServerContext } from '@labkey/api';
 
 import {
     Alert,
@@ -30,9 +31,8 @@ import {
     getSampleAliquots,
     getSampleAssayQueryConfigs,
     getSampleAssayResultViewConfigs,
-    SampleAssayResultViewConfig
+    SampleAssayResultViewConfig,
 } from './actions';
-import { Filter, getServerContext } from '@labkey/api';
 
 interface Props {
     sampleId?: string;
@@ -321,8 +321,7 @@ const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
     useEffect(() => {
         getSampleAssayResultViewConfigs()
             .then(setSampleAssayResultViewConfigs)
-            .catch(error => {
-                // TODO handle error
+            .catch(() => {
                 setSampleAssayResultViewConfigs([]);
             });
     }, []);

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -315,7 +315,8 @@ export const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
     );
 
     const isSourceSampleAssayGrid = useMemo(() => {
-        return sampleId === null && sourceSampleRows !== null;
+        // using type conversion comparison (i.e. == and !=) to check for both null and undefined
+        return sampleId == null && sourceSampleRows != null;
     }, [sampleId, sourceSampleRows]);
 
     const [aliquotRows, setAliquotRows] = useState<Record<string, any>[]>(undefined);

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -48,7 +48,7 @@ interface Props {
     emptySampleViewMsg?: string;
 }
 
-const AssayResultPanel: FC = ({ children }) => {
+export const AssayResultPanel: FC = ({ children }) => {
     return (
         <Panel>
             <Panel.Heading>Assay Results</Panel.Heading>
@@ -131,6 +131,27 @@ export const SampleAssayDetailButtonsRight: FC<SampleAssayDetailButtonsProps> = 
     );
 };
 
+// export for jest testing
+export const getSampleAssayDetailEmptyText = (
+    hasRows: boolean,
+    activeSampleAliquotType?: ALIQUOT_FILTER_MODE,
+    emptySampleViewMsg?: string,
+    emptyAliquotViewMsg?: string
+): string => {
+    if (!activeSampleAliquotType || activeSampleAliquotType === ALIQUOT_FILTER_MODE.all || hasRows) {
+        return undefined;
+    }
+
+    if (activeSampleAliquotType === ALIQUOT_FILTER_MODE.aliquots) {
+        return emptyAliquotViewMsg ?? 'No assay results available for aliquots of this sample.';
+    }
+
+    return (
+        emptySampleViewMsg ??
+        "Assay results are available for this sample's aliquots, but not available for this sample."
+    );
+};
+
 interface OwnProps {
     onSampleAliquotTypeChange?: (mode: ALIQUOT_FILTER_MODE) => any;
     activeSampleAliquotType?: ALIQUOT_FILTER_MODE;
@@ -142,7 +163,8 @@ interface OwnProps {
 
 type SampleAssayDetailBodyProps = Props & InjectedAssayModel & OwnProps;
 
-const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & InjectedQueryModels> = memo(props => {
+// export for jest testing
+export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & InjectedQueryModels> = memo(props => {
     const {
         actions,
         assayModel,
@@ -203,17 +225,12 @@ const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & InjectedQueryMo
 
     const getEmptyText = useCallback(
         activeModel => {
-            if (!activeSampleAliquotType || activeSampleAliquotType === ALIQUOT_FILTER_MODE.all || activeModel.hasRows)
-                return undefined;
-
-            if (activeSampleAliquotType === ALIQUOT_FILTER_MODE.aliquots) {
-                return emptyAliquotViewMsg ?? 'No assay results available for aliquots of this sample.';
-            } else {
-                return (
-                    emptySampleViewMsg ??
-                    "Assay results are available for this sample's aliquots, but not available for this sample."
-                );
-            }
+            return getSampleAssayDetailEmptyText(
+                activeModel?.hasRows,
+                activeSampleAliquotType,
+                emptySampleViewMsg,
+                emptyAliquotViewMsg
+            );
         },
         [activeSampleAliquotType, emptyAliquotViewMsg, emptySampleViewMsg]
     );
@@ -225,7 +242,7 @@ const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & InjectedQueryMo
             <AssayResultPanel>
                 <Alert bsStyle="warning">
                     There are no assay designs defined that reference this sample type as either a result field or run
-                    property
+                    property.
                 </Alert>
             </AssayResultPanel>
         );

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -71,7 +71,8 @@ interface SampleAssayDetailButtonsOwnProps {
 
 type SampleAssayDetailButtonsProps = SampleAssayDetailButtonsOwnProps & RequiresModelAndActions;
 
-const SampleAssayDetailButtons: FC<SampleAssayDetailButtonsProps> = props => {
+// exported for jest testing
+export const SampleAssayDetailButtons: FC<SampleAssayDetailButtonsProps> = props => {
     const { assayModel, model, sampleModel } = props;
     const { user } = useServerContext();
 
@@ -111,7 +112,8 @@ const SampleAssayDetailButtons: FC<SampleAssayDetailButtonsProps> = props => {
     }
 };
 
-const SampleAssayDetailButtonsRight: FC<SampleAssayDetailButtonsProps> = props => {
+// export for jest testing
+export const SampleAssayDetailButtonsRight: FC<SampleAssayDetailButtonsProps> = props => {
     const { activeSampleAliquotType, onSampleAliquotTypeChange, isSourceSampleAssayGrid } = props;
 
     return (

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -424,21 +424,25 @@ const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
             configs = { ...configs, ...unfilteredConfigs };
         }
 
-        // add in the config objects for those module defined sample assay result views (i.e. TargetedMS module),
+        // add in the config objects for those module-defined sample assay result views (e.g. TargetedMS module),
         // note that the moduleName from the config must be active/enabled in the container
         const activeModules = getServerContext().container.activeModules;
         sampleAssayResultViewConfigs.forEach(config => {
             if (activeModules?.indexOf(config.moduleName) > -1) {
+                const baseConfig = {
+                    title: config.title,
+                    schemaQuery: SchemaQuery.create(config.schemaName, config.queryName, config.viewName),
+                    containerFilter: config.containerFilter,
+                };
+
                 let modelId = `${ASSAY_GRID_ID_PREFIX}:${config.title}:${sampleId}`;
                 let sampleFilterValues = sampleRows.map(
                     row => caseInsensitive(row, config.sampleRowKey ?? 'RowId')?.value
                 );
                 configs[modelId] = {
+                    ...baseConfig,
                     id: modelId,
-                    title: config.title,
-                    schemaQuery: SchemaQuery.create(config.schemaName, config.queryName, config.viewName),
                     baseFilters: [Filter.create(config.filterKey, sampleFilterValues, Filter.Types.IN)],
-                    containerFilter: config.containerFilter,
                 };
 
                 if (includeUnfilteredConfigs) {
@@ -447,11 +451,9 @@ const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
                         row => caseInsensitive(row, config.sampleRowKey ?? 'RowId')?.value
                     );
                     configs[modelId] = {
+                        ...baseConfig,
                         id: modelId,
-                        title: config.title,
-                        schemaQuery: SchemaQuery.create(config.schemaName, config.queryName, config.viewName),
                         baseFilters: [Filter.create(config.filterKey, sampleFilterValues, Filter.Types.IN)],
-                        containerFilter: config.containerFilter,
                     };
                 }
             }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -733,22 +733,23 @@ export type SampleAssayResultViewConfig = {
     schemaName: string;
     queryName: string;
     viewName?: string;
-    sampleRowKey?: string; // sample row property to use for key in baseFilter, defaults to 'RowId'
+    sampleRowKey?: string; // sample row property to use for key in baseFilter, defaults to 'RowId' when value is undefined
     filterKey: string; // field key of the query/view to use for the sample filter IN clause
-    containerFilter?: Query.ContainerFilter; // Defaults to 'current'
+    containerFilter?: string; // Defaults to 'current' when value is undefined
 };
 
 export function getSampleAssayResultViewConfigs(): Promise<SampleAssayResultViewConfig[]> {
     return new Promise((resolve, reject) => {
-        resolve([]);
-        // resolve([{
-        //     title: 'Skyline Documents',
-        //     moduleName: 'TargetedMS',
-        //     schemaName: 'targetedms',
-        //     queryName: 'SampleFileAssayResults',
-        //     sampleRowKey: 'Name',
-        //     filterKey: 'SampleName',
-        //     containerFilter: Query.ContainerFilter.allFolders,
-        // }])
+        return Ajax.request({
+            url: buildURL('sampleManager', 'getSampleAssayResultsViewConfigs.api'),
+            method: 'GET',
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response.configs ?? []);
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                console.error(response);
+                reject(response);
+            }),
+        });
     });
 }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
 import { fromJS, List, Map, OrderedMap } from 'immutable';
+import { ActionURL, Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
 
 import { EntityChoice, EntityDataType, IEntityTypeDetails, IEntityTypeOption } from '../entities/models';
 import { deleteEntityType, getEntityTypeOptions } from '../entities/actions';
@@ -725,4 +725,30 @@ export function getSampleAliquotsQueryConfig(
             Filter.create('Lsid', sampleLsid, Filter.Types.EXP_CHILD_OF),
         ],
     };
+}
+
+export type SampleAssayResultViewConfig = {
+    title: string;
+    moduleName: string;
+    schemaName: string;
+    queryName: string;
+    viewName?: string;
+    sampleRowKey?: string; // sample row property to use for key in baseFilter, defaults to 'RowId'
+    filterKey: string; // field key of the query/view to use for the sample filter IN clause
+    containerFilter?: Query.ContainerFilter; // Defaults to 'current'
+};
+
+export function getSampleAssayResultViewConfigs(): Promise<SampleAssayResultViewConfig[]> {
+    return new Promise((resolve, reject) => {
+        resolve([]);
+        // resolve([{
+        //     title: 'Skyline Documents',
+        //     moduleName: 'TargetedMS',
+        //     schemaName: 'targetedms',
+        //     queryName: 'SampleFileAssayResults',
+        //     sampleRowKey: 'Name',
+        //     filterKey: 'SampleName',
+        //     containerFilter: Query.ContainerFilter.allFolders,
+        // }])
+    });
 }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -623,22 +623,19 @@ export function saveIdsToFind(fieldType: FindField, ids: string[], sessionKey: s
     });
 }
 
-export function getSampleAliquots(sampleId: number | string): Promise<number[]> {
+export function getSampleAliquotRows(sampleId: number | string): Promise<Record<string, any>[]> {
     return new Promise((resolve, reject) => {
         Query.executeSql({
             sql:
-                'SELECT m.RowId\n' +
+                'SELECT m.RowId, m.Name\n' +
                 'FROM exp.materials m \n' +
                 'WHERE m.RootMaterialLSID = (SELECT lsid FROM exp.materials mi WHERE mi.RowId = ' +
                 sampleId +
                 ')',
             schemaName: SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
+            requiredVersion: 17.1,
             success: result => {
-                const aliquotIds = [];
-                result.rows.forEach(row => {
-                    aliquotIds.push(caseInsensitive(row, 'RowId'));
-                });
-                resolve(aliquotIds);
+                resolve(result.rows);
             },
             failure: reason => {
                 console.error(reason);

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -128,16 +128,22 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
             <div className={classNames('tabbed-grid-panel__body', { 'panel-body': asPanel })}>
                 {(tabOrder.length > 1 || alwaysShowTabs) && (
                     <ul className="nav nav-tabs">
-                        {tabOrder.map(modelId => (
-                            <GridTab
-                                key={modelId}
-                                model={queryModels[modelId]}
-                                isActive={activeId === modelId}
-                                onSelect={onSelect}
-                                pullRight={rightTabs.indexOf(modelId) > -1}
-                                showRowCount={showRowCountOnTabs}
-                            />
-                        ))}
+                        {tabOrder.map(modelId => {
+                            if (queryModels[modelId]) {
+                                return (
+                                    <GridTab
+                                        key={modelId}
+                                        model={queryModels[modelId]}
+                                        isActive={activeId === modelId}
+                                        onSelect={onSelect}
+                                        pullRight={rightTabs.indexOf(modelId) > -1}
+                                        showRowCount={showRowCountOnTabs}
+                                    />
+                                );
+                            } else {
+                                return null;
+                            }
+                        })}
                     </ul>
                 )}
 


### PR DESCRIPTION
#### Rationale
We want to allow for non-standard assays (i.e. those defined in customModules but not part of the assay designer infrastructure) to have a chance to participate in the Sample > Assays tabbed grid view within the LKB and LKSM apps. This PR updates the SampleAssayDetail component to query for these module defined configs and add them to the TabbedGridPanel queryConfigs with the appropriate schema/query, filter, etc. for the given sample/source/aliquots.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/649
* https://github.com/LabKey/platform/pull/2667
* https://github.com/LabKey/targetedms/pull/436
* https://github.com/LabKey/sampleManagement/pull/719
* https://github.com/LabKey/biologics/pull/1019
* https://github.com/LabKey/dataintegration/pull/129

#### Changes
* SampleAssayDetail component update to account for queryConfigs based on the module defined configs
* add getSampleAssayResultViewConfigs() action to query for module defined configs
