### PR TITLE
Item 9584: ManageSampleStatusesPanel for sample statuses CRUD within a given container

### DIFF
--- a/packages/build/webpack/README.md
+++ b/packages/build/webpack/README.md
@@ -58,7 +58,7 @@ To configure a LabKey module to participant in the React page build process:
     and generated JS/CSS artifacts.
 
 You can see examples of each of these files in the following LabKey modules:
-[assay], [experiment], and [list].
+[assay], [experiment], and [pipeline].
 
 ### Building LabKey React pages
 
@@ -143,7 +143,7 @@ build before publishing a new `@labkey/build` version, you can do one of the fol
 [LabKey Gradle build]: https://www.labkey.org/Documentation/wiki-page.view?name=gradleBuild
 [assay]: https://github.com/LabKey/platform/tree/develop/assay
 [experiment]: https://github.com/LabKey/platform/tree/develop/experiment
-[list]: https://github.com/LabKey/platform/tree/develop/list
+[pipeline]: https://github.com/LabKey/platform/tree/develop/pipeline
 [experiment]: https://github.com/LabKey/platform/blob/develop/experiment/package.json
 [entryPoints.js]: https://github.com/LabKey/platform/blob/develop/experiment/src/client/entryPoints.js
 [.npmrc]: https://github.com/LabKey/platform/blob/develop/experiment/.npmrc

--- a/packages/build/webpack/README.md
+++ b/packages/build/webpack/README.md
@@ -27,13 +27,13 @@ and code live. Each `entryPoint` will have output files generated as part of the
 [LabKey Gradle build] steps for that module. The artifacts will be generated and placed into the
 standard LabKey `views` directory to make the pages available to the server through the module's
 controller. The generated `<entryPoint>.html` and `<entryPoint>.view.xml` files will be placed in the
-`<module>/resources/views` directory and the generated JS/CSS artifacts will be placed in the
-`<module>/resources/web/<module>/gen` directory.
+`<module>/resources/views/gen` directory and the generated JS/CSS artifacts will be placed in the
+`<module>/resources/web/gen` directory.
 
 If your `entryPoint` is to be used in a JSP or included in another LabKey page and you don't want to expose it
 directly as its own `view`, you can set the `generateLib` property for your `entryPoint`. This will generate
-the same JS/CSS artifacts in the `<module>/resources/web/<module>/gen` directory but will skip the `resources/views`
-generation step and instead create an `<entryPoint>.lib.xml` file in the `<module>/resources/web/<module>/gen` directory.
+the same JS/CSS artifacts in the `<module>/resources/web/gen` directory but will skip the `resources/views`
+generation step and instead create an `<entryPoint>.lib.xml` file in the `<module>/resources/web/gen` directory.
 This lib.xml can then be used in your JSP or other LabKey page. You can see an example of this in the experiment
 [entryPoints.js] file.
 

--- a/packages/build/webpack/README.md
+++ b/packages/build/webpack/README.md
@@ -16,10 +16,9 @@ module's `package.json` file at them.
     1. use one of the three configuration files based on your script target: `prod.config.js`, `dev.config.js`,
         or `watch.config.js`
     1. make sure to pass the following environment variables as part of your webpack command:
-        1.  `NODE_ENV` - development or production
-        1. `LK_MODULE_CONTAINER` - if your module is in a module container repository with other modules,
-            this is the name of the repository
-        1.  `LK_MODULE` - module name
+        1. `NODE_ENV` - development or production
+        2. `PROD_SOURCE_MAP` - optional source map setting for the production webpack config to use,
+           defaults to `nosources-source-map`
 
 ### How it works
 

--- a/packages/build/webpack/README.md
+++ b/packages/build/webpack/README.md
@@ -12,7 +12,7 @@ module's `package.json` file at them.
 
 1. Add the `@labkey/build` package to your module's `package.json` devDependencies.
 1. Add/update the `scripts` in your `package.json` to reference the relevant config file in
-    `node_modules/@labkey/build/webpack`. See examples from the [study] module.
+    `node_modules/@labkey/build/webpack`. See examples from the [experiment] module.
     1. use one of the three configuration files based on your script target: `prod.config.js`, `dev.config.js`,
         or `watch.config.js`
     1. make sure to pass the following environment variables as part of your webpack command:
@@ -42,7 +42,7 @@ This lib.xml can then be used in your JSP or other LabKey page. You can see an e
 
 To configure a LabKey module to participant in the React page build process:
 1. Add the following files to your module's main directory:
-    1. `package.json` - Defines your module's npm build scripts, see [study] module example, and npm package
+    1. `package.json` - Defines your module's npm build scripts, see [experiment] module example, and npm package
         dependencies. Note that after your first successful build of this module after adding this,
         a new `package-lock.json` file will be generated. You will want to add that file to your git repo
         and check it in as well. Note that in this file the `npm clean` command might need to be adjusted
@@ -144,7 +144,6 @@ build before publishing a new `@labkey/build` version, you can do one of the fol
 [assay]: https://github.com/LabKey/platform/tree/develop/assay
 [experiment]: https://github.com/LabKey/platform/tree/develop/experiment
 [list]: https://github.com/LabKey/platform/tree/develop/list
-[study]: https://github.com/LabKey/platform/blob/develop/study/package.json
+[experiment]: https://github.com/LabKey/platform/blob/develop/experiment/package.json
 [entryPoints.js]: https://github.com/LabKey/platform/blob/develop/experiment/src/client/entryPoints.js
-[.npmrc]: https://github.com/LabKey/platform/blob/develop/study/.npmrc
-[tsconfig.json]: https://github.com/LabKey/platform/blob/develop/study/tsconfig.json
+[.npmrc]: https://github.com/LabKey/platform/blob/develop/experiment/.npmrc

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.85.0",
+  "version": "2.85.0-fb-smManageStatuses.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.84.0-fb-smManageStatuses.4",
+  "version": "2.84.0-fb-smManageStatuses.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.85.0-fb-smManageStatuses.4",
+  "version": "2.86.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.84.0-fb-smManageStatuses.3",
+  "version": "2.84.0-fb-smManageStatuses.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.84.0",
+  "version": "2.84.0-fb-smManageStatuses.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.85.0-fb-smManageStatuses.0",
+  "version": "2.85.0-fb-smManageStatuses.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.84.0-fb-smManageStatuses.1",
+  "version": "2.84.0-fb-smManageStatuses.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.85.0-fb-smManageStatuses.2",
+  "version": "2.85.0-fb-smManageStatuses.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.84.0-fb-smManageStatuses.2",
+  "version": "2.84.0-fb-smManageStatuses.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.85.0-fb-smManageStatuses.3",
+  "version": "2.85.0-fb-smManageStatuses.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.84.0-fb-smManageStatuses.0",
+  "version": "2.84.0-fb-smManageStatuses.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.85.0-fb-smManageStatuses.1",
+  "version": "2.85.0-fb-smManageStatuses.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.96.0
+### version 2.86.0
 *Released*: 22 October 2021
 * Item 9584: ManageSampleStatusesPanel for sample statuses CRUD operations
   * Update APIWrapper to take mockFn as a param instead of adding jest dependency directly

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD October 2021
-* Item 9584: ManageSampleStatesPanel to display, update, add, remove sample statuses for a container
+* Item 9584: ManageSampleStatusesPanel for sample statuses CRUD operations
+  * Update APIWrapper to take mockFn as a param instead of adding jest dependency directly
+  * getSampleStatuses action to call API and return SampleState array
+  * NameIdSettings component update to support optional titleCls prop
 
 ### version 2.85.0
 *Released*: 18 October 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2021
+* Item 9584: ManageSampleStatesPanel to display, update, add, remove sample statuses for a container
+
 ### version 2.84.0
 *Released*: 14 October 2021
 * Item 9440: Enable picklists for LKB

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2021
+### version 2.96.0
+*Released*: 22 October 2021
 * Item 9584: ManageSampleStatusesPanel for sample statuses CRUD operations
   * Update APIWrapper to take mockFn as a param instead of adding jest dependency directly
   * getSampleStatuses action to call API and return SampleState array

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -487,6 +487,7 @@ import {
 } from './internal/components/samples/models';
 import { DisableableMenuItem } from './internal/components/samples/DisableableMenuItem';
 import { SampleStatusTag } from './internal/components/samples/SampleStatusTag';
+import { ManageSampleStatesPanel } from './internal/components/samples/ManageSampleStatesPanel';
 import {
     FIND_BY_IDS_QUERY_PARAM,
     SAMPLE_ID_FIND_FIELD,
@@ -932,6 +933,7 @@ export {
     SAMPLE_INVENTORY_ITEM_SELECTION_KEY,
     getFindSamplesByIdData,
     getOmittedSampleTypeColumns,
+    ManageSampleStatesPanel,
     // entities
     EntityTypeDeleteConfirmModal,
     EntityDeleteConfirmModal,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -487,7 +487,7 @@ import {
 } from './internal/components/samples/models';
 import { DisableableMenuItem } from './internal/components/samples/DisableableMenuItem';
 import { SampleStatusTag } from './internal/components/samples/SampleStatusTag';
-import { ManageSampleStatesPanel } from './internal/components/samples/ManageSampleStatesPanel';
+import { ManageSampleStatusesPanel } from './internal/components/samples/ManageSampleStatusesPanel';
 import {
     FIND_BY_IDS_QUERY_PARAM,
     SAMPLE_ID_FIND_FIELD,
@@ -933,7 +933,7 @@ export {
     SAMPLE_INVENTORY_ITEM_SELECTION_KEY,
     getFindSamplesByIdData,
     getOmittedSampleTypeColumns,
-    ManageSampleStatesPanel,
+    ManageSampleStatusesPanel,
     // entities
     EntityTypeDeleteConfirmModal,
     EntityDeleteConfirmModal,

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -11,9 +11,12 @@ export function getDefaultAPIWrapper(): ComponentsAPIWrapper {
     };
 }
 
-export function getTestAPIWrapper(overrides: Partial<ComponentsAPIWrapper> = {}): ComponentsAPIWrapper {
+/**
+ * Note: Intentionally does not use jest.fn() to avoid jest becoming an implicit external package dependency.
+ */
+export function getTestAPIWrapper(mockFn = (): any => () => {}, overrides: Partial<ComponentsAPIWrapper> = {}): ComponentsAPIWrapper {
     return {
-        samples: getSamplesTestAPIWrapper(overrides.samples),
+        samples: getSamplesTestAPIWrapper(mockFn, overrides.samples),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -14,7 +14,10 @@ export function getDefaultAPIWrapper(): ComponentsAPIWrapper {
 /**
  * Note: Intentionally does not use jest.fn() to avoid jest becoming an implicit external package dependency.
  */
-export function getTestAPIWrapper(mockFn = (): any => () => {}, overrides: Partial<ComponentsAPIWrapper> = {}): ComponentsAPIWrapper {
+export function getTestAPIWrapper(
+    mockFn = (): any => () => {},
+    overrides: Partial<ComponentsAPIWrapper> = {}
+): ComponentsAPIWrapper {
     return {
         samples: getSamplesTestAPIWrapper(mockFn, overrides.samples),
         ...overrides,

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -87,7 +87,7 @@ export const BIOLOGICS_APP_PROPERTIES : AppProperties = {
     logoBadgeImageUrl: imageURL('biologics/images', 'lk-bio-logo-badge.svg'),
     controllerName: BIOLOGICS_CONTROLLER_NAME,
     moduleName: 'biologics',
-}
+};
 
 export const SAMPLE_MANAGER_APP_PROPERTIES: AppProperties = {
     productId: SAMPLE_MANAGER_PRODUCT_ID,
@@ -96,7 +96,7 @@ export const SAMPLE_MANAGER_APP_PROPERTIES: AppProperties = {
     logoBadgeImageUrl: imageURL('sampleManagement/images', 'LK-SampleManager-Badge-WHITE.svg'),
     controllerName: SAMPLE_MANAGER_CONTROLLER_NAME,
     moduleName: 'sampleManagement',
-}
+};
 
 export const FREEZER_MANAGER_APP_PROPERTIES: AppProperties = {
     productId: FREEZER_MANAGER_PRODUCT_ID,
@@ -104,5 +104,5 @@ export const FREEZER_MANAGER_APP_PROPERTIES: AppProperties = {
     logoWithTextImageUrl: imageURL('_images', 'LK-noTAG-overcast.svg'),
     logoBadgeImageUrl: imageURL('_images', 'mobile-logo-overcast.svg'),
     controllerName: FREEZER_MANAGER_CONTROLLER_NAME,
-    moduleName: 'inventory'
-}
+    moduleName: 'inventory',
+};

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -3,8 +3,10 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { AppURL } from '../url/AppURL';
-import { AppProperties } from './models';
+
 import { imageURL } from '../url/ActionURL';
+
+import { AppProperties } from './models';
 
 // These ids should match what is used by the MenuProviders in the Java code so we can avoid toLowerCase comparisons.
 export const LKS_PRODUCT_ID = 'LabKeyServer';
@@ -15,11 +17,11 @@ const FREEZER_MANAGER_PRODUCT_ID = 'FreezerManager';
 const SAMPLE_MANAGER_PRODUCT_NAME = 'Sample Manager';
 const BIOLOGICS_PRODUCT_NAME = 'Biologics';
 export const LABKEY_SERVER_PRODUCT_NAME = 'LabKey Server';
-const FREEZER_MANAGER_PRODUCT_NAME = "Freezer Manager";
+const FREEZER_MANAGER_PRODUCT_NAME = 'Freezer Manager';
 
-const BIOLOGICS_CONTROLLER_NAME = "biologics";
-const SAMPLE_MANAGER_CONTROLLER_NAME = "sampleManager";
-const FREEZER_MANAGER_CONTROLLER_NAME = "freezerManager";
+const BIOLOGICS_CONTROLLER_NAME = 'biologics';
+const SAMPLE_MANAGER_CONTROLLER_NAME = 'sampleManager';
+const FREEZER_MANAGER_CONTROLLER_NAME = 'freezerManager';
 
 export const ASSAYS_KEY = 'assays';
 export const ASSAY_DESIGN_KEY = 'assayDesign';
@@ -37,7 +39,7 @@ export const FIND_SAMPLES_KEY = 'findSamples';
 export const REQUESTS_KEY = 'requests';
 export const MEDIA_KEY = 'media';
 export const NOTEBOOKS_KEY = 'notebooks';
-export const REGISTRY_KEY ='registry';
+export const REGISTRY_KEY = 'registry';
 
 export const FIND_SAMPLES_HREF = AppURL.create(FIND_SAMPLES_KEY);
 export const NEW_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new');
@@ -80,7 +82,7 @@ export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';
 
-export const BIOLOGICS_APP_PROPERTIES : AppProperties = {
+export const BIOLOGICS_APP_PROPERTIES: AppProperties = {
     productId: BIOLOGICS_PRODUCT_ID,
     name: BIOLOGICS_PRODUCT_NAME,
     logoWithTextImageUrl: imageURL('biologics/images', 'lk-bio-logo-text.svg'),

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -198,7 +198,7 @@ export class BarChartViewer extends PureComponent<Props, State> {
                     barFillColors={barFillColors}
                     data={data}
                     defaultBorderColor="#555"
-                    onClick={this.onBarClick}
+                    onClick={selectedGroup.getAppURL ? this.onBarClick : undefined}
                     title={`${selectedGroup.label} (${currentChartOptions.label})`}
                 />
             );
@@ -223,16 +223,18 @@ export class BarChartViewer extends PureComponent<Props, State> {
                                 </MenuItem>
                             ))}
                         </DropdownButton>
-                        <DropdownButton id="sample-set-selected-chart-menu" title={currentChartOptions.label}>
-                            {selectedCharts.map((chart, i) => (
-                                <MenuItem active={currentChart === i} key={i} onClick={() => this.selectChart(i)}>
-                                    {chart.label}
-                                </MenuItem>
-                            ))}
-                        </DropdownButton>
+                        {selectedCharts?.length > 1 && (
+                            <DropdownButton id="sample-set-selected-chart-menu" title={currentChartOptions.label}>
+                                {selectedCharts.map((chart, i) => (
+                                    <MenuItem active={currentChart === i} key={i} onClick={() => this.selectChart(i)}>
+                                        {chart.label}
+                                    </MenuItem>
+                                ))}
+                            </DropdownButton>
+                        )}
                     </div>
                 )}
-                {!hasError && (
+                {!hasError && selectedCharts?.length > 1 && (
                     <div className="btn-group pull-right">
                         <Tip caption="Previous">
                             <Button disabled={currentChart === 0} onClick={this.prevChart}>

--- a/packages/components/src/internal/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/internal/components/chart/BaseBarChart.tsx
@@ -12,7 +12,7 @@ interface Props {
     data: ChartData[];
     defaultBorderColor?: string;
     defaultFillColor?: string;
-    onClick: (evt: any, row: any) => void;
+    onClick?: (evt: any, row: any) => void;
     title: string;
 }
 

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -47,4 +47,18 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         queryName: 'SampleSetCounts',
         schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
     },
+    SampleStatuses: {
+        charts: [
+            CHART_SELECTORS.All,
+        ],
+        colorPath: ['Color', 'value'],
+        createText: 'Create Samples',
+        createURL: () => App.NEW_SAMPLES_HREF,
+        // getAppURL: row => AppURL.create(SAMPLES_KEY),
+        itemCountSQ: SCHEMAS.CORE_TABLES.DATA_STATES,
+        key: SAMPLES_KEY,
+        label: 'Sample Count by Status',
+        queryName: 'SampleStatusCounts',
+        schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
+    },
 };

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -48,9 +48,7 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
     },
     SampleStatuses: {
-        charts: [
-            CHART_SELECTORS.All,
-        ],
+        charts: [CHART_SELECTORS.All],
         colorPath: ['Color', 'value'],
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,

--- a/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditMenuItem.tsx
@@ -3,8 +3,9 @@ import { MenuItem } from 'react-bootstrap';
 
 import { AuditBehaviorTypes } from '@labkey/api';
 
-import { capitalizeFirstChar, EntityDataType, QueryModel, SelectionMenuItem } from '../../..';
+import { capitalizeFirstChar, QueryModel, SelectionMenuItem } from '../../..';
 
+import { EntityDataType } from './models';
 import { EntityLineageEditModal } from './EntityLineageEditModal';
 
 interface Props {

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.spec.tsx
@@ -68,8 +68,8 @@ const DEFAULT_PROPS = {
     onSuccess: jest.fn,
     childEntityDataType: SampleTypeDataType,
     parentEntityDataTypes: [SampleTypeDataType, DataClassDataType],
-    api: getTestAPIWrapper({
-        samples: getSamplesTestAPIWrapper({
+    api: getTestAPIWrapper(jest.fn, {
+        samples: getSamplesTestAPIWrapper(jest.fn, {
             getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITHOUT_ALIQUOTS),
         }),
     }),
@@ -104,8 +104,8 @@ describe('EntityLineageEditModal', () => {
             <EntityLineageEditModal
                 {...DEFAULT_PROPS}
                 queryModel={MODEL}
-                api={getTestAPIWrapper({
-                    samples: getSamplesTestAPIWrapper({
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
                         getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_WITH_ALIQUOTS),
                     }),
                 })}
@@ -126,8 +126,8 @@ describe('EntityLineageEditModal', () => {
             <EntityLineageEditModal
                 {...DEFAULT_PROPS}
                 queryModel={MODEL}
-                api={getTestAPIWrapper({
-                    samples: getSamplesTestAPIWrapper({
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
                         getSampleSelectionLineageData: () => Promise.resolve(LINEAGE_DATA_ALL_ALIQUOTS),
                     }),
                 })}

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -12,7 +12,6 @@ import {
     caseInsensitive,
     createNotification,
     LoadingSpinner,
-    ParentEntityEditPanel,
     Progress,
     QueryModel,
     resolveErrorMessage,
@@ -21,12 +20,13 @@ import {
 
 import { getOriginalParentsFromSampleLineage } from '../samples/actions';
 
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-
 import { EntityChoice, EntityDataType } from './models';
 import { getEntityNoun, getUpdatedLineageRowsForBulkEdit } from './utils';
 
 import { ParentEntityLineageColumns } from './constants';
+import { ParentEntityEditPanel } from './ParentEntityEditPanel';
+
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface Props {
     queryModel: QueryModel;

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -44,8 +44,8 @@ export const PicklistList: FC<PicklistListProps> = memo(props => {
                     onClick={onSelect.bind(this, item)}
                     type="button"
                 >
-                    {showSharedIcon && item.isPublic() && <span className="fa fa-users" />}
                     {item.name}
+                    {showSharedIcon && item.isPublic() && <span className="fa fa-users pull-right" title="Team Picklist" />}
                 </button>
             ))}
             {items.length === 0 && <p className="choices-list__empty-message">{emptyMessage}</p>}

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -45,7 +45,9 @@ export const PicklistList: FC<PicklistListProps> = memo(props => {
                     type="button"
                 >
                     {item.name}
-                    {showSharedIcon && item.isPublic() && <span className="fa fa-users pull-right" title="Team Picklist" />}
+                    {showSharedIcon && item.isPublic() && (
+                        <span className="fa fa-users pull-right" title="Team Picklist" />
+                    )}
                 </button>
             ))}
             {items.length === 0 && <p className="choices-list__empty-message">{emptyMessage}</p>}

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -6,7 +6,7 @@ import {
     getSampleAliquotRows,
     getSampleAssayResultViewConfigs,
     getSampleSelectionLineageData,
-    getSampleStates,
+    getSampleStatuses,
     SampleAssayResultViewConfig,
     SampleState,
 } from './actions';
@@ -22,14 +22,14 @@ export interface SamplesAPIWrapper {
         columns?: string[]
     ) => Promise<ISelectRowsResult>;
 
-    getSampleStates: () => Promise<SampleState[]>;
+    getSampleStatuses: () => Promise<SampleState[]>;
 }
 
 export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
     getSampleAliquotRows = getSampleAliquotRows;
     getSampleAssayResultViewConfigs = getSampleAssayResultViewConfigs;
     getSampleSelectionLineageData = getSampleSelectionLineageData;
-    getSampleStates = getSampleStates;
+    getSampleStatuses = getSampleStatuses;
 }
 
 export function getSamplesTestAPIWrapper(overrides: Partial<SamplesAPIWrapper> = {}): SamplesAPIWrapper {
@@ -37,7 +37,7 @@ export function getSamplesTestAPIWrapper(overrides: Partial<SamplesAPIWrapper> =
         getSampleAliquotRows: jest.fn(),
         getSampleAssayResultViewConfigs: jest.fn(),
         getSampleSelectionLineageData: jest.fn(),
-        getSampleStates: jest.fn(),
+        getSampleStatuses: jest.fn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -6,7 +6,9 @@ import {
     getSampleAliquotRows,
     getSampleAssayResultViewConfigs,
     getSampleSelectionLineageData,
+    getSampleStates,
     SampleAssayResultViewConfig,
+    SampleState,
 } from './actions';
 
 export interface SamplesAPIWrapper {
@@ -19,12 +21,15 @@ export interface SamplesAPIWrapper {
         sampleType: string,
         columns?: string[]
     ) => Promise<ISelectRowsResult>;
+
+    getSampleStates: () => Promise<SampleState[]>;
 }
 
 export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
     getSampleAliquotRows = getSampleAliquotRows;
     getSampleAssayResultViewConfigs = getSampleAssayResultViewConfigs;
     getSampleSelectionLineageData = getSampleSelectionLineageData;
+    getSampleStates = getSampleStates;
 }
 
 export function getSamplesTestAPIWrapper(overrides: Partial<SamplesAPIWrapper> = {}): SamplesAPIWrapper {
@@ -32,6 +37,7 @@ export function getSamplesTestAPIWrapper(overrides: Partial<SamplesAPIWrapper> =
         getSampleAliquotRows: jest.fn(),
         getSampleAssayResultViewConfigs: jest.fn(),
         getSampleSelectionLineageData: jest.fn(),
+        getSampleStates: jest.fn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -8,8 +8,8 @@ import {
     getSampleSelectionLineageData,
     getSampleStatuses,
     SampleAssayResultViewConfig,
-    SampleState,
 } from './actions';
+import { SampleState } from './models';
 
 export interface SamplesAPIWrapper {
     getSampleAliquotRows: (sampleId: number | string) => Promise<Record<string, any>[]>;

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -32,12 +32,15 @@ export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
     getSampleStatuses = getSampleStatuses;
 }
 
-export function getSamplesTestAPIWrapper(overrides: Partial<SamplesAPIWrapper> = {}): SamplesAPIWrapper {
+/**
+ * Note: Intentionally does not use jest.fn() to avoid jest becoming an implicit external package dependency.
+ */
+export function getSamplesTestAPIWrapper(mockFn = (): any => () => {}, overrides: Partial<SamplesAPIWrapper> = {}): SamplesAPIWrapper {
     return {
-        getSampleAliquotRows: jest.fn(),
-        getSampleAssayResultViewConfigs: jest.fn(),
-        getSampleSelectionLineageData: jest.fn(),
-        getSampleStatuses: jest.fn(),
+        getSampleAliquotRows: mockFn(),
+        getSampleAssayResultViewConfigs: mockFn(),
+        getSampleSelectionLineageData: mockFn(),
+        getSampleStatuses: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -35,7 +35,10 @@ export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
 /**
  * Note: Intentionally does not use jest.fn() to avoid jest becoming an implicit external package dependency.
  */
-export function getSamplesTestAPIWrapper(mockFn = (): any => () => {}, overrides: Partial<SamplesAPIWrapper> = {}): SamplesAPIWrapper {
+export function getSamplesTestAPIWrapper(
+    mockFn = (): any => () => {},
+    overrides: Partial<SamplesAPIWrapper> = {}
+): SamplesAPIWrapper {
     return {
         getSampleAliquotRows: mockFn(),
         getSampleAssayResultViewConfigs: mockFn(),

--- a/packages/components/src/internal/components/samples/ManageSampleStatesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatesPanel.tsx
@@ -1,0 +1,234 @@
+import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { FormGroup } from 'react-bootstrap';
+import classNames from 'classnames';
+
+import { LoadingSpinner } from '../base/LoadingSpinner';
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
+import { Alert } from '../base/Alert';
+import { LockIcon } from '../base/LockIcon';
+
+import { SampleState } from './actions';
+import { AddEntityButton } from '../buttons/AddEntityButton';
+import { DomainFieldLabel } from '../domainproperties/DomainFieldLabel';
+import { SchemaQuery } from '../../../public/SchemaQuery';
+import { SelectInput } from '../forms/input/SelectInput';
+import { selectRows } from '../../query/api';
+import { caseInsensitive } from '../../util/utils';
+
+const TITLE = 'Manage Sample Statuses';
+const STATE_TYPE_SQ = SchemaQuery.create('exp', 'SampleStateType');
+const DEFAULT_TYPE_OPTIONS = [{ value: 'Available' }, { value: 'Consumed' }, { value: 'Locked' }];
+const NEW_STATUS_INDEX = -1;
+
+interface Props {
+    api?: ComponentsAPIWrapper;
+    titleCls?: string;
+}
+
+export const ManageSampleStatesPanel: FC<Props> = memo(props => {
+    const { api, titleCls } = props;
+    const [states, setStates] = useState<SampleState[]>();
+    const [error, setError] = useState<string>();
+    const [selected, setSelected] = useState<number>();
+    const addNew = useMemo(() => selected === NEW_STATUS_INDEX, [selected]);
+
+    useEffect(() => {
+        api.samples
+            .getSampleStates()
+            .then(setStates)
+            .catch(() => {
+                setStates([]);
+                setError('Error: Unable to load sample states.');
+            });
+    }, [api]);
+
+    const onSetSelected = useCallback((index: number) => {
+        setSelected(index);
+    }, []);
+
+    const onAddState = useCallback(() => {
+        setSelected(NEW_STATUS_INDEX);
+    }, []);
+
+    return (
+        <div className="panel panel-default">
+            {!titleCls && <div className="panel-heading">{TITLE}</div>}
+            <div className="panel-body">
+                {titleCls && <h4 className={titleCls}>{TITLE}</h4>}
+                {error && <Alert>{error}</Alert>}
+                {!states && <LoadingSpinner />}
+                {states && (
+                    <div className="row choices-container">
+                        <div className="col-lg-4 col-md-6">
+                            <SampleStatesList states={states} selected={selected} onSelect={onSetSelected} />
+                            <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />
+                        </div>
+                        <div className="col-lg-8 col-md-6">
+                            <SampleStateDetail state={states[selected]} addNew={addNew} />
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+});
+
+ManageSampleStatesPanel.defaultProps = {
+    api: getDefaultAPIWrapper(),
+};
+
+ManageSampleStatesPanel.displayName = 'ManageSampleStatesPanel';
+
+interface SampleStatesListProps {
+    onSelect: (index: number) => void;
+    selected: number;
+    states: SampleState[];
+}
+
+const SampleStatesList: FC<SampleStatesListProps> = memo(props => {
+    const { states, onSelect, selected } = props;
+
+    return (
+        <div className="list-group">
+            {states.map((state, index) => <SampleStatesListItem state={state} index={index} active={index === selected} onSelect={onSelect} />)}
+            {states.length === 0 && <p className="choices-list__empty-message">No sample states defined.</p>}
+        </div>
+    );
+});
+SampleStatesList.displayName = 'SampleStatesList';
+
+interface SampleStatesListItemProps {
+    active?: boolean;
+    index: number;
+    onSelect: (index: number) => void;
+    state: SampleState;
+}
+
+const SampleStatesListItem: FC<SampleStatesListItemProps> = memo(props => {
+    const { state, index, active, onSelect } = props;
+    const onClick = useCallback(() => {
+        onSelect(index);
+    }, [onSelect, index]);
+
+    return (
+        <button className={classNames('list-group-item', { active })} onClick={onClick} type="button">
+            {state.label}
+            {state.stateType !== state.label && <span className="choices-list__item-type">{state.stateType}</span>}
+            {state.inUse && (
+                <LockIcon
+                    iconCls="pull-right"
+                    body={
+                        <p>This sample state is in-use so its type cannot be changed and it cannot be removed.</p>
+                    }
+                    id="sample-state-lock-icon"
+                    title="Sample State Locked"
+                />
+            )}
+        </button>
+    );
+});
+SampleStatesList.displayName = 'SampleStatesList';
+
+interface SampleStateDetailProps {
+    addNew: boolean;
+    state: SampleState;
+}
+
+const SampleStateDetail: FC<SampleStateDetailProps> = memo(props => {
+    const { state, addNew } = props;
+    const [typeOptions, setTypeOptions] = useState<Record<string, any>[]>();
+    const [updatedState, setUpdatedState] = useState<SampleState>();
+
+    useEffect(() => {
+        selectRows({
+            schemaName: STATE_TYPE_SQ.schemaName,
+            queryName: STATE_TYPE_SQ.queryName,
+            columns: 'RowId,Value',
+        })
+            .then(({ key, models, orderedModels }) => {
+                const data = orderedModels[key]
+                    .map(id => {
+                        return { value: caseInsensitive(models[key][id], 'Value').value };
+                    })
+                    .toArray();
+                setTypeOptions(data);
+            })
+            .catch(error => {
+                console.error(error);
+                setTypeOptions(DEFAULT_TYPE_OPTIONS);
+            });
+    }, []);
+
+    useEffect(() => {
+        if (state) setUpdatedState(state);
+        if (addNew) setUpdatedState(new SampleState({ stateType: typeOptions?.[0]?.value }))
+    }, [state, addNew]);
+
+    const onFormChange = useCallback((evt): void => {
+        const {name, value} = evt.target;
+        setUpdatedState(updatedState.set(name, value));
+    }, [updatedState]);
+
+    const onSelectChange = useCallback((name, value): void => {
+        setUpdatedState(updatedState.set(name, value));
+    }, [updatedState]);
+
+    return (
+        <>
+            {!updatedState && <p className="choices-detail__empty-message">Select a sample status to view details.</p>}
+            {updatedState && (
+                <form className="form-horizontal content-form">
+                    <FormGroup>
+                        <div className="col-sm-4">
+                            <DomainFieldLabel label="Label" required />
+                        </div>
+                        <div className="col-sm-8">
+                            <input
+                                className="form-control"
+                                name="label"
+                                onChange={onFormChange}
+                                placeholder="Enter status label"
+                                // ref={nameRef}
+                                type="text"
+                                value={updatedState.label ?? ''}
+                            />
+                        </div>
+                    </FormGroup>
+                    <FormGroup>
+                        <div className="col-sm-4">
+                            <DomainFieldLabel label="Description" />
+                        </div>
+                        <div className="col-sm-8">
+                            <textarea
+                                className="form-control"
+                                name="description"
+                                onChange={onFormChange}
+                                value={updatedState.description ?? ''}
+                            />
+                        </div>
+                    </FormGroup>
+                    <FormGroup>
+                        <div className="col-sm-4">
+                            <DomainFieldLabel label="Status Type" required />
+                        </div>
+                        <div className="col-sm-8">
+                            <SelectInput
+                                name="stateType"
+                                inputClass="col-sm-12"
+                                labelKey="value"
+                                clearable={false}
+                                onChange={onSelectChange}
+                                disabled={updatedState.inUse}
+                                options={typeOptions}
+                                value={updatedState.stateType}
+                            />
+                        </div>
+                    </FormGroup>
+                </form>
+            )}
+        </>
+    );
+});
+SampleStateDetail.displayName = 'SampleStateDetail';

--- a/packages/components/src/internal/components/samples/ManageSampleStatesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatesPanel.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { FormGroup } from 'react-bootstrap';
+import { FormGroup, Button } from 'react-bootstrap';
+import { List } from 'immutable';
 import classNames from 'classnames';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
@@ -9,13 +10,16 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 import { Alert } from '../base/Alert';
 import { LockIcon } from '../base/LockIcon';
 
-import { SampleState } from './actions';
 import { AddEntityButton } from '../buttons/AddEntityButton';
 import { DomainFieldLabel } from '../domainproperties/DomainFieldLabel';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SelectInput } from '../forms/input/SelectInput';
-import { selectRows } from '../../query/api';
+import { selectRows, updateRows, insertRows, deleteRows } from '../../query/api';
 import { caseInsensitive } from '../../util/utils';
+import { SCHEMAS } from '../../schemas';
+import { resolveErrorMessage } from '../../util/messaging';
+
+import { SampleState } from './actions';
 
 const TITLE = 'Manage Sample Statuses';
 const STATE_TYPE_SQ = SchemaQuery.create('exp', 'SampleStateType');
@@ -34,15 +38,22 @@ export const ManageSampleStatesPanel: FC<Props> = memo(props => {
     const [selected, setSelected] = useState<number>();
     const addNew = useMemo(() => selected === NEW_STATUS_INDEX, [selected]);
 
-    useEffect(() => {
+    const querySampleStates = useCallback((newStatusLabel?: string) => {
         api.samples
             .getSampleStates()
-            .then(setStates)
+            .then((sampleStates => {
+                setStates(sampleStates);
+                if (newStatusLabel) setSelected(sampleStates.findIndex(state => state.label === newStatusLabel));
+            }))
             .catch(() => {
                 setStates([]);
                 setError('Error: Unable to load sample states.');
             });
     }, [api]);
+
+    useEffect(() => {
+        querySampleStates();
+    }, [querySampleStates]);
 
     const onSetSelected = useCallback((index: number) => {
         setSelected(index);
@@ -51,6 +62,10 @@ export const ManageSampleStatesPanel: FC<Props> = memo(props => {
     const onAddState = useCallback(() => {
         setSelected(NEW_STATUS_INDEX);
     }, []);
+
+    const onSaveSuccess = useCallback((newStatusLabel?: string) => {
+        querySampleStates(newStatusLabel);
+    }, [querySampleStates, states, addNew]);
 
     return (
         <div className="panel panel-default">
@@ -66,7 +81,7 @@ export const ManageSampleStatesPanel: FC<Props> = memo(props => {
                             <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />
                         </div>
                         <div className="col-lg-8 col-md-6">
-                            <SampleStateDetail state={states[selected]} addNew={addNew} />
+                            <SampleStateDetail state={states[selected]} addNew={addNew} onSaveSuccess={onSaveSuccess} />
                         </div>
                     </div>
                 )}
@@ -92,7 +107,9 @@ const SampleStatesList: FC<SampleStatesListProps> = memo(props => {
 
     return (
         <div className="list-group">
-            {states.map((state, index) => <SampleStatesListItem state={state} index={index} active={index === selected} onSelect={onSelect} />)}
+            {states.map((state, index) => (
+                <SampleStatesListItem state={state} index={index} active={index === selected} onSelect={onSelect} />
+            ))}
             {states.length === 0 && <p className="choices-list__empty-message">No sample states defined.</p>}
         </div>
     );
@@ -120,7 +137,9 @@ const SampleStatesListItem: FC<SampleStatesListItemProps> = memo(props => {
                 <LockIcon
                     iconCls="pull-right"
                     body={
-                        <p>This sample state is in-use so its type cannot be changed and it cannot be removed.</p>
+                        <p>
+                            This sample state is in-use so its status type cannot be changed and it cannot be removed.
+                        </p>
                     }
                     id="sample-state-lock-icon"
                     title="Sample State Locked"
@@ -133,13 +152,17 @@ SampleStatesList.displayName = 'SampleStatesList';
 
 interface SampleStateDetailProps {
     addNew: boolean;
+    onSaveSuccess: (newStatusLabel?: string) => void;
     state: SampleState;
 }
 
 const SampleStateDetail: FC<SampleStateDetailProps> = memo(props => {
-    const { state, addNew } = props;
-    const [typeOptions, setTypeOptions] = useState<Record<string, any>[]>();
+    const { state, addNew, onSaveSuccess } = props;
+    const [typeOptions, setTypeOptions] = useState<Array<Record<string, any>>>();
     const [updatedState, setUpdatedState] = useState<SampleState>();
+    const [dirty, setDirty] = useState<boolean>();
+    const [saving, setSaving] = useState<boolean>();
+    const [error, setError] = useState<string>();
 
     useEffect(() => {
         selectRows({
@@ -163,23 +186,68 @@ const SampleStateDetail: FC<SampleStateDetailProps> = memo(props => {
 
     useEffect(() => {
         if (state) setUpdatedState(state);
-        if (addNew) setUpdatedState(new SampleState({ stateType: typeOptions?.[0]?.value }))
+        if (addNew) setUpdatedState(new SampleState({ stateType: typeOptions?.[0]?.value }));
+        setDirty(addNew);
+        setSaving(false);
+        setError(undefined);
     }, [state, addNew]);
 
-    const onFormChange = useCallback((evt): void => {
-        const {name, value} = evt.target;
-        setUpdatedState(updatedState.set(name, value));
+    const onFormChange = useCallback(
+        (evt): void => {
+            const { name, value } = evt.target;
+            setUpdatedState(updatedState.set(name, value));
+            setDirty(true);
+        },
+        [updatedState]
+    );
+
+    const onSelectChange = useCallback(
+        (name, value): void => {
+            setUpdatedState(updatedState.set(name, value));
+            setDirty(true);
+        },
+        [updatedState]
+    );
+
+    const onSave = useCallback(() => {
+        setError(undefined);
+        setSaving(true);
+        if (updatedState.rowId) {
+            updateRows({
+                schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
+                rows: [updatedState],
+            })
+                .then(() => {
+                    onSaveSuccess();
+                })
+                .catch(error => {
+                    setError(resolveErrorMessage(error, 'status', 'statuses', 'updating'));
+                    setSaving(false);
+                });
+        } else {
+            insertRows({
+                schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
+                rows: List([updatedState]),
+            })
+                .then(() => {
+                    onSaveSuccess(updatedState.label);
+                })
+                .catch(response => {
+                    setError(resolveErrorMessage(response.get('error'), 'status', 'statuses', 'inserting'));
+                    setSaving(false);
+                });
+        }
     }, [updatedState]);
 
-    const onSelectChange = useCallback((name, value): void => {
-        setUpdatedState(updatedState.set(name, value));
-    }, [updatedState]);
+    // TODO
+    const onDeleteConfirm = useCallback(() => {}, []);
 
     return (
         <>
             {!updatedState && <p className="choices-detail__empty-message">Select a sample status to view details.</p>}
             {updatedState && (
                 <form className="form-horizontal content-form">
+                    {error && <Alert>{error}</Alert>}
                     <FormGroup>
                         <div className="col-sm-4">
                             <DomainFieldLabel label="Label" required />
@@ -189,6 +257,7 @@ const SampleStateDetail: FC<SampleStateDetailProps> = memo(props => {
                                 className="form-control"
                                 name="label"
                                 onChange={onFormChange}
+                                disabled={saving}
                                 placeholder="Enter status label"
                                 // ref={nameRef}
                                 type="text"
@@ -205,6 +274,7 @@ const SampleStateDetail: FC<SampleStateDetailProps> = memo(props => {
                                 className="form-control"
                                 name="description"
                                 onChange={onFormChange}
+                                disabled={saving}
                                 value={updatedState.description ?? ''}
                             />
                         </div>
@@ -220,12 +290,23 @@ const SampleStateDetail: FC<SampleStateDetailProps> = memo(props => {
                                 labelKey="value"
                                 clearable={false}
                                 onChange={onSelectChange}
-                                disabled={updatedState.inUse}
+                                disabled={updatedState.inUse || saving}
                                 options={typeOptions}
                                 value={updatedState.stateType}
                             />
                         </div>
                     </FormGroup>
+                    <div>
+                        {!addNew && (
+                            <Button bsStyle="default" disabled={updatedState.inUse || saving} onClick={onDeleteConfirm}>
+                                <span className="fa fa-trash" />
+                                <span>&nbsp;Delete</span>
+                            </Button>
+                        )}
+                        <Button bsStyle="success" className="pull-right" disabled={!dirty || saving} onClick={onSave}>
+                            {saving ? 'Saving...' : 'Save'}
+                        </Button>
+                    </div>
                 </form>
             )}
         </>

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { waitForLifecycle } from '../../testHelpers';
+import { LoadingSpinner } from '../base/LoadingSpinner';
+import { AddEntityButton } from '../buttons/AddEntityButton';
+import { Alert } from '../base/Alert';
+import { SampleState } from './actions';
+
+import { ManageSampleStatusesPanel, SampleStatusDetail, SampleStatusesList } from './ManageSampleStatusesPanel';
+
+import { getTestAPIWrapper } from '../../APIWrapper';
+import { getSamplesTestAPIWrapper } from './APIWrapper';
+
+const DEFAULT_PROPS = {
+    api: getTestAPIWrapper(jest.fn, {
+        samples: getSamplesTestAPIWrapper(jest.fn, {
+            getSampleStatuses: () => Promise.resolve([new SampleState()]),
+        }),
+    }),
+};
+
+describe('ManageSampleStatusesPanel', () => {
+    function validate(wrapper: ReactWrapper, hasError = false, hasTitleCls = false): void {
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
+        expect(wrapper.find(Alert)).toHaveLength(hasError ? 1 : 0);
+
+        expect(wrapper.find('.panel')).toHaveLength(1);
+        expect(wrapper.find('h4')).toHaveLength(hasTitleCls ? 1 : 0);
+        expect(wrapper.find('.panel-heading')).toHaveLength(!hasTitleCls ? 1 : 0);
+
+        const elCount = !hasError ? 1 : 0;
+        expect(wrapper.find('.choices-container')).toHaveLength(elCount);
+        expect(wrapper.find(SampleStatusesList)).toHaveLength(elCount);
+        expect(wrapper.find(AddEntityButton)).toHaveLength(elCount);
+        expect(wrapper.find(SampleStatusDetail)).toHaveLength(elCount);
+    }
+
+    test('loading', async () => {
+        const wrapper = mount(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />);
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('no states', async () => {
+        const wrapper = mount(
+            <ManageSampleStatusesPanel
+                {...DEFAULT_PROPS}
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
+                        getSampleStatuses: () => Promise.resolve([]),
+                    }),
+                })}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(SampleStatusesList).prop('states').length).toBe(0);
+        expect(wrapper.find(SampleStatusDetail).prop('state')).toBe(null);
+        wrapper.unmount();
+    });
+
+    test('with states and selection', async () => {
+        const wrapper = mount(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />);
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(SampleStatusesList).prop('states').length).toBe(1);
+        expect(wrapper.find(SampleStatusesList).prop('selected')).toBe(undefined);
+        expect(wrapper.find(SampleStatusDetail).prop('state')).toBeUndefined();
+
+        // click on a status row to select it
+        wrapper.find('.list-group-item').first().simulate('click');
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(SampleStatusesList).prop('states').length).toBe(1);
+        expect(wrapper.find(SampleStatusesList).prop('selected')).toBe(0);
+        expect(wrapper.find(SampleStatusDetail).prop('state')).toBeDefined();
+
+        wrapper.unmount();
+    });
+
+    test('error retrieving states', async () => {
+        const wrapper = mount(
+            <ManageSampleStatusesPanel
+                {...DEFAULT_PROPS}
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
+                        getSampleStatuses: () => Promise.reject({ exception: 'Failure' }),
+                    }),
+                })}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('add new', async () => {
+        const wrapper = mount(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />);
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(SampleStatusesList).prop('states').length).toBe(1);
+        expect(wrapper.find(SampleStatusesList).prop('selected')).toBe(undefined);
+        expect(wrapper.find(SampleStatusDetail).prop('state')).toBeUndefined();
+        expect(wrapper.find(SampleStatusDetail).prop('addNew')).toBe(false);
+        expect(wrapper.find(AddEntityButton).prop('disabled')).toBe(false);
+
+        wrapper.find('.btn').simulate('click');
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(SampleStatusesList).prop('states').length).toBe(1);
+        expect(wrapper.find(SampleStatusesList).prop('selected')).toBe(-1);
+        expect(wrapper.find(SampleStatusDetail).prop('state')).toBeUndefined();
+        expect(wrapper.find(SampleStatusDetail).prop('addNew')).toBe(true);
+        expect(wrapper.find(AddEntityButton).prop('disabled')).toBe(true);
+
+        wrapper.unmount();
+    });
+
+    test('titleCls', async () => {
+        const wrapper = mount(<ManageSampleStatusesPanel {...DEFAULT_PROPS} titleCls="test-cls" />);
+        await waitForLifecycle(wrapper);
+        validate(wrapper, false, true);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
@@ -5,6 +5,7 @@ import { waitForLifecycle } from '../../testHelpers';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { AddEntityButton } from '../buttons/AddEntityButton';
 import { Alert } from '../base/Alert';
+import { LockIcon } from '../base/LockIcon';
 import { SampleState } from './actions';
 
 import {
@@ -166,6 +167,48 @@ describe('SampleStatusesList', () => {
         validate(wrapper, states.length);
         expect(wrapper.find(SampleStatusesListItem).first().prop('active')).toBe(false);
         expect(wrapper.find(SampleStatusesListItem).last().prop('active')).toBe(true);
+        wrapper.unmount();
+    });
+});
+
+describe('SampleStatusesListItem', () => {
+    const DEFAULT_PROPS = {
+        index: 0,
+        state: new SampleState({ label: 'Available', stateType: 'Available', inUse: false }),
+        onSelect: jest.fn,
+    };
+
+    function validate(wrapper: ReactWrapper, active = false, inUse = false, text = 'Available'): void {
+        expect(wrapper.find('button')).toHaveLength(1);
+        expect(wrapper.find('.active')).toHaveLength(active ? 1 : 0);
+        expect(wrapper.find('.choices-list__item-type')).toHaveLength(text !== 'Available' ? 1 : 0);
+        expect(wrapper.find(LockIcon)).toHaveLength(inUse ? 1 : 0);
+        expect(wrapper.find('button').text()).toBe(text);
+    }
+
+    test('default props', () => {
+        const wrapper = mount(<SampleStatusesListItem {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('active', () => {
+        const wrapper = mount(<SampleStatusesListItem {...DEFAULT_PROPS} active />);
+        validate(wrapper, true);
+        wrapper.unmount();
+    });
+
+    test('stateType not same as label', () => {
+        const state = new SampleState({ label: 'Received', stateType: 'Available', inUse: false });
+        const wrapper = mount(<SampleStatusesListItem {...DEFAULT_PROPS} state={state} />);
+        validate(wrapper, false, false, 'ReceivedAvailable');
+        wrapper.unmount();
+    });
+
+    test('in use', () => {
+        const state = new SampleState({ label: 'Available', stateType: 'Available', inUse: true });
+        const wrapper = mount(<SampleStatusesListItem {...DEFAULT_PROPS} state={state} />);
+        validate(wrapper, false, true);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
@@ -11,8 +11,7 @@ import { DomainFieldLabel } from '../domainproperties/DomainFieldLabel';
 import { SelectInput } from '../forms/input/SelectInput';
 import { ConfirmModal } from '../base/ConfirmModal';
 
-import { SampleState } from './actions';
-
+import { SampleState } from './models';
 import {
     ManageSampleStatusesPanel,
     SampleStatusDetail,
@@ -259,7 +258,9 @@ describe('SampleStatusDetail', () => {
         expect(wrapper.find(SelectInput).prop('value')).toBe(STATE.stateType);
         expect(wrapper.find(SelectInput).prop('disabled')).toBe(false);
         expect(wrapper.find(Button)).toHaveLength(2);
+        expect(wrapper.find(Button).first().text()).toContain('Delete');
         expect(wrapper.find(Button).first().prop('disabled')).toBe(false);
+        expect(wrapper.find(Button).last().text()).toBe('Save');
         expect(wrapper.find(Button).last().prop('disabled')).toBe(true); // save initially disabled
         wrapper.unmount();
     });
@@ -273,7 +274,9 @@ describe('SampleStatusDetail', () => {
         expect(wrapper.find('textarea').prop('disabled')).toBe(false);
         expect(wrapper.find(SelectInput).prop('disabled')).toBe(true);
         expect(wrapper.find(Button)).toHaveLength(2);
+        expect(wrapper.find(Button).first().text()).toContain('Delete');
         expect(wrapper.find(Button).first().prop('disabled')).toBe(true); // delete disabled
+        expect(wrapper.find(Button).last().text()).toBe('Save');
         expect(wrapper.find(Button).last().prop('disabled')).toBe(true); // save initially disabled
         wrapper.unmount();
     });
@@ -296,7 +299,9 @@ describe('SampleStatusDetail', () => {
         const wrapper = mount(<SampleStatusDetail {...DEFAULT_PROPS} addNew />);
         await waitForLifecycle(wrapper);
         validate(wrapper);
-        expect(wrapper.find(Button)).toHaveLength(1); // no delete button for add new
+        expect(wrapper.find(Button)).toHaveLength(2);
+        expect(wrapper.find(Button).first().text()).toBe('Cancel');
+        expect(wrapper.find(Button).first().prop('disabled')).toBe(false);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
@@ -7,20 +7,25 @@ import { AddEntityButton } from '../buttons/AddEntityButton';
 import { Alert } from '../base/Alert';
 import { SampleState } from './actions';
 
-import { ManageSampleStatusesPanel, SampleStatusDetail, SampleStatusesList } from './ManageSampleStatusesPanel';
+import {
+    ManageSampleStatusesPanel,
+    SampleStatusDetail,
+    SampleStatusesList,
+    SampleStatusesListItem,
+} from './ManageSampleStatusesPanel';
 
 import { getTestAPIWrapper } from '../../APIWrapper';
 import { getSamplesTestAPIWrapper } from './APIWrapper';
 
-const DEFAULT_PROPS = {
-    api: getTestAPIWrapper(jest.fn, {
-        samples: getSamplesTestAPIWrapper(jest.fn, {
-            getSampleStatuses: () => Promise.resolve([new SampleState()]),
-        }),
-    }),
-};
-
 describe('ManageSampleStatusesPanel', () => {
+    const DEFAULT_PROPS = {
+        api: getTestAPIWrapper(jest.fn, {
+            samples: getSamplesTestAPIWrapper(jest.fn, {
+                getSampleStatuses: () => Promise.resolve([new SampleState()]),
+            }),
+        }),
+    };
+
     function validate(wrapper: ReactWrapper, hasError = false, hasTitleCls = false): void {
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
         expect(wrapper.find(Alert)).toHaveLength(hasError ? 1 : 0);
@@ -123,6 +128,44 @@ describe('ManageSampleStatusesPanel', () => {
         const wrapper = mount(<ManageSampleStatusesPanel {...DEFAULT_PROPS} titleCls="test-cls" />);
         await waitForLifecycle(wrapper);
         validate(wrapper, false, true);
+        wrapper.unmount();
+    });
+});
+
+describe('SampleStatusesList', () => {
+    const DEFAULT_PROPS = {
+        states: [],
+        selected: undefined,
+        onSelect: jest.fn,
+    };
+
+    function validate(wrapper: ReactWrapper, count = 0): void {
+        expect(wrapper.find('.choices-list__empty-message')).toHaveLength(count === 0 ? 1 : 0);
+        expect(wrapper.find('.list-group')).toHaveLength(1);
+        expect(wrapper.find(SampleStatusesListItem)).toHaveLength(count);
+    }
+
+    test('no states', () => {
+        const wrapper = mount(<SampleStatusesList {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('with states, no selection', () => {
+        const states = [new SampleState(), new SampleState()];
+        const wrapper = mount(<SampleStatusesList {...DEFAULT_PROPS} states={states} />);
+        validate(wrapper, states.length);
+        expect(wrapper.find(SampleStatusesListItem).first().prop('active')).toBe(false);
+        expect(wrapper.find(SampleStatusesListItem).last().prop('active')).toBe(false);
+        wrapper.unmount();
+    });
+
+    test('with states, with selection', () => {
+        const states = [new SampleState(), new SampleState()];
+        const wrapper = mount(<SampleStatusesList {...DEFAULT_PROPS} states={states} selected={1} />);
+        validate(wrapper, states.length);
+        expect(wrapper.find(SampleStatusesListItem).first().prop('active')).toBe(false);
+        expect(wrapper.find(SampleStatusesListItem).last().prop('active')).toBe(true);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -32,7 +32,8 @@ interface SampleStatusDetailProps {
     state: SampleState;
 }
 
-const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
+// exported for jest testing
+export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
     const { state, addNew, onActionComplete } = props;
     const [typeOptions, setTypeOptions] = useState<Array<Record<string, any>>>();
     const [updatedState, setUpdatedState] = useState<SampleState>();
@@ -269,7 +270,8 @@ interface SampleStatusesListProps {
     states: SampleState[];
 }
 
-const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
+// exported for jest testing
+export const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
     const { states, onSelect, selected } = props;
 
     return (

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -256,7 +256,7 @@ const SampleStatusesListItem: FC<SampleStatusesListItemProps> = memo(props => {
             {state.inUse && (
                 <LockIcon
                     iconCls="pull-right choices-list__locked"
-                    body={<p>This sample status cannot change status type or be deleted because it is in-use.</p>}
+                    body={<p>This sample status cannot change status type or be deleted because it is in use.</p>}
                     id="sample-state-lock-icon"
                     title="Sample Status Locked"
                 />

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -5,10 +5,9 @@ import { List } from 'immutable';
 import classNames from 'classnames';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-
 import { Alert } from '../base/Alert';
 import { LockIcon } from '../base/LockIcon';
+import { ConfirmModal } from '../base/ConfirmModal';
 
 import { AddEntityButton } from '../buttons/AddEntityButton';
 import { DomainFieldLabel } from '../domainproperties/DomainFieldLabel';
@@ -18,10 +17,9 @@ import { selectRows, updateRows, insertRows, deleteRows } from '../../query/api'
 import { caseInsensitive } from '../../util/utils';
 import { SCHEMAS } from '../../schemas';
 import { resolveErrorMessage } from '../../util/messaging';
-
-import { ConfirmModal } from '../base/ConfirmModal';
-
 import { SampleState } from './actions';
+
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 const TITLE = 'Manage Sample Statuses';
 const STATE_TYPE_SQ = SchemaQuery.create('exp', 'SampleStateType');

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -102,13 +102,17 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
     const onSave = useCallback(() => {
         setError(undefined);
         setSaving(true);
-        if (updatedState.rowId) {
+
+        // trim the label string before saving
+        const stateToSave = updatedState.set('label', updatedState.label?.trim());
+
+        if (stateToSave.rowId) {
             updateRows({
                 schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
-                rows: [updatedState],
+                rows: [stateToSave],
             })
                 .then(() => {
-                    onActionComplete(updatedState.label);
+                    onActionComplete(stateToSave.label);
                 })
                 .catch(reason => {
                     setError(resolveErrorMessage(reason, 'status', 'statuses', 'updating'));
@@ -117,10 +121,10 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
         } else {
             insertRows({
                 schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
-                rows: List([updatedState]),
+                rows: List([stateToSave]),
             })
                 .then(() => {
-                    onActionComplete(updatedState.label);
+                    onActionComplete(stateToSave.label);
                 })
                 .catch(response => {
                     setError(resolveErrorMessage(response.get('error'), 'status', 'statuses', 'inserting'));

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -161,7 +161,6 @@ const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 onChange={onFormChange}
                                 disabled={saving}
                                 placeholder="Enter status label"
-                                // ref={nameRef}
                                 type="text"
                                 value={updatedState.label ?? ''}
                             />

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -241,7 +241,8 @@ interface SampleStatusesListItemProps {
     state: SampleState;
 }
 
-const SampleStatusesListItem: FC<SampleStatusesListItemProps> = memo(props => {
+// exported for jest testing
+export const SampleStatusesListItem: FC<SampleStatusesListItemProps> = memo(props => {
     const { state, index, active, onSelect } = props;
     const onClick = useCallback(() => {
         onSelect(index);

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -17,7 +17,7 @@ import { selectRows, updateRows, insertRows, deleteRows } from '../../query/api'
 import { caseInsensitive } from '../../util/utils';
 import { SCHEMAS } from '../../schemas';
 import { resolveErrorMessage } from '../../util/messaging';
-import { SampleState } from './actions';
+import { SampleState } from './models';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
@@ -62,6 +62,12 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
             });
     }, []);
 
+    const resetState = useCallback(() => {
+        setSaving(false);
+        setShowDeleteConfirm(false);
+        setError(undefined);
+    }, []);
+
     useEffect(() => {
         if (addNew) {
             setUpdatedState(new SampleState({ stateType: typeOptions?.[0]?.value }));
@@ -69,10 +75,8 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
             setUpdatedState(state);
         }
         setDirty(addNew);
-        setSaving(false);
-        setShowDeleteConfirm(false);
-        setError(undefined);
-    }, [state, addNew, typeOptions]);
+        resetState();
+    }, [state, addNew, typeOptions, resetState]);
 
     const onFormChange = useCallback(
         (evt): void => {
@@ -90,6 +94,10 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
         },
         [updatedState]
     );
+
+    const onCancel = useCallback(() => {
+        onActionComplete(undefined, true);
+    }, [onActionComplete]);
 
     const onSave = useCallback(() => {
         setError(undefined);
@@ -207,6 +215,11 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 <span>&nbsp;Delete</span>
                             </Button>
                         )}
+                        {addNew && (
+                            <Button bsStyle="default" disabled={saving} onClick={onCancel}>
+                                Cancel
+                            </Button>
+                        )}
                         <Button bsStyle="success" className="pull-right" disabled={!dirty || saving} onClick={onSave}>
                             {saving ? 'Saving...' : 'Save'}
                         </Button>
@@ -219,7 +232,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     confirmButtonText="Yes, Delete"
                     onCancel={onToggleDeleteConfirm}
                     onConfirm={onDeleteConfirm}
-                    title="Permanently delete status?"
+                    title="Permanently Delete Status?"
                 >
                     <span>
                         The <b>{updatedState.label}</b> status will be permanently deleted.

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
@@ -292,8 +292,8 @@ describe('SampleAssayDetailImpl', () => {
         const wrapper = mount(
             <SampleAssayDetailImpl
                 {...IMPL_PROPS}
-                api={getTestAPIWrapper({
-                    samples: getSamplesTestAPIWrapper({
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
                         getSampleAssayResultViewConfigs: () => Promise.resolve([]),
                     }),
                 })}
@@ -319,8 +319,8 @@ describe('SampleAssayDetailImpl', () => {
         const wrapper = mount(
             <SampleAssayDetailImpl
                 {...IMPL_PROPS}
-                api={getTestAPIWrapper({
-                    samples: getSamplesTestAPIWrapper({
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
                         getSampleAssayResultViewConfigs: () => Promise.resolve([moduleAssayConfig]),
                     }),
                 })}
@@ -338,8 +338,8 @@ describe('SampleAssayDetailImpl', () => {
         const wrapper = mount(
             <SampleAssayDetailImpl
                 {...IMPL_PROPS}
-                api={getTestAPIWrapper({
-                    samples: getSamplesTestAPIWrapper({
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
                         getSampleAssayResultViewConfigs: () => Promise.resolve([moduleAssayConfig]),
                     }),
                 })}
@@ -360,8 +360,8 @@ describe('SampleAssayDetailImpl', () => {
         const wrapper = mount(
             <SampleAssayDetailImpl
                 {...IMPL_PROPS}
-                api={getTestAPIWrapper({
-                    samples: getSamplesTestAPIWrapper({
+                api={getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
                         getSampleAssayResultViewConfigs: () =>
                             Promise.resolve([
                                 {

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -786,13 +786,13 @@ export class SampleState {
     }
 }
 
-export function getSampleStates(): Promise<SampleState[]> {
+export function getSampleStatuses(): Promise<SampleState[]> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
-            url: buildURL('sampleManager', 'getSampleStates.api'),
+            url: buildURL('sampleManager', 'getSampleStatuses.api'),
             method: 'GET',
             success: Utils.getCallbackWrapper(response => {
-                resolve(response.states?.map(state => new SampleState(state)) ?? []);
+                resolve(response.statuses?.map(state => new SampleState(state)) ?? []);
             }),
             failure: Utils.getCallbackWrapper(response => {
                 console.error(response);

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -15,7 +15,6 @@
  */
 import { fromJS, List, Map, OrderedMap } from 'immutable';
 import { ActionURL, Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
-import { Draft, immerable, produce } from 'immer';
 
 import { EntityChoice, EntityDataType, IEntityTypeDetails, IEntityTypeOption } from '../entities/models';
 import { deleteEntityType, getEntityTypeOptions } from '../entities/actions';
@@ -52,8 +51,9 @@ import { getInitialParentChoices } from '../entities/utils';
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../domainproperties/constants';
 
 import { isSampleStatusEnabled } from '../../app/utils';
+import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
-import { GroupedSampleFields, SampleAliquotsStats } from './models';
+import { GroupedSampleFields, SampleAliquotsStats, SampleState } from './models';
 import { IS_ALIQUOT_FIELD } from './constants';
 
 export function initSampleSetSelects(isUpdate: boolean, ssName: string, includeDataClasses: boolean): Promise<any[]> {
@@ -745,7 +745,7 @@ export type SampleAssayResultViewConfig = {
 export function getSampleAssayResultViewConfigs(): Promise<SampleAssayResultViewConfig[]> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
-            url: buildURL('sampleManager', 'getSampleAssayResultsViewConfigs.api'),
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getSampleAssayResultsViewConfigs.api'),
             method: 'GET',
             success: Utils.getCallbackWrapper(response => {
                 resolve(response.configs ?? []);
@@ -758,38 +758,10 @@ export function getSampleAssayResultViewConfigs(): Promise<SampleAssayResultView
     });
 }
 
-export class SampleState {
-    [immerable] = true;
-
-    readonly rowId: number;
-    readonly label: string;
-    readonly description: string;
-    readonly stateType: string;
-    readonly publicData: boolean;
-    readonly inUse: boolean;
-
-    constructor(values?: Partial<SampleState>) {
-        Object.assign(this, values);
-        if (this.publicData === undefined) {
-            Object.assign(this, { publicData: false });
-        }
-    }
-
-    set(name: string, value: any): SampleState {
-        return this.mutate({ [name]: value });
-    }
-
-    mutate(props: Partial<SampleState>): SampleState {
-        return produce(this, (draft: Draft<SampleState>) => {
-            Object.assign(draft, props);
-        });
-    }
-}
-
 export function getSampleStatuses(): Promise<SampleState[]> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
-            url: buildURL('sampleManager', 'getSampleStatuses.api'),
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getSampleStatuses.api'),
             method: 'GET',
             success: Utils.getCallbackWrapper(response => {
                 resolve(response.statuses?.map(state => new SampleState(state)) ?? []);

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -765,10 +765,14 @@ export class SampleState {
     readonly label: string;
     readonly description: string;
     readonly stateType: string;
+    readonly publicData: boolean;
     readonly inUse: boolean;
 
     constructor(values?: Partial<SampleState>) {
         Object.assign(this, values);
+        if (this.publicData === undefined) {
+            Object.assign(this, { publicData: false });
+        }
     }
 
     set(name: string, value: any): SampleState {

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -4,6 +4,7 @@ import { List } from 'immutable';
 import { QueryModel, User } from '../../..';
 
 import { SampleStateType } from './constants';
+import { Draft, immerable, produce } from "immer";
 
 export enum SampleCreationType {
     Independents = 'New samples',
@@ -122,3 +123,31 @@ export interface SampleStorageButtonsComponentProps {
 }
 
 export type SampleStorageButton = ComponentType<SampleStorageButtonsComponentProps>;
+
+export class SampleState {
+    [immerable] = true;
+
+    readonly rowId: number;
+    readonly label: string;
+    readonly description: string;
+    readonly stateType: string;
+    readonly publicData: boolean;
+    readonly inUse: boolean;
+
+    constructor(values?: Partial<SampleState>) {
+        Object.assign(this, values);
+        if (this.publicData === undefined) {
+            Object.assign(this, { publicData: false });
+        }
+    }
+
+    set(name: string, value: any): SampleState {
+        return this.mutate({ [name]: value });
+    }
+
+    mutate(props: Partial<SampleState>): SampleState {
+        return produce(this, (draft: Draft<SampleState>) => {
+            Object.assign(draft, props);
+        });
+    }
+}

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -1,10 +1,11 @@
 import { ComponentType } from 'react';
 import { List } from 'immutable';
 
+import { Draft, immerable, produce } from 'immer';
+
 import { QueryModel, User } from '../../..';
 
 import { SampleStateType } from './constants';
-import { Draft, immerable, produce } from "immer";
 
 export enum SampleCreationType {
     Independents = 'New samples',

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -9,10 +9,17 @@ import { sampleManagerIsPrimaryApp } from '../../app/utils';
 
 import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
 
-export const NameIdSettings: FC = memo(() => {
+const TITLE = 'ID/Name Settings';
+
+interface NameIdSettingsProps {
+    titleCls?: string;
+}
+
+export const NameIdSettings: FC<NameIdSettingsProps> = memo(props => {
     return (
         <RequiresPermission perms={PermissionTypes.Admin}>
             <NameIdSettingsForm
+                {...props}
                 saveNameExpressionOptions={saveNameExpressionOptions}
                 loadNameExpressionOptions={loadNameExpressionOptions}
             />
@@ -20,7 +27,7 @@ export const NameIdSettings: FC = memo(() => {
     );
 });
 
-interface Props {
+interface NameIdSettingsFormProps extends NameIdSettingsProps {
     loadNameExpressionOptions: () => Promise<{ prefix: string; allowUserSpecifiedNames: boolean }>;
     saveNameExpressionOptions: (key: string, value: string | boolean) => Promise<void>;
 }
@@ -44,8 +51,8 @@ const initialState: State = {
     allowUserSpecifiedNames: false,
     savingAllowUserSpecifiedNames: false,
 };
-export const NameIdSettingsForm: FC<Props> = props => {
-    const { loadNameExpressionOptions, saveNameExpressionOptions } = props;
+export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
+    const { loadNameExpressionOptions, saveNameExpressionOptions, titleCls } = props;
     const [state, setState] = useReducer(
         (currentState: State, newState: Partial<State>): State => ({ ...currentState, ...newState }),
         initialState
@@ -124,9 +131,10 @@ export const NameIdSettingsForm: FC<Props> = props => {
     }, []);
 
     return (
-        <div className="name-id-settings-panel panel">
+        <div className="name-id-settings-panel panel panel-default">
+            {!titleCls && <div className="panel-heading">{TITLE}</div>}
             <div className="panel-body">
-                <h4 className="name-id-setting__setting-panel-title">ID/Name Settings</h4>
+                {titleCls && <h4 className={titleCls}>{TITLE}</h4>}
                 <div className="name-id-setting__setting-section">
                     <h5> User-defined IDs/Names </h5>
 

--- a/packages/components/src/internal/components/settings/actions.ts
+++ b/packages/components/src/internal/components/settings/actions.ts
@@ -2,11 +2,12 @@ import { Ajax, Utils } from '@labkey/api';
 
 import { buildURL } from '../../url/AppURL';
 import { handleRequestFailure } from '../../util/utils';
+import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
 export const saveNameExpressionOptions = (key: string, value: string | boolean): Promise<null> => {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: buildURL('sampleManager', 'setNameExpressionOptions'),
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'setNameExpressionOptions'),
             jsonData: { [key]: value },
             method: 'POST',
             success: Utils.getCallbackWrapper(response => resolve(response)),
@@ -18,7 +19,7 @@ export const saveNameExpressionOptions = (key: string, value: string | boolean):
 export const loadNameExpressionOptions = (): Promise<{ prefix: string; allowUserSpecifiedNames: boolean }> => {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: buildURL('sampleManager', 'getNameExpressionOptions'),
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getNameExpressionOptions'),
             success: Utils.getCallbackWrapper(response => resolve(response)),
             failure: handleRequestFailure(reject, 'Failed to get name expression options.'),
         });

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -48,6 +48,7 @@ export const EXP_TABLES = {
 const CORE_SCHEMA = 'core';
 export const CORE_TABLES = {
     SCHEMA: CORE_SCHEMA,
+    DATA_STATES: SchemaQuery.create(CORE_SCHEMA, 'DataStates'),
     USERS: SchemaQuery.create(CORE_SCHEMA, 'Users'),
 };
 

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -25,6 +25,12 @@
     overflow: auto;
 }
 
+.choices-list__item-type {
+    padding-left: 10px;
+    font-size: smaller;
+    font-style: italic;
+}
+
 .choices-list .list-group-item .fa {
     margin-right: 6px;
 }

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -31,6 +31,10 @@
     font-style: italic;
 }
 
+.choices-list__locked {
+    margin: 0 !important;
+}
+
 .choices-list .list-group-item .fa {
     margin-right: 6px;
 }

--- a/packages/components/src/theme/settings.scss
+++ b/packages/components/src/theme/settings.scss
@@ -1,10 +1,3 @@
-.name-id-setting__setting-panel-title {
-    border-bottom: 1px solid #eeeeee;
-    font-weight: normal;
-    margin-bottom: 15px;
-    padding-bottom: 15px;
-}
-
 .name-id-setting__setting-section h5 {
     font-weight: bold;
     margin: 16px 0;


### PR DESCRIPTION
#### Rationale
Recent stories have added a Sample Status column and support for status change checks for permitted operations. This PR adds the UI component to manage the sample statuses available for a given container. It will be shown in LKS, LKSM, and LKB. In addition, this story adds in a SampleStatusService registered from the SM module so that by default the sample status support is not "enabled" unless the SM module is included in the build and registers the service implementation to support it.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/653
* https://github.com/LabKey/platform/pull/2698
* https://github.com/LabKey/sampleManagement/pull/726
* https://github.com/LabKey/biologics/pull/1026
* https://github.com/LabKey/inventory/pull/323

#### Changes
* ManageSampleStatusesPanel for sample statuses CRUD operations
* Update APIWrapper to take mockFn as a param instead of adding jest dependency directly
* getSampleStatuses action to call API and return SampleState array
* NameIdSettings component update to support optional titleCls prop
