### PR TITLE
Item 9537: Sample Status, Remove experimental feature flag

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.1-fb-smSampleStatusEnabled.1",
+  "version": "2.86.1-fb-smSampleStatusEnabled.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.1",
+  "version": "2.86.1-fb-smSampleStatusEnabled.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.88.1",
+  "version": "2.88.1-fb-smSampleStatusEnabled.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.1-fb-smSampleStatusEnabled.0",
+  "version": "2.86.1-fb-smSampleStatusEnabled.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.0-fb-smSampleStatusEnabled.0",
+  "version": "2.86.0-fb-smSampleStatusEnabled.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.86.0",
+  "version": "2.86.0-fb-smSampleStatusEnabled.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.88.1-fb-smSampleStatusEnabled.0",
+  "version": "2.88.1-fb-smSampleStatusEnabled.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.88.1-fb-smSampleStatusEnabled.1",
+  "version": "2.89.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,8 +3,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD October 2021
-* Item ...
-    * Add sample status column to picklist default view on creation, if sample status is enabled
+* Item 9537: Sample Status, Remove experimental feature flag
+    * Update isSampleStatusEnabled() check to be based on existence of SM module
+    * Add sample status column to allowed aliquot fields (for create, bulk insert/update dialogs)
+    * Sample URL resolver fix for LKB mixture batches
 
 ### version 2.88.1
 *Released*: 28 October 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD October 2021
 * Item ...
+  * Add sample status column to picklist default view on creation, if sample status is enabled
 
 ### version 2.86.0
 *Released*: 22 October 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -30,7 +30,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Update RunPropertiesPanel to render AssayTaskInput
 * Update resolveRenderer to use AssayTaskInput
 
-### 2.86.1
+### version 2.86.1
 *Released*: 26 October 2021
 * Auto-close confirm modal in case of error saving for 'ID/Name Settings' panel
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2021
+* Item ...
+
 ### version 2.86.0
 *Released*: 22 October 2021
 * Item 9584: ManageSampleStatusesPanel for sample statuses CRUD operations

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2021
+### version 2.89.0
+*Released*: 28 October 2021
 * Item 9537: Sample Status, Remove experimental feature flag
     * Update isSampleStatusEnabled() check to be based on existence of SM module
     * Add sample status column to allowed aliquot fields (for create, bulk insert/update dialogs)

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -24,10 +24,12 @@ import {
     getStorageSectionConfig,
     hasPremiumModule,
     isBiologicsEnabled,
+    isCommunityDistribution,
     isFreezerManagementEnabled,
     isPremiumProductEnabled,
     isProductNavigationEnabled,
     isSampleManagerEnabled,
+    isSampleStatusEnabled,
     sampleManagerIsPrimaryApp,
     userCanDesignLocations,
     userCanDesignSourceTypes,
@@ -268,6 +270,13 @@ describe('utils', () => {
         expect(isFreezerManagementEnabled({inventory: {}, samplemanagement: {}, biologics: {}}, SAMPLE_MANAGER_APP_PROPERTIES.productId)).toBeTruthy();
     });
 
+    test('isSampleStatusEnabled', () => {
+        LABKEY.moduleContext = { api: { moduleNames: [] } };
+        expect(isSampleStatusEnabled()).toBeFalsy();
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
+        expect(isSampleStatusEnabled()).toBeTruthy();
+    });
+
     test('isProductNavigationEnabled', () => {
         LABKEY.moduleContext = {};
         expect(isProductNavigationEnabled(SAMPLE_MANAGER_APP_PROPERTIES.productId)).toBeFalsy();
@@ -299,29 +308,31 @@ describe('utils', () => {
     });
 
     test('hasPremiumModule', () => {
-        const Component: FC = () => {
-            return <div>{hasPremiumModule() ? 'true' : 'false'}</div>;
-        };
-
         LABKEY.moduleContext = {};
-        let wrapper = mount(<Component />);
-        expect(wrapper.find('div').text()).toBe('false');
-        wrapper.unmount();
+        expect(hasPremiumModule()).toBeFalsy();
 
-        LABKEY.moduleContext = { api: { moduleNames: ['sampleManagement'] } };
-        wrapper = mount(<Component />);
-        expect(wrapper.find('div').text()).toBe('false');
-        wrapper.unmount();
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
+        expect(hasPremiumModule()).toBeFalsy();
 
         LABKEY.moduleContext = { api: { moduleNames: ['api', 'core', 'premium'] } };
-        wrapper = mount(<Component />);
-        expect(wrapper.find('div').text()).toBe('true');
-        wrapper.unmount();
+        expect(hasPremiumModule()).toBeTruthy();
 
         LABKEY.moduleContext = { api: {} };
-        wrapper = mount(<Component />);
-        expect(wrapper.find('div').text()).toBe('false');
-        wrapper.unmount();
+        expect(hasPremiumModule()).toBeFalsy();
+    });
+
+    test('isCommunityDistribution', () => {
+        LABKEY.moduleContext = {};
+        expect(isCommunityDistribution()).toBeTruthy();
+
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
+        expect(isCommunityDistribution()).toBeFalsy();
+
+        LABKEY.moduleContext = { api: { moduleNames: ['premium'] } };
+        expect(isCommunityDistribution()).toBeFalsy();
+
+        LABKEY.moduleContext = { api: { moduleNames: ['api'] } };
+        expect(isCommunityDistribution()).toBeTruthy();
     });
 
     test("isPremiumProductEnabled", () => {

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react';
 import { mount } from 'enzyme';
 
+import { List, Map } from 'immutable';
+
 import { MenuSectionConfig, User } from '../..';
 
 import {
@@ -49,7 +51,6 @@ import {
     USER_KEY,
     WORKFLOW_KEY,
 } from './constants';
-import { List, Map } from 'immutable';
 
 describe('getMenuSectionConfigs', () => {
     test('sampleManager enabled', () => {
@@ -159,9 +160,7 @@ describe('getMenuSectionConfigs', () => {
         expect(configs.getIn([3, 'freezers', 'seeAllURL'])).toEqual('#/home');
 
         expect(configs.hasIn([4, 'workflow'])).toBeTruthy();
-        expect(configs.getIn([4, 'workflow', 'seeAllURL'])).toEqual(
-            '/labkey/samplemanager/app.view#/workflow'
-        );
+        expect(configs.getIn([4, 'workflow', 'seeAllURL'])).toEqual('/labkey/samplemanager/app.view#/workflow');
 
         expect(configs.hasIn([4, 'user'])).toBeTruthy();
     });
@@ -211,7 +210,7 @@ describe('utils', () => {
             samplemanagement: {},
         };
         expect(isSampleManagerEnabled()).toBeTruthy();
-        expect(isSampleManagerEnabled({ inventory: {}})).toBeFalsy();
+        expect(isSampleManagerEnabled({ inventory: {} })).toBeFalsy();
     });
 
     test('isBiologicsEnabled', () => {
@@ -228,7 +227,7 @@ describe('utils', () => {
             biologics: {},
         };
         expect(isBiologicsEnabled()).toBeTruthy();
-        expect(isBiologicsEnabled({inventory: {}})).toBeFalsy();
+        expect(isBiologicsEnabled({ inventory: {} })).toBeFalsy();
     });
 
     test('isFreezerManagementEnabled', () => {
@@ -266,8 +265,13 @@ describe('utils', () => {
             biologics: { isFreezerManagerEnabled: true },
         };
         expect(isFreezerManagementEnabled()).toBeTruthy();
-        expect(isFreezerManagementEnabled({inventory: {}, samplemanagement: {}, biologics: {}})).toBeFalsy();
-        expect(isFreezerManagementEnabled({inventory: {}, samplemanagement: {}, biologics: {}}, SAMPLE_MANAGER_APP_PROPERTIES.productId)).toBeTruthy();
+        expect(isFreezerManagementEnabled({ inventory: {}, samplemanagement: {}, biologics: {} })).toBeFalsy();
+        expect(
+            isFreezerManagementEnabled(
+                { inventory: {}, samplemanagement: {}, biologics: {} },
+                SAMPLE_MANAGER_APP_PROPERTIES.productId
+            )
+        ).toBeTruthy();
     });
 
     test('isSampleStatusEnabled', () => {
@@ -335,48 +339,52 @@ describe('utils', () => {
         expect(isCommunityDistribution()).toBeTruthy();
     });
 
-    test("isPremiumProductEnabled", () => {
+    test('isPremiumProductEnabled', () => {
         LABKEY.moduleContext = {};
         expect(isPremiumProductEnabled({})).toBeFalsy();
-        expect(isPremiumProductEnabled({inventory: {}})).toBeFalsy();
-        expect(isPremiumProductEnabled({samplemanagement: {}, inventory: {}})).toBeTruthy();
-        expect(isPremiumProductEnabled({biologics: {}, samplemanagement: {}, inventory: {}})).toBeTruthy();
-        LABKEY.moduleContext = {inventory: {}};
+        expect(isPremiumProductEnabled({ inventory: {} })).toBeFalsy();
+        expect(isPremiumProductEnabled({ samplemanagement: {}, inventory: {} })).toBeTruthy();
+        expect(isPremiumProductEnabled({ biologics: {}, samplemanagement: {}, inventory: {} })).toBeTruthy();
+        LABKEY.moduleContext = { inventory: {} };
         expect(isPremiumProductEnabled()).toBeFalsy();
-        LABKEY.moduleContext = {samplemanagement: {}};
+        LABKEY.moduleContext = { samplemanagement: {} };
         expect(isPremiumProductEnabled()).toBeTruthy();
     });
 
-    test("sampleManagerIsPrimaryApp", () => {
+    test('sampleManagerIsPrimaryApp', () => {
         LABKEY.moduleContext = {};
         expect(sampleManagerIsPrimaryApp()).toBeFalsy();
-        expect(sampleManagerIsPrimaryApp({inventory: {}})).toBeFalsy();
-        expect(sampleManagerIsPrimaryApp({samplemanagement: {}, inventory: {}})).toBeTruthy();
-        expect(sampleManagerIsPrimaryApp({biologics: {}, samplemanagement: {}, inventory: {}})).toBeFalsy();
-        LABKEY.moduleContext = {samplemanagement: {}};
+        expect(sampleManagerIsPrimaryApp({ inventory: {} })).toBeFalsy();
+        expect(sampleManagerIsPrimaryApp({ samplemanagement: {}, inventory: {} })).toBeTruthy();
+        expect(sampleManagerIsPrimaryApp({ biologics: {}, samplemanagement: {}, inventory: {} })).toBeFalsy();
+        LABKEY.moduleContext = { samplemanagement: {} };
         expect(sampleManagerIsPrimaryApp()).toBeTruthy();
     });
 
-    test("biologcisIsPrimaryApp", () => {
+    test('biologcisIsPrimaryApp', () => {
         LABKEY.moduleContext = {};
         expect(biologicsIsPrimaryApp()).toBeFalsy();
-        expect(biologicsIsPrimaryApp({samplemanagement: {}})).toBeFalsy();
-        expect(biologicsIsPrimaryApp({inventory: {}})).toBeFalsy();
-        expect(biologicsIsPrimaryApp({biologics: {}, samplemanagement: {}, inventory: {}})).toBeTruthy();
-        LABKEY.moduleContext = {biologics: {}, samplemanagement: {}};
+        expect(biologicsIsPrimaryApp({ samplemanagement: {} })).toBeFalsy();
+        expect(biologicsIsPrimaryApp({ inventory: {} })).toBeFalsy();
+        expect(biologicsIsPrimaryApp({ biologics: {}, samplemanagement: {}, inventory: {} })).toBeTruthy();
+        LABKEY.moduleContext = { biologics: {}, samplemanagement: {} };
         expect(biologicsIsPrimaryApp()).toBeTruthy();
     });
 
-    test("getPrimaryAppProperties", () => {
+    test('getPrimaryAppProperties', () => {
         LABKEY.moduleContext = {};
         expect(getPrimaryAppProperties()).toBe(undefined);
-        expect(getPrimaryAppProperties({inventory: {}})).toStrictEqual(FREEZER_MANAGER_APP_PROPERTIES);
-        expect(getPrimaryAppProperties(({inventory: {}, samplemanagement: {}}))).toStrictEqual(SAMPLE_MANAGER_APP_PROPERTIES);
-        expect(getPrimaryAppProperties({inventory: {}, samplemanagement: {}, biologics: {}})).toStrictEqual(BIOLOGICS_APP_PROPERTIES);
+        expect(getPrimaryAppProperties({ inventory: {} })).toStrictEqual(FREEZER_MANAGER_APP_PROPERTIES);
+        expect(getPrimaryAppProperties({ inventory: {}, samplemanagement: {} })).toStrictEqual(
+            SAMPLE_MANAGER_APP_PROPERTIES
+        );
+        expect(getPrimaryAppProperties({ inventory: {}, samplemanagement: {}, biologics: {} })).toStrictEqual(
+            BIOLOGICS_APP_PROPERTIES
+        );
     });
 });
 
-describe("getCurrentAppProperties", () => {
+describe('getCurrentAppProperties', () => {
     const { location } = window;
 
     beforeAll(() => {
@@ -387,176 +395,234 @@ describe("getCurrentAppProperties", () => {
         window.location = location;
     });
 
-    test("Sample Manager controller", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Sam Man/samplemanager-app.view#",
-        });
+    test('Sample Manager controller', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Sam Man/samplemanager-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(SAMPLE_MANAGER_APP_PROPERTIES);
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Biologics/samplemanager-app.view#",
-        });
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Biologics/samplemanager-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(SAMPLE_MANAGER_APP_PROPERTIES);
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Biologics/sampleManager-app.view#",
-        });
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Biologics/sampleManager-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(SAMPLE_MANAGER_APP_PROPERTIES);
     });
 
-    test("Biologics controller", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "/Biologics/biologics-app.view#",
-        });
+    test('Biologics controller', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: '/Biologics/biologics-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(BIOLOGICS_APP_PROPERTIES);
-        window.location = Object.assign({ ...location }, {
-            pathname: "/samplemanager/biologics-app.view#",
-        });
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: '/samplemanager/biologics-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(BIOLOGICS_APP_PROPERTIES);
-        window.location = Object.assign({ ...location }, {
-            pathname: "/Biologics/BiologicS-app.view#",
-        });
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: '/Biologics/BiologicS-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(BIOLOGICS_APP_PROPERTIES);
     });
 
-    test("Freezer Manager controller", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "/Biologics/freezermanager-app.view#",
-        });
+    test('Freezer Manager controller', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: '/Biologics/freezermanager-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(FREEZER_MANAGER_APP_PROPERTIES);
-        window.location = Object.assign({ ...location }, {
-            pathname: "/sampleManager/FreezerManager-app.view#",
-        });
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: '/sampleManager/FreezerManager-app.view#',
+            }
+        );
         expect(getCurrentAppProperties()).toStrictEqual(FREEZER_MANAGER_APP_PROPERTIES);
     });
 
-    test("Non-app controller", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "/Biologics/project-begin.view",
-        });
+    test('Non-app controller', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: '/Biologics/project-begin.view',
+            }
+        );
         expect(getCurrentAppProperties()).toBe(undefined);
     });
 });
 
-describe("getStorageSectionConfig", () => {
-    test("FM not enabled", () => {
-        expect(getStorageSectionConfig(TEST_USER_EDITOR, SAMPLE_MANAGER_APP_PROPERTIES.productId, {}, 2)).toBe(undefined);
-        expect(getStorageSectionConfig(TEST_USER_EDITOR, BIOLOGICS_APP_PROPERTIES.productId, {inventory: {}, biologics: {}}, 2)).toBe(undefined);
-        expect(getStorageSectionConfig(TEST_USER_EDITOR, BIOLOGICS_APP_PROPERTIES.productId, {inventory: {}, biologics: { isFreezerManagerEnabled: false }}, 2)).toBe(undefined);
+describe('getStorageSectionConfig', () => {
+    test('FM not enabled', () => {
+        expect(getStorageSectionConfig(TEST_USER_EDITOR, SAMPLE_MANAGER_APP_PROPERTIES.productId, {}, 2)).toBe(
+            undefined
+        );
+        expect(
+            getStorageSectionConfig(
+                TEST_USER_EDITOR,
+                BIOLOGICS_APP_PROPERTIES.productId,
+                { inventory: {}, biologics: {} },
+                2
+            )
+        ).toBe(undefined);
+        expect(
+            getStorageSectionConfig(
+                TEST_USER_EDITOR,
+                BIOLOGICS_APP_PROPERTIES.productId,
+                { inventory: {}, biologics: { isFreezerManagerEnabled: false } },
+                2
+            )
+        ).toBe(undefined);
     });
 
-    test("reader, inventory app", () => {
-        const config = getStorageSectionConfig(TEST_USER_READER, FREEZER_MANAGER_APP_PROPERTIES.productId, { inventory: { productId: FREEZER_MANAGER_APP_PROPERTIES.productId}}, 3);
+    test('reader, inventory app', () => {
+        const config = getStorageSectionConfig(
+            TEST_USER_READER,
+            FREEZER_MANAGER_APP_PROPERTIES.productId,
+            { inventory: { productId: FREEZER_MANAGER_APP_PROPERTIES.productId } },
+            3
+        );
         expect(config.maxColumns).toBe(1);
         expect(config.maxItemsPerColumn).toBe(3);
-        expect(config.emptyText).toBe("No freezers have been defined");
+        expect(config.emptyText).toBe('No freezers have been defined');
         expect(config.emptyURL).toBe(undefined);
-        expect(config.iconURL).toBe("/labkey/_images/freezer_menu.svg")
-        expect(config.seeAllURL).toBe("#/home");
-        expect(config.headerURL).toBe("#/home");
+        expect(config.iconURL).toBe('/labkey/_images/freezer_menu.svg');
+        expect(config.seeAllURL).toBe('#/home');
+        expect(config.headerURL).toBe('#/home');
         expect(config.headerText).toBe(undefined);
     });
 
-    test("reader, non-inventory app", () => {
-        const config = getStorageSectionConfig(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, { inventory: { productId: FREEZER_MANAGER_APP_PROPERTIES.productId}}, 4);
+    test('reader, non-inventory app', () => {
+        const config = getStorageSectionConfig(
+            TEST_USER_READER,
+            SAMPLE_MANAGER_APP_PROPERTIES.productId,
+            { inventory: { productId: FREEZER_MANAGER_APP_PROPERTIES.productId } },
+            4
+        );
         expect(config.maxItemsPerColumn).toBe(4);
-        expect(config.seeAllURL).toBe("/labkey/freezermanager/app.view#/home");
-        expect(config.headerURL).toBe("/labkey/freezermanager/app.view#/home");
+        expect(config.seeAllURL).toBe('/labkey/freezermanager/app.view#/home');
+        expect(config.headerURL).toBe('/labkey/freezermanager/app.view#/home');
         expect(config.emptyURL).toBe(undefined);
     });
 
-    test("editor", () => {
-        const config = getStorageSectionConfig(TEST_USER_FOLDER_ADMIN, BIOLOGICS_APP_PROPERTIES.productId, { inventory: { productId: FREEZER_MANAGER_APP_PROPERTIES.productId}}, 4);
+    test('editor', () => {
+        const config = getStorageSectionConfig(
+            TEST_USER_FOLDER_ADMIN,
+            BIOLOGICS_APP_PROPERTIES.productId,
+            { inventory: { productId: FREEZER_MANAGER_APP_PROPERTIES.productId } },
+            4
+        );
         expect(config.maxItemsPerColumn).toBe(4);
-        expect(config.seeAllURL).toBe("/labkey/freezermanager/app.view#/home");
-        expect(config.headerURL).toBe("/labkey/freezermanager/app.view#/home");
-        expect(config.emptyURL).toBe("/labkey/freezermanager/app.view#/freezers/new")
-        expect(config.emptyURLText).toBe("Create a freezer")
+        expect(config.seeAllURL).toBe('/labkey/freezermanager/app.view#/home');
+        expect(config.headerURL).toBe('/labkey/freezermanager/app.view#/home');
+        expect(config.emptyURL).toBe('/labkey/freezermanager/app.view#/freezers/new');
+        expect(config.emptyURLText).toBe('Create a freezer');
     });
 });
 
-describe("addSourcesSectionConfig", () => {
-    test("reader", () => {
+describe('addSourcesSectionConfig', () => {
+    test('reader', () => {
         let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addSourcesSectionConfig(TEST_USER_READER, "/labkey/test/app.view", configs);
+        configs = addSourcesSectionConfig(TEST_USER_READER, '/labkey/test/app.view', configs);
         expect(configs.size).toBe(1);
         const sectionConfig = configs.get(0).get(SOURCES_KEY);
         expect(sectionConfig.maxColumns).toBe(1);
         expect(sectionConfig.maxItemsPerColumn).toBe(12);
-        expect(sectionConfig.emptyText).toBe("No source types have been defined");
+        expect(sectionConfig.emptyText).toBe('No source types have been defined');
         expect(sectionConfig.emptyURL).toBe(undefined);
-        expect(sectionConfig.seeAllURL).toBe("/labkey/test/app.view#/sources?viewAs=grid");
+        expect(sectionConfig.seeAllURL).toBe('/labkey/test/app.view#/sources?viewAs=grid');
         expect(sectionConfig.showActiveJobIcon).toBe(true);
-        expect(sectionConfig.iconURL).toBe("/labkey/_images/source_type.svg");
+        expect(sectionConfig.iconURL).toBe('/labkey/_images/source_type.svg');
         expect(sectionConfig.headerURL).toBe(undefined);
         expect(sectionConfig.headerText).toBe(undefined);
     });
 
-    test("admin", () => {
+    test('admin', () => {
         let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addSourcesSectionConfig(TEST_USER_FOLDER_ADMIN, "/labkey/test/app.view", configs);
+        configs = addSourcesSectionConfig(TEST_USER_FOLDER_ADMIN, '/labkey/test/app.view', configs);
         expect(configs.size).toBe(1);
         const sectionConfig = configs.get(0).get(SOURCES_KEY);
-        expect(sectionConfig.emptyText).toBe("No source types have been defined");
-        expect(sectionConfig.emptyURL).toBe("/labkey/test/app.view#/sourceType/new");
-        expect(sectionConfig.emptyURLText).toBe("Create a source type");
+        expect(sectionConfig.emptyText).toBe('No source types have been defined');
+        expect(sectionConfig.emptyURL).toBe('/labkey/test/app.view#/sourceType/new');
+        expect(sectionConfig.emptyURLText).toBe('Create a source type');
     });
 });
 
-describe("addSamplesSectionConfig", () => {
-    test("reader", () => {
+describe('addSamplesSectionConfig', () => {
+    test('reader', () => {
         let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addSamplesSectionConfig(TEST_USER_READER, "/labkey/samplemanager/app.view", configs);
+        configs = addSamplesSectionConfig(TEST_USER_READER, '/labkey/samplemanager/app.view', configs);
         expect(configs.size).toBe(1);
         const sectionConfig = configs.get(0).get(SAMPLES_KEY);
         expect(sectionConfig.maxColumns).toBe(1);
         expect(sectionConfig.maxItemsPerColumn).toBe(12);
-        expect(sectionConfig.emptyText).toBe("No sample types have been defined");
+        expect(sectionConfig.emptyText).toBe('No sample types have been defined');
         expect(sectionConfig.emptyURL).toBe(undefined);
-        expect(sectionConfig.seeAllURL).toBe("/labkey/samplemanager/app.view#/samples?viewAs=cards");
+        expect(sectionConfig.seeAllURL).toBe('/labkey/samplemanager/app.view#/samples?viewAs=cards');
         expect(sectionConfig.showActiveJobIcon).toBe(true);
-        expect(sectionConfig.iconURL).toBe("/labkey/_images/samples.svg");
+        expect(sectionConfig.iconURL).toBe('/labkey/_images/samples.svg');
         expect(sectionConfig.headerURL).toBe(undefined);
         expect(sectionConfig.headerText).toBe(undefined);
     });
 
-    test("admin", () => {
+    test('admin', () => {
         let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addSamplesSectionConfig(TEST_USER_FOLDER_ADMIN, "/labkey/samplemanager/app.view", configs);
+        configs = addSamplesSectionConfig(TEST_USER_FOLDER_ADMIN, '/labkey/samplemanager/app.view', configs);
         expect(configs.size).toBe(1);
         const sectionConfig = configs.get(0).get(SAMPLES_KEY);
-        expect(sectionConfig.emptyURL).toBe("/labkey/samplemanager/app.view#/sampleType/new");
-        expect(sectionConfig.emptyURLText).toBe("Create a sample type");
+        expect(sectionConfig.emptyURL).toBe('/labkey/samplemanager/app.view#/sampleType/new');
+        expect(sectionConfig.emptyURLText).toBe('Create a sample type');
     });
 });
 
-describe("addAssaySectionConfig", () => {
-    test("reader", () => {
+describe('addAssaySectionConfig', () => {
+    test('reader', () => {
         let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addAssaysSectionConfig(TEST_USER_READER, "/labkey/test/app.view", configs);
+        configs = addAssaysSectionConfig(TEST_USER_READER, '/labkey/test/app.view', configs);
         expect(configs.size).toBe(1);
         const sectionConfig = configs.get(0).get(ASSAYS_KEY);
         expect(sectionConfig.maxColumns).toBe(2);
         expect(sectionConfig.maxItemsPerColumn).toBe(12);
-        expect(sectionConfig.emptyText).toBe("No assays have been defined");
+        expect(sectionConfig.emptyText).toBe('No assays have been defined');
         expect(sectionConfig.emptyURL).toBe(undefined);
-        expect(sectionConfig.seeAllURL).toBe("/labkey/test/app.view#/assays?viewAs=grid");
+        expect(sectionConfig.seeAllURL).toBe('/labkey/test/app.view#/assays?viewAs=grid');
         expect(sectionConfig.showActiveJobIcon).toBe(true);
-        expect(sectionConfig.iconURL).toBe("/labkey/_images/assay.svg");
+        expect(sectionConfig.iconURL).toBe('/labkey/_images/assay.svg');
         expect(sectionConfig.headerURL).toBe(undefined);
         expect(sectionConfig.headerText).toBe(undefined);
     });
 
-    test("admin", () => {
+    test('admin', () => {
         let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addAssaysSectionConfig(TEST_USER_FOLDER_ADMIN, "/labkey/test/app.view", configs);
+        configs = addAssaysSectionConfig(TEST_USER_FOLDER_ADMIN, '/labkey/test/app.view', configs);
         expect(configs.size).toBe(1);
         const sectionConfig = configs.get(0).get(ASSAYS_KEY);
-        expect(sectionConfig.emptyText).toBe("No assays have been defined");
-        expect(sectionConfig.emptyURL).toBe("/labkey/test/app.view#/assayDesign/new");
-        expect(sectionConfig.emptyURLText).toBe("Create an assay design");
+        expect(sectionConfig.emptyText).toBe('No assays have been defined');
+        expect(sectionConfig.emptyURL).toBe('/labkey/test/app.view#/assayDesign/new');
+        expect(sectionConfig.emptyURLText).toBe('Create an assay design');
     });
 });
 
-describe("getMenuSectionConfigs", () => {
+describe('getMenuSectionConfigs', () => {
     const { location } = window;
 
     beforeAll(() => {
@@ -568,11 +634,17 @@ describe("getMenuSectionConfigs", () => {
         window.location = location;
     });
 
-    test("Sample Manager", () => {
-        window.location = Object.assign({...location}, {
-            pathname: "labkey/Samples/sampleManager-app.view#"
+    test('Sample Manager', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Samples/sampleManager-app.view#',
+            }
+        );
+        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
+            inventory: {},
+            samplemanagement: {},
         });
-        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {inventory: {}, samplemanagement: {}});
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, SOURCES_KEY])).toBeDefined();
         expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
@@ -582,11 +654,18 @@ describe("getMenuSectionConfigs", () => {
         expect(configs.getIn([4, USER_KEY])).toBeDefined();
     });
 
-    test("Biologics primary, in Sample Manager", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Biologics/samplemanager-app.view#",
+    test('Biologics primary, in Sample Manager', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Biologics/samplemanager-app.view#',
+            }
+        );
+        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
+            inventory: {},
+            samplemanagement: {},
+            biologics: {},
         });
-        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {inventory: {}, samplemanagement: {}, biologics: {}});
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, SOURCES_KEY])).toBeDefined();
         expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
@@ -596,11 +675,18 @@ describe("getMenuSectionConfigs", () => {
         expect(configs.getIn([4, USER_KEY])).toBeDefined();
     });
 
-    test("Biologics, no experimental features", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Biologics/biologics-app.view#",
+    test('Biologics, no experimental features', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Biologics/biologics-app.view#',
+            }
+        );
+        const configs = getMenuSectionConfigs(TEST_USER_READER, BIOLOGICS_APP_PROPERTIES.productId, {
+            inventory: {},
+            samplemanagement: {},
+            biologics: {},
         });
-        const configs = getMenuSectionConfigs(TEST_USER_READER, BIOLOGICS_APP_PROPERTIES.productId, {inventory: {}, samplemanagement: {}, biologics: {}});
         expect(configs.size).toBe(4);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();
         expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
@@ -610,12 +696,18 @@ describe("getMenuSectionConfigs", () => {
         expect(configs.getIn([3, NOTEBOOKS_KEY])).toBeDefined();
     });
 
-    test("Biologics with Requests", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Biologics/biologics-app.view#",
+    test('Biologics with Requests', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Biologics/biologics-app.view#',
+            }
+        );
+        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
+            inventory: {},
+            samplemanagement: {},
+            biologics: { 'experimental-biologics-requests-menu': true },
         });
-        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId,
-            {inventory: {}, samplemanagement: {}, biologics: {'experimental-biologics-requests-menu': true}});
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();
         expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
@@ -626,12 +718,18 @@ describe("getMenuSectionConfigs", () => {
         expect(configs.getIn([4, NOTEBOOKS_KEY])).toBeDefined();
     });
 
-    test("Biologics with FM", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Biologics/biologics-app.view#",
+    test('Biologics with FM', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Biologics/biologics-app.view#',
+            }
+        );
+        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
+            inventory: {},
+            samplemanagement: {},
+            biologics: { isFreezerManagerEnabled: true },
         });
-        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId,
-            {inventory: {}, samplemanagement: {}, biologics: {isFreezerManagerEnabled: true}});
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();
         expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
@@ -642,12 +740,18 @@ describe("getMenuSectionConfigs", () => {
         expect(configs.getIn([4, NOTEBOOKS_KEY])).toBeDefined();
     });
 
-    test("Biologics with FM and Requests", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Biologics/biologics-app.view#",
+    test('Biologics with FM and Requests', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Biologics/biologics-app.view#',
+            }
+        );
+        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
+            inventory: {},
+            samplemanagement: {},
+            biologics: { 'experimental-biologics-requests-menu': true, isFreezerManagerEnabled: true },
         });
-        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId,
-            {inventory: {}, samplemanagement: {}, biologics: {'experimental-biologics-requests-menu': true, isFreezerManagerEnabled: true}});
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();
         expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
@@ -659,15 +763,18 @@ describe("getMenuSectionConfigs", () => {
         expect(configs.getIn([4, NOTEBOOKS_KEY])).toBeDefined();
     });
 
-    test("Freezer Manager", () => {
-        window.location = Object.assign({ ...location }, {
-            pathname: "labkey/Cold Storage/freezermanager-app.view#",
+    test('Freezer Manager', () => {
+        window.location = Object.assign(
+            { ...location },
+            {
+                pathname: 'labkey/Cold Storage/freezermanager-app.view#',
+            }
+        );
+        const configs = getMenuSectionConfigs(TEST_USER_READER, FREEZER_MANAGER_APP_PROPERTIES.productId, {
+            inventory: {},
         });
-        const configs = getMenuSectionConfigs(TEST_USER_READER, FREEZER_MANAGER_APP_PROPERTIES.productId,
-            {inventory: {}});
         expect(configs.size).toBe(2);
         expect(configs.getIn([0, FREEZERS_KEY])).toBeDefined();
         expect(configs.getIn([1, USER_KEY])).toBeDefined();
     });
-
 });

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -158,8 +158,8 @@ export function biologicsIsPrimaryApp(moduleContext?: any): boolean {
     return getPrimaryAppProperties(moduleContext)?.productId === BIOLOGICS_APP_PROPERTIES.productId;
 }
 
-export function isSampleStatusEnabled(moduleContext?: any): boolean {
-    return (moduleContext ?? getServerContext().moduleContext)?.experiment?.['experimental-sample-status'] === true;
+export function isSampleStatusEnabled(): boolean {
+    return hasModule('SampleManagement');
 }
 
 export function getCurrentAppProperties(): AppProperties {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
@@ -102,7 +102,7 @@ describe('SampleTypeDesigner', () => {
     });
 
     test('open fields panel, with barcodes', async () => {
-        LABKEY.moduleContext = { api: { moduleNames: ['sampleManagement', 'api', 'core', 'premium'] } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement', 'api', 'core', 'premium'] } };
         const wrapped = mount(<SampleTypeDesigner {...BASE_PROPS} />);
         await sleep();
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -104,7 +104,7 @@ import {
     removeEntityParentType,
 } from './EntityParentTypeSelectors';
 
-const ALIQUOT_FIELD_COLS = ['aliquotedfrom', 'name', 'description'];
+const ALIQUOT_FIELD_COLS = ['aliquotedfrom', 'name', 'description', 'samplestate'];
 const ALIQUOT_NOUN_SINGULAR = 'Aliquot';
 const ALIQUOT_NOUN_PLURAL = 'Aliquots';
 class EntityGridLoader implements IGridLoader {

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -19,7 +19,6 @@ import { PICKLIST_KEY } from '../../app/constants';
 import { isSampleStatusEnabled } from '../../app/utils';
 
 import { Picklist, PICKLIST_KEY_COLUMN, PICKLIST_SAMPLE_ID_COLUMN } from './models';
-import { isSampleStatusEnabled } from "../../app/utils";
 
 export function getPicklists(): Promise<Picklist[]> {
     return new Promise((resolve, reject) => {

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -68,7 +68,7 @@ export function setPicklistDefaultView(name: string): Promise<string> {
             { fieldKey: 'SampleID/StorageLocation' },
             { fieldKey: 'SampleID/StorageRow' },
             { fieldKey: 'SampleID/StorageCol' },
-            { fieldKey: 'SampleID/isAliquot' },
+            { fieldKey: 'SampleID/isAliquot' }
         );
 
         const jsonData = {

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -17,6 +17,7 @@ import { SCHEMAS } from '../../../index';
 import { PICKLIST_KEY } from '../../app/constants';
 
 import { Picklist, PICKLIST_KEY_COLUMN, PICKLIST_SAMPLE_ID_COLUMN } from './models';
+import { isSampleStatusEnabled } from "../../app/utils";
 
 export function getPicklists(): Promise<Picklist[]> {
     return new Promise((resolve, reject) => {
@@ -47,29 +48,32 @@ export function getPicklists(): Promise<Picklist[]> {
 
 export function setPicklistDefaultView(name: string): Promise<string> {
     return new Promise((resolve, reject) => {
+        const columns = [
+            { fieldKey: 'SampleID/Name' },
+            { fieldKey: 'SampleID/LabelColor' },
+            { fieldKey: 'SampleID/SampleSet' },
+        ];
+        if (isSampleStatusEnabled()) {
+            columns.push({ fieldKey: 'SampleID/SampleState' });
+        }
+        columns.push(
+            { fieldKey: 'SampleID/StoredAmount' },
+            { fieldKey: 'SampleID/Units' },
+            { fieldKey: 'SampleID/freezeThawCount' },
+            { fieldKey: 'SampleID/StorageStatus' },
+            { fieldKey: 'SampleID/checkedOutBy' },
+            { fieldKey: 'SampleID/Created' },
+            { fieldKey: 'SampleID/CreatedBy' },
+            { fieldKey: 'SampleID/StorageLocation' },
+            { fieldKey: 'SampleID/StorageRow' },
+            { fieldKey: 'SampleID/StorageCol' },
+            { fieldKey: 'SampleID/isAliquot' },
+        );
+
         const jsonData = {
             schemaName: 'lists',
             queryName: name,
-            views: [
-                {
-                    columns: [
-                        { fieldKey: 'SampleID/Name' },
-                        { fieldKey: 'SampleID/LabelColor' },
-                        { fieldKey: 'SampleID/SampleSet' },
-                        { fieldKey: 'SampleID/StoredAmount' },
-                        { fieldKey: 'SampleID/Units' },
-                        { fieldKey: 'SampleID/freezeThawCount' },
-                        { fieldKey: 'SampleID/StorageStatus' },
-                        { fieldKey: 'SampleID/checkedOutBy' },
-                        { fieldKey: 'SampleID/Created' },
-                        { fieldKey: 'SampleID/CreatedBy' },
-                        { fieldKey: 'SampleID/StorageLocation' },
-                        { fieldKey: 'SampleID/StorageRow' },
-                        { fieldKey: 'SampleID/StorageCol' },
-                        { fieldKey: 'SampleID/isAliquot' },
-                    ],
-                },
-            ],
+            views: [{ columns }],
             shared: true,
         };
         return Ajax.request({

--- a/packages/components/src/internal/components/samples/SampleStatusTag.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusTag.spec.tsx
@@ -88,7 +88,6 @@ describe('SampleStatusTag', () => {
     });
 
     test('iconOnly, no description', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={availableNoDescription} iconOnly={true} />);
         validateIconOnly(wrapper, 'alert-success');
     });

--- a/packages/components/src/internal/components/samples/SampleStatusTag.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusTag.spec.tsx
@@ -7,6 +7,10 @@ import { LabelHelpTip } from '../base/LabelHelpTip';
 import { SampleStatusTag } from './SampleStatusTag';
 import { SampleStateType } from './constants';
 
+beforeEach(() => {
+    LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
+});
+
 describe('SampleStatusTag', () => {
     const lockedStatus = {
         label: 'Locked for testing',
@@ -63,49 +67,41 @@ describe('SampleStatusTag', () => {
     });
 
     test('enabled, no label', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={{ label: undefined, statusType: SampleStateType.Locked }} />);
         expect(wrapper.find('span').exists()).toBeFalsy();
     });
 
     test('iconOnly, locked', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={lockedStatus} iconOnly={true} />);
         validateIconOnly(wrapper, 'alert-danger');
     });
 
     test('iconOnly, consumed', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={consumedStatus} iconOnly={true} />);
         validateIconOnly(wrapper, 'alert-warning');
     });
 
     test('iconOnly, available', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={availableStatus} iconOnly={true} />);
         validateIconOnly(wrapper, 'alert-success');
     });
 
     test('not iconOnly, locked status type', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={lockedStatus} />);
         validateNotIconOnly(wrapper, 'alert-danger', lockedStatus.label);
     });
 
     test('consumed status type', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={consumedStatus} />);
         validateNotIconOnly(wrapper, 'alert-warning', consumedStatus.label);
     });
 
     test('available status type with description', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const wrapper = mount(<SampleStatusTag status={availableStatus} />);
         validateNotIconOnly(wrapper, 'alert-success', availableStatus.label);
     });
 
     test('available status type, no description', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
         const status = {
             label: 'Also available',
             statusType: SampleStateType.Available,

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
@@ -15,6 +15,13 @@ describe('SamplesBulkUpdateForm', () => {
         shownInUpdateView: true,
         userEditable: true,
     });
+    const COLUMN_STATUS = new QueryColumn({
+        fieldKey: 'samplestate',
+        name: 'samplestate',
+        fieldKeyArray: ['samplestate'],
+        shownInUpdateView: true,
+        userEditable: true,
+    });
     const COLUMN_META = new QueryColumn({
         fieldKey: 'meta',
         name: 'meta',
@@ -35,6 +42,7 @@ describe('SamplesBulkUpdateForm', () => {
         schemaName: 'schema',
         columns: {
             description: COLUMN_DESCRIPTION,
+            samplestate: COLUMN_STATUS,
             meta: COLUMN_META,
             aliquotspecific: COLUMN_ALIQUOT,
         },
@@ -80,8 +88,9 @@ describe('SamplesBulkUpdateForm', () => {
     test('all selected are samples', () => {
         const wrapper = mount(<SamplesBulkUpdateFormBase {...DEFAULT_PROPS} />);
         const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(2);
+        expect(queryInfo.columns.size).toBe(3);
         expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
+        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
         expect(queryInfo.columns.get('meta')).toBe(COLUMN_META);
         wrapper.unmount();
     });
@@ -93,8 +102,9 @@ describe('SamplesBulkUpdateForm', () => {
         };
         const wrapper = mount(<SamplesBulkUpdateFormBase {...props} />);
         const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(2);
+        expect(queryInfo.columns.size).toBe(3);
         expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
+        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
         expect(queryInfo.columns.get('aliquotspecific')).toBe(COLUMN_ALIQUOT);
 
         wrapper.unmount();
@@ -107,8 +117,9 @@ describe('SamplesBulkUpdateForm', () => {
         };
         const wrapper = mount(<SamplesBulkUpdateFormBase {...props} />);
         const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(2);
+        expect(queryInfo.columns.size).toBe(3);
         expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
+        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
         expect(queryInfo.columns.get('meta')).toBe(COLUMN_META);
 
         const aliquotWarning = wrapper.find(BulkUpdateForm).prop('header');
@@ -124,8 +135,9 @@ describe('SamplesBulkUpdateForm', () => {
         };
         const wrapper = mount(<SamplesBulkUpdateFormBase {...props} />);
         const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(2);
+        expect(queryInfo.columns.size).toBe(3);
         expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
+        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
         expect(queryInfo.columns.get('meta')).toBe(COLUMN_META);
 
         const aliquotWarning = wrapper.find(BulkUpdateForm).prop('header');

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
@@ -59,11 +59,12 @@ export class SamplesBulkUpdateFormBase extends React.Component<Props, any> {
 
         let columns = OrderedMap<string, QueryColumn>();
 
-        // if all are aliquots, only show pk, aliquot specific and description columns
+        // if all are aliquots, only show pk, aliquot specific and description/samplestate columns
         if (aliquots && aliquots.length === this.getGridSelectionSize()) {
             originalQueryInfo.columns.forEach((column, key) => {
                 const isAliquotField = sampleTypeDomainFields.aliquotFields.indexOf(column.fieldKey.toLowerCase()) > -1;
-                if (column.fieldKey.toLowerCase() === 'description' || isAliquotField)
+                const lcFieldKey = column.fieldKey.toLowerCase();
+                if (lcFieldKey === 'description' || lcFieldKey === 'samplestate' || isAliquotField)
                     columns = columns.set(key, column);
             });
             originalQueryInfo.getPkCols().forEach(column => {

--- a/packages/components/src/internal/components/samples/utils.spec.tsx
+++ b/packages/components/src/internal/components/samples/utils.spec.tsx
@@ -184,7 +184,7 @@ describe('filterSampleRowsForOperation', () => {
     }
 
     test('all available', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         const data = {
             1: availableRow1,
             2: availableRow2,
@@ -193,7 +193,7 @@ describe('filterSampleRowsForOperation', () => {
     });
 
     test('all locked', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         const data = {
             30: lockedRow1,
             31: lockedRow2,
@@ -203,7 +203,7 @@ describe('filterSampleRowsForOperation', () => {
     });
 
     test('mixed statuses', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         const data = {
             30: lockedRow1,
             20: consumedRow1,

--- a/packages/components/src/internal/components/samples/utils.spec.tsx
+++ b/packages/components/src/internal/components/samples/utils.spec.tsx
@@ -76,7 +76,7 @@ describe('getSampleDeleteMessage', () => {
     });
 
     test('cannot delete, status enabled', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         const wrapper = mount(<span>{getSampleDeleteMessage(false, false)}</span>);
         expect(wrapper.find(LoadingSpinner).exists()).toBeFalsy();
         expect(wrapper.text()).toContain(
@@ -95,13 +95,13 @@ describe('isSampleOperationPermitted', () => {
     });
 
     test('enabled, no status provided', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         expect(isSampleOperationPermitted(undefined, SampleOperation.EditMetadata)).toBeTruthy();
         expect(isSampleOperationPermitted(null, SampleOperation.EditLineage)).toBeTruthy();
     });
 
     test('enabled, with status type provided', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         expect(isSampleOperationPermitted(SampleStateType.Locked, SampleOperation.EditMetadata)).toBeFalsy();
         expect(isSampleOperationPermitted(SampleStateType.Locked, SampleOperation.AddToPicklist)).toBeTruthy();
         expect(isSampleOperationPermitted(SampleStateType.Consumed, SampleOperation.AddToStorage)).toBeFalsy();
@@ -117,12 +117,12 @@ describe('getFilterForSampleOperation', () => {
     });
 
     test('enabled, all allowed', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         expect(getFilterForSampleOperation(SampleOperation.AddToPicklist)).toBeNull();
     });
 
     test('enabled, some status does not allow', () => {
-        LABKEY.moduleContext = { experiment: { 'experimental-sample-status': true } };
+        LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
         expect(getFilterForSampleOperation(SampleOperation.EditLineage)).toStrictEqual(
             Filter.create(SAMPLE_STATE_TYPE_COLUMN_NAME, [SampleStateType.Locked], Filter.Types.NOT_IN)
         );

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -247,14 +247,14 @@ export class SamplesResolver implements AppRouteResolver {
                                 .then(info => {
                                     if (info) {
                                         if (info.isMedia) {
-                                            // for supporting MIXTURE_BATCHES => batches
+                                            // for supporting MIXTURE_BATCHES => mixturebatches
                                             this.samples = this.samples.set(
                                                 sampleRowId,
                                                 List([
                                                     'media',
                                                     info.name.toLowerCase() ===
                                                     SCHEMAS.SAMPLE_SETS.MIXTURE_BATCHES.queryName.toLowerCase()
-                                                        ? 'batches'
+                                                        ? 'mixturebatches'
                                                         : info.name,
                                                 ])
                                             );


### PR DESCRIPTION
#### Rationale
We are ready to enable the sample status feature for the LKB, LKSM, and LKFM apps. This set of PRs removes that experimental feature flag and turns on the sample status column/field for various grid displays, insert/update forms, etc.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/661
* https://github.com/LabKey/platform/pull/2722
* https://github.com/LabKey/sampleManagement/pull/734
* https://github.com/LabKey/biologics/pull/1037
* https://github.com/LabKey/inventory/pull/327
* https://github.com/LabKey/testAutomation/pull/893

#### Changes
* Update isSampleStatusEnabled() check to be based on existence of SM module
* Add sample status column to allowed aliquot fields (for create, bulk insert/update dialogs)
* Add sample status column to picklist default view on creation, if sample status is enabled
