### PR TITLE
Add support for Assay Run Workflow Task

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.6.7",
+    "@labkey/api": "1.6.8-fb-lp-assay-task-client.1",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.1",
+  "version": "2.87.0-fb-lp-assay-task-client.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.87.0-fb-lp-assay-task-client.1",
+  "version": "2.87.0-fb-lp-assay-task-client.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.87.0-fb-lp-assay-task-client.3",
+  "version": "2.87.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.87.0-fb-lp-assay-task-client.0",
+  "version": "2.87.0-fb-lp-assay-task-client.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.87.0-fb-lp-assay-task-client.2",
+  "version": "2.87.0-fb-lp-assay-task-client.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.6.8-fb-lp-assay-task-client.1",
+    "@labkey/api": "1.6.8",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.87.0
+*Released*: ?? October 2021
+* Bump @labkey/api dependency
+* Add AssayTaskInput
+* Update RunPropertiesPanel to render AssayTaskInput
+* Update resolveRenderer to use AssayTaskInput
+
 ### 2.86.1
 *Released*: 26 October 2021
 * Auto-close confirm modal in case of error saving for 'ID/Name Settings' panel

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.87.0
-*Released*: ?? October 2021
+*Released*: 27 October 2021
 * Bump @labkey/api dependency
 * Add AssayTaskInput
 * Update RunPropertiesPanel to render AssayTaskInput

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -204,7 +204,13 @@ class AssayImportPanelsBody extends Component<Props, State> {
     }
 
     initModel = (props: Props): void => {
-        const { assayDefinition, runId } = props;
+        const { assayDefinition, location, runId } = props;
+        let workflowTask;
+
+        if (location.query?.workflowTaskId) {
+            const _workflowTask = parseInt(location.query?.workflowTaskId, 10);
+            workflowTask = isNaN(_workflowTask) ? undefined : _workflowTask;
+        }
 
         if (this.state.model.isInit) {
             return;
@@ -228,6 +234,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                         batchProperties: this.getBatchPropertiesMap(),
                         runProperties: this.getRunPropertiesMap(),
                         queryInfo,
+                        workflowTask,
                     }),
                 }),
                 this.onGetQueryDetailsComplete

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -398,7 +398,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
 
     handleRunChange = (fieldValues: any, isChanged?: boolean): void => {
         const values = { ...this.state.model.runProperties.toObject(), ...fieldValues };
-        let { comment, runName } = this.state.model;
+        let { comment, runName, workflowTask } = this.state.model;
 
         const cleanedValues = Object.keys(values).reduce((result, key) => {
             const value = values[key];
@@ -406,6 +406,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 runName = value;
             } else if (key === 'comment') {
                 comment = value;
+            } else if (key === 'workflowtask') {
+                workflowTask = value;
             } else if (value !== undefined) {
                 result[key] = value;
             }
@@ -421,6 +423,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 model: state.model.merge({
                     runName,
                     comment,
+                    workflowTask,
                 }) as AssayWizardModel,
             }));
         });

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -82,6 +82,7 @@ export class AssayWizardModel
         jobDescription: undefined,
         jobNotificationProvider: undefined,
         forceAsync: false,
+        workflowTask: undefined,
     })
     implements FileAttachmentFormModel {
     declare assayDef: AssayDefinitionModel;
@@ -113,6 +114,7 @@ export class AssayWizardModel
     declare jobDescription?: string;
     declare jobNotificationProvider?: string;
     declare forceAsync?: boolean;
+    declare workflowTask?: number;
 
     isFilesTab(currentStep: AssayUploadTabs): boolean {
         return currentStep === AssayUploadTabs.Files;
@@ -179,6 +181,7 @@ export class AssayWizardModel
             jobDescription,
             jobNotificationProvider,
             forceAsync,
+            workflowTask,
         } = this;
 
         const assayData: any = {
@@ -193,6 +196,7 @@ export class AssayWizardModel
             jobDescription,
             jobNotificationProvider,
             forceAsync,
+            workflowTask,
         };
 
         Object.keys(assayData).forEach(k => {

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, memo } from 'react';
+import React, { FC, memo, useMemo } from 'react';
 import Formsy from 'formsy-react';
 import { Input, Textarea } from 'formsy-react-components';
 
@@ -24,7 +24,20 @@ import { AssayPropertiesPanelProps } from './models';
 
 export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
     const { model, onChange, title = 'Run Details', showQuerySelectPreviewOptions } = props;
-
+    const nameLabel = useMemo(
+        () => (
+            <LabelOverlay
+                description="The assay/experiment ID that uniquely identifies this assay run."
+                label="Assay ID"
+                type="Text (String)"
+            />
+        ),
+        []
+    );
+    const commentLabel = useMemo(
+        () => <LabelOverlay description="Contains comments about this run" label="Comments" type="Text (String)" />,
+        []
+    );
     return (
         <div className="panel panel-default">
             <div className="panel-heading">{title}</div>
@@ -33,13 +46,7 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                     <Input
                         changeDebounceInterval={0}
                         id="runname"
-                        label={
-                            <LabelOverlay
-                                description="The assay/experiment ID that uniquely identifies this assay run."
-                                label="Assay ID"
-                                type="Text (String)"
-                            />
-                        }
+                        label={nameLabel}
                         labelClassName="text-left"
                         name="runname"
                         type="text"
@@ -49,13 +56,7 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                         changeDebounceInterval={0}
                         cols={60}
                         id="comment"
-                        label={
-                            <LabelOverlay
-                                description="Contains comments about this run"
-                                label="Comments"
-                                type="Text (String)"
-                            />
-                        }
+                        label={commentLabel}
                         labelClassName="text-left"
                         name="comment"
                         rows={2}

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -18,6 +18,7 @@ import Formsy from 'formsy-react';
 import { Input, Textarea } from 'formsy-react-components';
 
 import { QueryFormInputs, LabelOverlay } from '../../..';
+import { AssayTaskInput } from '../forms/input/AssayTaskInput';
 
 import { AssayPropertiesPanelProps } from './models';
 
@@ -60,6 +61,7 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                         rows={2}
                         value={model.comment}
                     />
+                    <AssayTaskInput assayId={model.assayDef.id} isDetailInput={false} value={model.workflowTask} />
                     {model.runColumns.size !== 0 && (
                         <QueryFormInputs
                             fieldValues={model.runProperties.toObject()}

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -62,7 +62,12 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                         rows={2}
                         value={model.comment}
                     />
-                    <AssayTaskInput assayId={model.assayDef.id} isDetailInput={false} value={model.workflowTask} />
+                    <AssayTaskInput
+                        assayId={model.assayDef.id}
+                        isDetailInput={false}
+                        name="workflowtask"
+                        value={model.workflowTask}
+                    />
                     {model.runColumns.size !== 0 && (
                         <QueryFormInputs
                             fieldValues={model.runProperties.toObject()}

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -40,7 +40,11 @@ export const RUN_PROPERTIES_REQUIRED_COLUMNS = SCHEMAS.CBMB.concat(
     'ReplacedByRun',
     'DataOutputs',
     'DataOutputs/DataFileUrl',
-    'Batch'
+    'Batch',
+    // Below Columns are required for us to render the WorkflowTask in EditableDetails components
+    'WorkflowTask',
+    'WorkflowTask/Run',
+    'Protocol/RowId'
 ).toList();
 
 let assayDefinitionCache: { [key: string]: Promise<List<AssayDefinitionModel>> } = {};

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -216,6 +216,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                             return renderer(
                                 col,
                                 i,
+                                fieldValues,
                                 value,
                                 false,
                                 allowFieldDisable,

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -58,7 +58,7 @@ export function resolveDetailEditRenderer(
     options?: RenderOptions,
     fileInputRenderer = detailNonEditableRenderer
 ): Renderer {
-    return data => {
+    return (data, row) => {
         const editable = col.isEditable();
 
         // If the column cannot be edited, return as soon as possible
@@ -67,13 +67,13 @@ export function resolveDetailEditRenderer(
             return detailNonEditableRenderer(col, data);
         }
 
-        let value = resolveDetailFieldValue(data, false);
+        let value = resolveDetailFieldValue(data, col.isLookup());
 
         if (col.inputRenderer) {
             const renderer = resolveRenderer(col);
 
             if (renderer) {
-                return renderer(col, col.name, value, true);
+                return renderer(col, col.name, row, value, true);
             }
 
             throw new Error(`"${col.inputRenderer}" is not a valid inputRenderer.`);

--- a/packages/components/src/internal/components/forms/input/AliasInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.tsx
@@ -5,14 +5,14 @@ import { generateId, QueryColumn, SelectInput } from '../../../..';
 interface Props {
     allowDisable?: boolean;
     col: QueryColumn;
-    editing?: boolean;
+    isDetailInput?: boolean;
     initiallyDisabled: boolean;
     onToggleDisable?: (disabled: boolean) => void;
     value?: string | Array<Record<string, any>>;
 }
 
 export const AliasInput: FC<Props> = memo(props => {
-    const { allowDisable, col, editing, initiallyDisabled, onToggleDisable, value } = props;
+    const { allowDisable, col, isDetailInput, initiallyDisabled, onToggleDisable, value } = props;
     const id = useMemo(() => generateId(), []);
     const promptTextCreator = useCallback((text: string) => `Create alias "${text}"`, []);
 
@@ -23,7 +23,7 @@ export const AliasInput: FC<Props> = memo(props => {
             formsy
             id={id}
             initiallyDisabled={initiallyDisabled}
-            inputClass={editing ? 'col-sm-12' : undefined}
+            inputClass={isDetailInput ? 'col-sm-12' : undefined}
             joinValues
             label={col.caption}
             multiple

--- a/packages/components/src/internal/components/forms/input/AssayTaskInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AssayTaskInput.tsx
@@ -1,0 +1,135 @@
+import React, { FC, memo, useCallback, useEffect, useReducer } from 'react';
+import { Filter } from '@labkey/api';
+
+import { Alert, LoadingSpinner, SelectInput, selectRows } from '../../../..';
+
+interface InputOption {
+    label: string;
+    value: number;
+}
+
+async function loadInputOptions(assayId: number): Promise<InputOption[]> {
+    const { key, models } = await selectRows({
+        schemaName: 'samplemanagement',
+        queryName: 'Tasks',
+        columns: 'RowId,Name,AssayTypes,Run/Name',
+        filterArray: [
+            Filter.create('AssayTypes', undefined, Filter.Types.NONBLANK),
+            Filter.create('Status/Value', 'In Progress'),
+        ],
+        maxRows: -1,
+    });
+    const rows = Object.values(models[key]);
+    const taskOptions = [];
+
+    rows.forEach(row => {
+        const taskId = row['RowId'].value;
+        const jobName = row['Run/Name'].value;
+        const taskName = row['Name'].value;
+        const assays = row['AssayTypes'].value.split(',').map(Number);
+        const hasAssay = assays.find(id => assayId === id);
+
+        if (hasAssay) {
+            taskOptions.push({ label: `${jobName} - ${taskName}`, value: taskId });
+        }
+    });
+
+    return taskOptions;
+}
+
+interface WorkflowTaskInputOptionsState {
+    error: string;
+    loading: boolean;
+    taskOptions: InputOption[];
+    value: number;
+}
+
+interface WorkflowTaskInputHook {
+    setValue: (value: number) => void;
+    state: WorkflowTaskInputOptionsState;
+}
+
+const DEFAULT_STATE = {
+    taskOptions: undefined,
+    value: undefined,
+    loading: true,
+    error: undefined,
+};
+
+const inputReducer = (
+    state: WorkflowTaskInputOptionsState,
+    change: Partial<WorkflowTaskInputOptionsState>
+): WorkflowTaskInputOptionsState => ({ ...state, ...change });
+
+function useWorkflowTaskInputState(assayId: number, value?: number): WorkflowTaskInputHook {
+    const [state, setState] = useReducer(inputReducer, { ...DEFAULT_STATE, value });
+    const load = async (): Promise<void> => {
+        if (assayId === undefined) {
+            // If the components rendering the QueryFormInputs or EditableDetailPanel don't properly inject the assayId
+            // into the form data (via ASSAY_INDEX key defined above) then this will happen.
+            setState({ loading: false, error: 'Assay ID not set, cannot load Workflow Tasks' });
+            return;
+        }
+
+        try {
+            const taskOptions = await loadInputOptions(assayId);
+            setState({ taskOptions, loading: false });
+        } catch (error) {
+            console.error(error.exception);
+            setState({ loading: false, error: 'Error loading Workflow Tasks' });
+        }
+    };
+    useEffect(() => {
+        load();
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const setValue = useCallback((newValue: number) => setState({ value: newValue }), []);
+
+    return { setValue, state };
+}
+
+interface WorkflowTaskInputProps {
+    assayId: number;
+    isDetailInput: boolean;
+    value: number;
+}
+
+// Note: this component is specific to Workflow, and ideally would live in the Workflow package, however we do not
+// currently have a way for our Apps to override the InputRenderers used by resolveRenderer (see renderers.tsx).
+export const AssayTaskInput: FC<WorkflowTaskInputProps> = memo(props => {
+    const { assayId, isDetailInput } = props;
+    const { setValue, state } = useWorkflowTaskInputState(assayId, props.value);
+    const { error, loading, taskOptions, value } = state;
+    const onTaskSelect = useCallback((_, taskId) => setValue(taskId), [setValue]);
+    let label;
+    let description;
+
+    if (!isDetailInput) {
+        label = 'Workflow Task';
+        description = 'The Workflow Task associated with this Run';
+    }
+
+    return (
+        <div className="workflow-task-input">
+            {loading && <LoadingSpinner msg="Loading tasks" />}
+
+            {!loading && error && <Alert>{error}</Alert>}
+
+            {!loading && !error && (
+                <SelectInput
+                    formsy
+                    clearable
+                    description={description}
+                    disabled={taskOptions === undefined}
+                    inputClass={isDetailInput ? 'col-sm-12' : undefined}
+                    isLoading={loading}
+                    label={label}
+                    name="workflowtask"
+                    onChange={onTaskSelect}
+                    options={taskOptions}
+                    value={value}
+                />
+            )}
+        </div>
+    );
+});

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -92,7 +92,12 @@ const AssayTaskInputRenderer: InputRenderer = (
     value: any,
     isDetailInput: boolean
 ) => (
-    <AssayTaskInput assayId={data.getIn([ASSAY_ID_INDEX, 'value'])} isDetailInput={isDetailInput} value={value} />
+    <AssayTaskInput
+        assayId={data.getIn([ASSAY_ID_INDEX, 'value'])}
+        isDetailInput={isDetailInput}
+        name={col.name}
+        value={value}
+    />
 );
 
 export function resolveRenderer(column: QueryColumn): InputRenderer {

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -19,6 +19,7 @@ import { Input } from 'formsy-react-components';
 import { addValidationRule, validationRules } from 'formsy-react';
 
 import { QueryColumn } from '../../..';
+import { AssayTaskInput } from './input/AssayTaskInput';
 
 import { LabelOverlay } from './LabelOverlay';
 import { AliasInput } from './input/AliasInput';
@@ -26,8 +27,9 @@ import { AliasInput } from './input/AliasInput';
 type InputRenderer = (
     col: QueryColumn,
     key: ReactText,
-    value?: any,
-    editing?: boolean,
+    data: any, // The data for the entire row/form section
+    value: any,
+    isDetailInput: boolean, // Indicates whether or not the input is being rendered inside an EditableDetailPanel
     allowFieldDisable?: boolean,
     initiallyDisabled?: boolean,
     onToggleDisable?: (disabled: boolean) => void
@@ -36,15 +38,16 @@ type InputRenderer = (
 const AliasInputRenderer: InputRenderer = (
     col: QueryColumn,
     key: ReactText,
-    value?: any,
-    editing?: boolean,
+    data: any,
+    value: any,
+    isDetailInput: boolean,
     allowFieldDisable = false,
     initiallyDisabled = false,
     onToggleDisable?: (disabled: boolean) => void
 ) => (
     <AliasInput
         col={col}
-        editing={editing}
+        isDetailInput={isDetailInput}
         key={key}
         value={value}
         allowDisable={allowFieldDisable}
@@ -56,8 +59,9 @@ const AliasInputRenderer: InputRenderer = (
 const AppendUnitsInputRenderer: InputRenderer = (
     col: QueryColumn,
     key: ReactText,
-    value?: any,
-    editing?: boolean,
+    data: any,
+    value: any,
+    isDetailInput: boolean,
     allowFieldDisable = false,
     initiallyDisabled = false
 ) => (
@@ -66,7 +70,7 @@ const AppendUnitsInputRenderer: InputRenderer = (
         disabled={initiallyDisabled}
         addonAfter={<span>{col.units}</span>}
         changeDebounceInterval={0}
-        elementWrapperClassName={editing ? [{ 'col-sm-9': false }, 'col-sm-12'] : undefined}
+        elementWrapperClassName={isDetailInput ? [{ 'col-sm-9': false }, 'col-sm-12'] : undefined}
         id={col.name}
         key={key}
         label={<LabelOverlay column={col} inputId={col.name} />}
@@ -77,6 +81,18 @@ const AppendUnitsInputRenderer: InputRenderer = (
         value={value}
         validations="isNumericWithError"
     />
+);
+
+const ASSAY_ID_INDEX = 'Protocol/RowId';
+
+const AssayTaskInputRenderer: InputRenderer = (
+    col: QueryColumn,
+    key: ReactText,
+    data: any,
+    value: any,
+    isDetailInput: boolean
+) => (
+    <AssayTaskInput assayId={data.getIn([ASSAY_ID_INDEX, 'value'])} isDetailInput={isDetailInput} value={value} />
 );
 
 export function resolveRenderer(column: QueryColumn): InputRenderer {
@@ -93,6 +109,8 @@ export function resolveRenderer(column: QueryColumn): InputRenderer {
                 return AliasInputRenderer;
             case 'appendunitsinput':
                 return AppendUnitsInputRenderer;
+            case 'workflowtask':
+                return AssayTaskInputRenderer;
             default:
                 break;
         }

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -738,10 +738,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.8-fb-lp-assay-task-client.1":
-  version "1.6.8-fb-lp-assay-task-client.1"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.8-fb-lp-assay-task-client.1.tgz#2dd549bb487c843f741c10c1757b103b37648e9b"
-  integrity sha1-LdVJu0h8hD90HBDBdXsQOzdkjps=
+"@labkey/api@1.6.8":
+  version "1.6.8"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.8.tgz#a80b429bdbf1f4963eb52203d48b5969737a1831"
+  integrity sha1-qAtCm9vx9JY+tSID1ItZaXN6GDE=
 
 "@labkey/eslint-config-base@0.0.11-fb-discussions.2":
   version "0.0.11-fb-discussions.2"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -738,10 +738,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.7":
-  version "1.6.7"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz#20bff29d8be22838bc224d636543dd09ace9afd2"
-  integrity sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I=
+"@labkey/api@1.6.8-fb-lp-assay-task-client.1":
+  version "1.6.8-fb-lp-assay-task-client.1"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.8-fb-lp-assay-task-client.1.tgz#2dd549bb487c843f741c10c1757b103b37648e9b"
+  integrity sha1-LdVJu0h8hD90HBDBdXsQOzdkjps=
 
 "@labkey/eslint-config-base@0.0.11-fb-discussions.2":
   version "0.0.11-fb-discussions.2"


### PR DESCRIPTION
#### Rationale
This PR adds support needed for the Assay Run Workflow Task.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2709
* https://github.com/LabKey/labkey-api-js/pull/113
* https://github.com/LabKey/sampleManagement/pull/730
* https://github.com/LabKey/biologics/pull/1033

#### Changes
* Bump @labkey/api dependency
* Add AssayTaskInput
* Update RunPropertiesPanel to render AssayTaskInput
* Update resolveRenderer to use AssayTaskInput
