### PR TITLE
Render Container in SubNav / ExtendableAppContext

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.96.0-fb-navigation-container.0",
+  "version": "2.96.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0",
+  "version": "2.95.0-fb-navigation-container.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-navigation-container.0",
+  "version": "2.95.0-fb-navigation-container.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -66,6 +66,7 @@
     "react-datepicker": "4.2.1",
     "react-dom": "16.14.0",
     "react-input-autosize": "2.2.2",
+    "react-redux": "5.1.0",
     "react-router": "3.2.6",
     "react-select": "4.3.1",
     "react-sticky": "6.0.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-navigation-container.1",
+  "version": "2.95.0-fb-navigation-container.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-navigation-container.2",
+  "version": "2.96.0-fb-navigation-container.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.97.0",
+  "version": "2.98.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.96.0
-*Released*: ?? November 2021
+*Released*: 22 November 2021
 * Add ExtendableAppContext
   * This allows downstream apps to extend AppContext and add their own attributes
 * Add NavigationSettings to AppContext

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Add ExtendableAppContext
   * This allows downstream apps to extend AppContext and add their own attributes
 * Add NavigationSettings to AppContext
+* Add AppContexts component
 * Refactor SubNav
   * Renders the current container if configured in NavigationSettings
   * Re-written to be an FC

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ?? November 2021
 * Add ExtendableAppContext
   * This allows downstream apps to extend AppContext and add their own attributes
+* Add NavigationSettings to AppContext
+* Refactor SubNav
+  * Renders the current container if configured in NavigationSettings
+  * Re-written to be an FC
+  * No longer depends on jQuery
 
 ### version 2.95.0
 *Released*: 22 November 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.96.0
+*Released*: ?? November 2021
+* Add ExtendableAppContext
+  * This allows downstream apps to extend AppContext and add their own attributes
+
 ### version 2.95.0
 *Released*: 22 November 2021
 * Remove isFreezerManagerEnabledInBiologics experimental flag

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -302,6 +302,7 @@ import { SampleAliquotsSummary } from './internal/components/samples/SampleAliqu
 import { SampleAliquotsGridPanel } from './internal/components/samples/SampleAliquotsGridPanel';
 
 import { AppContextProvider, useAppContext } from './internal/AppContext';
+import { AppContexts } from './internal/AppContexts';
 
 import {
     filterSampleRowsForOperation,
@@ -1207,6 +1208,7 @@ export {
     User,
     AppContextProvider,
     useAppContext,
+    AppContexts,
     ServerContextProvider,
     ServerContextConsumer,
     useServerContext,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1363,7 +1363,7 @@ export type { UsersLoader } from './internal/components/forms/actions';
 export type { LineageGroupingOptions } from './internal/components/lineage/types';
 export type { AnnouncementModel, ThreadActions } from './internal/announcements/model';
 export type { AnnouncementsAPIWrapper } from './internal/announcements/APIWrapper';
-export type { AppContext } from './internal/AppContext';
+export type { AppContext, ExtendableAppContext } from './internal/AppContext';
 export type { ThreadBlockProps } from './internal/announcements/ThreadBlock';
 export type { ThreadEditorProps } from './internal/announcements/ThreadEditor';
 export type { SamplesEditableGridProps } from './internal/components/samples/SamplesEditableGrid';

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -17,8 +17,13 @@ import React, { createContext, FC, useContext, useMemo } from 'react';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from './APIWrapper';
 
+export interface NavigationSettings {
+    showCurrentContainer: boolean;
+}
+
 export interface AppContext {
-    api: ComponentsAPIWrapper;
+    api?: ComponentsAPIWrapper;
+    navigation?: NavigationSettings;
 }
 
 const Context = createContext<AppContext>(undefined);
@@ -28,8 +33,16 @@ export interface AppContextProviderProps {
 }
 
 export const AppContextProvider: FC<AppContextProviderProps> = ({ children, initialContext }) => {
-    // Provide a default API so that external users don't have to specify it
-    const value = useMemo<AppContext>(() => ({ api: getDefaultAPIWrapper(), ...initialContext }), [initialContext]);
+    const value = useMemo<AppContext>(
+        () => ({
+            // Provide a default API so that external users don't have to specify it
+            api: getDefaultAPIWrapper(),
+            // By default we don't show the container in SubNav, but apps can override this
+            navigation: { showCurrentContainer: false },
+            ...initialContext,
+        }),
+        [initialContext]
+    );
 
     return <Context.Provider value={value}>{children}</Context.Provider>;
 };

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -52,6 +52,7 @@ export interface AppContextProviderProps<T> {
  *       this, ask around if you need an example)
  *
  * Example code:
+ * ```ts
  * interface MyAppSettings {
  *     specialFeatureEnabled: boolean;
  * }
@@ -79,6 +80,7 @@ export interface AppContextProviderProps<T> {
  *     const message = `Special Feature is ${myAppSettings.specialFeatureEnabled ? 'Enabled' : 'Disabled'}`
  *     return <p>{message}</p>;
  * };
+ * ```
  */
 export function AppContextProvider<T>({
     children,
@@ -103,14 +105,16 @@ export function AppContextProvider<T>({
  * grabbing the same attribute or two from useAppContext it may be convenient to create a wrapper around this hook
  * that grabs only what you need, this is most helpful for our packages like Workflow e.g.:
  *
+ * ```ts
  * const useMyAppContext = (): MyAppSettings => {
  *     const appContext = useAppContext<MyAppSpecificContext>();
  *     return appContext.myAppSettings;
  * };
  *
- * Then, in your component:
+ * // Then, in your component:
  *
  * const { specialFeatureEnabled } = useMyAppContext();
+ * ```
  */
 export function useAppContext<T>(): ExtendableAppContext<T> {
     const context = useContext<ExtendableAppContext<T>>(Context);

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -80,25 +80,22 @@ export interface AppContextProviderProps<T> {
  *     return <p>{message}</p>;
  * };
  */
-export class AppContextProvider extends React.Component<PropsWithChildren<AppContextProviderProps<T>>> {
-    render(): ReactElement {
-        let {
-            children,
-            initialContext,
-        } = this.props;
-        const value = useMemo<AppContext>(
-            () => ({
-                // Provide a default API so that external users don't have to specify it
-                api: getDefaultAPIWrapper(),
-                // By default we don't show the container in SubNav, but apps can override this
-                navigation: { showCurrentContainer: false },
-                ...initialContext,
-            }),
-            [initialContext],
-        );
+export function AppContextProvider<T>({
+    children,
+    initialContext,
+}: PropsWithChildren<AppContextProviderProps<T>>): ReactElement {
+    const value = useMemo<AppContext>(
+        () => ({
+            // Provide a default API so that external users don't have to specify it
+            api: getDefaultAPIWrapper(),
+            // By default we don't show the container in SubNav, but apps can override this
+            navigation: { showCurrentContainer: false },
+            ...initialContext,
+        }),
+        [initialContext]
+    );
 
-        return <Context.Provider value={value}>{children}</Context.Provider>;
-    }
+    return <Context.Provider value={value}>{children}</Context.Provider>;
 }
 
 /**

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -28,7 +28,8 @@ export interface AppContext {
 
 export type ExtendableAppContext<T> = T & AppContext;
 
-// The "any" used here should be fine, it gets re-typed in useAppContext, so as long as you're using the
+// The "any" used here should be fine, it gets re-typed in useAppContext, so as long as you're using that and providing
+// a type (e.g. useAppContext<MyAppContextType>()) you'll be fine.
 const Context = createContext<ExtendableAppContext<any>>(undefined);
 
 export interface AppContextProviderProps<T> {

--- a/packages/components/src/internal/AppContexts.tsx
+++ b/packages/components/src/internal/AppContexts.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router';
+import { AppContextProvider, ExtendableAppContext } from './AppContext';
+import { ServerContext, ServerContextProvider } from './components/base/ServerContext';
+
+interface Props<T = {}> {
+    initialServerContext: ServerContext;
+    initialAppContext?: ExtendableAppContext<T>;
+    store: any;
+    history: any;
+}
+
+/**
+ * AppContexts is where you should add any additional contexts needed by our applications. At the moment all of our
+ * apps share the same basic context configurations, and this component makes it easy for us to update all of our Apps
+ * at once, and reduce the level of nesting needed in our Route configurations.
+ */
+export const AppContexts: FC<Props> = (props) => {
+    const { children, history, initialAppContext, initialServerContext, store } = props;
+    return (
+        <ServerContextProvider initialContext={initialServerContext}>
+            <AppContextProvider initialContext={initialAppContext}>
+                <Provider store={store}>
+                    <Router history={history}>{children}</Router>
+                </Provider>
+            </AppContextProvider>
+        </ServerContextProvider>
+    );
+};

--- a/packages/components/src/internal/AppContexts.tsx
+++ b/packages/components/src/internal/AppContexts.tsx
@@ -1,11 +1,11 @@
-import React, { FC } from 'react';
+import { getServerContext } from '@labkey/api';
+import React, { FC, useMemo } from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
 import { AppContextProvider, ExtendableAppContext } from './AppContext';
-import { ServerContext, ServerContextProvider } from './components/base/ServerContext';
+import { ServerContextProvider, withAppUser } from './components/base/ServerContext';
 
 interface Props<T = {}> {
-    initialServerContext: ServerContext;
     initialAppContext?: ExtendableAppContext<T>;
     store: any;
     history: any;
@@ -17,7 +17,8 @@ interface Props<T = {}> {
  * at once, and reduce the level of nesting needed in our Route configurations.
  */
 export const AppContexts: FC<Props> = (props) => {
-    const { children, history, initialAppContext, initialServerContext, store } = props;
+    const { children, history, initialAppContext, store } = props;
+    const initialServerContext = useMemo(() => withAppUser(getServerContext()), []);
     return (
         <ServerContextProvider initialContext={initialServerContext}>
             <AppContextProvider initialContext={initialAppContext}>

--- a/packages/components/src/internal/components/navigation/SubNav.tsx
+++ b/packages/components/src/internal/components/navigation/SubNav.tsx
@@ -36,7 +36,7 @@ export interface ITab {
 export const SubNav: FC<Props> = ({ noun, tabs }) => {
     const scrollable = useRef<HTMLDivElement>();
     const { navigation } = useAppContext();
-    const { container  } = useServerContext();
+    const { container } = useServerContext();
     const [isScrollable, setIsScrollable] = useState<boolean>(false);
     const scroll = useCallback(offset => {
         scrollable.current.scrollLeft = scrollable.current.scrollLeft + offset;
@@ -113,7 +113,9 @@ export const SubNav: FC<Props> = ({ noun, tabs }) => {
                 {navigation.showCurrentContainer && (
                     <div className="container-nav">
                         <span className="fa fa-folder-open" />
-                        <span className="container-nav__name">{container.name}</span>
+                        <span className="container-nav__name" title={container.name}>
+                            {container.name}
+                        </span>
                     </div>
                 )}
             </div>

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -251,7 +251,7 @@
 }
 
 .container-nav {
-    padding: 8px 0px 8px 10px;
+    padding: 10px 0 8px 10px;
     min-width: 100px;
     color: #9d9d9d;
     position: relative;
@@ -260,13 +260,19 @@
     border-left: 1px solid $navbar-border-color;
     content: '';
     height: 34px;
-    margin-top: -16px;
+    margin-top: -17px;
     position: absolute;
     left: 0;
     top: 50%;
 }
 .container-nav__name {
+    float: right;
+    font-size: small;
     margin-left: 4px;
+    max-width: 165px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .navbar-inverse {
@@ -295,7 +301,7 @@
         border-left: 1px solid $navbar-border-color;
         content: '';
         height: 34px;
-        margin-top: -16px;
+        margin-top: -15px;
         position: absolute;
         right: 0;
         top: 50%;
@@ -340,7 +346,7 @@
       border-left: 1px solid $navbar-border-color;
       content: '';
       height: 34px;
-      margin-top: -18px;
+      margin-top: -17px;
       position: absolute;
       left: 0;
       top: 50%;

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -257,7 +257,7 @@
     position: relative;
 }
 .container-nav:before {
-    border-left: 1px solid #cbccce;
+    border-left: 1px solid $navbar-border-color;
     content: '';
     height: 34px;
     margin-top: -16px;
@@ -292,7 +292,7 @@
       }
 
       &:after {
-        border-left: 1px solid #cbccce;
+        border-left: 1px solid $navbar-border-color;
         content: '';
         height: 34px;
         margin-top: -16px;
@@ -337,7 +337,7 @@
     display: inline-flex;
 
     &:before {
-      border-left: 1px solid #cbccce;
+      border-left: 1px solid $navbar-border-color;
       content: '';
       height: 34px;
       margin-top: -18px;

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -250,6 +250,25 @@
   border-radius: 0;
 }
 
+.container-nav {
+    padding: 8px 0px 8px 10px;
+    min-width: 100px;
+    color: #9d9d9d;
+    position: relative;
+}
+.container-nav:before {
+    border-left: 1px solid #cbccce;
+    content: '';
+    height: 34px;
+    margin-top: -16px;
+    position: absolute;
+    left: 0;
+    top: 50%;
+}
+.container-nav__name {
+    margin-left: 4px;
+}
+
 .navbar-inverse {
   min-height: 15px;
 
@@ -288,6 +307,7 @@
     display: inline-block;
     overflow-x: hidden;
     white-space: nowrap;
+    flex: 1;
 
     .navbar-nav {
       margin: 0;

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -252,7 +252,6 @@
 
 .container-nav {
     padding: 10px 0 8px 10px;
-    min-width: 100px;
     color: #9d9d9d;
     position: relative;
 }

--- a/packages/components/src/theme/variables.scss
+++ b/packages/components/src/theme/variables.scss
@@ -16,6 +16,7 @@ $brand-primary:   #2980b9;
 $brand-secondary: #236fa0;
 $brand-success:   #5cb85c;
 $border-color:    #cccccc;
+$navbar-border-color: #cbccce;
 
 $blue-highlight:       #2980B9;
 $gray-no-highlight:    $gray-lighten;

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -3539,7 +3539,7 @@ history@^3.0.0:
     query-string "^4.2.2"
     warning "^3.0.0"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5814,7 +5814,7 @@ react-input-autosize@^3.0.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5824,7 +5824,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
@@ -5860,6 +5860,19 @@ react-prop-types@^0.4.0:
   integrity sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=
   dependencies:
     warning "^3.0.0"
+
+react-redux@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.0.tgz#948b1e2686473d1999092bcfb32d0dc43d33f667"
+  integrity sha512-CRMpEx8+ccpoVxQrQDkG1obExNYpj6dZ1Ni7lUNFB9wcxOhy02tIqpFo4IUXc0kYvCGMu6ABj9A4imEX2VGZJQ==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    hoist-non-react-statics "^3.0.0"
+    invariant "^2.2.4"
+    loose-envify "^1.1.0"
+    prop-types "^15.6.1"
+    react-is "^16.6.0"
+    react-lifecycles-compat "^3.0.0"
 
 react-redux@^7.2.0:
   version "7.2.5"


### PR DESCRIPTION
#### Rationale
This PR adds a `navigation` property to the AppContext that allows apps to optionally render the current container in SubNav. It also adds `ExtendableAppContext` which allows apps extend the AppContext to add app-specific data to the app context (which will be used in my SM and Biologics branches).

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/753
* https://github.com/LabKey/biologics/pull/1063

#### Changes
* Add ExtendableAppContext
  * This allows downstream apps to extend AppContext and add their own attributes
* Add NavigationSettings to AppContext
* Refactor SubNav
  * Renders the current container if configured in NavigationSettings
  * Re-written to be an FC
  * No longer depends on jQuery
* Add AppContexts component