### PR TITLE
Auto-populate Samples for Assay Import

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.96.0",
+  "version": "2.97.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.94.0-fb-autopopsamples-1.0",
+  "version": "2.94.0-fb-autopopsamples-1.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.94.0",
+  "version": "2.94.0-fb-autopopsamples-1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Support auto-populating sample grid rows when importing run for a Job's Task's Assay
+
 ### version 2.94.0
 *Released*: 17 November 2021
 * Item 9500: Improve Sample display when spanning types

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.97.0
+*Released*: 23 November 2021
 * Support auto-populating sample grid rows when importing run for a Job's Task's Assay
 
 ### version 2.96.0

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -118,7 +118,7 @@ interface State {
     sampleStatusWarning: string;
 }
 
-export class AssayImportPanelsBody extends Component<Props, State> {
+class AssayImportPanelsBody extends Component<Props, State> {
     static defaultProps = {
         loadSelectedSamples,
         showUploadTabs: true,

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -331,7 +331,10 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 modelUpdates.selectedSamples = validSamples;
 
                 if (samples.size > 0) {
-                    sampleStatusWarning = getOperationNotPermittedMessage(SampleOperation.AddAssayData, statusConfirmationData);
+                    sampleStatusWarning = getOperationNotPermittedMessage(
+                        SampleOperation.AddAssayData,
+                        statusConfirmationData
+                    );
                 }
             } catch (e) {
                 this.setState({ error: STATUS_DATA_RETRIEVAL_ERROR });

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -148,7 +148,6 @@ export class AssayImportPanelsBody extends Component<Props, State> {
             selectStep(parseInt(location.query.dataTab, 10));
         }
 
-        console.log("location", location);
         this.initModel(this.props);
     }
 

--- a/packages/components/src/internal/components/forms/FormStep.tsx
+++ b/packages/components/src/internal/components/forms/FormStep.tsx
@@ -148,6 +148,14 @@ export const withFormSteps = (Component: any, defaultState?: WithFormStepsState)
         constructor(props) {
             super(props);
 
+            // console.log("withFormSteps1", props.initialStep);
+            // console.log("withFormSteps2", defaultState);
+            // console.log("withFormSteps3", props.initialStep
+            //     ? props.initialStep
+            //     : defaultState && defaultState.currentStep !== undefined
+            //         ? defaultState.currentStep
+            //         : 1);
+
             this.nextStep = this.nextStep.bind(this);
             this.previousStep = this.previousStep.bind(this);
             this.selectStep = this.selectStep.bind(this);
@@ -186,6 +194,7 @@ export const withFormSteps = (Component: any, defaultState?: WithFormStepsState)
 
         selectStep(requestedStep?: number): boolean {
             const { currentStep, furthestStep } = this.state;
+            // console.log("selectStep", requestedStep);
 
             if (furthestStep >= requestedStep && currentStep !== requestedStep) {
                 this.setState({

--- a/packages/components/src/internal/components/forms/FormStep.tsx
+++ b/packages/components/src/internal/components/forms/FormStep.tsx
@@ -148,14 +148,6 @@ export const withFormSteps = (Component: any, defaultState?: WithFormStepsState)
         constructor(props) {
             super(props);
 
-            // console.log("withFormSteps1", props.initialStep);
-            // console.log("withFormSteps2", defaultState);
-            // console.log("withFormSteps3", props.initialStep
-            //     ? props.initialStep
-            //     : defaultState && defaultState.currentStep !== undefined
-            //         ? defaultState.currentStep
-            //         : 1);
-
             this.nextStep = this.nextStep.bind(this);
             this.previousStep = this.previousStep.bind(this);
             this.selectStep = this.selectStep.bind(this);
@@ -194,7 +186,6 @@ export const withFormSteps = (Component: any, defaultState?: WithFormStepsState)
 
         selectStep(requestedStep?: number): boolean {
             const { currentStep, furthestStep } = this.state;
-            // console.log("selectStep", requestedStep);
 
             if (furthestStep >= requestedStep && currentStep !== requestedStep) {
                 this.setState({

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -153,7 +153,7 @@ export function fetchSamples(
     return selectRows({
         schemaName: schemaQuery.schemaName,
         queryName: schemaQuery.queryName,
-        columns: ['name', 'sampleId'],
+        columns: ['name', 'sampleId', 'RowId'],
         filterArray,
     }).then(response => {
         const { key, models, orderedModels } = response;


### PR DESCRIPTION
#### Rationale
Previously, when a user created a job with attached samples and assays, navigated to the job's tasks, and clicked 'Import Run' for a given assay, they were taken to a page where they could upload results data. With these changes, if there is a 'samples' column for the assay in question, we auto-populate the results grid data with the samples attached to the job.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1065
* https://github.com/LabKey/sampleManagement/pull/756

#### Changes
* Add ability to auto-populate grid with sample data from job samples while preserving option to auto-populate grid with sample data from a samples grid with selections
* Create helper function loadJobSamples
* Refactor function fetchSamples
* Bump version, add to components.md
