### PR TITLE
AppContext: React context for serving global application context

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.91.2",
+  "version": "2.92.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.92.0
+*Released*: 16 November 2021
+* Introduce `AppContext`. A React context for serving global application context.
+* Provide test utilities for working with components that utilize `AppContext`.
+
 ### version 2.91.2
 *Released*: 15 November 2021
 * Merge release21.11-SNAPSHOT to develop

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -302,6 +302,8 @@ import { SampleAliquotDetailHeader } from './internal/components/samples/SampleA
 import { SampleAliquotsSummary } from './internal/components/samples/SampleAliquotsSummary';
 import { SampleAliquotsGridPanel } from './internal/components/samples/SampleAliquotsGridPanel';
 
+import { AppContextProvider, useAppContext } from './internal/AppContext';
+
 import {
     filterSampleRowsForOperation,
     getFilterForSampleOperation,
@@ -471,7 +473,12 @@ import { ValidatorModal } from './internal/components/domainproperties/validatio
 import { RangeValidationOptions } from './internal/components/domainproperties/validation/RangeValidationOptions';
 
 import { AssayImportPanels } from './internal/components/assay/AssayImportPanels';
-import { makeQueryInfo, mountWithServerContextOptions, sleep } from './internal/testHelpers';
+import {
+    makeQueryInfo,
+    mountWithAppServerContextOptions,
+    mountWithServerContextOptions,
+    sleep,
+} from './internal/testHelpers';
 import { QueryModel } from './public/QueryModel/QueryModel';
 import { withQueryModels } from './public/QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './public/QueryModel/GridPanel';
@@ -1203,6 +1210,8 @@ export {
     // base models, enums, constants
     Container,
     User,
+    AppContextProvider,
+    useAppContext,
     ServerContextProvider,
     ServerContextConsumer,
     useServerContext,
@@ -1257,6 +1266,7 @@ export {
     sleep,
     createMockWithRouterProps,
     makeQueryInfo,
+    mountWithAppServerContextOptions,
     mountWithServerContextOptions,
     // Ontology
     OntologyBrowserPanel,
@@ -1364,5 +1374,6 @@ export type { UsersLoader } from './internal/components/forms/actions';
 export type { LineageGroupingOptions } from './internal/components/lineage/types';
 export type { AnnouncementModel, ThreadActions } from './internal/announcements/model';
 export type { AnnouncementsAPIWrapper } from './internal/announcements/APIWrapper';
+export type { AppContext } from './internal/AppContext';
 export type { ThreadBlockProps } from './internal/announcements/ThreadBlock';
 export type { ThreadEditorProps } from './internal/announcements/ThreadEditor';

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { createContext, FC, useContext, useMemo } from 'react';
+
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from './APIWrapper';
+
+export interface AppContext {
+    api: ComponentsAPIWrapper;
+}
+
+const Context = createContext<AppContext>(undefined);
+
+export interface AppContextProviderProps {
+    initialContext?: AppContext;
+}
+
+export const AppContextProvider: FC<AppContextProviderProps> = ({ children, initialContext }) => {
+    // Provide a default API so that external users don't have to specify it
+    const value = useMemo<AppContext>(() => ({ api: getDefaultAPIWrapper(), ...initialContext }), [initialContext]);
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export const useAppContext = (): AppContext => {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useAppContext must be used within a AppContext.Provider');
+    }
+    return context;
+};


### PR DESCRIPTION
#### Rationale
This PR introduces an "Application Context" that will be usable by our client-side applications to house globally provided context and functionality. This is intended to be both extended and utilized by applications for their specific needs.

**Note:** I will issue a version change for `@labkey/components`, however, I will not have any corollary application PRs. This is going to be utilized for feature development across a couple of downstream branches which will introduce usage in the apps.

#### Changes
* Introduce `AppContext`. A React context for serving global application context.
* Provide test utilities for working with components that utilize `AppContext`.
