### PR TITLE
Fix for BiologicsUniqueNameTest.testSamePrefixInAnotherContainerGetsWarning

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.0-fb-idnamemodal-0.0",
+  "version": "2.86.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.85.0",
+  "version": "2.85.0-fb-idnamemodal-0.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### TBD
+*Released*: TBD
+* Auto-close confirm modal in case of error saving for 'ID/Name Settings' panel
+
 ### version 2.85.0
 *Released*: 18 October 2021
 * Add settings panel 'ID/Name Settings' for use in LKB and LKSM

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### TBD
-*Released*: TBD
+### 2.86.1
+*Released*: 26 October 2021
 * Auto-close confirm modal in case of error saving for 'ID/Name Settings' panel
 
 ### version 2.86.0

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -104,10 +104,10 @@ export const NameIdSettingsForm: FC<Props> = props => {
 
         try {
             await saveNameExpressionOptions('prefix', prefix);
-            setState({ savingPrefix: false, confirmModalOpen: false });
         } catch (err) {
             displayError(err);
         }
+        setState({ savingPrefix: false, confirmModalOpen: false });
     }, [prefix, saveNameExpressionOptions]);
 
     const prefixOnChange = useCallback((evt: any) => {


### PR DESCRIPTION
#### Rationale
Upon displaying an error, the desired behavior is to auto-close the confirm modal.
This branch passed green on TC for the given test outage.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1034

#### Changes
* Close modal and set savingPrefix to false whether prefix saves successfully or not
