### PR TITLE
Issue 44250: Invalidate QueryInfo caches after change to NameIdSettings.allowUserSpecifiedNames

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.2-fb-allowUserSpecifiedNames44250.0",
+  "version": "2.90.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.2",
+  "version": "2.90.2-fb-allowUserSpecifiedNames44250.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.90.TBD
+*Released*: TBD November 2021
+* Issue 44250: Invalidate QueryInfo caches after change to NameIdSettings.allowUserSpecifiedNames
+
 ### version 2.90.2
 *Released*: 3 November 2021
 * Ensure LK instances without LKSM do not call prefix-related actions

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.90.TBD
-*Released*: TBD November 2021
+### version 2.90.3
+*Released*: 10 November 2021
 * Issue 44250: Invalidate QueryInfo caches after change to NameIdSettings.allowUserSpecifiedNames
 
 ### version 2.90.2

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -8,9 +8,10 @@ import DomainForm from '../DomainForm';
 import { getDomainPanelStatus, saveDomain } from '../actions';
 import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesigner } from '../BaseDomainDesigner';
 
+import { isSampleManagerEnabled } from '../../../app/utils';
+
 import { DataClassPropertiesPanel } from './DataClassPropertiesPanel';
 import { DataClassModel, DataClassModelConfig } from './models';
-import { isSampleManagerEnabled } from "../../../app/utils";
 
 interface Props {
     nounSingular?: string;
@@ -45,7 +46,7 @@ class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDomainDesi
         nounSingular: 'Data Class',
         nounPlural: 'Data Classes',
         domainFormDisplayOptions: { ...DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS, domainKindDisplayName: 'data class' },
-        loadNameExpressionOptions: loadNameExpressionOptions,
+        loadNameExpressionOptions,
     };
 
     constructor(props: Props & InjectedBaseDomainDesignerProps) {

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
@@ -19,8 +19,9 @@ import { loadNameExpressionOptions } from '../../settings/actions';
 
 import { PROPERTIES_PANEL_NAMING_PATTERN_WARNING_MSG } from '../constants';
 
+import { isSampleManagerEnabled } from '../../../app/utils';
+
 import { DataClassModel } from './models';
-import {isSampleManagerEnabled} from "../../../app/utils";
 
 const PROPERTIES_HEADER_ID = 'dataclass-properties-hdr';
 const FORM_IDS = {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -42,11 +42,7 @@ import { ENTITY_FORM_IDS } from '../entities/constants';
 
 import { AutoLinkToStudyDropdown } from '../AutoLinkToStudyDropdown';
 
-import {
-    getCurrentProductName,
-    isCommunityDistribution,
-    isSampleManagerEnabled
-} from '../../../app/utils';
+import { getCurrentProductName, isCommunityDistribution, isSampleManagerEnabled } from '../../../app/utils';
 
 import { loadNameExpressionOptions } from '../../settings/actions';
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -76,7 +76,7 @@ import { BulkAddData } from '../editable/EditableGrid';
 
 import { DERIVATION_DATA_SCOPE_CHILD_ONLY } from '../domainproperties/constants';
 
-import {getCurrentProductName, isSampleManagerEnabled} from '../../app/utils';
+import { getCurrentProductName, isSampleManagerEnabled } from '../../app/utils';
 
 import { fetchDomainDetails } from '../domainproperties/actions';
 

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -8,6 +8,7 @@ import { Alert, ConfirmModal, LabelHelpTip, LoadingSpinner, RequiresPermission }
 import { sampleManagerIsPrimaryApp } from '../../app/utils';
 
 import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
+import { invalidateQueryDetailsCache } from '../../query/api';
 
 const TITLE = 'ID/Name Settings';
 
@@ -97,6 +98,12 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
 
         try {
             await saveNameExpressionOptions('allowUserSpecifiedNames', !allowUserSpecifiedNames);
+
+            // Issue 44250: the sample type and data class queryInfo details for the name column will set the
+            // setShownInInsertView based on this allowUserSpecifiedNames setting so we need to invalidate the cache
+            // so that the updated information is retrieved for that table/query.
+            invalidateQueryDetailsCache();
+
             setState({
                 allowUserSpecifiedNames: !allowUserSpecifiedNames,
                 savingAllowUserSpecifiedNames: false,

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -7,8 +7,9 @@ import { Alert, ConfirmModal, LabelHelpTip, LoadingSpinner, RequiresPermission }
 
 import { sampleManagerIsPrimaryApp } from '../../app/utils';
 
-import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
 import { invalidateQueryDetailsCache } from '../../query/api';
+
+import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
 
 const TITLE = 'ID/Name Settings';
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -30,7 +30,11 @@ import {
     ViewInfo,
 } from '../..';
 
-const queryDetailsCache: { [key: string]: Promise<QueryInfo> } = {};
+let queryDetailsCache: { [key: string]: Promise<QueryInfo> } = {};
+
+export function invalidateQueryDetailsCache(): void {
+    queryDetailsCache = {};
+}
 
 export function invalidateQueryDetailsCacheKey(key: string): void {
     delete queryDetailsCache[key];


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44250

The sample type and data class queryInfo details for the name column will set the setShownInInsertView based on this allowUserSpecifiedNames setting so we need to invalidate the client side cache so that the updated information is retrieved for those table/query in the apps.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/669
* https://github.com/LabKey/biologics/pull/1045
* https://github.com/LabKey/sampleManagement/pull/742

#### Changes
* Add invalidateQueryDetailsCache() helper and call it after saveNameExpressionOptions() completes
