### PR TITLE
Release 2.90.1

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.0",
+  "version": "2.90.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.90.1
 *Released*: 1 November 2021
-* Previous release was built before merging from develop, so was missing features from 2.87.0 to 2.89.2
+* Previous release was built against an incorrect version of api-js which broke workflow task support included in 2.87.0
 
 ### version 2.90.0
 *Released*: 29 October 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.90.1
+*Released*: 1 November 2021
+* Previous release was built before merging from develop, so was missing features from 2.87.0 to 2.89.2
+
 ### version 2.90.0
 *Released*: 29 October 2021
 * Support 'Status' setting on Assay Designs


### PR DESCRIPTION
#### Rationale
The 2.90.0 release of ui-components is missing the features from 2.87.0 to 2.89.2. I suspect it was released before merging into develop, and before develop was merged into the feature branch for 2.90.0. This PR simply bumps the version to 2.90.1 so we can release a new version built from develop that includes missing features.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Bump components to 2.90.1