### PR TITLE
Container path support

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.1-fb-subfolder-eln.0",
+  "version": "2.91.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.1",
+  "version": "2.90.1-fb-subfolder-eln.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ## November 2021
 * getUsersWithPermissions: support alternate container paths
   * expose via UserSelectInput and useUsersWithPermissions
+* Export invalidateQueryDetailsCache
+  * Provides containerPath-sensitive cache clearing
 * Announcements: support supplying containerPath
 
 ### version 2.90.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.##.#
+*Released*: ## November 2021
+* getUsersWithPermissions: support alternate container paths
+    * expose via UserSelectInput and useUsersWithPermissions
+
 ### version 2.90.1
 *Released*: 1 November 2021
 * Previous release was built against an incorrect version of api-js which broke workflow task support included in 2.87.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.##.#
-*Released*: ## November 2021
+### version 2.91.0
+*Released*: 2 November 2021
 * getUsersWithPermissions: support alternate container paths
   * expose via UserSelectInput and useUsersWithPermissions
 * Export invalidateQueryDetailsCache

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.##.#
 *Released*: ## November 2021
 * getUsersWithPermissions: support alternate container paths
-    * expose via UserSelectInput and useUsersWithPermissions
+  * expose via UserSelectInput and useUsersWithPermissions
+* Announcements: support supplying containerPath
 
 ### version 2.90.1
 *Released*: 1 November 2021

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -179,6 +179,7 @@ import {
     InsertOptions,
     insertRows,
     InsertRowsResponse,
+    invalidateQueryDetailsCache,
     invalidateQueryDetailsCacheKey,
     searchRows,
     selectRows,
@@ -753,6 +754,7 @@ export {
     deleteRows,
     importData,
     getQueryDetails,
+    invalidateQueryDetailsCache,
     invalidateQueryDetailsCacheKey,
     // editable grid related items
     MAX_EDITABLE_GRID_ROWS,

--- a/packages/components/src/internal/announcements/APIWrapper.ts
+++ b/packages/components/src/internal/announcements/APIWrapper.ts
@@ -18,22 +18,22 @@ const createThreadForm = (thread: Partial<AnnouncementModel>, files: File[]) => 
 };
 
 export interface AnnouncementsAPIWrapper {
-    createThread: (thread: Partial<AnnouncementModel>, files: File[], reply?: boolean) => Promise<AnnouncementModel>;
-    deleteAttachment: (parent: string, name: string) => Promise<boolean>;
-    deleteThread: (threadRowId: number) => Promise<boolean>;
-    getDiscussions: (discussionSrcIdentifier: string) => Promise<AnnouncementModel[]>;
-    getThread: (threadRowId: number) => Promise<AnnouncementModel>;
-    renderContent: (content: string) => Promise<string>;
-    updateThread: (thread: Partial<AnnouncementModel>, files: File[]) => Promise<AnnouncementModel>;
+    createThread: (thread: Partial<AnnouncementModel>, files: File[], reply?: boolean, containerPath?: string) => Promise<AnnouncementModel>;
+    deleteAttachment: (parent: string, name: string, containerPath?: string) => Promise<boolean>;
+    deleteThread: (threadRowId: number, containerPath?: string) => Promise<boolean>;
+    getDiscussions: (discussionSrcIdentifier: string, containerPath?: string) => Promise<AnnouncementModel[]>;
+    getThread: (threadRowId: number, containerPath?: string) => Promise<AnnouncementModel>;
+    renderContent: (content: string, containerPath?: string) => Promise<string>;
+    updateThread: (thread: Partial<AnnouncementModel>, files: File[], containerPath?: string) => Promise<AnnouncementModel>;
 }
 
 export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
-    createThread = (thread: Partial<AnnouncementModel>, files, reply?: boolean): Promise<AnnouncementModel> => {
+    createThread = (thread: Partial<AnnouncementModel>, files, reply?: boolean, containerPath?: string): Promise<AnnouncementModel> => {
         const form = createThreadForm(thread, files);
         form.append('reply', (!!reply).toString());
         return new Promise((resolve, reject) => {
             return Ajax.request({
-                url: ActionURL.buildURL('announcements', 'createThread.api'),
+                url: ActionURL.buildURL('announcements', 'createThread.api', containerPath),
                 method: 'POST',
                 form,
                 success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),
@@ -41,10 +41,10 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
             });
         });
     };
-    deleteAttachment = (entityId: string, name: string): Promise<boolean> => {
+    deleteAttachment = (entityId: string, name: string, containerPath?: string): Promise<boolean> => {
         return new Promise((resolve, reject) => {
             return Ajax.request({
-                url: ActionURL.buildURL('announcements', 'deleteAttachment.api'),
+                url: ActionURL.buildURL('announcements', 'deleteAttachment.api', containerPath),
                 method: 'POST',
                 jsonData: { entityId, name },
                 success: Utils.getCallbackWrapper(({ success }) => resolve(success)),
@@ -52,10 +52,10 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
             });
         });
     };
-    deleteThread = (threadRowId: number): Promise<boolean> => {
+    deleteThread = (threadRowId: number, containerPath?: string): Promise<boolean> => {
         return new Promise((resolve, reject) => {
             return Ajax.request({
-                url: ActionURL.buildURL('announcements', 'deleteThread.api'),
+                url: ActionURL.buildURL('announcements', 'deleteThread.api', containerPath),
                 method: 'POST',
                 jsonData: { rowId: threadRowId },
                 success: Utils.getCallbackWrapper(({ success }) => resolve(success)),
@@ -63,10 +63,10 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
             });
         });
     };
-    getDiscussions = (discussionSrcIdentifier: string): Promise<AnnouncementModel[]> => {
+    getDiscussions = (discussionSrcIdentifier: string, containerPath?: string): Promise<AnnouncementModel[]> => {
         return new Promise((resolve, reject) => {
             return Ajax.request({
-                url: ActionURL.buildURL('announcements', 'getDiscussions.api'),
+                url: ActionURL.buildURL('announcements', 'getDiscussions.api', containerPath),
                 method: 'POST',
                 jsonData: { discussionSrcIdentifier },
                 success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),
@@ -74,10 +74,10 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
             });
         });
     };
-    getThread = (threadRowId: number): Promise<AnnouncementModel> => {
+    getThread = (threadRowId: number, containerPath?: string): Promise<AnnouncementModel> => {
         return new Promise((resolve, reject) => {
             return Ajax.request({
-                url: ActionURL.buildURL('announcements', 'getThread.api'),
+                url: ActionURL.buildURL('announcements', 'getThread.api', containerPath),
                 method: 'POST',
                 jsonData: { rowId: threadRowId },
                 success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),
@@ -85,10 +85,10 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
             });
         });
     };
-    renderContent = (content: string): Promise<string> => {
+    renderContent = (content: string, containerPath?: string): Promise<string> => {
         return new Promise((resolve, reject) => {
             return Ajax.request({
-                url: ActionURL.buildURL('core', 'transformWiki.api'),
+                url: ActionURL.buildURL('core', 'transformWiki.api', containerPath),
                 method: 'POST',
                 jsonData: { body: content, fromFormat: 'MARKDOWN', toFormat: 'HTML' },
                 success: Utils.getCallbackWrapper(({ body }) => { resolve(body); }),
@@ -96,11 +96,11 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
             });
         });
     };
-    updateThread = (thread: Partial<AnnouncementModel>, files: File[]): Promise<AnnouncementModel> => {
+    updateThread = (thread: Partial<AnnouncementModel>, files: File[], containerPath?: string): Promise<AnnouncementModel> => {
         const form = createThreadForm(thread, files);
         return new Promise((resolve, reject) => {
             return Ajax.request({
-                url: ActionURL.buildURL('announcements', 'updateThread.api'),
+                url: ActionURL.buildURL('announcements', 'updateThread.api', containerPath),
                 method: 'POST',
                 form,
                 success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),

--- a/packages/components/src/internal/announcements/APIWrapper.ts
+++ b/packages/components/src/internal/announcements/APIWrapper.ts
@@ -4,31 +4,45 @@ import { AnnouncementModel, EDITABLE_FIELDS } from './model';
 
 const createThreadForm = (thread: Partial<AnnouncementModel>, files: File[]) => {
     const form = new FormData();
-    EDITABLE_FIELDS.forEach((field) => {
+    EDITABLE_FIELDS.forEach(field => {
         const value = thread[field];
 
         if (value !== undefined) {
             form.append(`thread.${field}`, value.toString());
         }
     });
-    files.forEach((file, i)  => {
+    files.forEach((file, i) => {
         form.append(`file${i === 0 ? '' : i}`, file);
     });
     return form;
 };
 
 export interface AnnouncementsAPIWrapper {
-    createThread: (thread: Partial<AnnouncementModel>, files: File[], reply?: boolean, containerPath?: string) => Promise<AnnouncementModel>;
+    createThread: (
+        thread: Partial<AnnouncementModel>,
+        files: File[],
+        reply?: boolean,
+        containerPath?: string
+    ) => Promise<AnnouncementModel>;
     deleteAttachment: (parent: string, name: string, containerPath?: string) => Promise<boolean>;
     deleteThread: (threadRowId: number, containerPath?: string) => Promise<boolean>;
     getDiscussions: (discussionSrcIdentifier: string, containerPath?: string) => Promise<AnnouncementModel[]>;
     getThread: (threadRowId: number, containerPath?: string) => Promise<AnnouncementModel>;
     renderContent: (content: string, containerPath?: string) => Promise<string>;
-    updateThread: (thread: Partial<AnnouncementModel>, files: File[], containerPath?: string) => Promise<AnnouncementModel>;
+    updateThread: (
+        thread: Partial<AnnouncementModel>,
+        files: File[],
+        containerPath?: string
+    ) => Promise<AnnouncementModel>;
 }
 
 export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
-    createThread = (thread: Partial<AnnouncementModel>, files, reply?: boolean, containerPath?: string): Promise<AnnouncementModel> => {
+    createThread = (
+        thread: Partial<AnnouncementModel>,
+        files,
+        reply?: boolean,
+        containerPath?: string
+    ): Promise<AnnouncementModel> => {
         const form = createThreadForm(thread, files);
         form.append('reply', (!!reply).toString());
         return new Promise((resolve, reject) => {
@@ -36,8 +50,16 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
                 url: ActionURL.buildURL('announcements', 'createThread.api', containerPath),
                 method: 'POST',
                 form,
-                success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),
-                failure: Utils.getCallbackWrapper(error => { reject(error); }, undefined, true),
+                success: Utils.getCallbackWrapper(({ data }) => {
+                    resolve(data);
+                }),
+                failure: Utils.getCallbackWrapper(
+                    error => {
+                        reject(error);
+                    },
+                    undefined,
+                    true
+                ),
             });
         });
     };
@@ -48,7 +70,13 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
                 method: 'POST',
                 jsonData: { entityId, name },
                 success: Utils.getCallbackWrapper(({ success }) => resolve(success)),
-                failure: Utils.getCallbackWrapper(error => { reject(error); }, undefined, true),
+                failure: Utils.getCallbackWrapper(
+                    error => {
+                        reject(error);
+                    },
+                    undefined,
+                    true
+                ),
             });
         });
     };
@@ -59,7 +87,13 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
                 method: 'POST',
                 jsonData: { rowId: threadRowId },
                 success: Utils.getCallbackWrapper(({ success }) => resolve(success)),
-                failure: Utils.getCallbackWrapper(error => { reject(error); }, undefined, true),
+                failure: Utils.getCallbackWrapper(
+                    error => {
+                        reject(error);
+                    },
+                    undefined,
+                    true
+                ),
             });
         });
     };
@@ -69,8 +103,16 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
                 url: ActionURL.buildURL('announcements', 'getDiscussions.api', containerPath),
                 method: 'POST',
                 jsonData: { discussionSrcIdentifier },
-                success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),
-                failure: Utils.getCallbackWrapper(error => { reject(error); }, undefined, true),
+                success: Utils.getCallbackWrapper(({ data }) => {
+                    resolve(data);
+                }),
+                failure: Utils.getCallbackWrapper(
+                    error => {
+                        reject(error);
+                    },
+                    undefined,
+                    true
+                ),
             });
         });
     };
@@ -80,8 +122,16 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
                 url: ActionURL.buildURL('announcements', 'getThread.api', containerPath),
                 method: 'POST',
                 jsonData: { rowId: threadRowId },
-                success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),
-                failure: Utils.getCallbackWrapper(error => { reject(error); }, undefined, true),
+                success: Utils.getCallbackWrapper(({ data }) => {
+                    resolve(data);
+                }),
+                failure: Utils.getCallbackWrapper(
+                    error => {
+                        reject(error);
+                    },
+                    undefined,
+                    true
+                ),
             });
         });
     };
@@ -91,20 +141,40 @@ export class ServerAnnouncementsAPIWrapper implements AnnouncementsAPIWrapper {
                 url: ActionURL.buildURL('core', 'transformWiki.api', containerPath),
                 method: 'POST',
                 jsonData: { body: content, fromFormat: 'MARKDOWN', toFormat: 'HTML' },
-                success: Utils.getCallbackWrapper(({ body }) => { resolve(body); }),
-                failure: Utils.getCallbackWrapper(error => { reject(error); }, undefined, true),
+                success: Utils.getCallbackWrapper(({ body }) => {
+                    resolve(body);
+                }),
+                failure: Utils.getCallbackWrapper(
+                    error => {
+                        reject(error);
+                    },
+                    undefined,
+                    true
+                ),
             });
         });
     };
-    updateThread = (thread: Partial<AnnouncementModel>, files: File[], containerPath?: string): Promise<AnnouncementModel> => {
+    updateThread = (
+        thread: Partial<AnnouncementModel>,
+        files: File[],
+        containerPath?: string
+    ): Promise<AnnouncementModel> => {
         const form = createThreadForm(thread, files);
         return new Promise((resolve, reject) => {
             return Ajax.request({
                 url: ActionURL.buildURL('announcements', 'updateThread.api', containerPath),
                 method: 'POST',
                 form,
-                success: Utils.getCallbackWrapper(({ data }) => { resolve(data); }),
-                failure: Utils.getCallbackWrapper(error => { reject(error); }, undefined, true),
+                success: Utils.getCallbackWrapper(({ data }) => {
+                    resolve(data);
+                }),
+                failure: Utils.getCallbackWrapper(
+                    error => {
+                        reject(error);
+                    },
+                    undefined,
+                    true
+                ),
             });
         });
     };

--- a/packages/components/src/internal/announcements/Discussions.tsx
+++ b/packages/components/src/internal/announcements/Discussions.tsx
@@ -9,6 +9,7 @@ import { ThreadEditor } from './ThreadEditor';
 interface Props {
     api?: AnnouncementsAPIWrapper;
     autoLoad?: boolean;
+    containerPath?: string;
     discussionSrcIdentifier: string;
     discussionSrcEntityType?: string;
     nounPlural?: string;
@@ -21,6 +22,7 @@ export const Discussions: FC<Props> = memo(props => {
     const {
         api,
         autoLoad,
+        containerPath,
         discussionSrcIdentifier,
         discussionSrcEntityType,
         nounPlural,
@@ -39,11 +41,11 @@ export const Discussions: FC<Props> = memo(props => {
 
     const loadDiscussions = useCallback(async () => {
         try {
-            setDiscussions(await api.getDiscussions(discussionSrcIdentifier));
+            setDiscussions(await api.getDiscussions(discussionSrcIdentifier, containerPath));
         } catch (err) {
             setError(resolveErrorMessage(err, 'discussion', 'discussions', 'load'));
         }
-    }, [api, discussionSrcIdentifier]);
+    }, [api, containerPath, discussionSrcIdentifier]);
 
     const onCancel = useCallback(() => {
         setShowEditor(false);
@@ -79,6 +81,7 @@ export const Discussions: FC<Props> = memo(props => {
             {discussions.map(thread => (
                 <Thread
                     api={api}
+                    containerPath={containerPath}
                     discussionSrcIdentifier={discussionSrcIdentifier}
                     discussionSrcEntityType={discussionSrcEntityType}
                     key={thread.rowId}
@@ -103,6 +106,7 @@ export const Discussions: FC<Props> = memo(props => {
             {allowCreateThread && showEditor && (
                 <ThreadEditor
                     api={api}
+                    containerPath={containerPath}
                     discussionSrcIdentifier={discussionSrcIdentifier}
                     discussionSrcEntityType={discussionSrcEntityType}
                     nounPlural={nounPlural}

--- a/packages/components/src/internal/announcements/Discussions.tsx
+++ b/packages/components/src/internal/announcements/Discussions.tsx
@@ -1,6 +1,8 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { UserWithPermissions } from '@labkey/api';
+
 import { resolveErrorMessage } from '../../index';
+
 import { AnnouncementsAPIWrapper, getDefaultAnnouncementsAPIWrapper } from './APIWrapper';
 import { AnnouncementModel } from './model';
 import { Thread } from './Thread';

--- a/packages/components/src/internal/announcements/ThreadBlock.tsx
+++ b/packages/components/src/internal/announcements/ThreadBlock.tsx
@@ -5,6 +5,7 @@ import { User, UserWithPermissions } from '@labkey/api';
 
 import { Alert, resolveErrorMessage } from '../..';
 import { UserAvatar } from '../components/UserAvatars';
+
 import { AnnouncementModel } from './model';
 import { ThreadEditor, ThreadEditorProps } from './ThreadEditor';
 import { ThreadAttachments } from './ThreadAttachments';
@@ -21,13 +22,15 @@ const DeleteThreadModal: FC<DeleteThreadModalProps> = ({ cancel, onDelete }) => 
         </Modal.Header>
 
         <Modal.Body>
-            Deleting this comment will also delete any replies to the original comment.
-            Are you sure you want to delete this thread?
+            Deleting this comment will also delete any replies to the original comment. Are you sure you want to delete
+            this thread?
         </Modal.Body>
 
         <Modal.Footer>
             <div className="pull-left">
-                <button className="btn btn-default" onClick={cancel}>Cancel</button>
+                <button className="btn btn-default" onClick={cancel}>
+                    Cancel
+                </button>
             </div>
 
             <div className="pull-right">
@@ -49,7 +52,7 @@ interface ThreadBlockHeaderProps {
 
 const ThreadBlockHeader: FC<ThreadBlockHeaderProps> = props => {
     const { created, modified, onDelete, onEdit, user } = props;
-    const [ showDeleteModal, setShowDeleteModal ] = useState(false);
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
 
     const formattedCreate = useMemo(() => moment(created).fromNow(), [created]);
     const isEdited = useMemo(() => {
@@ -72,14 +75,11 @@ const ThreadBlockHeader: FC<ThreadBlockHeaderProps> = props => {
             </span>
             <div className="pull-right">
                 <span className="thread-block-header__date">
-                    {formattedCreate}{isEdited ? ' (Edited)' : ''}
+                    {formattedCreate}
+                    {isEdited ? ' (Edited)' : ''}
                 </span>
                 {(onDelete || onEdit) && (
-                    <Dropdown
-                        className="thread-block-header__menu"
-                        componentClass="span"
-                        id="thread-block-header-menu"
-                    >
+                    <Dropdown className="thread-block-header__menu" componentClass="span" id="thread-block-header-menu">
                         <Dropdown.Toggle useAnchor={true}>
                             <i className="fa fa-ellipsis-v" />
                         </Dropdown.Toggle>
@@ -127,11 +127,11 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
         thread,
         user,
     } = props;
-    const [ editing, setEditing ] = useState(false);
-    const [ error, setError ] = useState<string>(undefined);
-    const [ recentTimeout, setRecentTimeout ] = useState<number>(undefined);
-    const [ replying, setReplying ] = useState(false);
-    const [ showRecent, setShowRecent ] = useState(false);
+    const [editing, setEditing] = useState(false);
+    const [error, setError] = useState<string>(undefined);
+    const [recentTimeout, setRecentTimeout] = useState<number>(undefined);
+    const [replying, setReplying] = useState(false);
+    const [showRecent, setShowRecent] = useState(false);
 
     const threadBody = useMemo(() => ({ __html: thread.formattedHtml }), [thread.formattedHtml]);
     const allowDelete = !readOnly && user.canDelete;
@@ -177,9 +177,11 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
         onCreate?.(thread);
 
         setShowRecent(true);
-        setRecentTimeout(setTimeout(() => {
-            setShowRecent(false);
-        }, 10000) as any);
+        setRecentTimeout(
+            setTimeout(() => {
+                setShowRecent(false);
+            }, 10000) as any
+        );
     }, []);
 
     return (
@@ -201,7 +203,9 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
                         <ThreadAttachments attachments={thread.attachments ?? []} />
 
                         {allowReply && (
-                            <span className="clickable-text thread-block__reply" onClick={onReply}>Reply</span>
+                            <span className="clickable-text thread-block__reply" onClick={onReply}>
+                                Reply
+                            </span>
                         )}
                         {showReplyToggle && (
                             <span className="clickable-text thread-block__toggle-reply" onClick={onToggleResponses}>

--- a/packages/components/src/internal/announcements/ThreadBlock.tsx
+++ b/packages/components/src/internal/announcements/ThreadBlock.tsx
@@ -114,7 +114,19 @@ export interface ThreadBlockProps extends ThreadEditorProps {
 }
 
 export const ThreadBlock: FC<ThreadBlockProps> = props => {
-    const { api, canReply, onCreate, onDelete, onToggleResponses, onUpdate, readOnly, showResponses, thread, user } = props;
+    const {
+        api,
+        canReply,
+        containerPath,
+        onCreate,
+        onDelete,
+        onToggleResponses,
+        onUpdate,
+        readOnly,
+        showResponses,
+        thread,
+        user,
+    } = props;
     const [ editing, setEditing ] = useState(false);
     const [ error, setError ] = useState<string>(undefined);
     const [ recentTimeout, setRecentTimeout ] = useState<number>(undefined);
@@ -130,7 +142,7 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
     const onDeleteThread = useCallback(async () => {
         let deleted = false;
         try {
-            deleted = await api.deleteThread(thread.rowId);
+            deleted = await api.deleteThread(thread.rowId, containerPath);
         } catch (err) {
             setError(resolveErrorMessage(err, 'thread', 'thread', 'delete'));
         }
@@ -138,7 +150,7 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
         if (deleted) {
             onDelete?.(thread);
         }
-    }, [api, onDelete, thread]);
+    }, [api, containerPath, onDelete, thread]);
 
     const onCancel = useCallback(() => {
         setEditing(false);

--- a/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
+
 import { waitForLifecycle } from '../testHelpers';
 
 import { applyList, applyTemplate, handleBulletedListEnter, olMapper, ThreadEditor, ulMapper } from './ThreadEditor';
@@ -23,7 +24,7 @@ describe('ThreadEditor', () => {
             body: expectedBody,
             discussionSrcIdentifier: expectedIdentifier,
             title: `${NOUN_SINGULAR} thread`,
-        }
+        };
 
         const expectedReplyThread = { ...expectedCreateThread, parent: expectedParent };
 
@@ -119,7 +120,9 @@ describe('ThreadEditor', () => {
         wrapper.find('.dropdown li a').at(1).simulate('click');
         await waitForLifecycle(wrapper);
         expect(renderContent).toHaveBeenCalledWith(body, expectedContainerPath);
-        expect(wrapper.find('.thread-editor-preview div').props().dangerouslySetInnerHTML).toEqual({ __html: renderedBody });
+        expect(wrapper.find('.thread-editor-preview div').props().dangerouslySetInnerHTML).toEqual({
+            __html: renderedBody,
+        });
         // Toolbar buttons should all be disabled when rendering previews.
         wrapper.find(TOOLBAR_BUTTON).forEach(button => expect(button.props().disabled).toEqual(true));
     });
@@ -168,9 +171,9 @@ describe('ThreadEditor', () => {
     test('applyTemplate', () => {
         const value = 'hello world';
         const element = { selectionStart: 6, selectionEnd: 11, value } as HTMLTextAreaElement;
-        expect(applyTemplate(element, '*', '*')).toEqual(['hello *world*', 7, 12])
-        expect(applyTemplate(element, '**', '**')).toEqual(['hello **world**', 8, 13])
-        expect(applyTemplate(element, '[', '](url)')).toEqual(['hello [world](url)', 7, 12])
+        expect(applyTemplate(element, '*', '*')).toEqual(['hello *world*', 7, 12]);
+        expect(applyTemplate(element, '**', '**')).toEqual(['hello **world**', 8, 13]);
+        expect(applyTemplate(element, '[', '](url)')).toEqual(['hello [world](url)', 7, 12]);
     });
     test('applyList', () => {
         const value = 'one\ntwo\n';

--- a/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
@@ -17,6 +17,7 @@ describe('ThreadEditor', () => {
         const expectedBody = '### I have been created!';
         const expectedIdentifier = 'abc-123';
         const expectedParent = 'parent-1';
+        const expectedContainerPath = '/FolderOne';
 
         const expectedCreateThread = {
             body: expectedBody,
@@ -29,6 +30,7 @@ describe('ThreadEditor', () => {
         const wrapper = mount(
             <ThreadEditor
                 api={createTestAPIWrapper({ createThread })}
+                containerPath={expectedContainerPath}
                 discussionSrcIdentifier={expectedIdentifier}
                 nounPlural={NOUN_PLURAL}
                 nounSingular={NOUN_SINGULAR}
@@ -46,7 +48,7 @@ describe('ThreadEditor', () => {
 
         await waitForLifecycle(wrapper);
 
-        expect(createThread).toHaveBeenCalledWith(expectedCreateThread, [], false);
+        expect(createThread).toHaveBeenCalledWith(expectedCreateThread, [], false, expectedContainerPath);
         expect(onCreate).toHaveBeenCalledWith(THREAD);
 
         // supports reply
@@ -59,19 +61,21 @@ describe('ThreadEditor', () => {
 
         await waitForLifecycle(wrapper);
 
-        expect(createThread).toHaveBeenCalledWith(expectedReplyThread, [], true);
+        expect(createThread).toHaveBeenCalledWith(expectedReplyThread, [], true, expectedContainerPath);
         expect(onCreate).toHaveBeenCalledWith(THREAD);
     });
     test('updates thread', async () => {
         const updateThread = jest.fn().mockResolvedValue(THREAD);
         const onUpdate = jest.fn();
         const expectedBody = '**This is updated**';
+        const expectedContainerPath = '/FolderOne';
 
         const expectedUpdatedThread = { ...RESPONSE, body: expectedBody };
 
         const wrapper = mount(
             <ThreadEditor
                 api={createTestAPIWrapper({ updateThread })}
+                containerPath={expectedContainerPath}
                 nounPlural={NOUN_PLURAL}
                 nounSingular={NOUN_SINGULAR}
                 onUpdate={onUpdate}
@@ -91,11 +95,12 @@ describe('ThreadEditor', () => {
 
         await waitForLifecycle(wrapper);
 
-        expect(updateThread).toHaveBeenCalledWith(expectedUpdatedThread, []);
+        expect(updateThread).toHaveBeenCalledWith(expectedUpdatedThread, [], expectedContainerPath);
         expect(onUpdate).toHaveBeenCalledWith(THREAD);
     });
     test('renders preview', async () => {
         const body = '**This is a test preview**';
+        const expectedContainerPath = '/FolderOne';
         const renderedBody = '<div class="fake-class">This is a test preview</div>';
         // Note: the mocked response here doesn't have to match what would actually get rendered, we're not testing
         // our server response.
@@ -103,6 +108,7 @@ describe('ThreadEditor', () => {
         const wrapper = mount(
             <ThreadEditor
                 api={createTestAPIWrapper({ renderContent })}
+                containerPath={expectedContainerPath}
                 nounPlural={NOUN_PLURAL}
                 nounSingular={NOUN_SINGULAR}
                 user={COMMENTER}
@@ -112,7 +118,7 @@ describe('ThreadEditor', () => {
         wrapper.find(COMMENT_TEXTAREA).simulate('change', { target: { name: 'body', value: body } });
         wrapper.find('.dropdown li a').at(1).simulate('click');
         await waitForLifecycle(wrapper);
-        expect(renderContent).toHaveBeenCalledWith(body);
+        expect(renderContent).toHaveBeenCalledWith(body, expectedContainerPath);
         expect(wrapper.find('.thread-editor-preview div').props().dangerouslySetInnerHTML).toEqual({ __html: renderedBody });
         // Toolbar buttons should all be disabled when rendering previews.
         wrapper.find(TOOLBAR_BUTTON).forEach(button => expect(button.props().disabled).toEqual(true));

--- a/packages/components/src/internal/announcements/ThreadEditor.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.tsx
@@ -383,7 +383,17 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         if (createdThread) {
             onCreate?.(createdThread);
         }
-    }, [containerPath, model, discussionSrcIdentifier, discussionSrcEntityType, parent, nounSingular, api, files, onCreate]);
+    }, [
+        containerPath,
+        model,
+        discussionSrcIdentifier,
+        discussionSrcEntityType,
+        parent,
+        nounSingular,
+        api,
+        files,
+        onCreate,
+    ]);
 
     const updateThread = useCallback(async () => {
         let updatedThread: AnnouncementModel;

--- a/packages/components/src/internal/announcements/ThreadEditor.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.tsx
@@ -216,11 +216,12 @@ const ThreadEditorToolbar: FC<ThreadEditorToolbarProps> = memo(({ inputRef, setB
 });
 
 interface PreviewProps {
+    containerPath?: string;
     content: string;
-    renderContent: (content: string) => Promise<string>;
+    renderContent: (content: string, containerPath?: string) => Promise<string>;
 }
 
-const Preview: FC<PreviewProps> = memo(({ content, renderContent }) => {
+const Preview: FC<PreviewProps> = memo(({ containerPath, content, renderContent }) => {
     const [renderedContent, setRenderedContent] = useState<string>(undefined);
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [error, setError] = useState<string>(undefined);
@@ -231,7 +232,7 @@ const Preview: FC<PreviewProps> = memo(({ content, renderContent }) => {
             setLoadingState(LoadingState.LOADING);
 
             try {
-                const _renderedContent = await renderContent(content);
+                const _renderedContent = await renderContent(content, containerPath);
                 setError(undefined);
                 setRenderedContent(_renderedContent);
             } catch (e) {
@@ -240,7 +241,7 @@ const Preview: FC<PreviewProps> = memo(({ content, renderContent }) => {
                 setLoadingState(LoadingState.LOADED);
             }
         })();
-    }, [content]);
+    }, [containerPath, content]);
 
     return (
         <div className="thread-editor-preview">
@@ -253,6 +254,7 @@ const Preview: FC<PreviewProps> = memo(({ content, renderContent }) => {
 
 export interface ThreadEditorProps {
     api: AnnouncementsAPIWrapper;
+    containerPath?: string;
     discussionSrcIdentifier?: string;
     discussionSrcEntityType?: string;
     nounPlural: string;
@@ -268,6 +270,7 @@ export interface ThreadEditorProps {
 export const ThreadEditor: FC<ThreadEditorProps> = props => {
     const {
         api,
+        containerPath,
         discussionSrcIdentifier,
         discussionSrcEntityType,
         nounSingular,
@@ -326,7 +329,7 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
             // pre-existing attachment, delete from server
             setIsRemoving(true);
             try {
-                await api.deleteAttachment(attachment.parent, attachment.name);
+                await api.deleteAttachment(attachment.parent, attachment.name, containerPath);
                 const updatedAttachments = model.attachments.filter(att => att.name !== attachmentToRemove);
                 setModel({ ...model, attachments: updatedAttachments });
                 setAttachmentToRemove(undefined);
@@ -341,7 +344,7 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
             setFiles(files.filter(file => file.name !== attachmentToRemove));
             setAttachmentToRemove(undefined);
         }
-    }, [model, attachments, attachmentToRemove, files]);
+    }, [containerPath, model, attachments, attachmentToRemove, files]);
 
     const createThread = useCallback(async () => {
         const modelToCreate = { ...model };
@@ -370,7 +373,7 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         let createdThread: AnnouncementModel;
 
         try {
-            createdThread = await api.createThread(modelToCreate, files, parent !== undefined);
+            createdThread = await api.createThread(modelToCreate, files, parent !== undefined, containerPath);
         } catch (err) {
             setError(resolveErrorMessage(err, 'thread', 'create'));
         }
@@ -380,13 +383,13 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         if (createdThread) {
             onCreate?.(createdThread);
         }
-    }, [model, discussionSrcIdentifier, discussionSrcEntityType, parent, nounSingular, api, files, onCreate]);
+    }, [containerPath, model, discussionSrcIdentifier, discussionSrcEntityType, parent, nounSingular, api, files, onCreate]);
 
     const updateThread = useCallback(async () => {
         let updatedThread: AnnouncementModel;
 
         try {
-            updatedThread = await api.updateThread(model, files);
+            updatedThread = await api.updateThread(model, files, containerPath);
         } catch (err) {
             setError(resolveErrorMessage(err, 'thread', 'update'));
         }
@@ -396,7 +399,7 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         if (updatedThread) {
             onUpdate?.(updatedThread);
         }
-    }, [api, files, model, onUpdate]);
+    }, [api, containerPath, files, model, onUpdate]);
 
     const setBody = useCallback(
         (body, selectionStart?: number, selectionEnd?: number) => {
@@ -479,7 +482,9 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
                     </div>
                 )}
 
-                {view === EditorView.preview && <Preview content={model.body} renderContent={api.renderContent} />}
+                {view === EditorView.preview && (
+                    <Preview containerPath={containerPath} content={model.body} renderContent={api.renderContent} />
+                )}
 
                 <ThreadAttachments attachments={attachments} error={attachmentError} onRemove={openRemoveModal} />
 

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -29,7 +29,7 @@ import {
     selectRows,
 } from '../../..';
 
-import { getUsers, getUsersCacheKey, setUsers } from '../../global';
+import { getUsers, setUsers } from '../../global';
 
 import { similaritySortFactory } from '../../util/similaritySortFactory';
 

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -9,6 +9,7 @@ import { getUsersWithPermissions } from '../actions';
 import { SelectInput, SelectInputProps } from './SelectInput';
 
 interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loadOptions'> {
+    containerPath?: string;
     // specify whether this Select should correspond with a NotifyList on the server
     notifyList?: boolean;
     permissions?: string | string[];
@@ -16,7 +17,7 @@ interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loa
 }
 
 export const UserSelectInput: FC<UserSelectInputProps> = props => {
-    const { notifyList, permissions, useEmail, ...selectInputProps } = props;
+    const { containerPath, notifyList, permissions, useEmail, ...selectInputProps } = props;
 
     const loadOptions = useCallback(
         async (input: string) => {
@@ -24,7 +25,7 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
             const sanitizedInput = input?.trim().toLowerCase();
 
             try {
-                const users = await getUsersWithPermissions(permissions);
+                const users = await getUsersWithPermissions(permissions, containerPath);
                 options = users
                     .filter(v => {
                         if (sanitizedInput) {
@@ -44,7 +45,7 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
 
             return options;
         },
-        [notifyList, permissions, useEmail]
+        [containerPath, notifyList, permissions, useEmail]
     );
 
     return <SelectInput {...selectInputProps} delimiter={notifyList ? ';' : ','} loadOptions={loadOptions} />;

--- a/packages/components/src/internal/global.ts
+++ b/packages/components/src/internal/global.ts
@@ -332,7 +332,7 @@ export function updateLookupStore(store: LookupStore, updates: any, failIfNotFou
     return updatedStore;
 }
 
-function getPermissionsKey(permissions?: string | string[]): string {
+export function getUsersCacheKey(permissions?: string | string[], containerPath?: string): string {
     let key = 'allPermissions';
     if (permissions) {
         if (Array.isArray(permissions)) {
@@ -341,23 +341,28 @@ function getPermissionsKey(permissions?: string | string[]): string {
             key = permissions;
         }
     }
+    if (containerPath) {
+        key = [containerPath, key].join('|');
+    }
     return key;
 }
 
 /**
  * Get the users list from the global QueryGrid state
  */
-export function getUsers(permissions?: string | string[]): List<User> {
-    return getGlobalState('users').get(getPermissionsKey(permissions));
+export function getUsers(permissions?: string | string[], containerPath?: string): Promise<List<User>> {
+    return getGlobalState('users').get(getUsersCacheKey(permissions, containerPath));
 }
 
 /**
  * Sets the users list to be used for this application in the global QueryGrid state
  * @param users List of users
+ * @param permissions the PermissionType or array of PermissionType values that can be used to identify a list of users.
+ * @param containerPath the containerPath
  */
-export function setUsers(users: List<User>, permissions?: string | string[]): void {
+export function setUsers(users: Promise<List<User>>, permissions?: string | string[], containerPath?: string): void {
     setGlobal({
-        QueryGrid_users: getGlobalState('users').set(getPermissionsKey(permissions), users),
+        QueryGrid_users: getGlobalState('users').set(getUsersCacheKey(permissions, containerPath), users),
     });
 }
 
@@ -366,6 +371,6 @@ export function setUsers(users: List<User>, permissions?: string | string[]): vo
  */
 export function invalidateUsers(): void {
     setGlobal({
-        QueryGrid_users: Map<string, List<User>>(),
+        QueryGrid_users: Map<string, Promise<List<User>>>(),
     });
 }

--- a/packages/components/src/internal/global.ts
+++ b/packages/components/src/internal/global.ts
@@ -332,7 +332,7 @@ export function updateLookupStore(store: LookupStore, updates: any, failIfNotFou
     return updatedStore;
 }
 
-export function getUsersCacheKey(permissions?: string | string[], containerPath?: string): string {
+function getUsersCacheKey(permissions?: string | string[], containerPath?: string): string {
     let key = 'allPermissions';
     if (permissions) {
         if (Array.isArray(permissions)) {


### PR DESCRIPTION
#### Rationale
Add support for specifying the container path to `getUsersWithPermissions` and the Announcement module based components.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/118
* https://github.com/LabKey/biologics/pull/1031
* https://github.com/LabKey/labkey-ui-components/pull/655
* https://github.com/LabKey/platform/pull/2714

#### Changes
* getUsersWithPermissions: support alternate container paths. Expose via `UserSelectInput` and `useUsersWithPermissions`.
* Announcements: support supplying containerPath.
* Update cache behind `getUsersWithPermissions` to cache a `Promise<List<User>>` rather than a `List<User>` so there isn't any interstitial resolution that could result in multiple requests for the same information.
