### PR TITLE
Remove Prefix support for non-LKSM builds

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.1",
+  "version": "2.90.1-21.11-fb-fixdataclasstest1-1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.1-21.11-fb-fixdataclasstest1-1.0",
+  "version": "2.90.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 1 November 2021
 * Previous release was built against an incorrect version of api-js which broke workflow task support included in 2.87.0
 
+### version TBD
+*Released*: TBD
+* Ensure LK instances without LKSM do not call prefix-related actions
+
 ### version 2.90.0
 *Released*: 29 October 2021
 * Support 'Status' setting on Assay Designs

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,13 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.90.2
+*Released*: 3 November 2021
+* Ensure LK instances without LKSM do not call prefix-related actions
+
 ### version 2.90.1
 *Released*: 1 November 2021
 * Previous release was built against an incorrect version of api-js which broke workflow task support included in 2.87.0
-
-### version TBD
-*Released*: TBD
-* Ensure LK instances without LKSM do not call prefix-related actions
 
 ### version 2.90.0
 *Released*: 29 October 2021

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -10,6 +10,7 @@ import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesi
 
 import { DataClassPropertiesPanel } from './DataClassPropertiesPanel';
 import { DataClassModel, DataClassModelConfig } from './models';
+import { isSampleManagerEnabled } from "../../../app/utils";
 
 interface Props {
     nounSingular?: string;
@@ -59,7 +60,7 @@ class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDomainDesi
     }
 
     componentDidMount = async (): Promise<void> => {
-        if (this.state.model.isNew) {
+        if (this.state.model.isNew && isSampleManagerEnabled()) {
             const response = await this.props.loadNameExpressionOptions();
 
             this.setState(

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
@@ -20,6 +20,7 @@ import { loadNameExpressionOptions } from '../../settings/actions';
 import { PROPERTIES_PANEL_NAMING_PATTERN_WARNING_MSG } from '../constants';
 
 import { DataClassModel } from './models';
+import {isSampleManagerEnabled} from "../../../app/utils";
 
 const PROPERTIES_HEADER_ID = 'dataclass-properties-hdr';
 const FORM_IDS = {
@@ -61,11 +62,13 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
     state: Readonly<State> = { isValid: true, prefix: undefined, loadingError: undefined };
 
     componentDidMount = async (): Promise<void> => {
-        try {
-            const response = await loadNameExpressionOptions();
-            this.setState({ prefix: response.prefix ?? null });
-        } catch (error) {
-            this.setState({ loadingError: 'There was a problem retrieving the Naming Pattern prefix.' });
+        if (isSampleManagerEnabled()) {
+            try {
+                const response = await loadNameExpressionOptions();
+                this.setState({ prefix: response.prefix ?? null });
+            } catch (error) {
+                this.setState({ loadingError: 'There was a problem retrieving the Naming Pattern prefix.' });
+            }
         }
     };
 

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -1472,24 +1472,7 @@ exports[`DataClassDesigner initModel 1`] = `
       Symbol(immer-draftable): true,
     }
   }
-  loadNameExpressionOptions={
-    [MockFunction] {
-      "calls": Array [
-        Array [],
-        Array [],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": Promise {},
-        },
-        Object {
-          "type": "return",
-          "value": Promise {},
-        },
-      ],
-    }
-  }
+  loadNameExpressionOptions={[MockFunction]}
   onCancel={[MockFunction]}
   onComplete={[MockFunction]}
   testMode={true}
@@ -1819,24 +1802,7 @@ exports[`DataClassDesigner initModel 1`] = `
         Symbol(immer-draftable): true,
       }
     }
-    loadNameExpressionOptions={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-          Array [],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
-        ],
-      }
-    }
+    loadNameExpressionOptions={[MockFunction]}
     nounPlural="Data Classes"
     nounSingular="Data Class"
     onCancel={[MockFunction]}

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -42,7 +42,11 @@ import { ENTITY_FORM_IDS } from '../entities/constants';
 
 import { AutoLinkToStudyDropdown } from '../AutoLinkToStudyDropdown';
 
-import { getCurrentProductName, isCommunityDistribution } from '../../../app/utils';
+import {
+    getCurrentProductName,
+    isCommunityDistribution,
+    isSampleManagerEnabled
+} from '../../../app/utils';
 
 import { loadNameExpressionOptions } from '../../settings/actions';
 
@@ -157,11 +161,13 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
                 this.setState(() => ({ containers: List<Container>() }));
             });
 
-        try {
-            const response = await loadNameExpressionOptions();
-            this.setState({ prefix: response.prefix ?? null });
-        } catch (error) {
-            this.setState({ loadingError: 'There was a problem retrieving the Naming Pattern prefix.' });
+        if (isSampleManagerEnabled()) {
+            try {
+                const response = await loadNameExpressionOptions();
+                this.setState({ prefix: response.prefix ?? null });
+            } catch (error) {
+                this.setState({ loadingError: 'There was a problem retrieving the Naming Pattern prefix.' });
+            }
         }
     };
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -76,7 +76,7 @@ import { BulkAddData } from '../editable/EditableGrid';
 
 import { DERIVATION_DATA_SCOPE_CHILD_ONLY } from '../domainproperties/constants';
 
-import { getCurrentProductName } from '../../app/utils';
+import {getCurrentProductName, isSampleManagerEnabled} from '../../app/utils';
 
 import { fetchDomainDetails } from '../domainproperties/actions';
 
@@ -273,16 +273,18 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
         const allowParents = this.allowParents();
 
-        try {
-            const nameIdSettings = await this.props.loadNameExpressionOptions();
-            this.setState({ allowUserSpecifiedNames: nameIdSettings.allowUserSpecifiedNames });
-        } catch (error) {
-            this.setState({
-                error: getActionErrorMessage(
-                    'There was a problem retrieving name expression options.',
-                    this.typeTextPlural
-                ),
-            });
+        if (isSampleManagerEnabled()) {
+            try {
+                const nameIdSettings = await this.props.loadNameExpressionOptions();
+                this.setState({ allowUserSpecifiedNames: nameIdSettings.allowUserSpecifiedNames });
+            } catch (error) {
+                this.setState({
+                    error: getActionErrorMessage(
+                        'There was a problem retrieving name expression options.',
+                        this.typeTextPlural
+                    ),
+                });
+            }
         }
 
         let { insertModel } = this.state;


### PR DESCRIPTION
#### Rationale
In a previous feature that supported an administrative ability to set an optional prefix for data classes and sample types on a per container basis, we called a function `loadNameExpressionOptions()` in order to access a LKSM action that accesses the prefix value. But, for builds that lack LKSM, this call began to generate errors in the LKS-view of data classes and sample types. This PR conditionalizes the call to `loadNameExpressionOptions()` to when we know LKSM exists.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/652
* https://github.com/LabKey/platform/pull/2743

#### Changes
* For data classes, only load prefix when LKSM exists within build
* For sample types, only load prefix when LKSM exists within build
