### PR TITLE
Item 9574: Store aliquot count and total amount data in exp.materials table

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.0",
+  "version": "2.86.1-fb-smRollupPerf.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.89.1",
+  "version": "2.89.2-fb-smRollupPerf.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.89.0",
+  "version": "2.89.1-fb-smRollupPerf.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.89.2-fb-smRollupPerf.1",
+  "version": "2.89.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version XXX
+*Released*: XXX
+* Update aliquot rollup column field
+
 ### version 2.86.0
 *Released*: 22 October 2021
 * Item 9584: ManageSampleStatusesPanel for sample statuses CRUD operations

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version XXX
-*Released*: XXX
+### version 2.89.2
+*Released*: 29 October 2021
 * Update aliquot rollup column field
 
 ### version 2.89.1

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
@@ -23,7 +23,7 @@ const noAliquotVolume = {
 
 const zeroAliquotVolume = {
     AliquotVolume: {
-        value: null
+        value: 0
     },
     Units: {
         displayValue: null,

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
@@ -13,8 +13,8 @@ const DEFAULT_PROPS = {
 };
 
 const noAliquotVolume = {
-    AliquotTotalVolume: {
-        displayValue: null,
+    AliquotVolume: {
+        value: null
     },
     Units: {
         displayValue: null,
@@ -22,8 +22,8 @@ const noAliquotVolume = {
 };
 
 const zeroAliquotVolume = {
-    AliquotTotalVolume: {
-        displayValue: 0,
+    AliquotVolume: {
+        value: null
     },
     Units: {
         displayValue: null,
@@ -170,8 +170,8 @@ describe('<SampleAliquotsSummaryWithModels/>', () => {
                 sampleLsid="S-20200404-1"
                 sampleSet="dirt"
                 sampleRow={{
-                    AliquotTotalVolume: {
-                        displayValue: 0,
+                    AliquotVolume: {
+                        value: 0,
                     },
                     Units: {
                         displayValue: 'g',
@@ -200,8 +200,8 @@ describe('<SampleAliquotsSummaryWithModels/>', () => {
                 sampleLsid="S-20200404-1"
                 sampleSet="dirt"
                 sampleRow={{
-                    AliquotTotalVolume: {
-                        displayValue: 100.1,
+                    AliquotVolume: {
+                        value: 100.1,
                     },
                     Units: {
                         displayValue: null,
@@ -230,8 +230,8 @@ describe('<SampleAliquotsSummaryWithModels/>', () => {
                 sampleLsid="S-20200404-1"
                 sampleSet="dirt"
                 sampleRow={{
-                    AliquotTotalVolume: {
-                        displayValue: 150.6,
+                    AliquotVolume: {
+                        value: 150.6,
                     },
                     Units: {
                         displayValue: null,
@@ -277,8 +277,8 @@ describe('<SampleAliquotsSummaryWithModels/>', () => {
                 sampleLsid="S-20200404-1"
                 sampleSet="dirt"
                 sampleRow={{
-                    AliquotTotalVolume: {
-                        displayValue: 150.6,
+                    AliquotVolume: {
+                        value: 150.6,
                     },
                     Units: {
                         displayValue: 'mL',
@@ -317,8 +317,8 @@ describe('<SampleAliquotsSummaryWithModels/>', () => {
                 sampleLsid="S-20200404-1"
                 sampleSet="dirt"
                 sampleRow={{
-                    AliquotTotalVolume: {
-                        displayValue: 50600.1,
+                    AliquotVolume: {
+                        value: 50600.1,
                     },
                     Units: {
                         displayValue: 'mL',
@@ -357,8 +357,8 @@ describe('<SampleAliquotsSummaryWithModels/>', () => {
                 sampleLsid="S-20200404-1"
                 sampleSet="dirt"
                 sampleRow={{
-                    AliquotTotalVolume: {
-                        displayValue: 1100.1,
+                    AliquotVolume: {
+                        value: 1100.1,
                     },
                     Units: {
                         displayValue: 'mL',

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.spec.tsx
@@ -14,7 +14,7 @@ const DEFAULT_PROPS = {
 
 const noAliquotVolume = {
     AliquotVolume: {
-        value: null
+        value: null,
     },
     Units: {
         displayValue: null,
@@ -23,7 +23,7 @@ const noAliquotVolume = {
 
 const zeroAliquotVolume = {
     AliquotVolume: {
-        value: 0
+        value: 0,
     },
     Units: {
         displayValue: null,

--- a/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsSummary.tsx
@@ -50,7 +50,7 @@ export class SampleAliquotsSummaryWithModels extends PureComponent<Props & Sampl
             .addParam('sampleAliquotType', ALIQUOT_FILTER_MODE.aliquots)
             .toHref();
 
-        const totalAliquotVolume = caseInsensitive(sampleRow, 'AliquotTotalVolume')?.displayValue?.toLocaleString();
+        const totalAliquotVolume = caseInsensitive(sampleRow, 'AliquotVolume')?.value?.toLocaleString();
         const units = caseInsensitive(sampleRow, 'Units')?.displayValue ?? caseInsensitive(sampleRow, 'Units')?.value;
         const totalAliquotVolumeDisplay =
             totalAliquotVolume != null ? totalAliquotVolume + (units ? ' ' + units : '') : undefined;


### PR DESCRIPTION
#### Rationale
Switch to use rollup fields from exp.material

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2715
* https://github.com/LabKey/labkey-ui-components/pull/656
* https://github.com/LabKey/inventory/pull/326
* https://github.com/LabKey/sampleManagement/pull/729
* https://github.com/LabKey/biologics/pull/1032

#### Changes
* Update aliquot rollup column fields
