### PR TITLE
Issue 43793: Use field description as title attribute on grid columns

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.89.1-gridTitles.0",
+  "version": "2.89.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 43793: Use field descriptions as title attribute on grid column headers
+
 ### version 2.88.1
 *Released*: 28 October 2021
 * Issue 43687: UsersGridPanel update to not default to root container path for site/app admin users

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.89.1
+*Released*: 29 October 2021
 * Issue 43793: Use field descriptions as title attribute on grid column headers
 
 ### version 2.89.0

--- a/packages/components/src/internal/components/__snapshots__/PreviewGrid.spec.tsx.snap
+++ b/packages/components/src/internal/components/__snapshots__/PreviewGrid.spec.tsx.snap
@@ -43,6 +43,9 @@ exports[`PreviewGrid render PreviewGrid with data 1`] = `
                 "minWidth": undefined,
               }
             }
+            title="Contains a short name for this data object
+If not provided, a unique name will be generated from the expression:
+null"
           >
             Name
           </th>
@@ -54,6 +57,7 @@ exports[`PreviewGrid render PreviewGrid with data 1`] = `
                 "minWidth": undefined,
               }
             }
+            title="Contains a reference to a user-editable comment about this row"
           >
             Flag
           </th>
@@ -76,6 +80,7 @@ exports[`PreviewGrid render PreviewGrid with data 1`] = `
                 "minWidth": undefined,
               }
             }
+            title="The expiration period in days."
           >
             Expiration Time
           </th>
@@ -252,6 +257,9 @@ exports[`PreviewGrid render PreviewGrid with different numCols and numRows 1`] =
                 "minWidth": undefined,
               }
             }
+            title="Contains a short name for this data object
+If not provided, a unique name will be generated from the expression:
+null"
           >
             Name
           </th>
@@ -263,6 +271,7 @@ exports[`PreviewGrid render PreviewGrid with different numCols and numRows 1`] =
                 "minWidth": undefined,
               }
             }
+            title="Contains a reference to a user-editable comment about this row"
           >
             Flag
           </th>

--- a/packages/components/src/internal/components/__snapshots__/QueryGridPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/__snapshots__/QueryGridPanel.spec.tsx.snap
@@ -2196,6 +2196,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                       "minWidth": "62px",
                     }
                   }
+                  title="Contains a reference to a user-editable comment about this row"
                 >
                   <span>
                     Flag
@@ -2270,6 +2271,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                       "minWidth": undefined,
                     }
                   }
+                  title="Link to the run's graph"
                 >
                   <span>
                     
@@ -2283,6 +2285,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                       "minWidth": "94px",
                     }
                   }
+                  title="The assay/experiment ID that uniquely identifies this assay run."
                 >
                   <span>
                     Assay Id
@@ -2357,6 +2360,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                       "minWidth": "86px",
                     }
                   }
+                  title="Contains the time at which this run was created"
                 >
                   <span>
                     Created
@@ -2431,6 +2435,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                       "minWidth": "110px",
                     }
                   }
+                  title="Contains the user who created this run"
                 >
                   <span>
                     Created By
@@ -2505,6 +2510,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                       "minWidth": "110px",
                     }
                   }
+                  title="Contains a unique id for this run"
                 >
                   <span>
                     Run Groups
@@ -3023,6 +3029,7 @@ exports[`QueryGridPanel render with showTabs and two grid tabs with one empty (s
                       "minWidth": "70px",
                     }
                   }
+                  title="Contains the associated batch or empty if this run is not part of a batch."
                 >
                   <span>
                     Batch

--- a/packages/components/src/internal/components/assay/__snapshots__/RunDataPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/assay/__snapshots__/RunDataPanel.spec.tsx.snap
@@ -300,6 +300,7 @@ exports[`<RunDataPanel/> custom display props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="When a matching specimen exists in a study, can be used to identify subject and timepoint for assay. Alternately, supply ParticipantID and either VisitID or Date."
                       >
                         Specimen ID
                       </th>
@@ -311,6 +312,7 @@ exports[`<RunDataPanel/> custom display props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="Used with either VisitID or Date to identify subject and timepoint for assay."
                       >
                         Participant ID
                       </th>
@@ -322,6 +324,7 @@ exports[`<RunDataPanel/> custom display props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="Used with ParticipantID to identify subject and timepoint for assay."
                       >
                         Visit ID
                       </th>
@@ -333,6 +336,7 @@ exports[`<RunDataPanel/> custom display props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="Used with ParticipantID to identify subject and timepoint for assay."
                       >
                         Date
                       </th>
@@ -656,6 +660,7 @@ exports[`<RunDataPanel/> default props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="When a matching specimen exists in a study, can be used to identify subject and timepoint for assay. Alternately, supply ParticipantID and either VisitID or Date."
                       >
                         Specimen ID
                       </th>
@@ -667,6 +672,7 @@ exports[`<RunDataPanel/> default props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="Used with either VisitID or Date to identify subject and timepoint for assay."
                       >
                         Participant ID
                       </th>
@@ -678,6 +684,7 @@ exports[`<RunDataPanel/> default props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="Used with ParticipantID to identify subject and timepoint for assay."
                       >
                         Visit ID
                       </th>
@@ -689,6 +696,7 @@ exports[`<RunDataPanel/> default props 1`] = `
                             "minWidth": "100px",
                           }
                         }
+                        title="Used with ParticipantID to identify subject and timepoint for assay."
                       >
                         Date
                       </th>

--- a/packages/components/src/internal/components/base/Grid.spec.tsx
+++ b/packages/components/src/internal/components/base/Grid.spec.tsx
@@ -139,4 +139,31 @@ describe('Grid component', () => {
         const tree = renderer.create(<Grid data={gridData} messages={gridMessages} />).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    test("with phi data", () => {
+        let columns = gridColumns.push(new GridColumn({
+            index: 'age',
+            title: 'Age',
+            raw: {
+                phiProtected: true,
+                description: 'Your age'
+            },
+        }));
+        columns = columns.push(new GridColumn({
+            index: 'teamPlayer',
+            title: 'Team Player',
+            raw: {
+                description: 'Are you a team player?'
+            }
+        }));
+        columns = columns.push(new GridColumn({
+            index: 'lefty',
+            title: 'Lefty',
+            raw: {
+                phiProtected: true
+            }
+        }));
+        const tree = renderer.create(<Grid data={gridData} columns={columns} />).toJSON();
+        expect(tree).toMatchSnapshot();
+    })
 });

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -187,7 +187,11 @@ class GridHeader extends PureComponent<GridHeaderProps, any> {
                                 'grid-header-cell': headerCls === undefined,
                                 'phi-protected': raw?.phiProtected === true,
                             });
-                            const _title = raw?.phiProtected === true ? '(PHI protected data removed)' : undefined;
+                            let description = raw?.description || '';
+                             description = description + ' ' + (raw?.phiProtected === true ? '(PHI protected data removed)' : '');
+                             description = description.trim();
+                             if (!description)
+                                 description = undefined;
 
                             return (
                                 <th
@@ -195,7 +199,7 @@ class GridHeader extends PureComponent<GridHeaderProps, any> {
                                     key={index}
                                     onClick={this._handleClick.bind(this, column)}
                                     style={{ minWidth }}
-                                    title={_title}
+                                    title={description}
                                 >
                                     {headerCell ? headerCell(column, i, columns.size) : title}
                                 </th>

--- a/packages/components/src/internal/components/base/__snapshots__/Grid.spec.tsx.snap
+++ b/packages/components/src/internal/components/base/__snapshots__/Grid.spec.tsx.snap
@@ -838,3 +838,300 @@ exports[`Grid component rendering with no data and columns 1`] = `
   </table>
 </div>
 `;
+
+exports[`Grid component with phi data 1`] = `
+<div
+  className="table-responsive"
+>
+  <div
+    className="grid-messages"
+  />
+  <table
+    className="table table-striped table-bordered"
+  >
+    <thead>
+      <tr>
+        <th
+          className="grid-header-cell"
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+        >
+          Player Name
+        </th>
+        <th
+          className="grid-header-cell"
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+        >
+          Number
+        </th>
+        <th
+          className="grid-header-cell"
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+        >
+          Position
+        </th>
+        <th
+          className="grid-header-cell phi-protected"
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+          title="Your age (PHI protected data removed)"
+        >
+          Age
+        </th>
+        <th
+          className="grid-header-cell"
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+          title="Are you a team player?"
+        >
+          Team Player
+        </th>
+        <th
+          className="grid-header-cell phi-protected"
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+          title="(PHI protected data removed)"
+        >
+          Lefty
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Dee Gordon
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          9
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          2B
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+      </tr>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Mike Zunino
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          3
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          C
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+      </tr>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Kyle Seager
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          15
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          3B
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+      </tr>
+      <tr
+        className=""
+      >
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Zero
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          0
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        >
+          Bench
+        </td>
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+        <td
+          style={
+            Object {
+              "textAlign": "left",
+            }
+          }
+        />
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;


### PR DESCRIPTION
#### Rationale
In [Issue 43793](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43793) it is noted that in LKS we use the field descriptions in the title attributes for column headers in our data grids but do not do this for our apps.  This PR adds descriptions if we've got 'em.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1038
* https://github.com/LabKey/sampleManagement/pull/736

#### Changes
* Update `Grid` component to use column description field to construct column header's title attribute
