### PR TITLE
Item 9587: Remove FM Biologics experimental flag

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.94.0",
+  "version": "2.95.0-fb-enableFM.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.91.1",
+  "version": "2.92.0-fb-enableFM.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-enableFM.1",
+  "version": "2.95.0-fb-enableFM.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-enableFM.3",
+  "version": "2.95.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-enableFM.2",
+  "version": "2.95.0-fb-enableFM.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.95.0
+*Released*: 22 November 2021
+* Remove isFreezerManagerEnabledInBiologics experimental flag
+
 ### version 2.94.0
 *Released*: 17 November 2021
 * Item 9500: Improve Sample display when spanning types
@@ -31,10 +35,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.91.1
 *Released*: 10 November 2021
 * Bump @labkey/api dependency
-
-### version XXX
-*Released*: XXX
-* Remove isFreezerManagerEnabledInBiologics experimental flag
 
 ### version 2.91.0
 *Released*: 2 November 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 10 November 2021
 * Bump @labkey/api dependency
 
+### version XXX
+*Released*: XXX
+* Remove isFreezerManagerEnabledInBiologics experimental flag
+
 ### version 2.91.0
 *Released*: 2 November 2021
 * getUsersWithPermissions: support alternate container paths

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -497,7 +497,6 @@ import { DisableableMenuItem } from './internal/components/samples/DisableableMe
 import { SampleStatusTag } from './internal/components/samples/SampleStatusTag';
 import { ManageSampleStatusesPanel } from './internal/components/samples/ManageSampleStatusesPanel';
 import {
-    ALIQUOTED_FROM_COL,
     DEFAULT_SAMPLE_FIELD_CONFIG,
     FIND_BY_IDS_QUERY_PARAM,
     SAMPLE_DATA_EXPORT_CONFIG,
@@ -507,7 +506,6 @@ import {
     SAMPLE_INVENTORY_ITEM_SELECTION_KEY,
     SAMPLE_STATE_DESCRIPTION_COLUMN_NAME,
     SAMPLE_STATE_TYPE_COLUMN_NAME,
-    SAMPLE_STORAGE_COLUMNS,
     SampleOperation,
     SampleStateType,
     UNIQUE_ID_FIND_FIELD,
@@ -891,12 +889,10 @@ export {
     SAMPLE_STATE_DESCRIPTION_COLUMN_NAME,
     FIND_BY_IDS_QUERY_PARAM,
     UNIQUE_ID_FIND_FIELD,
-    ALIQUOTED_FROM_COL,
     SAMPLE_DATA_EXPORT_CONFIG,
     SAMPLE_EXPORT_CONFIG,
     SAMPLE_ID_FIND_FIELD,
     SAMPLE_INSERT_EXTRA_COLUMNS,
-    SAMPLE_STORAGE_COLUMNS,
     IS_ALIQUOT_COL,
     SampleTypeModel,
     deleteSampleSet,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -458,10 +458,7 @@ import {
 } from './internal/components/domainproperties/list/actions';
 import { fetchIssuesListDefDesign } from './internal/components/domainproperties/issues/actions';
 import { fetchDatasetDesign } from './internal/components/domainproperties/dataset/actions';
-import {
-    DEFAULT_SAMPLE_FIELD_CONFIG,
-    SampleTypeDesigner,
-} from './internal/components/domainproperties/samples/SampleTypeDesigner';
+import { SampleTypeDesigner } from './internal/components/domainproperties/samples/SampleTypeDesigner';
 import { ListDesignerPanels } from './internal/components/domainproperties/list/ListDesignerPanels';
 import { DataClassDesigner } from './internal/components/domainproperties/dataclasses/DataClassDesigner';
 import { DataClassModel } from './internal/components/domainproperties/dataclasses/models';
@@ -493,14 +490,20 @@ import { DisableableMenuItem } from './internal/components/samples/DisableableMe
 import { SampleStatusTag } from './internal/components/samples/SampleStatusTag';
 import { ManageSampleStatusesPanel } from './internal/components/samples/ManageSampleStatusesPanel';
 import {
+    ALIQUOTED_FROM_COL,
+    DEFAULT_SAMPLE_FIELD_CONFIG,
     FIND_BY_IDS_QUERY_PARAM,
+    SAMPLE_DATA_EXPORT_CONFIG,
+    SAMPLE_EXPORT_CONFIG,
     SAMPLE_ID_FIND_FIELD,
+    SAMPLE_INSERT_EXTRA_COLUMNS,
     SAMPLE_INVENTORY_ITEM_SELECTION_KEY,
     SAMPLE_STATE_DESCRIPTION_COLUMN_NAME,
     SAMPLE_STATE_TYPE_COLUMN_NAME,
+    SAMPLE_STORAGE_COLUMNS,
     SampleOperation,
     SampleStateType,
-    UNIQUE_ID_FIND_FIELD,
+    UNIQUE_ID_FIND_FIELD
 } from './internal/components/samples/constants';
 import { createMockWithRouterProps } from './test/mockUtils';
 import { ConceptModel } from './internal/components/ontology/models';
@@ -895,7 +898,12 @@ export {
     SAMPLE_STATE_DESCRIPTION_COLUMN_NAME,
     FIND_BY_IDS_QUERY_PARAM,
     UNIQUE_ID_FIND_FIELD,
+    ALIQUOTED_FROM_COL,
+    SAMPLE_DATA_EXPORT_CONFIG,
+    SAMPLE_EXPORT_CONFIG,
     SAMPLE_ID_FIND_FIELD,
+    SAMPLE_INSERT_EXTRA_COLUMNS,
+    SAMPLE_STORAGE_COLUMNS,
     SampleTypeModel,
     deleteSampleSet,
     fetchSamples,

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -664,7 +664,7 @@ describe('getMenuSectionConfigs', () => {
         const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
             inventory: {},
             samplemanagement: {},
-            biologics: {'experimental-biologics-requests-menu': true},
+            biologics: { 'experimental-biologics-requests-menu': true },
         });
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -451,28 +451,6 @@ describe('getCurrentAppProperties', () => {
 });
 
 describe('getStorageSectionConfig', () => {
-    test('FM not enabled', () => {
-        expect(getStorageSectionConfig(TEST_USER_EDITOR, SAMPLE_MANAGER_APP_PROPERTIES.productId, {}, 2)).toBe(
-            undefined
-        );
-        expect(
-            getStorageSectionConfig(
-                TEST_USER_EDITOR,
-                BIOLOGICS_APP_PROPERTIES.productId,
-                { inventory: {}, biologics: {} },
-                2
-            )
-        ).toBe(undefined);
-        expect(
-            getStorageSectionConfig(
-                TEST_USER_EDITOR,
-                BIOLOGICS_APP_PROPERTIES.productId,
-                { inventory: {}, biologics: {} },
-                2
-            )
-        ).toBe(undefined);
-    });
-
     test('reader, inventory app', () => {
         const config = getStorageSectionConfig(
             TEST_USER_READER,
@@ -654,50 +632,7 @@ describe('getMenuSectionConfigs', () => {
         expect(configs.getIn([4, USER_KEY])).toBeDefined();
     });
 
-    test('Biologics, no experimental features', () => {
-        window.location = Object.assign(
-            { ...location },
-            {
-                pathname: 'labkey/Biologics/biologics-app.view#',
-            }
-        );
-        const configs = getMenuSectionConfigs(TEST_USER_READER, BIOLOGICS_APP_PROPERTIES.productId, {
-            inventory: {},
-            samplemanagement: {},
-            biologics: {},
-        });
-        expect(configs.size).toBe(4);
-        expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();
-        expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
-        expect(configs.getIn([2, ASSAYS_KEY])).toBeDefined();
-        expect(configs.getIn([3, WORKFLOW_KEY])).toBeDefined();
-        expect(configs.getIn([3, MEDIA_KEY])).toBeDefined();
-        expect(configs.getIn([3, NOTEBOOKS_KEY])).toBeDefined();
-    });
-
-    test('Biologics with Requests', () => {
-        window.location = Object.assign(
-            { ...location },
-            {
-                pathname: 'labkey/Biologics/biologics-app.view#',
-            }
-        );
-        const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
-            inventory: {},
-            samplemanagement: {},
-            biologics: { 'experimental-biologics-requests-menu': true },
-        });
-        expect(configs.size).toBe(5);
-        expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();
-        expect(configs.getIn([1, SAMPLES_KEY])).toBeDefined();
-        expect(configs.getIn([2, ASSAYS_KEY])).toBeDefined();
-        expect(configs.getIn([3, REQUESTS_KEY])).toBeDefined();
-        expect(configs.getIn([4, WORKFLOW_KEY])).toBeDefined();
-        expect(configs.getIn([4, MEDIA_KEY])).toBeDefined();
-        expect(configs.getIn([4, NOTEBOOKS_KEY])).toBeDefined();
-    });
-
-    test('Biologics with FM', () => {
+    test('Biologics', () => {
         window.location = Object.assign(
             { ...location },
             {
@@ -719,7 +654,7 @@ describe('getMenuSectionConfigs', () => {
         expect(configs.getIn([4, NOTEBOOKS_KEY])).toBeDefined();
     });
 
-    test('Biologics with FM and Requests', () => {
+    test('Biologics with Requests', () => {
         window.location = Object.assign(
             { ...location },
             {
@@ -729,7 +664,7 @@ describe('getMenuSectionConfigs', () => {
         const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
             inventory: {},
             samplemanagement: {},
-            biologics: {},
+            biologics: {'experimental-biologics-requests-menu': true},
         });
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -250,28 +250,7 @@ describe('utils', () => {
             samplemanagement: {},
             biologics: {},
         };
-        expect(isFreezerManagementEnabled()).toBeFalsy();
-
-        LABKEY.moduleContext = {
-            inventory: {},
-            samplemanagement: {},
-            biologics: { isFreezerManagerEnabled: false },
-        };
-        expect(isFreezerManagementEnabled()).toBeFalsy();
-
-        LABKEY.moduleContext = {
-            inventory: {},
-            samplemanagement: {},
-            biologics: { isFreezerManagerEnabled: true },
-        };
         expect(isFreezerManagementEnabled()).toBeTruthy();
-        expect(isFreezerManagementEnabled({ inventory: {}, samplemanagement: {}, biologics: {} })).toBeFalsy();
-        expect(
-            isFreezerManagementEnabled(
-                { inventory: {}, samplemanagement: {}, biologics: {} },
-                SAMPLE_MANAGER_APP_PROPERTIES.productId
-            )
-        ).toBeTruthy();
     });
 
     test('isSampleStatusEnabled', () => {
@@ -488,7 +467,7 @@ describe('getStorageSectionConfig', () => {
             getStorageSectionConfig(
                 TEST_USER_EDITOR,
                 BIOLOGICS_APP_PROPERTIES.productId,
-                { inventory: {}, biologics: { isFreezerManagerEnabled: false } },
+                { inventory: {}, biologics: {} },
                 2
             )
         ).toBe(undefined);
@@ -728,7 +707,7 @@ describe('getMenuSectionConfigs', () => {
         const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
             inventory: {},
             samplemanagement: {},
-            biologics: { isFreezerManagerEnabled: true },
+            biologics: {},
         });
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();
@@ -750,7 +729,7 @@ describe('getMenuSectionConfigs', () => {
         const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
             inventory: {},
             samplemanagement: {},
-            biologics: { 'experimental-biologics-requests-menu': true, isFreezerManagerEnabled: true },
+            biologics: {},
         });
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, REGISTRY_KEY])).toBeDefined();

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -113,15 +113,8 @@ export function userCanDesignLocations(user: User): boolean {
     return hasAllPermissions(user, [PermissionTypes.Admin]);
 }
 
-export function isFreezerManagementEnabled(moduleContext?: any, currentProductId?: string): boolean {
-    return (
-        (moduleContext ?? getServerContext().moduleContext)?.inventory !== undefined &&
-        (!isBiologicsEnabled(moduleContext) ||
-            isFreezerManagerEnabledInBiologics(moduleContext) ||
-            // if looking at the SM app or FM within a Biologics folder but the FM in Biologics flag is off,
-            // you still want to see the Storage menu
-            (currentProductId && currentProductId !== BIOLOGICS_APP_PROPERTIES.productId))
-    );
+export function isFreezerManagementEnabled(moduleContext?: any): boolean {
+    return (moduleContext ?? getServerContext().moduleContext)?.inventory !== undefined;
 }
 
 export function isProductNavigationEnabled(productId: string): boolean {
@@ -185,10 +178,6 @@ export function getPrimaryAppProperties(moduleContext?: any): AppProperties {
     }
 }
 
-function isFreezerManagerEnabledInBiologics(moduleContext?: any): boolean {
-    return (moduleContext ?? getServerContext().moduleContext)?.biologics?.isFreezerManagerEnabled === true;
-}
-
 export function isRequestsEnabled(moduleContext?: any): boolean {
     return (moduleContext ?? getServerContext().moduleContext)?.biologics?.[EXPERIMENTAL_REQUESTS_MENU] === true;
 }
@@ -213,7 +202,7 @@ export function getStorageSectionConfig(
     moduleContext: any,
     maxItemsPerColumn: number
 ): MenuSectionConfig {
-    if (isFreezerManagementEnabled(moduleContext, currentProductId)) {
+    if (isFreezerManagementEnabled(moduleContext)) {
         const fmAppBase = getApplicationUrlBase(
             FREEZER_MANAGER_APP_PROPERTIES.moduleName,
             currentProductId,
@@ -472,9 +461,9 @@ export function getCurrentProductName() {
 // TODO when isFreezerManagerEnabled goes away, we can put this data in the AppProperties constants instead
 export function getAppProductIds(appProductId: string): List<string> {
     let productIds = List.of(appProductId);
-    if (
-        appProductId === SAMPLE_MANAGER_APP_PROPERTIES.productId ||
-        (appProductId == BIOLOGICS_APP_PROPERTIES.productId && isFreezerManagementEnabled())
+    if (appProductId === SAMPLE_MANAGER_APP_PROPERTIES.productId
+        || appProductId == BIOLOGICS_APP_PROPERTIES.productId
+
     ) {
         productIds = productIds.push(FREEZER_MANAGER_APP_PROPERTIES.productId);
     }

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -461,9 +461,9 @@ export function getCurrentProductName() {
 // TODO when isFreezerManagerEnabled goes away, we can put this data in the AppProperties constants instead
 export function getAppProductIds(appProductId: string): List<string> {
     let productIds = List.of(appProductId);
-    if (appProductId === SAMPLE_MANAGER_APP_PROPERTIES.productId
-        || appProductId == BIOLOGICS_APP_PROPERTIES.productId
-
+    if (
+        appProductId === SAMPLE_MANAGER_APP_PROPERTIES.productId ||
+        appProductId == BIOLOGICS_APP_PROPERTIES.productId
     ) {
         productIds = productIds.push(FREEZER_MANAGER_APP_PROPERTIES.productId);
     }

--- a/packages/components/src/internal/components/auditlog/utils.spec.ts
+++ b/packages/components/src/internal/components/auditlog/utils.spec.ts
@@ -21,10 +21,11 @@ describe('utils', () => {
 
         LABKEY.moduleContext = {
             samplemanagement: {},
+            biologics: {},
         };
         auditQueries = getAuditQueries();
-        expect(auditQueries.length).toBe(12);
-        expect(auditQueries.findIndex(entry => entry.value === 'inventoryauditevent')).toBe(-1);
+        expect(auditQueries.length).toBe(13);
+        expect(auditQueries.findIndex(entry => entry.value === 'inventoryauditevent')).toBe(5);
 
         LABKEY.moduleContext = {};
         auditQueries = getAuditQueries();

--- a/packages/components/src/internal/components/auditlog/utils.ts
+++ b/packages/components/src/internal/components/auditlog/utils.ts
@@ -9,7 +9,7 @@ import { Query } from '@labkey/api';
 import { AppURL } from '../../..';
 import { isSampleManagerEnabled } from '../../app/utils';
 import { ASSAYS_KEY, BOXES_KEY, SAMPLES_KEY, USER_KEY, WORKFLOW_KEY } from '../../app/constants';
-import { SAMPLE_MANAGER_AUDIT_QUERIES } from "../samples/constants";
+import { SAMPLE_MANAGER_AUDIT_QUERIES } from '../samples/constants';
 
 export type AuditQuery = {
     containerFilter?: Query.ContainerFilter;

--- a/packages/components/src/internal/components/auditlog/utils.ts
+++ b/packages/components/src/internal/components/auditlog/utils.ts
@@ -7,8 +7,9 @@ import { Map } from 'immutable';
 import { Query } from '@labkey/api';
 
 import { AppURL } from '../../..';
-import { isBiologicsEnabled, isFreezerManagementEnabled, isSampleManagerEnabled } from '../../app/utils';
+import { isSampleManagerEnabled } from '../../app/utils';
 import { ASSAYS_KEY, BOXES_KEY, SAMPLES_KEY, USER_KEY, WORKFLOW_KEY } from '../../app/constants';
+import { SAMPLE_MANAGER_AUDIT_QUERIES } from "../samples/constants";
 
 export type AuditQuery = {
     containerFilter?: Query.ContainerFilter;
@@ -18,58 +19,7 @@ export type AuditQuery = {
 };
 
 export function getAuditQueries(): AuditQuery[] {
-    const auditQueries = [];
-
-    if (isBiologicsEnabled()) {
-        auditQueries.push(
-            { value: 'attachmentauditevent', label: 'Attachment Events' },
-            { value: 'experimentauditevent', label: 'Assay Events' },
-            { value: 'domainauditevent', label: 'Domain Events' },
-            { value: 'domainpropertyauditevent', label: 'Domain Property Events' },
-            { value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true },
-            { value: 'samplesetauditevent', label: 'Sample Type Events' },
-            { value: 'sampletimelineevent', label: 'Sample Timeline Events', hasDetail: true },
-            { value: 'samplesworkflowauditevent', label: 'Sample Workflow Events', hasDetail: true },
-            { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true },
-            { value: 'userauditevent', label: 'User Events', containerFilter: Query.ContainerFilter.allFolders },
-            { value: 'listauditevent', label: 'List Events' },
-            {
-                value: 'groupauditevent',
-                label: 'Roles and Assignment Events',
-                containerFilter: Query.ContainerFilter.allFolders,
-            }
-        );
-    } else {
-        if (isSampleManagerEnabled()) {
-            auditQueries.push(
-                { value: 'attachmentauditevent', label: 'Attachment Events' },
-                { value: 'experimentauditevent', label: 'Assay Events' },
-                { value: 'domainauditevent', label: 'Domain Events' },
-                { value: 'domainpropertyauditevent', label: 'Domain Property Events' },
-                { value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true }
-            );
-        }
-        if (isFreezerManagementEnabled()) {
-            auditQueries.push({ value: 'inventoryauditevent', label: 'Freezer Management Events', hasDetail: true });
-        }
-        if (isSampleManagerEnabled()) {
-            auditQueries.push(
-                { value: 'listauditevent', label: 'List Events' },
-                {
-                    value: 'groupauditevent',
-                    label: 'Roles and Assignment Events',
-                    containerFilter: Query.ContainerFilter.allFolders,
-                },
-                { value: 'samplesetauditevent', label: 'Sample Type Events' },
-                { value: 'sampletimelineevent', label: 'Sample Timeline Events', hasDetail: true },
-                { value: 'samplesworkflowauditevent', label: 'Sample Workflow Events', hasDetail: true },
-                { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true },
-                { value: 'userauditevent', label: 'User Events', containerFilter: Query.ContainerFilter.allFolders }
-            );
-        }
-    }
-
-    return auditQueries;
+    return isSampleManagerEnabled() ? SAMPLE_MANAGER_AUDIT_QUERIES : [];
 }
 
 export function getEventDataValueDisplay(d: any, showLink = true): ReactNode {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -32,7 +32,6 @@ import { AliquotNamePatternProps, IParentAlias, SampleTypeModel } from './models
 import { SampleTypePropertiesPanel } from './SampleTypePropertiesPanel';
 import { UniqueIdBanner } from './UniqueIdBanner';
 
-
 const NEW_SAMPLE_SET_OPTION: IParentOption = {
     label: `(Current ${SAMPLE_SET_DISPLAY_TEXT})`,
     value: '{{this_sample_set}}',

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -20,10 +20,11 @@ import {
 import { DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS } from '../constants';
 import { addDomainField, getDomainPanelStatus, saveDomain } from '../actions';
 import { initSampleSetSelects } from '../../samples/actions';
+import { DEFAULT_SAMPLE_FIELD_CONFIG } from '../../samples/constants';
 import { SAMPLE_SET_DISPLAY_TEXT } from '../../../constants';
 import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesigner } from '../BaseDomainDesigner';
 
-import { SAMPLE_TYPE, UNIQUE_ID_TYPE } from '../PropDescType';
+import { UNIQUE_ID_TYPE } from '../PropDescType';
 
 import { hasModule, isCommunityDistribution } from '../../../app/utils';
 
@@ -31,16 +32,6 @@ import { AliquotNamePatternProps, IParentAlias, SampleTypeModel } from './models
 import { SampleTypePropertiesPanel } from './SampleTypePropertiesPanel';
 import { UniqueIdBanner } from './UniqueIdBanner';
 
-export const DEFAULT_SAMPLE_FIELD_CONFIG = {
-    required: true,
-    dataType: SAMPLE_TYPE,
-    conceptURI: SAMPLE_TYPE.conceptURI,
-    rangeURI: SAMPLE_TYPE.rangeURI,
-    lookupSchema: 'exp',
-    lookupQuery: 'Materials',
-    lookupType: { ...SAMPLE_TYPE },
-    name: 'SampleID',
-} as Partial<IDomainField>;
 
 const NEW_SAMPLE_SET_OPTION: IParentOption = {
     label: `(Current ${SAMPLE_SET_DISPLAY_TEXT})`,

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useState } from 'react';
 
 import { User } from '../base/models/User';
-import { isFreezerManagementEnabled, userCanManagePicklists } from '../../app/utils';
+import { userCanManagePicklists } from '../../app/utils';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { SelectionMenuItem } from '../menus/SelectionMenuItem';
 
@@ -54,7 +54,7 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
         }
     }, [queryModel, sampleIds]);
 
-    if (!userCanManagePicklists(user) || !isFreezerManagementEnabled()) {
+    if (!userCanManagePicklists(user)) {
         return null;
     }
 

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 
 import { MenuItem } from 'react-bootstrap';
 
-import { isFreezerManagementEnabled, userCanManagePicklists } from '../../app/utils';
+import { userCanManagePicklists } from '../../app/utils';
 
 import { User } from '../base/models/User';
 
@@ -40,7 +40,7 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
         setShowModal(true);
     };
 
-    if (!userCanManagePicklists(user) || !isFreezerManagementEnabled()) {
+    if (!userCanManagePicklists(user)) {
         return null;
     }
 

--- a/packages/components/src/internal/components/picklist/PicklistOverview.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistOverview.tsx
@@ -36,6 +36,7 @@ import { PicklistDeleteConfirm } from './PicklistDeleteConfirm';
 import { PicklistEditModal } from './PicklistEditModal';
 import { PicklistGridButtons } from './PicklistGridButtons';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+import { ALIQUOTED_FROM_COL } from "../samples/constants";
 
 const PICKLIST_ITEMS_ID_PREFIX = 'picklist-items-';
 const PICKLIST_PER_SAMPLE_TYPE_ID_PREFIX = 'picklist-per-sample-type-';
@@ -56,6 +57,12 @@ interface ImplProps {
 }
 
 type Props = OwnProps & ImplProps & InjectedQueryModels;
+
+export const PICKLIST_EXPORT_CONFIG = {
+    'exportAlias.SampleID/AliquotedFromLSID': ALIQUOTED_FROM_COL,
+    'exportAlias.AliquotedFromLSID': ALIQUOTED_FROM_COL,
+    includeColumn: ['SampleID/AliquotedFromLSID', 'AliquotedFromLSID']
+};
 
 // exported for jest testing
 export const PicklistOverviewImpl: FC<Props> = memo(props => {
@@ -80,6 +87,10 @@ export const PicklistOverviewImpl: FC<Props> = memo(props => {
     const hideDeletePicklistConfirm = useCallback(() => {
         setShowDeleteModal(false);
     }, []);
+
+    const exportConfig = useMemo(() => {
+        return advancedExportOptions ? {...PICKLIST_EXPORT_CONFIG, ...advancedExportOptions} : PICKLIST_EXPORT_CONFIG;
+    }, [advancedExportOptions])
 
     const deletePicklist = useCallback(() => {
         deletePicklists([picklist])
@@ -208,7 +219,7 @@ export const PicklistOverviewImpl: FC<Props> = memo(props => {
                             afterSampleActionComplete={afterSampleActionComplete}
                             samplesEditableGridProps={samplesEditableGridProps}
                             tabbedGridPanelProps={{
-                                advancedExportOptions,
+                                advancedExportOptions: exportConfig,
                                 alwaysShowTabs: true,
                             }}
                         />
@@ -276,7 +287,7 @@ export const PicklistOverview: FC<OwnProps> = memo(props => {
                 id: gridId,
                 title: 'All Samples',
                 schemaQuery: SchemaQuery.create(SCHEMAS.PICKLIST_TABLES.SCHEMA, picklist.name),
-                requiredColumns: ['Created'],
+                requiredColumns: ['Created', 'SampleID/AliquotedFromLsid', 'AliquotedFromLSID'],
             };
 
             // add a queryConfig for each distinct sample type of the picklist samples, with an filter clause

--- a/packages/components/src/internal/components/picklist/RemoveFromPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/RemoveFromPicklistMenuItem.tsx
@@ -10,7 +10,7 @@ import { getConfirmDeleteMessage } from '../../util/messaging';
 import { createNotification, withTimeout } from '../notifications/actions';
 import { User } from '../base/models/User';
 
-import { isFreezerManagementEnabled, userCanManagePicklists } from '../../app/utils';
+import { userCanManagePicklists } from '../../app/utils';
 
 import { removeSamplesFromPicklist } from './actions';
 import { Picklist } from './models';
@@ -50,7 +50,7 @@ export const RemoveFromPicklistMenuItem: FC<Props> = memo(props => {
         }
     }, [model, picklist, afterSampleActionComplete, onHideRemoveFromList]);
 
-    if (!userCanManagePicklists(user) || !isFreezerManagementEnabled()) {
+    if (!userCanManagePicklists(user)) {
         return null;
     }
 

--- a/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
+++ b/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
@@ -45,8 +45,6 @@ import {
     removeEntityParentType,
 } from '../entities/EntityParentTypeSelectors';
 
-import { isFreezerManagementEnabled } from '../../app/utils';
-
 import { SamplesSelectionProviderProps, SamplesSelectionResultProps } from './models';
 import { getOriginalParentsFromSampleLineage } from './actions';
 import { SamplesSelectionProvider } from './SamplesSelectionContextProvider';
@@ -276,9 +274,7 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     };
 
     initStorageEditableGrid = (): void => {
-        if (isFreezerManagementEnabled()) {
-            gridInit(this.getStorageEditorQueryGridModel(), true, this);
-        }
+        gridInit(this.getStorageEditorQueryGridModel(), true, this);
     };
 
     getLineageEditorQueryGridModel = (): QueryGridModel => {
@@ -450,7 +446,7 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     getStorageUpdateData(storageRows: any[]) {
         const { sampleItems, sampleTypeDomainFields, noStorageSamples, selection, getConvertedStorageUpdateData } =
             this.props;
-        if (!isFreezerManagementEnabled() || storageRows.length === 0 || !getConvertedStorageUpdateData) return null;
+        if (storageRows.length === 0 || !getConvertedStorageUpdateData) return null;
 
         const sampleTypeUnit = sampleTypeDomainFields.metricUnit;
 
@@ -629,16 +625,10 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
         if (!samplesGrid || !samplesGrid.isLoaded) return <LoadingSpinner />;
 
         const models = [samplesGrid];
-        if (isFreezerManagementEnabled()) {
-            const storageGrid = this.getStorageEditorQueryGridModel();
-            if (!storageGrid || !storageGrid.isLoaded) return <LoadingSpinner />;
 
-            models.push(storageGrid);
-        } else {
-            // add a null to the models array so that the tabIndices line up for other parts of the render,
-            // this can be removed soon once LKB supports freezer management
-            models.push(null);
-        }
+        const storageGrid = this.getStorageEditorQueryGridModel();
+        if (!storageGrid || !storageGrid.isLoaded) return <LoadingSpinner />;
+        models.push(storageGrid);
 
         const lineageGrid = this.getLineageEditorQueryGridModel();
         if (!lineageGrid || !lineageGrid.isLoaded) return <LoadingSpinner />;

--- a/packages/components/src/internal/components/samples/SamplesManageButton.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesManageButton.spec.tsx
@@ -35,8 +35,8 @@ describe('SamplesManageButton', () => {
         wrapper: ReactWrapper,
         show = true,
         parentEntityItemCount = 2,
-        selMenuItemCount = 5,
-        menuItemCount = 6,
+        selMenuItemCount = 6,
+        menuItemCount = 7,
         deleteItemCount = 1,
         picklistItemCount = 1
     ): void {
@@ -83,7 +83,7 @@ describe('SamplesManageButton', () => {
         const wrapper = mountWithServerContext(<SamplesManageButton {...DEFAULT_PROPS} combineParentTypes />, {
             user: TEST_USER_EDITOR,
         });
-        validate(wrapper, true, 1, 4, 5);
+        validate(wrapper, true, 1, 5, 6);
         wrapper.unmount();
     });
 
@@ -125,7 +125,7 @@ describe('SamplesManageButton', () => {
         const wrapper = mountWithServerContext(<SamplesManageButton {...DEFAULT_PROPS} model={model} />, {
             user: TEST_USER_EDITOR,
         });
-        validate(wrapper, true, 2, 5, 5);
+        validate(wrapper, true, 2, 6, 6);
         wrapper.unmount();
     });
 
@@ -134,7 +134,7 @@ describe('SamplesManageButton', () => {
         const wrapper = mountWithServerContext(<SamplesManageButton {...DEFAULT_PROPS} showLinkToStudy />, {
             user: TEST_USER_EDITOR,
         });
-        validate(wrapper, true, 2, 6, 7);
+        validate(wrapper, true, 2, 7, 8);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/samples/SamplesSelectionContextProvider.tsx
+++ b/packages/components/src/internal/components/samples/SamplesSelectionContextProvider.tsx
@@ -8,8 +8,6 @@ import { LoadingSpinner, SampleOperation } from '../../..';
 
 import { getSampleOperationConfirmationData } from '../entities/actions';
 
-import { isFreezerManagementEnabled } from '../../app/utils';
-
 import { SamplesSelectionProviderProps, SamplesSelectionResultProps } from './models';
 import {
     getAliquotSampleIds,
@@ -105,7 +103,7 @@ export function SamplesSelectionProvider<T>(
 
         loadStorageData(): void {
             const { selection, sampleSet, determineStorage } = this.props;
-            if (determineStorage && isFreezerManagementEnabled() && selection && selection.size > 0) {
+            if (determineStorage && selection && selection.size > 0) {
                 getNotInStorageSampleIds(selection, sampleSet)
                     .then(samples => {
                         this.setState({
@@ -170,7 +168,7 @@ export function SamplesSelectionProvider<T>(
                 if (
                     !editStatusData ||
                     !aliquots ||
-                    (determineStorage && isFreezerManagementEnabled() && !noStorageSamples) ||
+                    (determineStorage && !noStorageSamples) ||
                     (determineLineage && !sampleLineage)
                 ) {
                     isLoaded = false;

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -1,7 +1,10 @@
-import { FindField } from './models';
+import { Query } from '@labkey/api';
+
 import { IDomainField } from '../domainproperties/models';
+
 import { SAMPLE_TYPE } from '../domainproperties/PropDescType';
-import { Query } from "@labkey/api";
+
+import { FindField } from './models';
 
 export const SAMPLE_INVENTORY_ITEM_SELECTION_KEY = 'inventoryItems';
 
@@ -149,37 +152,48 @@ export const DEFAULT_SAMPLE_FIELD_CONFIG = {
 export const ALIQUOTED_FROM_COL = 'AliquotedFrom';
 const STATUS_COL = 'Status';
 
-export const SAMPLE_STORAGE_COLUMNS = ['StorageLocation','StorageRow','StorageCol','StoredAmount','Units','FreezeThawCount','EnteredStorage','CheckedOut','CheckedOutBy','StorageComment'];
+export const SAMPLE_STORAGE_COLUMNS = [
+    'StorageLocation',
+    'StorageRow',
+    'StorageCol',
+    'StoredAmount',
+    'Units',
+    'FreezeThawCount',
+    'EnteredStorage',
+    'CheckedOut',
+    'CheckedOutBy',
+    'StorageComment',
+];
 
 export const SAMPLE_INSERT_EXTRA_COLUMNS = [...SAMPLE_STORAGE_COLUMNS, ALIQUOTED_FROM_COL];
 
 export const SAMPLE_EXPORT_CONFIG = {
     'exportAlias.name': DEFAULT_SAMPLE_FIELD_CONFIG.name,
     'exportAlias.aliquotedFromLSID': ALIQUOTED_FROM_COL,
-    'exportAlias.sampleState': STATUS_COL
+    'exportAlias.sampleState': STATUS_COL,
 };
 
 export const SAMPLE_DATA_EXPORT_CONFIG = {
     ...SAMPLE_EXPORT_CONFIG,
-    includeColumn: ['AliquotedFromLSID']
+    includeColumn: ['AliquotedFromLSID'],
 };
 
 export const SAMPLE_MANAGER_AUDIT_QUERIES = [
-        { value: 'attachmentauditevent', label: 'Attachment Events' },
-        { value: 'experimentauditevent', label: 'Assay Events' },
-        { value: 'domainauditevent', label: 'Domain Events' },
-        { value: 'domainpropertyauditevent', label: 'Domain Property Events' },
-        { value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true },
-        { value: 'inventoryauditevent', label: 'Freezer Management Events', hasDetail: true },
-        { value: 'listauditevent', label: 'List Events' },
-        {
-            value: 'groupauditevent',
-            label: 'Roles and Assignment Events',
-            containerFilter: Query.ContainerFilter.allFolders,
-        },
-        { value: 'samplesetauditevent', label: 'Sample Type Events' },
-        { value: 'sampletimelineevent', label: 'Sample Timeline Events', hasDetail: true },
-        { value: 'samplesworkflowauditevent', label: 'Sample Workflow Events', hasDetail: true },
-        { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true },
-        { value: 'userauditevent', label: 'User Events', containerFilter: Query.ContainerFilter.allFolders }
-    ];
+    { value: 'attachmentauditevent', label: 'Attachment Events' },
+    { value: 'experimentauditevent', label: 'Assay Events' },
+    { value: 'domainauditevent', label: 'Domain Events' },
+    { value: 'domainpropertyauditevent', label: 'Domain Property Events' },
+    { value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true },
+    { value: 'inventoryauditevent', label: 'Freezer Management Events', hasDetail: true },
+    { value: 'listauditevent', label: 'List Events' },
+    {
+        value: 'groupauditevent',
+        label: 'Roles and Assignment Events',
+        containerFilter: Query.ContainerFilter.allFolders,
+    },
+    { value: 'samplesetauditevent', label: 'Sample Type Events' },
+    { value: 'sampletimelineevent', label: 'Sample Timeline Events', hasDetail: true },
+    { value: 'samplesworkflowauditevent', label: 'Sample Workflow Events', hasDetail: true },
+    { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true },
+    { value: 'userauditevent', label: 'User Events', containerFilter: Query.ContainerFilter.allFolders },
+];

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -147,6 +147,7 @@ export const DEFAULT_SAMPLE_FIELD_CONFIG = {
 } as Partial<IDomainField>;
 
 export const ALIQUOTED_FROM_COL = 'AliquotedFrom';
+const STATUS_COL = 'Status';
 
 export const SAMPLE_STORAGE_COLUMNS = ['StorageLocation','StorageRow','StorageCol','StoredAmount','Units','FreezeThawCount','EnteredStorage','CheckedOut','CheckedOutBy','StorageComment'];
 
@@ -154,7 +155,8 @@ export const SAMPLE_INSERT_EXTRA_COLUMNS = [...SAMPLE_STORAGE_COLUMNS, ALIQUOTED
 
 export const SAMPLE_EXPORT_CONFIG = {
     'exportAlias.name': DEFAULT_SAMPLE_FIELD_CONFIG.name,
-    'exportAlias.aliquotedFromLSID': ALIQUOTED_FROM_COL
+    'exportAlias.aliquotedFromLSID': ALIQUOTED_FROM_COL,
+    'exportAlias.sampleState': STATUS_COL
 };
 
 export const SAMPLE_DATA_EXPORT_CONFIG = {

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -1,4 +1,7 @@
 import { FindField } from './models';
+import { IDomainField } from '../domainproperties/models';
+import { SAMPLE_TYPE } from '../domainproperties/PropDescType';
+import { Query } from "@labkey/api";
 
 export const SAMPLE_INVENTORY_ITEM_SELECTION_KEY = 'inventoryItems';
 
@@ -129,3 +132,50 @@ export const operationRestrictionMessage = {
     //    Not needed because only possible from LKS
     // }
 };
+
+export const DEFAULT_SAMPLE_FIELD_CONFIG = {
+    required: true,
+    dataType: SAMPLE_TYPE,
+    conceptURI: SAMPLE_TYPE.conceptURI,
+    rangeURI: SAMPLE_TYPE.rangeURI,
+    lookupSchema: 'exp',
+    lookupQuery: 'Materials',
+    lookupType: { ...SAMPLE_TYPE },
+    name: 'SampleID',
+} as Partial<IDomainField>;
+
+export const ALIQUOTED_FROM_COL = 'AliquotedFrom';
+
+export const SAMPLE_STORAGE_COLUMNS = ['StorageLocation','StorageRow','StorageCol','StoredAmount','Units','FreezeThawCount','EnteredStorage','CheckedOut','CheckedOutBy','StorageComment'];
+
+export const SAMPLE_INSERT_EXTRA_COLUMNS = [...SAMPLE_STORAGE_COLUMNS, ALIQUOTED_FROM_COL];
+
+export const SAMPLE_EXPORT_CONFIG = {
+    'exportAlias.name': DEFAULT_SAMPLE_FIELD_CONFIG.name,
+    'exportAlias.aliquotedFromLSID': ALIQUOTED_FROM_COL
+};
+
+export const SAMPLE_DATA_EXPORT_CONFIG = {
+    ...SAMPLE_EXPORT_CONFIG,
+    includeColumn: ['AliquotedFromLSID']
+};
+
+export const SAMPLE_MANAGER_AUDIT_QUERIES = [
+        { value: 'attachmentauditevent', label: 'Attachment Events' },
+        { value: 'experimentauditevent', label: 'Assay Events' },
+        { value: 'domainauditevent', label: 'Domain Events' },
+        { value: 'domainpropertyauditevent', label: 'Domain Property Events' },
+        { value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true },
+        { value: 'inventoryauditevent', label: 'Freezer Management Events', hasDetail: true },
+        { value: 'listauditevent', label: 'List Events' },
+        {
+            value: 'groupauditevent',
+            label: 'Roles and Assignment Events',
+            containerFilter: Query.ContainerFilter.allFolders,
+        },
+        { value: 'samplesetauditevent', label: 'Sample Type Events' },
+        { value: 'sampletimelineevent', label: 'Sample Timeline Events', hasDetail: true },
+        { value: 'samplesworkflowauditevent', label: 'Sample Workflow Events', hasDetail: true },
+        { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true },
+        { value: 'userauditevent', label: 'User Events', containerFilter: Query.ContainerFilter.allFolders }
+    ];


### PR DESCRIPTION
#### Rationale
FreezerManager as well as picklist functions were enabled for LKB under experimental flag. We are now ready to enable those features and remove the experimental flag.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2789
* https://github.com/LabKey/labkey-ui-components/pull/675
* https://github.com/LabKey/inventory/pull/331
* https://github.com/LabKey/sampleManagement/pull/755
* https://github.com/LabKey/biologics/pull/1064

#### Changes
* Remove isFreezerManagerEnabledInBiologics util, but keep isFreezerManagementEnabled
* Remove check for isFreezerManagementEnabled for various components used exclusively by LKSM and LKB
