### PR TITLE
Issue 43687: UsersGridPanel update to not default to root container path for site/app admin users

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.88.0",
+  "version": "2.88.0-fb-siteUsersGridPanel43687.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.88.0-fb-siteUsersGridPanel43687.0",
+  "version": "2.88.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.87.0",
+  "version": "2.87.0-fb-siteUsersGridPanel43687.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2021
+### version 2.88.1
+*Released*: 28 October 2021
 * Issue 43687: UsersGridPanel update to not default to root container path for site/app admin users
   * always use the given containerPath
   * rename SiteUsersGridPanel to UsersGridPanel

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD October 2021
 * Issue 43687: UsersGridPanel update to not default to root container path for site/app admin users
-  * instead just always use the given containerPath
+  * always use the given containerPath
   * rename SiteUsersGridPanel to UsersGridPanel
 
 ### version 2.88.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2021
+* Issue 43687: UsersGridPanel update to not default to root container path for site/app admin users
+  * instead just always use the given containerPath
+  * rename SiteUsersGridPanel to UsersGridPanel
+
 ### version 2.87.0
 *Released*: 27 October 2021
 * Bump @labkey/api dependency

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -379,7 +379,7 @@ import { UserSelectInput } from './internal/components/forms/input/UserSelectInp
 import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
-import { SiteUsersGridPanel } from './internal/components/user/SiteUsersGridPanel';
+import { UsersGridPanel } from './internal/components/user/UsersGridPanel';
 import { UserProvider, useUserProperties } from './internal/components/user/UserProvider';
 import { UserLink } from './internal/components/user/UserLink';
 import { FieldEditorOverlay } from './internal/components/forms/FieldEditorOverlay';
@@ -839,7 +839,7 @@ export {
     UserProfile,
     UserLink,
     ChangePasswordModal,
-    SiteUsersGridPanel,
+    UsersGridPanel,
     InsufficientPermissionsPage,
     APPLICATION_SECURITY_ROLES,
     SITE_SECURITY_ROLES,

--- a/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
@@ -27,7 +27,7 @@ import { makeTestActions, makeTestQueryModel } from '../../../public/QueryModel/
 import { SCHEMAS } from '../../schemas';
 import { QueryInfo } from '../../../public/QueryInfo';
 
-import { SiteUsersGridPanelImpl } from './SiteUsersGridPanel';
+import { UsersGridPanelImpl } from './UsersGridPanel';
 
 const POLICY = SecurityPolicy.create(policyJSON);
 const ROLES = processGetRolesResponse(rolesJSON.roles);
@@ -37,7 +37,7 @@ beforeAll(() => {
     initQueryGridState();
 });
 
-describe('<SiteUsersGridPanel/>', () => {
+describe('<UsersGridPanel/>', () => {
     const DEFAULT_PROPS = {
         user: TEST_USER_APP_ADMIN,
         onCreateComplete: jest.fn(),
@@ -74,7 +74,7 @@ describe('<SiteUsersGridPanel/>', () => {
     };
 
     test('active users view', () => {
-        const component = <SiteUsersGridPanelImpl {...DEFAULT_PROPS} />;
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} />;
 
         const wrapper = mount(component);
         expect(wrapper.find('GridPanel')).toHaveLength(1);
@@ -93,7 +93,7 @@ describe('<SiteUsersGridPanel/>', () => {
     });
 
     test('without delete or deactivate', () => {
-        const component = <SiteUsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_PROJECT_ADMIN} />;
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_PROJECT_ADMIN} />;
 
         const wrapper = mount(component);
         expect(wrapper.find('GridPanel')).toHaveLength(1);
@@ -112,7 +112,7 @@ describe('<SiteUsersGridPanel/>', () => {
     });
 
     test('without create, delete, or deactivate', () => {
-        const component = <SiteUsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_FOLDER_ADMIN} />;
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_FOLDER_ADMIN} />;
 
         const wrapper = mount(component);
         expect(wrapper.find('GridPanel')).toHaveLength(1);
@@ -131,7 +131,7 @@ describe('<SiteUsersGridPanel/>', () => {
     });
 
     test('inactive users view', () => {
-        const component = <SiteUsersGridPanelImpl {...DEFAULT_PROPS} />;
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} />;
 
         const wrapper = mount(component);
         wrapper.setState({ usersView: 'inactive' });
@@ -152,7 +152,7 @@ describe('<SiteUsersGridPanel/>', () => {
     });
 
     test('all users view', () => {
-        const component = <SiteUsersGridPanelImpl {...DEFAULT_PROPS} />;
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} />;
 
         const wrapper = mount(component);
         wrapper.setState({ usersView: 'all' });
@@ -173,14 +173,14 @@ describe('<SiteUsersGridPanel/>', () => {
     });
 
     test('showDetailsPanel false', () => {
-        const component = <SiteUsersGridPanelImpl {...DEFAULT_PROPS} showDetailsPanel={false} />;
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} showDetailsPanel={false} />;
         const wrapper = mount(component);
         expect(wrapper.find('UserDetailsPanel')).toHaveLength(0);
         wrapper.unmount();
     });
 
     test('loading', () => {
-        const component = <SiteUsersGridPanelImpl {...DEFAULT_PROPS} queryModels={{}} />;
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} queryModels={{}} />;
         const wrapper = mount(component);
         expect(wrapper.find('LoadingSpinner')).toHaveLength(1);
         expect(wrapper.find('GridPanel')).toHaveLength(0);

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -74,7 +74,7 @@ interface State {
 }
 
 // exported for jest testing
-export class SiteUsersGridPanelImpl extends PureComponent<Props, State> {
+export class UsersGridPanelImpl extends PureComponent<Props, State> {
     static defaultProps = {
         showDetailsPanel: true,
         allowResetPassword: true,
@@ -136,7 +136,6 @@ export class SiteUsersGridPanelImpl extends PureComponent<Props, State> {
         actions.addModel(
             {
                 id: this.getUsersModelId(),
-                containerPath: user.hasManageUsersPermission() ? '/' : undefined, // use root container for app admins to get all site users
                 schemaQuery: SCHEMAS.CORE_TABLES.USERS,
                 baseFilters,
                 omittedColumns: OMITTED_COLUMNS,
@@ -364,4 +363,4 @@ export class SiteUsersGridPanelImpl extends PureComponent<Props, State> {
     }
 }
 
-export const SiteUsersGridPanel = withQueryModels(SiteUsersGridPanelImpl);
+export const UsersGridPanel = withQueryModels(UsersGridPanelImpl);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43687

In the SM app, the Administration > Users grid was showing all site users when the user logged in was a site or application admin (i.e. had root container admin permissions). This was causing some confusion in the app as the expectation was that the grid would should just users that had permissions to the given container/project. 

This PR updates that component/grid to show the core.Users table for the given container instead of the root container for the site/application admins. This is effectively the same as the LKS Project Users grid / page.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/660
* https://github.com/LabKey/sampleManagement/pull/733
* https://github.com/LabKey/platform/pull/2721

#### Changes
* rename SiteUsersGridPanel to UsersGridPanel
* UsersGridPanel update to not default to root container path for site/app admin users
