### PR TITLE
Cross-Folder Sample Types

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.6.9-fb-subfolder-perms.0",
+    "@labkey/api": "1.6.10",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.6.9",
+    "@labkey/api": "1.6.9-fb-subfolder-perms.0",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.100.0",
+  "version": "2.100.0-fb-subfolder-perms.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.100.0-fb-subfolder-perms.0",
+  "version": "2.101.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,21 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.##.0
+*Released*: ## November 2021
+* Add `getContainerFilter()` for resolving default container filter based on folder context.
+* Add `SecurityAPIWrapper` to support fetching containers. This is provided to components via `AppContext`.
+* Specify React hooks exported by `@labkey/components` on a `Hooks` object for easier mocking.
+* Update `ParentEntityEditPanel` to fetch and persist parent metadata. This allows the component to operate independent of the configuration of the model as supplied by the caller.
+* Update `EditableDetailPanel` to accept `containerPath`.
+* QueryModel
+    * Add `loadErrors` and `hasLoadErrors()` utilities to `QueryModel` to reduce the number of checks callers need to do to ensure errors are handled.
+    * Add `getRowValue()` utility method to `QueryModel` which allows for fetching the specific value of a row by column name (case-insensitive).
+* Domain Editing
+    * Add `domainContainerPath` prop to `QueryInfo` as now specified by `query-getQueryDetails.api` endpoint.
+    * Support requesting PHI level cross-folder.
+    * Make domain save requests against domain's folder.
+
 ### version 2.100.0
 *Released*: 29 November 2021
 * Item 9703: Add support for LabKey Vis API stacked bar plot

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.##.0
-*Released*: ## November 2021
+### version 2.101.0
+*Released*: 30 November 2021
 * Add `getContainerFilter()` for resolving default container filter based on folder context.
 * Add `SecurityAPIWrapper` to support fetching containers. This is provided to components via `AppContext`.
 * Specify React hooks exported by `@labkey/components` on a `Hooks` object for easier mocking.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -304,7 +304,7 @@ import { SampleAliquotsGridPanel } from './internal/components/samples/SampleAli
 
 import { AppContextProvider, useAppContext } from './internal/AppContext';
 import { AppContexts } from './internal/AppContexts';
-import { getContainerUser, useContainerUser } from './internal/components/container/actions';
+import { ContainerActions, getContainerUser, useContainerUser } from './internal/components/container/actions';
 
 import {
     filterSampleRowsForOperation,
@@ -1213,6 +1213,7 @@ export {
     User,
     getContainerUser,
     useContainerUser,
+    ContainerActions,
     AppContextProvider,
     useAppContext,
     AppContexts,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -716,7 +716,10 @@ const Hooks = {
     useAppContext,
     useContainerUser,
     useEnterEscape,
+    useRouteLeave,
     useServerContext,
+    useUserProperties,
+    useUsersWithPermissions,
 };
 
 export {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -304,6 +304,7 @@ import { SampleAliquotsGridPanel } from './internal/components/samples/SampleAli
 
 import { AppContextProvider, useAppContext } from './internal/AppContext';
 import { AppContexts } from './internal/AppContexts';
+import { getContainerUser, useContainerUser } from './internal/components/container/actions';
 
 import {
     filterSampleRowsForOperation,
@@ -1210,6 +1211,8 @@ export {
     // base models, enums, constants
     Container,
     User,
+    getContainerUser,
+    useContainerUser,
     AppContextProvider,
     useAppContext,
     AppContexts,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -712,10 +712,18 @@ const App = {
     TEST_USER_APP_ADMIN,
 };
 
+const Hooks = {
+    useAppContext,
+    useContainerUser,
+    useEnterEscape,
+    useServerContext,
+};
+
 export {
     // internal application
     App,
     AppModel,
+    Hooks,
     LogoutReason,
     // global state functions
     initQueryGridState,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -304,7 +304,7 @@ import { SampleAliquotsGridPanel } from './internal/components/samples/SampleAli
 
 import { AppContextProvider, useAppContext } from './internal/AppContext';
 import { AppContexts } from './internal/AppContexts';
-import { ContainerActions, getContainerUser, useContainerUser } from './internal/components/container/actions';
+import { getContainerUser, useContainerUser } from './internal/components/container/actions';
 
 import {
     filterSampleRowsForOperation,
@@ -1223,8 +1223,6 @@ export {
     Container,
     User,
     getContainerUser,
-    useContainerUser,
-    ContainerActions,
     AppContextProvider,
     useAppContext,
     AppContexts,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -305,7 +305,7 @@ import { SampleAliquotsGridPanel } from './internal/components/samples/SampleAli
 
 import { AppContextProvider, useAppContext } from './internal/AppContext';
 import { AppContexts } from './internal/AppContexts';
-import { getContainerUser, useContainerUser } from './internal/components/container/actions';
+import { useContainerUser } from './internal/components/container/actions';
 
 import {
     filterSampleRowsForOperation,
@@ -1224,7 +1224,6 @@ export {
     // base models, enums, constants
     Container,
     User,
-    getContainerUser,
     AppContextProvider,
     useAppContext,
     AppContexts,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -173,6 +173,7 @@ import {
 } from './internal/global';
 import {
     deleteRows,
+    getContainerFilter,
     getQueryDetails,
     importData,
     InsertFormats,
@@ -731,6 +732,7 @@ export {
     // global state functions
     initQueryGridState,
     initNotificationsState,
+    getContainerFilter,
     getStateQueryGridModel,
     getStateModelId,
     getQueryGridModel,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1376,3 +1376,4 @@ export type { AppContext, ExtendableAppContext } from './internal/AppContext';
 export type { ThreadBlockProps } from './internal/announcements/ThreadBlock';
 export type { ThreadEditorProps } from './internal/announcements/ThreadEditor';
 export type { SamplesEditableGridProps } from './internal/components/samples/SamplesEditableGrid';
+export type { ContainerUser, UseContainerUser } from './internal/components/container/actions';

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -4,17 +4,19 @@ import {
     PicklistServerAPIWrapper,
     getPicklistTestAPIWrapper,
 } from './components/picklist/APIWrapper';
+import { getSecurityTestAPIWrapper, SecurityAPI, SecurityAPIWrapper } from './components/security/SecurityAPI';
 
 export interface ComponentsAPIWrapper {
-    // TODO add more wrappers for other functional areas of this package
-    samples: SamplesAPIWrapper;
     picklist: PicklistAPIWrapper;
+    samples: SamplesAPIWrapper;
+    security: SecurityAPI;
 }
 
 export function getDefaultAPIWrapper(): ComponentsAPIWrapper {
     return {
-        samples: new SamplesServerAPIWrapper(),
         picklist: new PicklistServerAPIWrapper(),
+        samples: new SamplesServerAPIWrapper(),
+        security: new SecurityAPIWrapper(),
     };
 }
 
@@ -26,8 +28,9 @@ export function getTestAPIWrapper(
     overrides: Partial<ComponentsAPIWrapper> = {}
 ): ComponentsAPIWrapper {
     return {
-        samples: getSamplesTestAPIWrapper(mockFn, overrides.samples),
         picklist: getPicklistTestAPIWrapper(mockFn, overrides.picklist),
+        samples: getSamplesTestAPIWrapper(mockFn, overrides.samples),
+        security: getSecurityTestAPIWrapper(mockFn, overrides.security),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -4,19 +4,23 @@ import {
     PicklistServerAPIWrapper,
     getPicklistTestAPIWrapper,
 } from './components/picklist/APIWrapper';
-import { getSecurityTestAPIWrapper, SecurityAPI, SecurityAPIWrapper } from './components/security/SecurityAPI';
+import {
+    getSecurityTestAPIWrapper,
+    SecurityAPIWrapper,
+    ServerSecurityAPIWrapper,
+} from './components/security/APIWrapper';
 
 export interface ComponentsAPIWrapper {
     picklist: PicklistAPIWrapper;
     samples: SamplesAPIWrapper;
-    security: SecurityAPI;
+    security: SecurityAPIWrapper;
 }
 
 export function getDefaultAPIWrapper(): ComponentsAPIWrapper {
     return {
         picklist: new PicklistServerAPIWrapper(),
         samples: new SamplesServerAPIWrapper(),
-        security: new SecurityAPIWrapper(),
+        security: new ServerSecurityAPIWrapper(),
     };
 }
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -131,6 +131,10 @@ export function isSampleManagerNavigationEnabled(): boolean {
     return getServerContext().moduleContext?.biologics?.isBiologicsSampleManagerNavEnabled === true;
 }
 
+export function isSubfolderDataEnabled(): boolean {
+    return getServerContext().moduleContext?.biologics?.isSubfolderDataEnabled === true;
+}
+
 export function isSampleManagerEnabled(moduleContext?: any): boolean {
     return (moduleContext ?? getServerContext().moduleContext)?.samplemanagement !== undefined;
 }

--- a/packages/components/src/internal/components/base/models/Container.ts
+++ b/packages/components/src/internal/components/base/models/Container.ts
@@ -3,6 +3,7 @@ import { Container as IContainer } from '@labkey/api';
 
 const defaultContainer: Partial<IContainer> = {
     activeModules: [],
+    effectivePermissions: [],
     folderType: '',
     hasRestrictedActiveModule: false,
     id: '',
@@ -22,6 +23,7 @@ const defaultContainer: Partial<IContainer> = {
  */
 export class Container extends Record(defaultContainer) implements Partial<IContainer> {
     declare activeModules: string[];
+    declare effectivePermissions: string[];
     declare folderType: string;
     declare hasRestrictedActiveModule: boolean;
     declare id: string;

--- a/packages/components/src/internal/components/base/models/User.ts
+++ b/packages/components/src/internal/components/base/models/User.ts
@@ -65,6 +65,10 @@ export class User extends Record(defaultUser) implements IUserProps {
         return new User(defaultUser);
     }
 
+    hasAdminPermission(): boolean {
+        return hasAllPermissions(this, [PermissionTypes.Admin], false);
+    }
+
     hasUpdatePermission(): boolean {
         return hasAllPermissions(this, [PermissionTypes.Update]);
     }

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -38,7 +38,7 @@ export async function getContainerUser(
     return { container, user: applyPermissions(container, user) };
 }
 
-interface UseContainerUser extends ContainerUser {
+export interface UseContainerUser extends ContainerUser {
     error: string;
     isLoaded: boolean;
 }

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -100,9 +100,3 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
 
     return { container, error, isLoaded: !isLoading(loadingState), user: contextUser };
 }
-
-export class ContainerActions {
-    static useContainerUser(containerIdOrPath: string): UseContainerUser {
-        return useContainerUser(containerIdOrPath);
-    }
-}

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -98,7 +98,7 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
 }
 
 export class ContainerActions {
-    useContainerUser(containerIdOrPath: string): UseContainerUser {
+    static useContainerUser(containerIdOrPath: string): UseContainerUser {
         return useContainerUser(containerIdOrPath);
     }
 }

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -84,10 +84,12 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
             }
 
             const container_ = containers[containerIdOrPath];
-            const contextUser_ = applyPermissions(container_, user);
-
             setContainer(container_);
-            setContextUser(contextUser_);
+
+            if (container_) {
+                setContextUser(applyPermissions(container_, user));
+            }
+
             setLoadingState(LoadingState.LOADED);
         })();
     }, [api, containerIdOrPath, user]);

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -98,5 +98,7 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
 }
 
 export class ContainerActions {
-    useContainerUser = useContainerUser;
+    useContainerUser(containerIdOrPath: string): UseContainerUser {
+        return useContainerUser(containerIdOrPath);
+    }
 }

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -42,16 +42,18 @@ export async function getContainerUser(
     user: User,
     api: ComponentsAPIWrapper
 ): Promise<ContainerUser> {
-    const containers = await api.security.fetchContainers(
-        {
-            containerPath: containerIdOrPath,
-        },
-        containerIdOrPath
-    );
+    const containers = await api.security.fetchContainers({ containerPath: containerIdOrPath });
 
-    const container = containers[containerIdOrPath];
+    if (containers.length > 0) {
+        const container = containers[0];
 
-    return { container, user: applyPermissions(container, user) };
+        return {
+            container,
+            user: applyPermissions(container, user),
+        };
+    }
+
+    return undefined;
 }
 
 export interface UseContainerUser extends ContainerUser {
@@ -74,20 +76,15 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
             setError(undefined);
             setLoadingState(LoadingState.LOADING);
 
-            let containers: Record<string, Container> = {};
+            let containers = [];
 
             try {
-                containers = await api.security.fetchContainers(
-                    {
-                        containerPath: containerIdOrPath,
-                    },
-                    containerIdOrPath
-                );
+                containers = await api.security.fetchContainers({ containerPath: containerIdOrPath });
             } catch (e) {
                 setError(resolveErrorMessage(e));
             }
 
-            const container_ = containers[containerIdOrPath];
+            const container_ = containers[0];
             setContainer(container_);
 
             if (container_) {

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -9,10 +9,22 @@ import { Container } from '../base/models/Container';
 import { User } from '../base/models/User';
 import { resolveErrorMessage } from '../../util/messaging';
 
+/**
+ * Applies the permissions on the container to the user. Only permission related User fields are mutated.
+ */
 function applyPermissions(container: Container, user: User): User {
-    return user.merge({
-        // TODO: isAdmin, canUpdate, etc...
-        permissionsList: List(container.effectivePermissions),
+    return user.withMutations(u => {
+        // Must set the permissionsList prior to configuring permission bits (e.g. "canDelete", "canUpdate", etc)
+        const u_ = u.set('permissionsList', List(container.effectivePermissions)) as User;
+
+        return u_.merge({
+            canDelete: u_.hasDeletePermission(),
+            canDeleteOwn: u_.hasDeletePermission(),
+            canInsert: u_.hasInsertPermission(),
+            canUpdate: u_.hasUpdatePermission(),
+            canUpdateOwn: u_.hasUpdatePermission(),
+            isAdmin: u_.hasAdminPermission(),
+        });
     }) as User;
 }
 

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -96,3 +96,7 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
 
     return { container, error, isLoaded: !isLoading(loadingState), user: contextUser };
 }
+
+export class ContainerActions {
+    useContainerUser = useContainerUser;
+}

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { List, Record } from 'immutable';
+import { Security } from '@labkey/api';
+
+import { User } from '../base/models/User';
+import { isLoading, LoadingState } from '../../../public/LoadingState';
+import { useServerContext } from '../base/ServerContext';
+import { resolveErrorMessage } from '../../util/messaging';
+import { Container } from '../base/models/Container';
+
+function applyPermissions(container: Container, user: User): User {
+    return user.merge({
+        // TODO: isAdmin, canUpdate, etc...
+        permissionsList: List(container.effectivePermissions),
+    }) as User;
+}
+
+type FetchContainersResult = Promise<Record<string, Container>>;
+type FetchContainerOptions = Omit<Security.GetContainersOptions, 'success' | 'failure' | 'scope'>;
+
+const FETCH_CONTAINERS_CACHE: Record<string, FetchContainersResult> = {};
+
+export function fetchContainers(options: FetchContainerOptions, cacheKey?: string): FetchContainersResult {
+    if (cacheKey && FETCH_CONTAINERS_CACHE[cacheKey]) {
+        return FETCH_CONTAINERS_CACHE[cacheKey];
+    }
+
+    const result: FetchContainersResult = new Promise((resolve, reject) => {
+        Security.getContainers({
+            ...options,
+            success: (hierarchy: Security.ContainerHierarchy) => {
+                const containers = [
+                    new Container(hierarchy),
+                    // TODO: Consider filtering filter(c => c.type === 'folder') or adding option to API to exclude hidden folders
+                    ...hierarchy.children.map(c => new Container(c)),
+                ];
+
+                const containerMap = containers.reduce((map, c) => {
+                    map[c.id] = c;
+                    map[c.path] = c;
+                    return map;
+                }, {});
+
+                resolve(containerMap);
+            },
+            failure: error => {
+                console.error('Failed to fetch containers', error);
+                reject(error);
+            },
+        });
+    });
+
+    if (cacheKey) {
+        FETCH_CONTAINERS_CACHE[cacheKey] = result;
+    }
+
+    return result;
+}
+
+export interface ViewContext {
+    container: Container;
+    user: User;
+}
+
+export async function getViewContext(containerIdOrPath: string, user: User): Promise<ViewContext> {
+    const containers = await fetchContainers(
+        {
+            containerPath: containerIdOrPath,
+        },
+        containerIdOrPath
+    );
+
+    const container = containers[containerIdOrPath];
+
+    return { container, user: applyPermissions(container, user) };
+}
+
+interface UseViewContext extends ViewContext {
+    error: string;
+    isLoaded: boolean;
+}
+
+export function useViewContext(containerIdOrPath: string): UseViewContext {
+    const [container, setContainer] = useState<Container>();
+    const [error, setError] = useState<string>();
+    const [contextUser, setContextUser] = useState<User>();
+    const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
+    const { user } = useServerContext();
+
+    useEffect(() => {
+        if (!containerIdOrPath) return;
+
+        (async () => {
+            setError(undefined);
+            setLoadingState(LoadingState.LOADING);
+
+            let containers = {};
+
+            try {
+                containers = await fetchContainers(
+                    {
+                        containerPath: containerIdOrPath,
+                    },
+                    containerIdOrPath
+                );
+            } catch (e) {
+                setError(resolveErrorMessage(e));
+            }
+
+            const container_ = containers[containerIdOrPath];
+            const contextUser_ = applyPermissions(container_, user);
+
+            setContainer(container_);
+            setContextUser(contextUser_);
+            setLoadingState(LoadingState.LOADED);
+        })();
+    }, [containerIdOrPath, user]);
+
+    return { container, error, isLoaded: !isLoading(loadingState), user: contextUser };
+}

--- a/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
@@ -16,9 +16,9 @@ export interface InjectedBaseDomainDesignerProps {
     visitedPanels: List<number>;
     validatePanel: number;
     firstState: boolean;
-    setSubmitting: (submitting: boolean, callback?: () => any) => any;
-    onTogglePanel: (index: number, collapsed: boolean, callback: () => any) => any;
-    onFinish: (isValid: boolean, save: () => any) => any;
+    setSubmitting: (submitting: boolean, callback?: () => void) => void;
+    onTogglePanel: (index: number, collapsed: boolean, callback: () => void) => void;
+    onFinish: (isValid: boolean, save: () => void) => void;
 }
 
 interface State {
@@ -45,7 +45,7 @@ export function withBaseDomainDesigner<Props>(
             };
         }
 
-        onTogglePanel = (index: number, collapsed: boolean, callback: () => any) => {
+        onTogglePanel = (index: number, collapsed: boolean, callback: () => any): void => {
             const { visitedPanels, currentPanelIndex } = this.state;
             const updatedVisitedPanels = getUpdatedVisitedPanelsList(visitedPanels, index);
 
@@ -76,7 +76,7 @@ export function withBaseDomainDesigner<Props>(
             }
         };
 
-        onFinish = (isValid: boolean, save: () => any) => {
+        onFinish = (isValid: boolean, save: () => void): void => {
             const { visitedPanels, currentPanelIndex } = this.state;
             const updatedVisitedPanels = getUpdatedVisitedPanelsList(visitedPanels, currentPanelIndex);
 
@@ -97,13 +97,11 @@ export function withBaseDomainDesigner<Props>(
             );
         };
 
-        setSubmitting = (submitting: boolean, callback?: () => any) => {
+        setSubmitting = (submitting: boolean, callback?: () => void): void => {
             this.setState(
                 () => ({ submitting }),
                 () => {
-                    if (callback) {
-                        callback();
-                    }
+                    callback?.();
                 }
             );
         };
@@ -143,7 +141,7 @@ interface BaseDomainDesignerProps {
     saveBtnText?: string;
 }
 
-export class BaseDomainDesigner extends React.PureComponent<BaseDomainDesignerProps, any> {
+export class BaseDomainDesigner extends PureComponent<BaseDomainDesignerProps> {
     static defaultProps = {
         saveBtnText: 'Save',
     };

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1233,15 +1233,8 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             successBsStyle,
             domainFormDisplayOptions,
         } = this.props;
-        const {
-            expandedRowIndex,
-            expandTransition,
-            fieldDetails,
-            maxPhiLevel,
-            dragId,
-            availableTypes,
-            search,
-        } = this.state;
+        const { expandedRowIndex, expandTransition, fieldDetails, maxPhiLevel, dragId, availableTypes, search } =
+            this.state;
 
         return (
             <DragDropContext onDragEnd={this.onDragEnd} onBeforeDragStart={this.onBeforeDragStart}>

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -216,10 +216,10 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
 
         if (!maxPhiLevel) {
             try {
-                const nextMaxPhiLevel = await getMaxPhiLevel();
+                const nextMaxPhiLevel = await getMaxPhiLevel(domain.container);
                 this.setState({ maxPhiLevel: nextMaxPhiLevel });
             } catch (error) {
-                console.error('Unable to retrieve max PHI level.');
+                console.error('Unable to retrieve max PHI level.', error);
             }
         }
 
@@ -833,11 +833,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
 
             if (!fieldErrors.isEmpty()) {
                 const errorsWithIndex = fieldErrors.filter(error => {
-                    return (
-                        error.rowIndexes.findIndex(idx => {
-                            return idx === index;
-                        }) >= 0
-                    );
+                    return error.rowIndexes.findIndex(idx => idx === index) >= 0;
                 });
                 return errorsWithIndex.get(0);
             }
@@ -1268,6 +1264,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                                                 ref={ref => {
                                                     this.refsArray[i] = ref;
                                                 }}
+                                                domainContainerPath={domain.container}
                                                 domainId={domain.domainId}
                                                 helpNoun={helpNoun}
                                                 key={'domain-row-key-' + i}

--- a/packages/components/src/internal/components/domainproperties/DomainRow.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.spec.tsx
@@ -30,7 +30,7 @@ import {
     TEXT_TYPE,
 } from './PropDescType';
 
-import { DomainRow } from './DomainRow';
+import { DomainRow, DomainRowProps } from './DomainRow';
 import {
     ATTACHMENT_RANGE_URI,
     DOMAIN_EDITABLE_DEFAULT,
@@ -75,31 +75,28 @@ const DEFAULT_OPTIONS = List<string>([
 ]);
 
 describe('DomainRow', () => {
-    test('with empty domain form', () => {
-        const field = DomainField.create({});
-        const tree = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={1}
-                    domainIndex={1}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
-        );
+    function getDefaultProps(): DomainRowProps {
+        return {
+            availableTypes: PROP_DESC_TYPES,
+            defaultDefaultValueType: DOMAIN_EDITABLE_DEFAULT,
+            defaultValueOptions: DEFAULT_OPTIONS,
+            domainIndex: 1,
+            dragging: false,
+            expanded: false,
+            expandTransition: EXPAND_TRANSITION,
+            field: DomainField.create({}),
+            helpNoun: 'domain',
+            index: 1,
+            maxPhiLevel: PHILEVEL_RESTRICTED_PHI,
+            onChange: jest.fn(),
+            onDelete: jest.fn(),
+            onExpand: jest.fn(),
+            showDefaultValueSettings: true,
+        };
+    }
 
+    test('with empty domain form', () => {
+        const tree = mount(wrapDraggable(<DomainRow {...getDefaultProps()} />));
         expect(tree).toMatchSnapshot();
         tree.unmount();
     });
@@ -118,26 +115,7 @@ describe('DomainRow', () => {
         });
 
         const row = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={_index}
-                    domainIndex={_domainIndex}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
         );
 
         const type = row.find({
@@ -180,26 +158,7 @@ describe('DomainRow', () => {
         });
 
         const row = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={_index}
-                    domainIndex={_domainIndex}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
         );
 
         const type = row.find({
@@ -242,26 +201,7 @@ describe('DomainRow', () => {
         });
 
         const row = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={_index}
-                    domainIndex={_domainIndex}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
         );
 
         const type = row.find({
@@ -304,26 +244,7 @@ describe('DomainRow', () => {
         });
 
         const row = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={_index}
-                    domainIndex={_domainIndex}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
         );
 
         const type = row.find({
@@ -376,24 +297,7 @@ describe('DomainRow', () => {
 
         const row = mount(
             wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={_index}
-                    domainIndex={_domainIndex}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={true}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
+                <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} expanded />
             )
         );
 
@@ -451,26 +355,7 @@ describe('DomainRow', () => {
         });
 
         const row = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={_index}
-                    domainIndex={_domainIndex}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
         );
 
         const type = row.find({
@@ -518,27 +403,7 @@ describe('DomainRow', () => {
         });
 
         const row = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={1}
-                    domainIndex={1}
-                    field={field}
-                    fieldError={domainFieldError}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} field={field} fieldError={domainFieldError} />)
         );
 
         // test row highlighting for a warning
@@ -578,27 +443,7 @@ describe('DomainRow', () => {
         });
 
         const row = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={1}
-                    domainIndex={1}
-                    field={field}
-                    fieldError={domainFieldError}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} field={field} fieldError={domainFieldError} />)
         );
 
         // test row highlighting for error
@@ -626,51 +471,11 @@ describe('DomainRow', () => {
             propertyURI: 'test',
             selected: true,
         });
-        const treeSelected = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={1}
-                    domainIndex={1}
-                    field={field}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
-        );
+        const treeSelected = mount(wrapDraggable(<DomainRow {...getDefaultProps()} field={field} />));
         expect(treeSelected.find('.domain-field-check-icon').first().props().checked).toBeTruthy();
 
         const treeNonselected = mount(
-            wrapDraggable(
-                <DomainRow
-                    key="domain-row-key-1"
-                    index={1}
-                    domainIndex={1}
-                    field={field.set('selected', false) as DomainField}
-                    onChange={jest.fn()}
-                    onExpand={jest.fn()}
-                    onDelete={jest.fn()}
-                    expanded={false}
-                    expandTransition={EXPAND_TRANSITION}
-                    maxPhiLevel={PHILEVEL_RESTRICTED_PHI}
-                    availableTypes={PROP_DESC_TYPES}
-                    dragging={false}
-                    showDefaultValueSettings={true}
-                    defaultDefaultValueType={DOMAIN_EDITABLE_DEFAULT}
-                    defaultValueOptions={DEFAULT_OPTIONS}
-                    helpNoun="domain"
-                />
-            )
+            wrapDraggable(<DomainRow {...getDefaultProps()} field={field.set('selected', false) as DomainField} />)
         );
         expect(treeNonselected.find('.domain-field-check-icon').first().props().checked).toBeFalsy();
 

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -62,7 +62,8 @@ import {
 import { DomainRowExpandedOptions } from './DomainRowExpandedOptions';
 import { AdvancedSettings } from './AdvancedSettings';
 
-interface IDomainRowProps {
+export interface DomainRowProps {
+    domainContainerPath?: string;
     domainId?: number;
     helpNoun: string;
     expanded: boolean;
@@ -84,11 +85,11 @@ interface IDomainRowProps {
     successBsStyle?: string;
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
     getDomainFields?: () => List<DomainField>;
-    fieldDetailsInfo?: { [key: string]: string };
+    fieldDetailsInfo?: Record<string, string>;
     isDragDisabled?: boolean;
 }
 
-interface IDomainRowState {
+interface DomainRowState {
     showAdv: boolean;
     closing: boolean;
     showingModal: boolean;
@@ -98,7 +99,7 @@ interface IDomainRowState {
 /**
  * React component for one property in a domain
  */
-export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowState> {
+export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowState> {
     static defaultProps = {
         domainFormDisplayOptions: DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
     };
@@ -117,11 +118,11 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
     }
 
     // Used in DomainPropertiesGrid
-    scrollIntoView = () => {
+    scrollIntoView = (): void => {
         this[`${this.props.index}_ref`].current.scrollIntoView({ behavior: 'smooth' });
     };
 
-    UNSAFE_componentWillReceiveProps(nextProps: Readonly<IDomainRowProps>, nextContext: any): void {
+    UNSAFE_componentWillReceiveProps(nextProps: DomainRowProps): void {
         // if there was a prop change to isDragDisabled, need to call setDragDisabled
         if (nextProps.isDragDisabled !== this.props.isDragDisabled) {
             this.setDragDisabled(nextProps.isDragDisabled, false);
@@ -222,23 +223,16 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
     };
 
     onSingleFieldChange = (id: string, value: any, index?: number, expand?: boolean): void => {
-        const { onChange } = this.props;
-
-        if (onChange) {
-            onChange(List([{ id, value } as IFieldChange]), index, expand === true);
-        }
+        const changes = List([{ id, value } as IFieldChange]);
+        this.props.onChange(changes, index, expand === true);
     };
 
     onMultiFieldChange = (changes: List<IFieldChange>): void => {
-        const { onChange, index } = this.props;
-
-        if (onChange) {
-            onChange(changes, index, true);
-        }
+        this.props.onChange(changes, this.props.index, true);
     };
 
-    onNameChange = evt => {
-        const { index, onChange, domainIndex } = this.props;
+    onNameChange = (evt: any): void => {
+        const { index, domainIndex } = this.props;
 
         const value = evt.target.value;
         const nameAndErrorList = List<IFieldChange>().asMutable();
@@ -272,57 +266,45 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
             });
         }
 
-        if (onChange) {
-            onChange(nameAndErrorList, index, false);
-        }
+        this.props.onChange(nameAndErrorList, index, false);
     };
 
-    onDataTypeChange = (evt: any): any => {
+    onDataTypeChange = (evt: any): void => {
         this.onFieldChange(evt, PropDescType.isLookup(evt.target.value));
     };
 
     onShowAdvanced = (): any => {
-        this.setState(() => ({ showAdv: true }));
-
+        this.setState({ showAdv: true });
         this.setDragDisabled(this.props.isDragDisabled, true);
     };
 
     onHideAdvanced = (): any => {
-        this.setState(() => ({ showAdv: false }));
-
+        this.setState({ showAdv: false });
         this.setDragDisabled(this.props.isDragDisabled, false);
     };
 
-    onDelete = (): any => {
-        const { index, onDelete } = this.props;
-
-        if (onDelete) {
-            onDelete(index);
-        }
+    onDelete = (): void => {
+        this.props.onDelete?.(this.props.index);
     };
 
-    onExpand = (): any => {
-        const { index, onExpand } = this.props;
-
-        if (onExpand) {
-            onExpand(index);
-        }
+    onExpand = (): void => {
+        this.props.onExpand?.(this.props.index);
     };
 
     onCollapsed = (): void => {
-        this.setState(() => ({ closing: false }));
+        this.setState({ closing: false });
     };
 
     onCollapsing = (): void => {
-        this.setState(() => ({ closing: true }));
+        this.setState({ closing: true });
     };
 
     setDragDisabled = (propDragDisabled: boolean, disabled: boolean): void => {
-        this.setState(() => ({ isDragDisabled: disabled || propDragDisabled }));
+        this.setState({ isDragDisabled: disabled || propDragDisabled });
     };
 
-    showingModal = (showing: boolean): void => {
-        this.setState(() => ({ showingModal: showing }));
+    showingModal = (showingModal: boolean): void => {
+        this.setState({ showingModal });
     };
 
     disableNameInput(field: DomainField): boolean {
@@ -435,6 +417,7 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
     render() {
         const { closing, isDragDisabled, showAdv, showingModal } = this.state;
         const {
+            domainContainerPath,
             index,
             field,
             expanded,
@@ -536,6 +519,7 @@ export class DomainRow extends React.PureComponent<IDomainRowProps, IDomainRowSt
                         >
                             <div>
                                 <DomainRowExpandedOptions
+                                    domainContainerPath={domainContainerPath}
                                     field={field}
                                     index={index}
                                     domainIndex={domainIndex}

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -63,37 +63,37 @@ import { DomainRowExpandedOptions } from './DomainRowExpandedOptions';
 import { AdvancedSettings } from './AdvancedSettings';
 
 export interface DomainRowProps {
-    domainContainerPath?: string;
-    domainId?: number;
-    helpNoun: string;
-    expanded: boolean;
-    dragging: boolean;
-    expandTransition: number;
-    field: DomainField;
-    index: number;
-    maxPhiLevel: string;
+    appPropertiesOnly?: boolean;
     availableTypes: List<PropDescType>;
-    onChange: DomainOnChange;
-    fieldError?: DomainFieldError;
-    onDelete: (any) => void;
-    onExpand: (index?: number) => void;
-    showDefaultValueSettings: boolean;
     defaultDefaultValueType: string;
     defaultValueOptions: List<string>;
-    appPropertiesOnly?: boolean;
-    domainIndex: number;
-    successBsStyle?: string;
+    domainContainerPath?: string;
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
-    getDomainFields?: () => List<DomainField>;
+    domainId?: number;
+    domainIndex: number;
+    dragging: boolean;
+    expanded: boolean;
+    expandTransition: number;
+    field: DomainField;
     fieldDetailsInfo?: Record<string, string>;
+    fieldError?: DomainFieldError;
+    getDomainFields?: () => List<DomainField>;
+    helpNoun: string;
+    index: number;
     isDragDisabled?: boolean;
+    maxPhiLevel: string;
+    onChange: DomainOnChange;
+    onDelete: (index?: number) => void;
+    onExpand: (index?: number) => void;
+    showDefaultValueSettings: boolean;
+    successBsStyle?: string;
 }
 
 interface DomainRowState {
-    showAdv: boolean;
     closing: boolean;
-    showingModal: boolean;
     isDragDisabled: boolean;
+    showAdv: boolean;
+    showingModal: boolean;
 }
 
 /**
@@ -266,7 +266,7 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
             });
         }
 
-        this.props.onChange(nameAndErrorList, index, false);
+        this.props.onChange(nameAndErrorList.asImmutable(), index, false);
     };
 
     onDataTypeChange = (evt: any): void => {
@@ -284,11 +284,11 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
     };
 
     onDelete = (): void => {
-        this.props.onDelete?.(this.props.index);
+        this.props.onDelete(this.props.index);
     };
 
     onExpand = (): void => {
-        this.props.onExpand?.(this.props.index);
+        this.props.onExpand(this.props.index);
     };
 
     onCollapsed = (): void => {

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -34,6 +34,7 @@ import { SampleFieldOptions } from './SampleFieldOptions';
 import { DerivationDataScopeFieldOptions } from './DerivationDataScopeFieldOptions';
 
 interface IDomainRowExpandedOptionsProps {
+    domainContainerPath?: string;
     field: DomainField;
     index: number;
     onChange: (fieldId: string, value: any, index?: number, expand?: boolean) => void;
@@ -49,6 +50,7 @@ interface IDomainRowExpandedOptionsProps {
 export class DomainRowExpandedOptions extends React.Component<IDomainRowExpandedOptionsProps> {
     typeDependentOptions = () => {
         const {
+            domainContainerPath,
             field,
             index,
             onChange,
@@ -182,6 +184,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
 
                 return (
                     <OntologyLookupOptions
+                        domainContainerPath={domainContainerPath}
                         index={index}
                         domainIndex={domainIndex}
                         label="Ontology Lookup Options"

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
@@ -376,7 +376,6 @@ exports[`DomainRow Sample Field 1`] = `
                 }
                 helpNoun="domain"
                 index={0}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}
@@ -2614,7 +2613,6 @@ exports[`DomainRow client side warning on field 1`] = `
                 }
                 helpNoun="domain"
                 index={1}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}
@@ -4791,7 +4789,6 @@ exports[`DomainRow date time field 1`] = `
                 }
                 helpNoun="domain"
                 index={0}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}
@@ -7127,7 +7124,6 @@ exports[`DomainRow decimal field 1`] = `
                 }
                 helpNoun="domain"
                 index={2}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}
@@ -9498,7 +9494,6 @@ exports[`DomainRow participant id field 1`] = `
                 }
                 helpNoun="domain"
                 index={0}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}
@@ -11641,7 +11636,6 @@ exports[`DomainRow server side error on reserved field 1`] = `
                 }
                 helpNoun="domain"
                 index={1}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}
@@ -13707,7 +13701,6 @@ exports[`DomainRow string field test 1`] = `
                 }
                 helpNoun="domain"
                 index={1}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}
@@ -16148,7 +16141,6 @@ exports[`DomainRow with empty domain form 1`] = `
                 }
                 helpNoun="domain"
                 index={1}
-                key="domain-row-key-1"
                 maxPhiLevel="Restricted"
                 onChange={[MockFunction]}
                 onDelete={[MockFunction]}

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
@@ -157,6 +157,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -188,6 +189,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                       Object {
                         "activeContainer": Immutable.Record {
                           "activeModules": Array [],
+                          "effectivePermissions": Array [],
                           "folderType": "",
                           "hasRestrictedActiveModule": false,
                           "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -218,6 +220,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                         Object {
                           "activeContainer": Immutable.Record {
                             "activeModules": Array [],
+                            "effectivePermissions": Array [],
                             "folderType": "",
                             "hasRestrictedActiveModule": false,
                             "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -282,6 +285,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -367,6 +371,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -711,6 +716,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -742,6 +748,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                       Object {
                         "activeContainer": Immutable.Record {
                           "activeModules": Array [],
+                          "effectivePermissions": Array [],
                           "folderType": "",
                           "hasRestrictedActiveModule": false,
                           "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -772,6 +779,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                         Object {
                           "activeContainer": Immutable.Record {
                             "activeModules": Array [],
+                            "effectivePermissions": Array [],
                             "folderType": "",
                             "hasRestrictedActiveModule": false,
                             "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -848,6 +856,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -959,6 +968,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -1368,6 +1378,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -1399,6 +1410,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                       Object {
                         "activeContainer": Immutable.Record {
                           "activeModules": Array [],
+                          "effectivePermissions": Array [],
                           "folderType": "",
                           "hasRestrictedActiveModule": false,
                           "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -1429,6 +1441,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                         Object {
                           "activeContainer": Immutable.Record {
                             "activeModules": Array [],
+                            "effectivePermissions": Array [],
                             "folderType": "",
                             "hasRestrictedActiveModule": false,
                             "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -1505,6 +1518,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -1616,6 +1630,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -2025,6 +2040,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -2056,6 +2072,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                       Object {
                         "activeContainer": Immutable.Record {
                           "activeModules": Array [],
+                          "effectivePermissions": Array [],
                           "folderType": "",
                           "hasRestrictedActiveModule": false,
                           "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -2086,6 +2103,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                         Object {
                           "activeContainer": Immutable.Record {
                             "activeModules": Array [],
+                            "effectivePermissions": Array [],
                             "folderType": "",
                             "hasRestrictedActiveModule": false,
                             "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -2162,6 +2180,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",
@@ -2270,6 +2289,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                     Object {
                       "activeContainer": Immutable.Record {
                         "activeModules": Array [],
+                        "effectivePermissions": Array [],
                         "folderType": "",
                         "hasRestrictedActiveModule": false,
                         "id": "e0ea3e55-3420-1035-8057-68fea9bfb3a0",

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -301,7 +301,7 @@ export function fetchOntologies(containerPath?: string): Promise<OntologyModel[]
     });
 }
 
-export function getMaxPhiLevel(containerPath: string): Promise<string> {
+export function getMaxPhiLevel(containerPath?: string): Promise<string> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL('security', 'getMaxPhiLevel.api', undefined, { container: containerPath }),

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -22,7 +22,6 @@ import {
     ConceptModel,
     Container,
     DomainDetails,
-    naturalSort,
     naturalSortByProperty,
     QueryColumn,
     SchemaDetails,

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -161,11 +161,7 @@ export function fetchDomainDetails(domainId: number, schemaName: string, queryNa
             schemaName,
             queryName,
             success: data => {
-                resolve(
-                    DomainDetails.create(
-                        Map<string, any>({ ...data })
-                    )
-                );
+                resolve(DomainDetails.create(Map<string, any>({ ...data })));
             },
             failure: error => {
                 reject(error);
@@ -941,7 +937,7 @@ export function getUpdatedVisitedPanelsList(visitedPanels: List<number>, index: 
     return updatedVisitedPanels;
 }
 
-function updateOntologyDomainCols (
+function updateOntologyDomainCols(
     fieldIndex: number,
     domainIndex: number,
     updatedDomain: DomainDesign,
@@ -977,11 +973,27 @@ export function updateOntologyFieldProperties(
     if (ontField.dataType.isOntologyLookup()) {
         // if the concept field prop is set and the field's name or data type has changed, update it based on the updatedDomain
         if (ontField.conceptImportColumn) {
-            updatedDomain = updateOntologyDomainCols(fieldIndex, domainIndex, updatedDomain, origDomain, removedFieldIndexes, DOMAIN_FIELD_ONTOLOGY_IMPORT_COL, ontField.conceptImportColumn);
+            updatedDomain = updateOntologyDomainCols(
+                fieldIndex,
+                domainIndex,
+                updatedDomain,
+                origDomain,
+                removedFieldIndexes,
+                DOMAIN_FIELD_ONTOLOGY_IMPORT_COL,
+                ontField.conceptImportColumn
+            );
         }
 
         if (ontField.conceptLabelColumn) {
-            updatedDomain = updateOntologyDomainCols(fieldIndex, domainIndex, updatedDomain, origDomain, removedFieldIndexes, DOMAIN_FIELD_ONTOLOGY_LABEL_COL, ontField.conceptLabelColumn);
+            updatedDomain = updateOntologyDomainCols(
+                fieldIndex,
+                domainIndex,
+                updatedDomain,
+                origDomain,
+                removedFieldIndexes,
+                DOMAIN_FIELD_ONTOLOGY_LABEL_COL,
+                ontField.conceptLabelColumn
+            );
         }
     }
     return updatedDomain;
@@ -997,7 +1009,7 @@ export function getOntologyUpdatedFieldName(
 ): [boolean, string] {
     // Check if field name and/or index have changed
     let origFieldIndex = origDomain.findFieldIndexByName(propFieldName);
-    let updateFieldIndex = updatedDomain.findFieldIndexByName(propFieldName);
+    const updateFieldIndex = updatedDomain.findFieldIndexByName(propFieldName);
     const originalPropField = origDomain.fields.get(origFieldIndex);
 
     // check for a field removal prior to the ontology lookup field
@@ -1019,9 +1031,13 @@ export function getOntologyUpdatedFieldName(
     }
 
     const updatedPropField = updatedDomain.fields.get(origFieldIndex);
-    const fieldChanged = propFieldRemoved
-        || origFieldIndex !== updateFieldIndex
-        || originalPropField.rangeURI !== updatedPropField?.rangeURI;
+    const fieldChanged =
+        propFieldRemoved ||
+        origFieldIndex !== updateFieldIndex ||
+        originalPropField.rangeURI !== updatedPropField?.rangeURI;
 
-    return [fieldChanged, !propFieldRemoved && updatedPropField.dataType.isString() ? updatedPropField.name : undefined];
+    return [
+        fieldChanged,
+        !propFieldRemoved && updatedPropField.dataType.isString() ? updatedPropField.name : undefined,
+    ];
 }

--- a/packages/components/src/internal/components/domainproperties/assay/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/assay/actions.ts
@@ -100,10 +100,12 @@ export function setAssayDomainException(model: AssayProtocolModel, exception: Do
     return updatedModel;
 }
 
-export function getValidPublishTargets(): Promise<List<Container>> {
+export function getValidPublishTargets(containerPath?: string): Promise<List<Container>> {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: buildURL('assay', 'getValidPublishTargets.api'),
+            url: buildURL('assay', 'getValidPublishTargets.api', undefined, {
+                container: containerPath,
+            }),
             success: Utils.getCallbackWrapper(response => {
                 resolve(List<Container>(response.containers.map(container => new Container(container))));
             }),

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -8642,6 +8642,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                             "LAST_ENTERED",
                                                           ]
                                                         }
+                                                        domainContainerPath="3E40EE5E-91B7-1036-BF18-F5B7057C168C"
                                                         domainFormDisplayOptions={
                                                           Object {
                                                             "disableMvEnabled": false,
@@ -9470,6 +9471,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                       >
                                                                         <DomainRowExpandedOptions
                                                                           appPropertiesOnly={false}
+                                                                          domainContainerPath="3E40EE5E-91B7-1036-BF18-F5B7057C168C"
                                                                           domainFormDisplayOptions={
                                                                             Object {
                                                                               "disableMvEnabled": false,
@@ -11004,6 +11006,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                             "LAST_ENTERED",
                                                           ]
                                                         }
+                                                        domainContainerPath="3E40EE5E-91B7-1036-BF18-F5B7057C168C"
                                                         domainFormDisplayOptions={
                                                           Object {
                                                             "disableMvEnabled": false,
@@ -11804,6 +11807,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                       >
                                                                         <DomainRowExpandedOptions
                                                                           appPropertiesOnly={false}
+                                                                          domainContainerPath="3E40EE5E-91B7-1036-BF18-F5B7057C168C"
                                                                           domainFormDisplayOptions={
                                                                             Object {
                                                                               "disableMvEnabled": false,
@@ -13263,6 +13267,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                             "LAST_ENTERED",
                                                           ]
                                                         }
+                                                        domainContainerPath="3E40EE5E-91B7-1036-BF18-F5B7057C168C"
                                                         domainFormDisplayOptions={
                                                           Object {
                                                             "disableMvEnabled": false,
@@ -14045,6 +14050,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                       >
                                                                         <DomainRowExpandedOptions
                                                                           appPropertiesOnly={false}
+                                                                          domainContainerPath="3E40EE5E-91B7-1036-BF18-F5B7057C168C"
                                                                           domainFormDisplayOptions={
                                                                             Object {
                                                                               "disableMvEnabled": false,

--- a/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.spec.tsx
@@ -16,29 +16,35 @@ import { ListPropertiesPanel } from './ListPropertiesPanel';
 import { ListModel } from './models';
 import { ListDesignerPanels } from './ListDesignerPanels';
 
-const emptyNewModel = ListModel.create(null, DEFAULT_LIST_SETTINGS);
-const populatedExistingModel = ListModel.create(getDomainDetailsJSON);
-
-const BASE_PROPS = {
-    onComplete: jest.fn(),
-    onCancel: jest.fn(),
-    testMode: true,
-};
-
 beforeAll(() => {
     initUnitTestMocks();
 });
 
 describe('ListDesignerPanel', () => {
-    test('new list', () => {
-        const listDesignerPanels = <ListDesignerPanels {...BASE_PROPS} initModel={emptyNewModel} />;
+    const emptyNewModel = ListModel.create(null, DEFAULT_LIST_SETTINGS);
 
-        const tree = renderer.create(listDesignerPanels).toJSON();
+    function getDefaultProps() {
+        return {
+            initModel: emptyNewModel,
+            onComplete: jest.fn(),
+            onCancel: jest.fn(),
+            testMode: true,
+        };
+    }
+
+    test('new list', () => {
+        const listDesignerPanels = <ListDesignerPanels {...getDefaultProps()} />;
+
+        const tree = renderer.create(listDesignerPanels);
         expect(tree).toMatchSnapshot();
     });
 
     test('existing list', async () => {
-        const listDesignerPanels = mount(<ListDesignerPanels {...BASE_PROPS} initModel={populatedExistingModel} />);
+        const populatedExistingModel = ListModel.create(getDomainDetailsJSON);
+
+        const listDesignerPanels = mount(
+            <ListDesignerPanels {...getDefaultProps()} initModel={populatedExistingModel} />
+        );
         await sleep();
 
         expect(listDesignerPanels).toMatchSnapshot();
@@ -46,7 +52,7 @@ describe('ListDesignerPanel', () => {
     });
 
     test('visible properties', async () => {
-        const listDesignerPanels = mount(<ListDesignerPanels {...BASE_PROPS} initModel={emptyNewModel} />);
+        const listDesignerPanels = mount(<ListDesignerPanels {...getDefaultProps()} />);
         await sleep();
 
         expect(listDesignerPanels.find(ListPropertiesPanel)).toHaveLength(1);
@@ -55,7 +61,7 @@ describe('ListDesignerPanel', () => {
     });
 
     test('open fields panel', async () => {
-        const listDesignerPanels = mount(<ListDesignerPanels {...BASE_PROPS} initModel={emptyNewModel} />);
+        const listDesignerPanels = mount(<ListDesignerPanels {...getDefaultProps()} />);
         await sleep();
 
         const panelHeader = listDesignerPanels.find('div#domain-header');

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -473,9 +473,9 @@ describe('DomainDesign', () => {
         expect(domain.hasInvalidNameField({ name: 'ABC' })).toBeTruthy();
     });
 
-    test('container', () => {
+    test('getDomainContainer', () => {
         const domain = DomainDesign.create({ name: 'Test Container' });
-        expect(domain.container).toBe(undefined);
+        expect(domain.getDomainContainer()).toBe(undefined);
 
         const domain2 = DomainDesign.create({ name: 'Test Container', container: 'SOMETHINGELSE' });
         expect(domain2.getDomainContainer()).toBe('SOMETHINGELSE');

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -473,9 +473,9 @@ describe('DomainDesign', () => {
         expect(domain.hasInvalidNameField({ name: 'ABC' })).toBeTruthy();
     });
 
-    test('getDomainContainer', () => {
+    test('container', () => {
         const domain = DomainDesign.create({ name: 'Test Container' });
-        expect(domain.getDomainContainer()).toBe(undefined);
+        expect(domain.container).toBe(undefined);
 
         const domain2 = DomainDesign.create({ name: 'Test Container', container: 'SOMETHINGELSE' });
         expect(domain2.getDomainContainer()).toBe('SOMETHINGELSE');

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -79,9 +79,7 @@ export interface IFieldChange {
     value: any;
 }
 
-export interface DomainOnChange {
-    (changes: List<IFieldChange>, index?: number, expand?: boolean): any;
-}
+export type DomainOnChange = (changes: List<IFieldChange>, index?: number, expand?: boolean) => void;
 
 export interface IBannerMessage {
     message: string;

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -151,7 +151,8 @@ export class DomainDesign
         instructions: undefined,
         domainKindName: undefined,
     })
-    implements IDomainDesign {
+    implements IDomainDesign
+{
     declare name: string;
     declare container: string;
     declare description: string;
@@ -448,7 +449,8 @@ export class DomainIndex
         columns: List<string>(),
         type: undefined,
     })
-    implements IDomainIndex {
+    implements IDomainIndex
+{
     declare columns: List<string>;
     declare type: 'primary' | 'unique';
 
@@ -489,7 +491,8 @@ export class ConditionalFormat
         textColor: undefined,
         backgroundColor: undefined,
     })
-    implements IConditionalFormat {
+    implements IConditionalFormat
+{
     declare formatFilter: string;
     declare bold: boolean;
     declare italic: boolean;
@@ -537,7 +540,8 @@ export class PropertyValidatorProperties
     extends Record({
         failOnMatch: false,
     })
-    implements IPropertyValidatorProperties {
+    implements IPropertyValidatorProperties
+{
     declare failOnMatch: boolean;
 }
 
@@ -563,7 +567,8 @@ export class PropertyValidator
         rowId: undefined,
         expression: undefined,
     })
-    implements IPropertyValidator {
+    implements IPropertyValidator
+{
     declare type: string;
     declare name: string;
     declare properties: PropertyValidatorProperties;
@@ -729,7 +734,8 @@ export class DomainField
         derivationDataScope: undefined,
         selected: false,
     })
-    implements IDomainField {
+    implements IDomainField
+{
     declare conceptURI?: string;
     declare conditionalFormats: List<ConditionalFormat>;
     declare defaultScale?: string;
@@ -1319,7 +1325,8 @@ export class ColumnInfoLite
         jsonType: undefined,
         name: undefined,
     })
-    implements IColumnInfoLite {
+    implements IColumnInfoLite
+{
     declare friendlyType?: string;
     declare isKeyField?: boolean;
     declare jsonType?: string;
@@ -1366,7 +1373,8 @@ export class QueryInfoLite
         title: undefined,
         viewDataUrl: undefined,
     })
-    implements IQueryInfoLite {
+    implements IQueryInfoLite
+{
     declare canEdit?: boolean;
     declare canEditSharedViews?: boolean;
     declare columns?: List<ColumnInfoLite>;
@@ -1455,7 +1463,8 @@ export class DomainException
         domainName: undefined,
         errors: List<DomainFieldError>(),
     })
-    implements IDomainException {
+    implements IDomainException
+{
     declare exception: string;
     declare success: boolean;
     declare severity: string;
@@ -1614,7 +1623,8 @@ export class DomainFieldError
         newRowIndexes: undefined,
         extraInfo: undefined,
     })
-    implements IDomainFieldError {
+    implements IDomainFieldError
+{
     declare message: string;
     declare fieldName: string;
     declare propertyId?: number;

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -280,8 +280,7 @@ export class DomainDesign
     }
 
     getDomainContainer(): string {
-        const currentContainer = getServerContext().container.id;
-        return this.container || currentContainer;
+        return this.container ?? getServerContext().container.id;
     }
 
     isSharedDomain(): boolean {
@@ -290,7 +289,7 @@ export class DomainDesign
     }
 
     findFieldIndexByName(fieldName: string): number {
-        return this.fields.findIndex((field: DomainField) => fieldName && field.name === fieldName);
+        return this.fields.findIndex(field => fieldName && field.name === fieldName);
     }
 
     getFieldDetails(): FieldDetails {
@@ -1310,6 +1309,11 @@ interface IColumnInfoLite {
     name?: string;
 }
 
+export interface LookupInfo {
+    name: string;
+    type: PropDescType;
+}
+
 export class ColumnInfoLite
     extends Record({
         friendlyType: undefined,
@@ -1390,8 +1394,8 @@ export class QueryInfoLite
         );
     }
 
-    getLookupInfo(rangeURI?: string): List<{ name: string; type: PropDescType }> {
-        let infos = List<{ name: string; type: PropDescType }>();
+    getLookupInfo(rangeURI?: string): List<LookupInfo> {
+        let infos = List<LookupInfo>();
 
         // allow for queries with only 1 primary key or with 2 primary key columns when one of them is container (see Issue 39879)
         let pkCols =

--- a/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
+++ b/packages/components/src/internal/components/domainproperties/propertiesUtil.ts
@@ -39,17 +39,17 @@ function isLegalNameChar(ch: string, first: boolean): boolean {
 
 export function isFieldPartiallyLocked(lockType: string): boolean {
     // with partially locked can't change name and type, but can change other properties
-    return lockType == DOMAIN_FIELD_PARTIALLY_LOCKED;
+    return lockType === DOMAIN_FIELD_PARTIALLY_LOCKED;
 }
 
 export function isFieldFullyLocked(lockType: string): boolean {
     // with fully locked, can't change any properties
-    return lockType == DOMAIN_FIELD_FULLY_LOCKED;
+    return lockType === DOMAIN_FIELD_FULLY_LOCKED;
 }
 
 export function isPrimaryKeyFieldLocked(lockType: string): boolean {
     // with PK locked, can't change type or required, but can change other properties
-    return lockType == DOMAIN_FIELD_PRIMARY_KEY_LOCKED;
+    return lockType === DOMAIN_FIELD_PRIMARY_KEY_LOCKED;
 }
 
 export function generateBulkDeleteWarning(deletabilityInfo, undeletableNames) {
@@ -96,10 +96,10 @@ export function isFieldDeletable(field: DomainField): boolean {
 }
 
 export function getVisibleFieldCount(domain: DomainDesign): number {
-    return domain.fields.filter((field: DomainField) => field.visible).size;
+    return domain.fields.filter(field => field.visible).size;
 }
 
-export function compareStringsAlphabetically(a: string, b: string, direction): number {
+export function compareStringsAlphabetically(a: string, b: string, direction: string): number {
     const aStr = a ? a.toUpperCase() : '';
     const bStr = b ? b.toUpperCase() : '';
     const isAsc = direction === '+';

--- a/packages/components/src/internal/components/domainproperties/samples/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/samples/models.spec.ts
@@ -1,6 +1,6 @@
-import { fromJS } from 'immutable';
+import { fromJS, Map } from 'immutable';
 
-import { DomainDetails } from '../models';
+import { DomainDesign, DomainDetails } from '../models';
 
 import { SampleTypeModel } from './models';
 
@@ -106,6 +106,15 @@ describe('SampleTypeModel', () => {
         expect(
             SampleTypeModel.create({ options: fromJS({ metricUnit: 'ml' }) } as DomainDetails, undefined).metricUnit
         ).toBe('ml');
+    });
+
+    test('containerPath', () => {
+        expect(SampleTypeModel.create().containerPath).toBeUndefined();
+        expect(SampleTypeModel.create({ containerPath: 'Bam' } as any).containerPath).toBeUndefined();
+
+        const expectedContainerPath = '/Some/Container/Path';
+        const model = SampleTypeModel.create().set('domain', DomainDesign.create({ container: expectedContainerPath })) as SampleTypeModel;
+        expect(model.containerPath).toEqual(expectedContainerPath);
     });
 
     // TODO add tests for getDuplicateAlias

--- a/packages/components/src/internal/components/domainproperties/samples/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/samples/models.spec.ts
@@ -113,7 +113,10 @@ describe('SampleTypeModel', () => {
         expect(SampleTypeModel.create({ containerPath: 'Bam' } as any).containerPath).toBeUndefined();
 
         const expectedContainerPath = '/Some/Container/Path';
-        const model = SampleTypeModel.create().set('domain', DomainDesign.create({ container: expectedContainerPath })) as SampleTypeModel;
+        const model = SampleTypeModel.create().set(
+            'domain',
+            DomainDesign.create({ container: expectedContainerPath })
+        ) as SampleTypeModel;
         expect(model.containerPath).toEqual(expectedContainerPath);
     });
 

--- a/packages/components/src/internal/components/domainproperties/samples/models.ts
+++ b/packages/components/src/internal/components/domainproperties/samples/models.ts
@@ -37,11 +37,7 @@ export class SampleTypeModel extends Record({
     declare exception: string;
 
     static create(raw?: DomainDetails, name?: string): SampleTypeModel {
-        if (!raw) return new SampleTypeModel();
-
-        const domain = raw.domainDesign ? raw.domainDesign : DomainDesign.create({});
-
-        const { options } = raw;
+        const options = raw?.options;
         let importAliases = Map<string, string>();
         if (options) {
             const aliases = options.get('importAliases') || {};
@@ -52,11 +48,11 @@ export class SampleTypeModel extends Record({
             ...options?.toJS(),
             aliquotNameExpression: options?.get('aliquotNameExpression') || '',
             name,
-            nameReadOnly: raw.nameReadOnly,
+            nameReadOnly: raw?.nameReadOnly,
             importAliases,
             labelColor: options?.get('labelColor') || undefined, // helps to convert null to undefined
             metricUnit: options?.get('metricUnit') || undefined,
-            domain,
+            domain: raw?.domainDesign ?? DomainDesign.create({}),
         });
     }
 
@@ -129,6 +125,10 @@ export class SampleTypeModel extends Record({
         }
 
         return returnAliases ? dupeAliases : dupeIds;
+    }
+
+    get containerPath(): string {
+        return this.domain.container;
     }
 }
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -82,7 +82,7 @@ import { fetchDomainDetails } from '../domainproperties/actions';
 
 import { SAMPLE_INVENTORY_ITEM_SELECTION_KEY } from '../samples/constants';
 
-import { loadNameExpressionOptions } from '../settings/actions';
+import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../settings/actions';
 
 import {
     EntityDataType,
@@ -139,6 +139,8 @@ interface OwnProps {
     fileImportParameters: Record<string, any>;
     importHelpLinkNode: ReactNode;
     importOnly?: boolean;
+    // loadNameExpressionOptions is a prop for testing purposes only, see default implementation below
+    loadNameExpressionOptions?: (containerPath?: string) => Promise<GetNameExpressionOptionsResponse>;
     maxEntities?: number;
     nounPlural: string;
     nounSingular: string;
@@ -148,8 +150,6 @@ interface OwnProps {
     onDataChange?: (dirty: boolean, changeType?: IMPORT_DATA_FORM_TYPES) => void;
     onParentChange?: (parentTypes: Map<string, List<EntityParentType>>) => void;
     parentDataTypes?: List<EntityDataType>;
-    // loadNameExpressionOptions is a prop for testing purposes only, see default implementation below
-    loadNameExpressionOptions?: () => Promise<{ prefix: string; allowUserSpecifiedNames: boolean }>;
 }
 
 interface FromLocationProps {

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -24,13 +24,13 @@ import { getOriginalParentsFromSampleLineage } from '../samples/actions';
 
 import { IS_ALIQUOT_COL } from '../samples/constants';
 
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
 import { EntityChoice, EntityDataType, OperationConfirmationData } from './models';
 import { getEntityNoun, getUpdatedLineageRowsForBulkEdit } from './utils';
 
 import { ParentEntityLineageColumns } from './constants';
 import { ParentEntityEditPanel } from './ParentEntityEditPanel';
-
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface Props {
     api?: ComponentsAPIWrapper;

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -98,9 +98,10 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
         setHasParentUpdates(entityParents.size > 0);
     }, []);
 
-    const onConfirm = useCallback(async () => {
+    const onConfirm = async (): Promise<void> => {
         setSubmitting(true);
 
+        // TODO: Configure "containerPath" for getOriginalParentsFromSampleLineage() call
         const { originalParents } = await getOriginalParentsFromSampleLineage(allowedForUpdate);
         const rows = getUpdatedLineageRowsForBulkEdit(
             allowedForUpdate,
@@ -132,7 +133,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
             onSuccess();
             createNotification(`No ${childEntityDataType.nounPlural} updated since no ${lcParentNounPlural} changed.`);
         }
-    }, [selectedParents, auditBehavior, childEntityDataType, queryModel, allowedForUpdate]);
+    };
 
     if (!queryModel || !statusData) {
         return null;
@@ -215,10 +216,8 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                             <ParentEntityEditPanel
                                 auditBehavior={auditBehavior}
                                 canUpdate={true}
-                                childQueryInfo={queryModel.queryInfo}
-                                childData={undefined}
+                                childSchemaQuery={queryModel.schemaQuery}
                                 parentDataTypes={parentEntityDataTypes}
-                                childName={undefined}
                                 childNounSingular={childEntityDataType.nounSingular}
                                 key={`parent${parentNounPlural}-${queryModel.id}`}
                                 onUpdate={onConfirm}

--- a/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityLineageEditModal.tsx
@@ -33,13 +33,13 @@ import { ParentEntityEditPanel } from './ParentEntityEditPanel';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface Props {
+    api?: ComponentsAPIWrapper;
     queryModel: QueryModel;
     onCancel: () => void;
     onSuccess: () => void;
     childEntityDataType: EntityDataType;
     auditBehavior?: AuditBehaviorTypes;
     parentEntityDataTypes: EntityDataType[];
-    api?: ComponentsAPIWrapper;
 }
 
 export const EntityLineageEditModal: FC<Props> = memo(props => {
@@ -101,7 +101,6 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
     const onConfirm = async (): Promise<void> => {
         setSubmitting(true);
 
-        // TODO: Configure "containerPath" for getOriginalParentsFromSampleLineage() call
         const { originalParents } = await getOriginalParentsFromSampleLineage(allowedForUpdate);
         const rows = getUpdatedLineageRowsForBulkEdit(
             allowedForUpdate,

--- a/packages/components/src/internal/components/entities/ParentEntityEditPanel.spec.tsx
+++ b/packages/components/src/internal/components/entities/ParentEntityEditPanel.spec.tsx
@@ -6,7 +6,7 @@ import { Button } from 'react-bootstrap';
 
 import PanelHeading from 'react-bootstrap/lib/PanelHeading';
 
-import { Alert, DataClassDataType, LoadingSpinner, QueryInfo } from '../../..';
+import { Alert, DataClassDataType, LoadingSpinner, QueryInfo, SchemaQuery } from '../../..';
 import { DetailPanelHeader } from '../forms/detail/DetailPanelHeader';
 import { initUnitTestMocks } from '../../testHelperMocks';
 
@@ -18,24 +18,31 @@ beforeAll(() => {
 });
 
 describe('<ParentEntityEditPanel>', () => {
-    const queryInfo = new QueryInfo({
-        schemaName: 'samples',
-        queryName: 'example',
+    const schemaQuery = SchemaQuery.create('samples', 'example');
+    const queryInfo = QueryInfo.create({
+        schemaName: schemaQuery.schemaName,
+        queryName: schemaQuery.queryName,
     });
 
     test('error state', () => {
         const panel = mount(
             <ParentEntityEditPanel
-                childQueryInfo={queryInfo}
-                childData={{}}
                 canUpdate={false}
-                childName="Test"
                 childNounSingular="Testing"
+                childSchemaQuery={schemaQuery}
                 title="Test 123"
                 parentDataTypes={[DataClassDataType]}
             />
         );
-        panel.setState({ error: 'My error message', loading: false });
+
+        panel.setState({
+            childData: {},
+            childQueryInfo: queryInfo,
+            childName: 'Test',
+            error: 'My error message',
+            loading: false,
+        });
+
         const header = panel.find(DetailPanelHeader);
         expect(header).toHaveLength(1);
         expect(header.text()).toContain('Test 123');
@@ -48,16 +55,14 @@ describe('<ParentEntityEditPanel>', () => {
     test('loading state', () => {
         const panel = mount(
             <ParentEntityEditPanel
-                childQueryInfo={queryInfo}
-                childData={{}}
                 canUpdate={false}
-                childName="Test"
                 childNounSingular="Testing"
+                childSchemaQuery={schemaQuery}
                 title="Test 123"
                 parentDataTypes={[DataClassDataType]}
             />
         );
-        panel.setState({ loading: true });
+        panel.setState({ childName: 'Test', loading: true });
         expect(panel.find(LoadingSpinner)).toHaveLength(1);
         expect(panel).toMatchSnapshot();
         panel.unmount();
@@ -66,16 +71,15 @@ describe('<ParentEntityEditPanel>', () => {
     test('editing, no data', () => {
         const panel = mount(
             <ParentEntityEditPanel
-                childQueryInfo={queryInfo}
-                childData={{}}
                 canUpdate={false}
-                childName="Test"
                 childNounSingular="Testing"
+                childSchemaQuery={schemaQuery}
                 title="Test 123"
                 parentDataTypes={[DataClassDataType]}
             />
         );
         panel.setState({
+            childName: 'Test',
             loading: false,
             editing: true,
             originalParents: List<EntityChoice>(),
@@ -91,17 +95,16 @@ describe('<ParentEntityEditPanel>', () => {
     test('hideButtons', () => {
         const panel = mount(
             <ParentEntityEditPanel
-                childQueryInfo={queryInfo}
-                childData={{}}
                 canUpdate={true}
-                childName="Test"
                 childNounSingular="Testing"
+                childSchemaQuery={schemaQuery}
                 title="Test 123"
                 hideButtons={true}
                 parentDataTypes={[DataClassDataType]}
             />
         );
         panel.setState({
+            childName: 'Test',
             loading: false,
             editing: true,
             originalParents: List<EntityChoice>(),
@@ -113,17 +116,16 @@ describe('<ParentEntityEditPanel>', () => {
     test('excludePanelHeader', () => {
         const panel = mount(
             <ParentEntityEditPanel
-                childQueryInfo={queryInfo}
-                childData={{}}
                 canUpdate={true}
-                childName="Test"
                 childNounSingular="Testing"
+                childSchemaQuery={schemaQuery}
                 title="Test 123"
                 includePanelHeader={false}
                 parentDataTypes={[DataClassDataType]}
             />
         );
         panel.setState({
+            childName: 'Test',
             loading: false,
             originalParents: List<EntityChoice>(),
             currentParents: List<EntityChoice>(),

--- a/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
@@ -166,6 +166,10 @@ export class ParentEntityEditPanel extends Component<Props, State> {
         });
     };
 
+    compactEditDisplay(): boolean {
+        return !this.state.childName;
+    }
+
     hasParents = (): boolean => {
         return this.state.currentParents && !this.state.currentParents.isEmpty();
     };
@@ -316,13 +320,13 @@ export class ParentEntityEditPanel extends Component<Props, State> {
 
     renderParentData = (): ReactNode => {
         const { childContainerPath, parentDataTypes, childNounSingular } = this.props;
-        const { childName, editing } = this.state;
+        const { editing } = this.state;
 
         if (this.hasParents()) {
             return this.state.currentParents
                 .map((choice, index) => (
                     <div key={choice.type ? choice.type.label + '-' + index : 'unknown-' + index}>
-                        {editing && (childName || index > 0) && <hr />}
+                        {editing && (!this.compactEditDisplay() || index > 0) && <hr />}
                         <SingleParentEntityPanel
                             containerPath={childContainerPath}
                             parentDataType={parentDataTypes[0]}
@@ -344,7 +348,7 @@ export class ParentEntityEditPanel extends Component<Props, State> {
 
         return (
             <div>
-                {childName && <hr />}
+                {!this.compactEditDisplay() && <hr />}
                 <SingleParentEntityPanel
                     editing={editing}
                     containerPath={childContainerPath}

--- a/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
@@ -409,16 +409,8 @@ export class ParentEntityEditPanel extends Component<Props, State> {
     };
 
     render() {
-        const {
-            cancelText,
-            parentDataTypes,
-            title,
-            canUpdate,
-            hideButtons,
-            submitText,
-            editOnly,
-            includePanelHeader,
-        } = this.props;
+        const { cancelText, parentDataTypes, title, canUpdate, hideButtons, submitText, editOnly, includePanelHeader } =
+            this.props;
         const { childName, editing, error, loading, submitting } = this.state;
 
         const parentDataType = parentDataTypes[0];

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -16,7 +16,6 @@ import {
     RemoveEntityButton,
     SampleOperation,
     SchemaQuery,
-    SCHEMAS,
     SelectInput,
 } from '../../..';
 
@@ -41,6 +40,7 @@ interface OwnProps {
 interface Props {
     childNounSingular?: string;
     chosenValue?: string | any[];
+    containerPath?: string;
     editing?: boolean;
     index: number;
     onChangeParentType?: (fieldName: string, formValue: any, selectedOption: IEntityTypeOption, index: number) => void;
@@ -96,7 +96,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
     };
 
     renderParentSelection = (model: QueryModel): ReactNode => {
-        const { chosenType, chosenValue, parentLSIDs, parentTypeOptions, parentDataType, index } = this.props;
+        const { chosenType, chosenValue, containerPath, parentLSIDs, parentTypeOptions, parentDataType, index } = this.props;
 
         if (model?.rowsError || model?.queryInfoError) {
             return <Alert>{model.rowsError || model.queryInfoError}</Alert>;
@@ -148,6 +148,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
                         <QuerySelect
                             componentId={'parentEntityValue_' + chosenType.label} // important that this key off of the schemaQuery or it won't update when the SelectInput changes
                             containerClass="row"
+                            containerPath={containerPath}
                             inputClass="col-sm-6"
                             label={capitalizeFirstChar(parentDataType.nounSingular) + ' IDs'}
                             labelClass={labelClasses + ' entity-insert--parent-label entity-insert--parent-select'}
@@ -253,7 +254,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
 const SingleParentEntityPanelBody = withQueryModels<Props & OwnProps>(SingleParentEntity);
 
 export const SingleParentEntityPanel: FC<Props> = memo(props => {
-    const { parentTypeOptions, parentLSIDs, parentEntityType } = props;
+    const { containerPath, parentTypeOptions, parentLSIDs, parentEntityType } = props;
     const [chosenType, setChosenType] = useState<IEntityTypeOption>(parentEntityType);
     const [chosenValue, setChosenValue] = useState<string | string[]>(props.chosenValue);
 
@@ -267,10 +268,11 @@ export const SingleParentEntityPanel: FC<Props> = memo(props => {
             model: {
                 baseFilters: parentLSIDs?.length > 0 ? [Filter.create('LSID', parentLSIDs, Filter.Types.IN)] : [],
                 bindURL: false,
+                containerPath,
                 schemaQuery: SchemaQuery.create(chosenType.schema, chosenType.query),
             },
         };
-    }, [chosenType, parentTypeOptions, parentLSIDs]);
+    }, [chosenType, containerPath, parentTypeOptions, parentLSIDs]);
 
     return (
         <SingleParentEntityPanelBody

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -96,7 +96,8 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
     };
 
     renderParentSelection = (model: QueryModel): ReactNode => {
-        const { chosenType, chosenValue, containerPath, parentLSIDs, parentTypeOptions, parentDataType, index } = this.props;
+        const { chosenType, chosenValue, containerPath, parentLSIDs, parentTypeOptions, parentDataType, index } =
+            this.props;
 
         if (model?.rowsError || model?.queryInfoError) {
             return <Alert>{model.rowsError || model.queryInfoError}</Alert>;

--- a/packages/components/src/internal/components/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
@@ -4,36 +4,12 @@ exports[`<ParentEntityEditPanel> editing, no data 1`] = `
 <ParentEntityEditPanel
   canUpdate={false}
   cancelText="Cancel"
-  childData={Object {}}
-  childName="Test"
   childNounSingular="Testing"
-  childQueryInfo={
+  childSchemaQuery={
     Immutable.Record {
-      "columns": Immutable.OrderedMap {},
-      "description": undefined,
-      "importTemplates": Immutable.List [],
-      "iconURL": "default",
-      "lastAction": undefined,
-      "name": undefined,
-      "pkCols": Immutable.List [],
       "schemaName": "samples",
-      "status": 2,
-      "title": undefined,
-      "titleColumn": undefined,
-      "views": Immutable.Map {},
-      "importUrlDisabled": undefined,
-      "importUrl": undefined,
-      "insertUrlDisabled": undefined,
-      "insertUrl": undefined,
-      "appEditableTable": false,
-      "isLoading": false,
-      "isMedia": false,
-      "queryLabel": undefined,
-      "schemaLabel": undefined,
-      "schemaQuery": undefined,
-      "showInsertNewButton": true,
-      "singular": undefined,
-      "plural": undefined,
+      "queryName": "example",
+      "viewName": undefined,
     }
   }
   includePanelHeader={true}
@@ -2187,36 +2163,12 @@ exports[`<ParentEntityEditPanel> error state 1`] = `
 <ParentEntityEditPanel
   canUpdate={false}
   cancelText="Cancel"
-  childData={Object {}}
-  childName="Test"
   childNounSingular="Testing"
-  childQueryInfo={
+  childSchemaQuery={
     Immutable.Record {
-      "columns": Immutable.OrderedMap {},
-      "description": undefined,
-      "importTemplates": Immutable.List [],
-      "iconURL": "default",
-      "lastAction": undefined,
-      "name": undefined,
-      "pkCols": Immutable.List [],
       "schemaName": "samples",
-      "status": 2,
-      "title": undefined,
-      "titleColumn": undefined,
-      "views": Immutable.Map {},
-      "importUrlDisabled": undefined,
-      "importUrl": undefined,
-      "insertUrlDisabled": undefined,
-      "insertUrl": undefined,
-      "appEditableTable": false,
-      "isLoading": false,
-      "isMedia": false,
-      "queryLabel": undefined,
-      "schemaLabel": undefined,
-      "schemaQuery": undefined,
-      "showInsertNewButton": true,
-      "singular": undefined,
-      "plural": undefined,
+      "queryName": "example",
+      "viewName": undefined,
     }
   }
   includePanelHeader={true}
@@ -2581,36 +2533,12 @@ exports[`<ParentEntityEditPanel> loading state 1`] = `
 <ParentEntityEditPanel
   canUpdate={false}
   cancelText="Cancel"
-  childData={Object {}}
-  childName="Test"
   childNounSingular="Testing"
-  childQueryInfo={
+  childSchemaQuery={
     Immutable.Record {
-      "columns": Immutable.OrderedMap {},
-      "description": undefined,
-      "importTemplates": Immutable.List [],
-      "iconURL": "default",
-      "lastAction": undefined,
-      "name": undefined,
-      "pkCols": Immutable.List [],
       "schemaName": "samples",
-      "status": 2,
-      "title": undefined,
-      "titleColumn": undefined,
-      "views": Immutable.Map {},
-      "importUrlDisabled": undefined,
-      "importUrl": undefined,
-      "insertUrlDisabled": undefined,
-      "insertUrl": undefined,
-      "appEditableTable": false,
-      "isLoading": false,
-      "isMedia": false,
-      "queryLabel": undefined,
-      "schemaLabel": undefined,
-      "schemaQuery": undefined,
-      "showInsertNewButton": true,
-      "singular": undefined,
-      "plural": undefined,
+      "queryName": "example",
+      "viewName": undefined,
     }
   }
   includePanelHeader={true}

--- a/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -3215,6 +3215,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             },
           ],
           "bindURL": false,
+          "containerPath": undefined,
           "schemaQuery": Immutable.Record {
             "schemaName": "exp.data",
             "queryName": "Second Source",
@@ -3359,6 +3360,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
               },
             ],
             "bindURL": false,
+            "containerPath": undefined,
             "schemaQuery": Immutable.Record {
               "schemaName": "exp.data",
               "queryName": "Second Source",

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -406,11 +406,15 @@ export function getChosenParentData(
 
 // get back a map from the typeListQueryName (e.g., 'SampleSet') and the list of options for that query
 // where the schema field for those options is the typeSchemaName (e.g., 'samples')
-export function getEntityTypeOptions(entityDataType: EntityDataType): Promise<Map<string, List<IEntityTypeOption>>> {
+export function getEntityTypeOptions(
+    entityDataType: EntityDataType,
+    containerPath?: string
+): Promise<Map<string, List<IEntityTypeOption>>> {
     const { typeListingSchemaQuery, filterArray, instanceSchemaName } = entityDataType;
 
     return new Promise((resolve, reject) => {
         selectRows({
+            containerPath,
             schemaName: typeListingSchemaQuery.schemaName,
             queryName: typeListingSchemaQuery.queryName,
             columns: 'LSID,Name,RowId,Folder/Path',

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -466,7 +466,7 @@ export function getEntityTypeData(
             getEntityTypeOptions(entityDataType),
             // get all the parent schemaQuery data
             getChosenParentData(model, parentSchemaQueries, allowParents, isItemSamples),
-            ...parentSchemaQueries.map(getEntityTypeOptions).toArray(),
+            ...parentSchemaQueries.map(edt => getEntityTypeOptions(edt)).toArray(),
         ];
 
         let partial: Partial<EntityIdCreationModel> = {};

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -57,6 +57,8 @@ export const ParentEntityLineageColumns = List.of('Inputs/Materials/First', 'Inp
 export const ParentEntityRequiredColumns = SCHEMAS.CBMB.concat(
     'LSID',
     'Name',
+    'Folder',
+    'RowId',
     'Description',
     'AliquotedFromLSID/Name',
     'RootMaterialLSID',

--- a/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
+++ b/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
@@ -43,6 +43,6 @@ class CountsWithLineageImpl extends PureComponent<InjectedLineage> {
 const CountsWithLineage = withLineage<{}>(CountsWithLineageImpl, false, true, false);
 
 // Don't expose props from withLineage in public component
-export const SampleTypeLineageCounts: FunctionComponent<{ seed: string }> = props => {
-    return <CountsWithLineage lsid={props.seed} />;
+export const SampleTypeLineageCounts: FunctionComponent<{ seed: string, seedContainer?: string }> = props => {
+    return <CountsWithLineage lsid={props.seed} seedContainer={props.seedContainer} />;
 };

--- a/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
+++ b/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
@@ -43,6 +43,6 @@ class CountsWithLineageImpl extends PureComponent<InjectedLineage> {
 const CountsWithLineage = withLineage<{}>(CountsWithLineageImpl, false, true, false);
 
 // Don't expose props from withLineage in public component
-export const SampleTypeLineageCounts: FunctionComponent<{ seed: string, seedContainer?: string }> = props => {
-    return <CountsWithLineage lsid={props.seed} seedContainer={props.seedContainer} />;
+export const SampleTypeLineageCounts: FunctionComponent<{ seed: string }> = props => {
+    return <CountsWithLineage lsid={props.seed} />;
 };

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -93,9 +93,11 @@ function fetchNodeMetadata(lineage: LineageResult): Array<Promise<ISelectRowsRes
         .filter(n => n.schemaName !== undefined && n.queryName !== undefined && n.pkFilters.length === 1)
         .groupBy(n => SchemaQuery.create(n.schemaName, n.queryName))
         .map((nodes, schemaQuery) => {
-            const { fieldKey } = nodes.first().pkFilters[0];
+            const node = nodes.first();
+            const { fieldKey } = node.pkFilters[0];
 
             return selectRows({
+                containerPath: node.container,
                 schemaName: schemaQuery.schemaName,
                 queryName: schemaQuery.queryName,
                 // TODO: Is there a better way to determine set of columns? Can we follow convention for detail views?

--- a/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
@@ -1,26 +1,22 @@
 import React, { FC, memo, useMemo } from 'react';
 import { Experiment, Filter } from '@labkey/api';
 
-import { DetailPanelWithModel, SchemaQuery } from '../../../..';
+import { DetailPanelWithModel, QueryConfig, SchemaQuery } from '../../../..';
 
 export interface LineageDetailProps {
     item: Experiment.LineageItemBase;
 }
 
 export const LineageDetail: FC<LineageDetailProps> = memo(({ item }) => {
-    const queryConfig = useMemo(
+    const queryConfig: QueryConfig = useMemo(
         () => ({
             baseFilters: item.pkFilters.map(pkFilter => Filter.create(pkFilter.fieldKey, pkFilter.value)),
+            containerPath: item.container,
             schemaQuery: SchemaQuery.create(item.schemaName, item.queryName),
         }),
-        [item],
+        [item]
     );
 
     // Without providing "key" the DetailPanelWithModel will stop updates
-    return (
-        <DetailPanelWithModel
-            key={item.lsid}
-            queryConfig={queryConfig}
-        />
-    );
+    return <DetailPanelWithModel key={item.lsid} queryConfig={queryConfig} />;
 });

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -68,11 +68,11 @@ export class LineageNodeDetail extends PureComponent<LineageNodeDetailProps, Lin
                 <LineageDetail item={node} />
                 <LineageSummary
                     {...lineageOptions}
+                    containerPath={node.container}
                     highlightNode={highlightNode}
                     key={node.lsid}
                     lsid={node.lsid}
                     prefetchSeed={false}
-                    seedContainer={node.container}
                 />
             </>
         );

--- a/packages/components/src/internal/components/lineage/withLineage.tsx
+++ b/packages/components/src/internal/components/lineage/withLineage.tsx
@@ -18,7 +18,7 @@ export interface LoadLineage {
 }
 
 export interface WithLineageOptions extends LoadLineage, LineageOptions {
-    seedContainer?: string;
+    containerPath?: string;
     lsid: string;
 }
 
@@ -40,7 +40,7 @@ export function withLineage<Props>(
         private _mounted = true;
 
         loadLineage = async (forceReload?: boolean): Promise<void> => {
-            const { distance, prefetchSeed, lsid, seedContainer } = this.props;
+            const { containerPath, distance, prefetchSeed, lsid } = this.props;
 
             // Lineage is already processed
             if (this.state.lineage && lsid === this.state.lineage.seed && !forceReload) {
@@ -61,7 +61,7 @@ export function withLineage<Props>(
             }
 
             try {
-                const result = await loadLineageResult(lsid, seedContainer, distance, this.props);
+                const result = await loadLineageResult(lsid, containerPath, distance, this.props);
 
                 let sampleStats: any;
                 if (allowLoadSampleStats) {
@@ -83,12 +83,12 @@ export function withLineage<Props>(
         };
 
         loadSeed = async (): Promise<void> => {
-            const { lsid, seedContainer } = this.props;
+            const { containerPath, lsid } = this.props;
 
             await this.updateLineage({ seedResultLoadingState: LoadingState.LOADING });
 
             try {
-                const seedResult = await loadSeedResult(lsid, seedContainer, this.props);
+                const seedResult = await loadSeedResult(lsid, containerPath, this.props);
 
                 await this.updateLineage({
                     seedResult,

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.spec.tsx
@@ -13,15 +13,6 @@ import { DOMAIN_FIELD_FULLY_LOCKED } from '../domainproperties/constants';
 import { OntologyLookupOptions } from './OntologyLookupOptions';
 import { OntologyConceptSelectButton } from './OntologyConceptSelectButton';
 
-const DEFAULT_PROPS = {
-    index: 0,
-    domainIndex: 0,
-    label: 'Test',
-    lockType: undefined,
-    onChange: jest.fn(),
-    onMultiChange: jest.fn(),
-};
-
 const field1 = DomainField.create({
     name: 'field1',
     conceptURI: ONTOLOGY_LOOKUP_TYPE.conceptURI,
@@ -56,6 +47,18 @@ beforeAll(() => {
 });
 
 describe('OntologyLookupOptions', () => {
+    function getDefaultProps() {
+        return {
+            domainContainerPath: '/Where/The/Domain/Lives',
+            index: 0,
+            domainIndex: 0,
+            label: 'Test',
+            lockType: undefined,
+            onChange: jest.fn(),
+            onMultiChange: jest.fn(),
+        };
+    }
+
     function validate(
         wrapper: ReactWrapper,
         disabled: boolean,
@@ -106,7 +109,9 @@ describe('OntologyLookupOptions', () => {
         const field = DomainField.create({});
         const domainFields = List.of(field);
 
-        const wrapper = mount(<OntologyLookupOptions {...DEFAULT_PROPS} field={field} domainFields={domainFields} />);
+        const wrapper = mount(
+            <OntologyLookupOptions {...getDefaultProps()} field={field} domainFields={domainFields} />
+        );
         await sleep();
         wrapper.update();
 
@@ -116,7 +121,9 @@ describe('OntologyLookupOptions', () => {
 
     test('with additional fields and ontology field props', async () => {
         const domainFields = List.of(field1, field2, field3, field4, field5, field6);
-        const wrapper = mount(<OntologyLookupOptions {...DEFAULT_PROPS} field={field1} domainFields={domainFields} />);
+        const wrapper = mount(
+            <OntologyLookupOptions {...getDefaultProps()} field={field1} domainFields={domainFields} />
+        );
         await sleep();
         wrapper.update();
 
@@ -128,7 +135,7 @@ describe('OntologyLookupOptions', () => {
         const domainFields = List.of(field1, field2, field3, field4, field5, field6);
         const wrapper = mount(
             <OntologyLookupOptions
-                {...DEFAULT_PROPS}
+                {...getDefaultProps()}
                 field={field1}
                 domainFields={domainFields}
                 lockType={DOMAIN_FIELD_FULLY_LOCKED}

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactNode, FC, memo } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 import { List } from 'immutable';
 
-import { ConceptModel, DomainField, IFieldChange, LabelHelpTip } from '../../..';
+import { DomainField, IFieldChange, LabelHelpTip } from '../../..';
 import { helpLinkNode, ONTOLOGY_LOOKUP_TOPIC } from '../../util/helpLinks';
 
 import { isFieldFullyLocked } from '../domainproperties/propertiesUtil';
@@ -25,6 +25,7 @@ import { fetchParentPaths, getParentsConceptCodePath } from './actions';
 const LEARN_MORE = <p>Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in LabKey.</p>;
 
 interface Props extends ITypeDependentProps {
+    domainContainerPath: string;
     field: DomainField;
     domainFields: List<DomainField>;
     onMultiChange: (changes: List<IFieldChange>) => void;
@@ -41,13 +42,11 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
         ontologies: [],
     };
 
-    componentDidMount(): void {
-        this.loadData();
-    }
+    componentDidMount = async (): Promise<void> => {
+        const { domainContainerPath } = this.props;
 
-    loadData = async (): Promise<void> => {
         try {
-            const newOntologies = await fetchOntologies();
+            const newOntologies = await fetchOntologies(domainContainerPath);
             this.setState(
                 () => ({
                     loading: false,

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
@@ -59,6 +59,7 @@ const DEFAULT_PROPS = {
     sampleModel,
     model,
     actions: makeTestActions(),
+    user: TEST_USER_READER,
 };
 
 describe('SampleAssayDetailButtons', () => {
@@ -68,27 +69,21 @@ describe('SampleAssayDetailButtons', () => {
     }
 
     test('without insert perm', () => {
-        const wrapper = mountWithServerContext(<SampleAssayDetailButtons {...DEFAULT_PROPS} />, {
-            user: TEST_USER_READER,
-        });
+        const wrapper = mount(<SampleAssayDetailButtons {...DEFAULT_PROPS} />);
         validate(wrapper);
         wrapper.unmount();
     });
 
     test('currentAssayHref undefined', () => {
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'Other Assay' });
-        const wrapper = mountWithServerContext(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />, {
-            user: TEST_USER_AUTHOR,
-        });
+        const wrapper = mount(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} user={TEST_USER_AUTHOR} />);
         validate(wrapper);
         wrapper.unmount();
     });
 
     test('multiple menu items', () => {
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'NAb Assay' });
-        const wrapper = mountWithServerContext(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} />, {
-            user: TEST_USER_AUTHOR,
-        });
+        const wrapper = mount(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} user={TEST_USER_AUTHOR} />);
         validate(wrapper, 2);
         expect(wrapper.find(SplitButton).prop('href')).toBe('test2');
         wrapper.unmount();
@@ -107,9 +102,8 @@ describe('SampleAssayDetailButtons', () => {
             definitionsLoadingState: LoadingState.LOADED,
         });
 
-        const wrapper = mountWithServerContext(
-            <SampleAssayDetailButtons {...DEFAULT_PROPS} assayModel={assayModel} />,
-            { user: TEST_USER_AUTHOR }
+        const wrapper = mount(
+            <SampleAssayDetailButtons {...DEFAULT_PROPS} assayModel={assayModel} user={TEST_USER_AUTHOR} />
         );
         validate(wrapper, 1);
         expect(wrapper.find(Button).prop('href')).toBe('test1');
@@ -172,6 +166,7 @@ const IMPL_PROPS = {
     onTabChange: jest.fn,
     actions: makeTestActions(),
     queryModels: {},
+    user: TEST_USER_READER,
 };
 
 describe('SampleAssayDetailBodyImpl', () => {

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -13,7 +13,6 @@ import {
     isSampleOperationPermitted,
     LoadingSpinner,
     naturalSortByProperty,
-    QueryConfig,
     QueryModel,
     RequiresModelAndActions,
     SampleAliquotViewSelector,
@@ -155,11 +154,11 @@ export const getSampleAssayDetailEmptyText = (
 };
 
 interface OwnProps {
-    onSampleAliquotTypeChange?: (mode: ALIQUOT_FILTER_MODE) => any;
+    onSampleAliquotTypeChange?: (mode: ALIQUOT_FILTER_MODE) => void;
     activeSampleAliquotType?: ALIQUOT_FILTER_MODE;
     showImportBtn?: boolean;
     isSourceSampleAssayGrid?: boolean;
-    onTabChange: (tabId: string) => any;
+    onTabChange: (tabId: string) => void;
     activeTabId?: string;
     user: User;
 }
@@ -191,10 +190,10 @@ export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & Injected
 
     useEffect(() => {
         actions.loadAllModels(true);
-    }, []);
+    }, [actions]);
 
-    const queryModelsWithData = useMemo(() => {
-        const models = {};
+    const { queryModelsWithData, tabOrder } = useMemo(() => {
+        const models: Record<string, QueryModel> = {};
         let targetQueryModels = Object.values(queryModels);
         const isFilteredView =
             showAliquotViewSelector &&
@@ -218,14 +217,14 @@ export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & Injected
                 models[targetModel.id] = targetModel;
             }
         });
-        return models;
-    }, [allLoaded, queryModels, showAliquotViewSelector, activeSampleAliquotType]);
 
-    const tabOrder = useMemo(() => {
-        return Object.values(queryModelsWithData)
-            .sort(naturalSortByProperty<QueryConfig>('title'))
-            .map((config: QueryConfig) => config.id);
-    }, [queryModelsWithData]);
+        return {
+            queryModelsWithData: models,
+            tabOrder: Object.values(models)
+                .sort(naturalSortByProperty('title'))
+                .map(model => model.id),
+        };
+    }, [activeSampleAliquotType, queryModels, showAliquotViewSelector]);
 
     const getEmptyText = useCallback(
         activeModel => {
@@ -349,7 +348,7 @@ export const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
                     message: 'Unable to load sample aliquots. Your session may have expired.',
                 });
             });
-    }, [sampleId, showAliquotViewSelector]);
+    }, [api, sampleId, showAliquotViewSelector]);
 
     const [sampleAssayResultViewConfigs, setSampleAssayResultViewConfigs] =
         useState<SampleAssayResultViewConfig[]>(undefined);
@@ -360,7 +359,7 @@ export const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
             .catch(() => {
                 setSampleAssayResultViewConfigs([]);
             });
-    }, []);
+    }, [api]);
 
     const loadingDefinitions =
         isLoading(assayModel.definitionsLoadingState) || sampleAssayResultViewConfigs === undefined;

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -20,7 +20,7 @@ import {
     SampleOperation,
     SchemaQuery,
     TabbedGridPanel,
-    useServerContext,
+    User,
 } from '../../..';
 
 import { withAssayModels } from '../assay/withAssayModels';
@@ -47,6 +47,7 @@ interface Props {
     emptyAssayResultDisplay?: ReactNode;
     emptyAliquotViewMsg?: string;
     emptySampleViewMsg?: string;
+    user: User;
 }
 
 export const AssayResultPanel: FC = ({ children }) => {
@@ -63,19 +64,19 @@ const UNFILTERED_PREFIX = 'unfiltered-';
 const UNFILTERED_GRID_ID_PREFIX = UNFILTERED_PREFIX + ASSAY_GRID_ID_PREFIX;
 
 interface SampleAssayDetailButtonsOwnProps {
-    assayModel: AssayStateModel;
-    sampleModel: QueryModel;
     activeSampleAliquotType?: ALIQUOT_FILTER_MODE;
-    onSampleAliquotTypeChange?: (mode: ALIQUOT_FILTER_MODE) => any;
+    assayModel: AssayStateModel;
     isSourceSampleAssayGrid?: boolean;
+    onSampleAliquotTypeChange?: (mode: ALIQUOT_FILTER_MODE) => void;
+    sampleModel: QueryModel;
+    user: User;
 }
 
 type SampleAssayDetailButtonsProps = SampleAssayDetailButtonsOwnProps & RequiresModelAndActions;
 
 // exported for jest testing
 export const SampleAssayDetailButtons: FC<SampleAssayDetailButtonsProps> = props => {
-    const { assayModel, model, sampleModel } = props;
-    const { user } = useServerContext();
+    const { assayModel, model, sampleModel, user } = props;
 
     if (!user.hasInsertPermission()) {
         return null;
@@ -160,6 +161,7 @@ interface OwnProps {
     isSourceSampleAssayGrid?: boolean;
     onTabChange: (tabId: string) => any;
     activeTabId?: string;
+    user: User;
 }
 
 type SampleAssayDetailBodyProps = Props & InjectedAssayModel & OwnProps;
@@ -182,6 +184,7 @@ export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & Injected
         emptySampleViewMsg,
         onTabChange,
         activeTabId,
+        user,
     } = props;
     const allModels = Object.values(queryModels);
     const allLoaded = allModels.every(model => !model.isLoading);
@@ -290,6 +293,7 @@ export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & Injected
                 onSampleAliquotTypeChange,
                 activeSampleAliquotType,
                 isSourceSampleAssayGrid,
+                user,
             }}
             ButtonsComponentRight={showAliquotViewSelector ? SampleAssayDetailButtonsRight : undefined}
             getEmptyText={getEmptyText}

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -40,8 +40,8 @@ interface Props {
     showAliquotViewSelector?: boolean;
     sampleAliquotType?: ALIQUOT_FILTER_MODE;
     sourceId?: number | string;
-    sourceSampleRows?: Record<string, any>[];
-    sourceAliquotRows?: Record<string, any>[];
+    sourceSampleRows?: Array<Record<string, any>>;
+    sourceAliquotRows?: Array<Record<string, any>>;
     emptyAssayDefDisplay?: ReactNode;
     emptyAssayResultDisplay?: ReactNode;
     emptyAliquotViewMsg?: string;
@@ -333,7 +333,7 @@ export const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
         return sampleId == null && sourceSampleRows != null;
     }, [sampleId, sourceSampleRows]);
 
-    const [aliquotRows, setAliquotRows] = useState<Record<string, any>[]>(undefined);
+    const [aliquotRows, setAliquotRows] = useState<Array<Record<string, any>>>(undefined);
     useEffect(() => {
         if (!showAliquotViewSelector || !sampleId) return;
 

--- a/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
+++ b/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
@@ -5,7 +5,6 @@ import { Alert, Panel } from 'react-bootstrap';
 import { Filter } from '@labkey/api';
 
 import {
-    caseInsensitive,
     DefaultRenderer,
     DetailPanelWithModel,
     getActionErrorMessage,
@@ -81,8 +80,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
 
     getAliquotRootSampleQueryConfig = (): QueryConfig => {
         const { model, sampleSet } = this.props;
-
-        const rootLsid = caseInsensitive(model.getRow(), 'RootMaterialLSID')?.value;
+        const rootLsid = model.getRowValue('RootMaterialLSID');
 
         return {
             schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet),
@@ -113,9 +111,9 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
 
         const row = this.getRow();
 
-        const parent = caseInsensitive(row, 'AliquotedFromLSID/Name');
-        const root = caseInsensitive(row, 'rootmateriallsid/name');
-        const isAliquot = !!parent?.value;
+        const parent = model.getRowValue('AliquotedFromLSID/Name');
+        const root = model.getRowValue('rootmateriallsid/name');
+        const isAliquot = !!parent;
 
         const { aliquotHeaderDisplayColumns, displayColumns, editColumns } = this.getUpdateDisplayColumns(isAliquot);
 
@@ -141,7 +139,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
                     <Panel>
                         <Panel.Heading>Original Sample Details</Panel.Heading>
                         <Panel.Body>
-                            {root?.value !== parent?.value && (
+                            {root !== parent && (
                                 <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table">
                                     <tbody>
                                         <tr key="originalSample">
@@ -153,10 +151,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
                                     </tbody>
                                 </table>
                             )}
-                            <DetailPanelWithModel
-                                key={root?.value}
-                                queryConfig={this.getAliquotRootSampleQueryConfig()}
-                            />
+                            <DetailPanelWithModel key={root} queryConfig={this.getAliquotRootSampleQueryConfig()} />
                         </Panel.Body>
                     </Panel>
                 )}

--- a/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
+++ b/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
@@ -5,6 +5,7 @@ import { Alert, Panel } from 'react-bootstrap';
 import { Filter } from '@labkey/api';
 
 import {
+    caseInsensitive,
     DefaultRenderer,
     DetailPanelWithModel,
     getActionErrorMessage,
@@ -110,10 +111,9 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
         }
 
         const row = this.getRow();
-
-        const parent = model.getRowValue('AliquotedFromLSID/Name');
-        const root = model.getRowValue('rootmateriallsid/name');
-        const isAliquot = !!parent;
+        const parent = caseInsensitive(row, 'AliquotedFromLSID/Name');
+        const root = caseInsensitive(row, 'RootMaterialLSID/Name');
+        const isAliquot = !!parent?.value;
 
         const { aliquotHeaderDisplayColumns, displayColumns, editColumns } = this.getUpdateDisplayColumns(isAliquot);
 
@@ -139,7 +139,7 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
                     <Panel>
                         <Panel.Heading>Original Sample Details</Panel.Heading>
                         <Panel.Body>
-                            {root !== parent && (
+                            {root?.value !== parent?.value && (
                                 <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table">
                                     <tbody>
                                         <tr key="originalSample">
@@ -151,7 +151,10 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
                                     </tbody>
                                 </table>
                             )}
-                            <DetailPanelWithModel key={root} queryConfig={this.getAliquotRootSampleQueryConfig()} />
+                            <DetailPanelWithModel
+                                key={root?.value}
+                                queryConfig={this.getAliquotRootSampleQueryConfig()}
+                            />
                         </Panel.Body>
                     </Panel>
                 )}

--- a/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
+++ b/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
@@ -2,41 +2,29 @@ import React, { PureComponent } from 'react';
 import { fromJS, List } from 'immutable';
 import { Alert, Panel } from 'react-bootstrap';
 
-import { AuditBehaviorTypes, Filter } from '@labkey/api';
+import { Filter } from '@labkey/api';
 
 import {
-    Actions,
     caseInsensitive,
     DefaultRenderer,
     DetailPanelWithModel,
-    EditableDetailPanel,
     getActionErrorMessage,
     LoadingPage,
     QueryConfig,
-    QueryModel,
     SAMPLE_STATUS_REQUIRED_COLUMNS,
     SampleAliquotDetailHeader,
     SchemaQuery,
     SCHEMAS,
 } from '../../..';
 
-import { DetailRenderer } from '../forms/detail/DetailDisplay';
+import { EditableDetailPanel, EditableDetailPanelProps } from '../../../public/QueryModel/EditableDetailPanel';
 
 import { GroupedSampleFields } from './models';
 import { getGroupedSampleDisplayColumns, getGroupedSampleDomainFields, GroupedSampleDisplayColumns } from './actions';
 import { IS_ALIQUOT_COL } from './constants';
 
-interface Props {
-    actions?: Actions;
-    auditBehavior: AuditBehaviorTypes;
-    canUpdate?: boolean;
-    detailEditRenderer?: DetailRenderer;
-    detailRenderer?: DetailRenderer;
-    onEditToggle?: (isEditing: boolean) => void;
-    onUpdate: () => void;
+interface Props extends EditableDetailPanelProps {
     sampleSet: string;
-    title: string;
-    queryModel?: QueryModel;
 }
 
 interface State {
@@ -45,33 +33,17 @@ interface State {
 }
 
 export class SampleDetailEditing extends PureComponent<Props, State> {
-    static defaultProps = {
-        canUpdate: false,
-    };
-
     state: Readonly<State> = {
         hasError: false,
         sampleTypeDomainFields: undefined,
     };
-
-    constructor(props: Props) {
-        super(props);
-
-        if (!props.queryModel) {
-            throw new Error('SampleDetailEditing: Requires that a "queryModel" be provided.');
-        } else if (props.queryModel && !props.actions) {
-            throw new Error('SampleDetailEditing: If a "queryModel" is specified, then "actions" are required.');
-        }
-    }
 
     componentDidMount(): void {
         this.loadSampleType();
     }
 
     componentDidUpdate(prevProps: Props): void {
-        const { sampleSet } = this.props;
-
-        if (sampleSet !== prevProps.sampleSet) {
+        if (this.props.sampleSet !== prevProps.sampleSet) {
             this.setState(
                 () => ({
                     sampleTypeDomainFields: undefined,
@@ -96,23 +68,21 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
     };
 
     getRow = (): Record<string, any> => {
-        const { queryModel } = this.props;
-        return queryModel.getRow() ?? {};
+        return this.props.model.getRow() ?? {};
     };
 
     getUpdateDisplayColumns = (isAliquot: boolean): GroupedSampleDisplayColumns => {
         const {
-            queryModel: { detailColumns, updateColumns },
+            model: { detailColumns, updateColumns },
         } = this.props;
         const { sampleTypeDomainFields } = this.state;
         return getGroupedSampleDisplayColumns(detailColumns, updateColumns, sampleTypeDomainFields, isAliquot);
     };
 
     getAliquotRootSampleQueryConfig = (): QueryConfig => {
-        const { sampleSet } = this.props;
+        const { model, sampleSet } = this.props;
 
-        const row = this.getRow();
-        const rootLsid = caseInsensitive(row, 'RootMaterialLSID')?.value;
+        const rootLsid = caseInsensitive(model.getRow(), 'RootMaterialLSID')?.value;
 
         return {
             schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet),
@@ -123,18 +93,11 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
     };
 
     render() {
-        const {
-            actions,
-            auditBehavior,
-            canUpdate,
-            detailEditRenderer,
-            detailRenderer,
-            onEditToggle,
-            onUpdate,
-            queryModel,
-            title,
-        } = this.props;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { sampleSet, ...editableDetailPanelProps } = this.props;
         const { hasError, sampleTypeDomainFields } = this.state;
+        const { model, title } = editableDetailPanelProps;
+        let { detailHeader } = editableDetailPanelProps;
 
         if (hasError) {
             return (
@@ -144,61 +107,52 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
             );
         }
 
-        if (!sampleTypeDomainFields || (queryModel && queryModel.isLoading)) {
+        if (!sampleTypeDomainFields || model.isLoading) {
             return <LoadingPage title={title} />;
         }
 
         const row = this.getRow();
 
         const parent = caseInsensitive(row, 'AliquotedFromLSID/Name');
+        const root = caseInsensitive(row, 'rootmateriallsid/name');
         const isAliquot = !!parent?.value;
 
-        const root = caseInsensitive(row, 'rootmateriallsid/name');
-
-        const showRootSampleName = root?.value !== parent?.value;
-
         const { aliquotHeaderDisplayColumns, displayColumns, editColumns } = this.getUpdateDisplayColumns(isAliquot);
-        const detailHeader = isAliquot ? (
-            <SampleAliquotDetailHeader
-                aliquotHeaderDisplayColumns={List(aliquotHeaderDisplayColumns)}
-                row={fromJS(row)}
-            />
-        ) : null;
 
-        const parentDetailHeader = showRootSampleName ? (
-            <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table">
-                <tbody>
-                    <tr key="originalSample">
-                        <td>Original sample</td>
-                        <td>
-                            <DefaultRenderer data={fromJS(root)} />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        ) : null;
+        if (!detailHeader && isAliquot) {
+            detailHeader = (
+                <SampleAliquotDetailHeader
+                    aliquotHeaderDisplayColumns={List(aliquotHeaderDisplayColumns)}
+                    row={fromJS(row)}
+                />
+            );
+        }
 
         return (
             <>
                 <EditableDetailPanel
-                    actions={actions}
-                    auditBehavior={auditBehavior}
-                    canUpdate={canUpdate}
-                    detailEditRenderer={detailEditRenderer}
+                    {...editableDetailPanelProps}
                     detailHeader={detailHeader}
-                    detailRenderer={detailRenderer}
                     editColumns={editColumns}
-                    model={queryModel}
-                    onEditToggle={onEditToggle}
-                    onUpdate={onUpdate}
                     queryColumns={displayColumns}
-                    title={isAliquot ? 'Aliquot Details' : undefined}
+                    title={title ?? (isAliquot ? 'Aliquot Details' : undefined)}
                 />
                 {isAliquot && (
                     <Panel>
                         <Panel.Heading>Original Sample Details</Panel.Heading>
                         <Panel.Body>
-                            {parentDetailHeader}
+                            {root?.value !== parent?.value && (
+                                <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table">
+                                    <tbody>
+                                        <tr key="originalSample">
+                                            <td>Original sample</td>
+                                            <td>
+                                                <DefaultRenderer data={fromJS(root)} />
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            )}
                             <DetailPanelWithModel
                                 key={root?.value}
                                 queryConfig={this.getAliquotRootSampleQueryConfig()}

--- a/packages/components/src/internal/components/samples/SampleLineageGraph.tsx
+++ b/packages/components/src/internal/components/samples/SampleLineageGraph.tsx
@@ -16,6 +16,7 @@ import { LineageDepthLimitMessage } from '../lineage/LineageGraph';
 interface Props {
     sampleLsid: string;
     sampleID: string;
+    seedContainer: string;
     goToLineageGrid: () => void;
     onLineageNodeDblClick: (node: VisGraphNode) => void;
     groupTitles?: Map<LINEAGE_DIRECTIONS, Map<string, string>>;
@@ -118,8 +119,15 @@ export class SampleLineageGraph extends PureComponent<Props, State> {
     }
 
     render() {
-        const { sampleLsid, sampleID, goToLineageGrid, onLineageNodeDblClick, groupTitles, groupingOptions } =
-            this.props;
+        const {
+            sampleLsid,
+            sampleID,
+            seedContainer,
+            goToLineageGrid,
+            onLineageNodeDblClick,
+            groupTitles,
+            groupingOptions,
+        } = this.props;
 
         const grouping = {
             ...(groupingOptions ?? { childDepth: DEFAULT_LINEAGE_DISTANCE }),
@@ -140,6 +148,7 @@ export class SampleLineageGraph extends PureComponent<Props, State> {
                         navigate={onLineageNodeDblClick}
                         groupTitles={groupTitles}
                         runProtocolLsid={this.getRunProtocolLsid()}
+                        seedContainer={seedContainer}
                     />
                     <LineageDepthLimitMessage maxDistance={grouping.childDepth} nodeName={sampleID} />
                 </Panel.Body>

--- a/packages/components/src/internal/components/samples/SampleLineageGraph.tsx
+++ b/packages/components/src/internal/components/samples/SampleLineageGraph.tsx
@@ -14,9 +14,9 @@ import { DEFAULT_LINEAGE_DISTANCE, SAMPLE_ALIQUOT_PROTOCOL_LSID } from '../linea
 import { LineageDepthLimitMessage } from '../lineage/LineageGraph';
 
 interface Props {
+    containerPath?: string;
     sampleLsid: string;
     sampleID: string;
-    seedContainer?: string;
     goToLineageGrid: () => void;
     onLineageNodeDblClick: (node: VisGraphNode) => void;
     groupTitles?: Map<LINEAGE_DIRECTIONS, Map<string, string>>;
@@ -120,9 +120,9 @@ export class SampleLineageGraph extends PureComponent<Props, State> {
 
     render() {
         const {
+            containerPath,
             sampleLsid,
             sampleID,
-            seedContainer,
             goToLineageGrid,
             onLineageNodeDblClick,
             groupTitles,
@@ -142,13 +142,13 @@ export class SampleLineageGraph extends PureComponent<Props, State> {
                     {this.renderFilter()}
 
                     <LineageGraph
+                        containerPath={containerPath}
                         lsid={sampleLsid}
                         grouping={grouping}
                         filters={this.getLineageFilters()}
                         navigate={onLineageNodeDblClick}
                         groupTitles={groupTitles}
                         runProtocolLsid={this.getRunProtocolLsid()}
-                        seedContainer={seedContainer}
                     />
                     <LineageDepthLimitMessage maxDistance={grouping.childDepth} nodeName={sampleID} />
                 </Panel.Body>

--- a/packages/components/src/internal/components/samples/SampleLineageGraph.tsx
+++ b/packages/components/src/internal/components/samples/SampleLineageGraph.tsx
@@ -16,7 +16,7 @@ import { LineageDepthLimitMessage } from '../lineage/LineageGraph';
 interface Props {
     sampleLsid: string;
     sampleID: string;
-    seedContainer: string;
+    seedContainer?: string;
     goToLineageGrid: () => void;
     onLineageNodeDblClick: (node: VisGraphNode) => void;
     groupTitles?: Map<LINEAGE_DIRECTIONS, Map<string, string>>;

--- a/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
+++ b/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
@@ -300,6 +300,8 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     };
 
     initLineageEditableGrid = async (): Promise<void> => {
+        // TODO: Who is handling errors here?
+        // TODO: Configure "containerPath" for getOriginalParentsFromSampleLineage() call
         const { originalParents, parentTypeOptions } = await getOriginalParentsFromSampleLineage(
             this.props.sampleLineage
         );

--- a/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
+++ b/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
@@ -300,8 +300,6 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     };
 
     initLineageEditableGrid = async (): Promise<void> => {
-        // TODO: Who is handling errors here?
-        // TODO: Configure "containerPath" for getOriginalParentsFromSampleLineage() call
         const { originalParents, parentTypeOptions } = await getOriginalParentsFromSampleLineage(
             this.props.sampleLineage
         );

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -26,6 +26,7 @@ import {
     DataClassDataType,
     DomainDetails,
     FindField,
+    getContainerFilter,
     getSelectedData,
     getSelection,
     getStateModelId,
@@ -670,6 +671,7 @@ export function saveIdsToFind(fieldType: FindField, ids: string[], sessionKey: s
 export function getSampleAliquotRows(sampleId: number | string): Promise<Array<Record<string, any>>> {
     return new Promise((resolve, reject) => {
         Query.executeSql({
+            containerFilter: getContainerFilter(),
             sql:
                 'SELECT m.RowId, m.Name\n' +
                 'FROM exp.materials m \n' +

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -110,9 +110,10 @@ export function getSampleSet(config: IEntityTypeDetails): Promise<any> {
     });
 }
 
-export function getSampleTypeDetails(query?: SchemaQuery, domainId?: number): Promise<DomainDetails> {
+export function getSampleTypeDetails(query?: SchemaQuery, domainId?: number, containerPath?: string): Promise<DomainDetails> {
     return new Promise((resolve, reject) => {
         return Domain.getDomainDetails({
+            containerPath,
             domainId,
             queryName: query ? query.getQuery() : undefined,
             schemaName: query ? query.getSchema() : undefined,

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -26,7 +26,6 @@ import {
     DataClassDataType,
     DomainDetails,
     FindField,
-    getFilterForSampleOperation,
     getSelectedData,
     getSelection,
     getStateModelId,
@@ -38,7 +37,6 @@ import {
     resolveErrorMessage,
     SAMPLE_ID_FIND_FIELD,
     SAMPLE_STATUS_REQUIRED_COLUMNS,
-    SampleOperation,
     SampleTypeDataType,
     SchemaQuery,
     SCHEMAS,
@@ -247,14 +245,6 @@ export function getAliquotSampleIds(selection: List<any>, sampleType: string): P
 
 export function getNotInStorageSampleIds(selection: List<any>, sampleType: string): Promise<any[]> {
     return getFilteredSampleSelection(selection, sampleType, [Filter.create('StorageStatus', 'Not in storage')]);
-}
-
-export function getNotPermittedSampleIds(
-    selection: List<any>,
-    sampleType: string,
-    operation: SampleOperation
-): Promise<any[]> {
-    return getFilteredSampleSelection(selection, sampleType, [getFilterForSampleOperation(operation, false)]);
 }
 
 function getFilteredSampleSelection(

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -109,7 +109,11 @@ export function getSampleSet(config: IEntityTypeDetails): Promise<any> {
     });
 }
 
-export function getSampleTypeDetails(query?: SchemaQuery, domainId?: number, containerPath?: string): Promise<DomainDetails> {
+export function getSampleTypeDetails(
+    query?: SchemaQuery,
+    domainId?: number,
+    containerPath?: string
+): Promise<DomainDetails> {
     return new Promise((resolve, reject) => {
         return Domain.getDomainDetails({
             containerPath,

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -4,11 +4,11 @@ import { Container } from '../base/models/Container';
 
 export type FetchContainerOptions = Omit<Security.GetContainersOptions, 'success' | 'failure' | 'scope'>;
 
-export interface SecurityAPI {
+export interface SecurityAPIWrapper {
     fetchContainers: (options: FetchContainerOptions) => Promise<Container[]>;
 }
 
-export class SecurityAPIWrapper implements SecurityAPI {
+export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
     fetchContainers = (options: FetchContainerOptions): Promise<Container[]> => {
         return new Promise((resolve, reject) => {
             Security.getContainers({
@@ -37,8 +37,8 @@ function recurseContainerHierarchy(data: Security.ContainerHierarchy, container:
  */
 export function getSecurityTestAPIWrapper(
     mockFn = (): any => () => {},
-    overrides: Partial<SecurityAPI> = {}
-): SecurityAPI {
+    overrides: Partial<SecurityAPIWrapper> = {}
+): SecurityAPIWrapper {
     return {
         fetchContainers: mockFn(),
         ...overrides,

--- a/packages/components/src/internal/components/security/SecurityAPI.ts
+++ b/packages/components/src/internal/components/security/SecurityAPI.ts
@@ -1,0 +1,63 @@
+import { Security } from '@labkey/api';
+
+import { Container } from '../base/models/Container';
+
+export type FetchContainerOptions = Omit<Security.GetContainersOptions, 'success' | 'failure' | 'scope'>;
+
+export interface SecurityAPI {
+    fetchContainers: (options: FetchContainerOptions, cacheKey?: string) => Promise<Record<string, Container>>;
+}
+
+const FETCH_CONTAINERS_CACHE: Record<string, Promise<Record<string, Container>>> = {};
+
+export class SecurityAPIWrapper implements SecurityAPI {
+    fetchContainers = (options: FetchContainerOptions, cacheKey?: string): Promise<Record<string, Container>> => {
+        if (cacheKey && FETCH_CONTAINERS_CACHE[cacheKey]) {
+            return FETCH_CONTAINERS_CACHE[cacheKey];
+        }
+
+        const result: Promise<Record<string, Container>> = new Promise((resolve, reject) => {
+            Security.getContainers({
+                ...options,
+                success: (hierarchy: Security.ContainerHierarchy) => {
+                    const containers = [
+                        new Container(hierarchy),
+                        // TODO: Consider filtering filter(c => c.type === 'folder') or adding option to API to exclude hidden folders
+                        ...hierarchy.children.map(c => new Container(c)),
+                    ];
+
+                    const containerMap = containers.reduce((map, c) => {
+                        map[c.id] = c;
+                        map[c.path] = c;
+                        return map;
+                    }, {});
+
+                    resolve(containerMap);
+                },
+                failure: error => {
+                    console.error('Failed to fetch containers', error);
+                    reject(error);
+                },
+            });
+        });
+
+        if (cacheKey) {
+            FETCH_CONTAINERS_CACHE[cacheKey] = result;
+        }
+
+        return result;
+    };
+}
+
+/**
+ * Note: Intentionally does not use jest.fn() to avoid jest becoming an implicit external package dependency.
+ */
+export function getSecurityTestAPIWrapper(
+    mockFn = (): any => () => {},
+    overrides: Partial<SecurityAPI> = {}
+): SecurityAPI {
+    return {
+        fetchContainers: mockFn(),
+        ...overrides,
+    };
+}

--- a/packages/components/src/internal/components/settings/actions.ts
+++ b/packages/components/src/internal/components/settings/actions.ts
@@ -18,7 +18,7 @@ export const saveNameExpressionOptions = (key: string, value: string | boolean, 
     });
 };
 
-interface GetNameExpressionOptionsResponse {
+export interface GetNameExpressionOptionsResponse {
     allowUserSpecifiedNames: boolean;
     prefix: string;
 }

--- a/packages/components/src/internal/components/settings/actions.ts
+++ b/packages/components/src/internal/components/settings/actions.ts
@@ -4,10 +4,12 @@ import { buildURL } from '../../url/AppURL';
 import { handleRequestFailure } from '../../util/utils';
 import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
-export const saveNameExpressionOptions = (key: string, value: string | boolean): Promise<null> => {
+export const saveNameExpressionOptions = (key: string, value: string | boolean, containerPath?: string): Promise<null> => {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'setNameExpressionOptions'),
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'setNameExpressionOptions.api', undefined, {
+                container: containerPath,
+            }),
             jsonData: { [key]: value },
             method: 'POST',
             success: Utils.getCallbackWrapper(response => resolve(response)),
@@ -16,10 +18,17 @@ export const saveNameExpressionOptions = (key: string, value: string | boolean):
     });
 };
 
-export const loadNameExpressionOptions = (): Promise<{ prefix: string; allowUserSpecifiedNames: boolean }> => {
+interface GetNameExpressionOptionsResponse {
+    allowUserSpecifiedNames: boolean;
+    prefix: string;
+}
+
+export const loadNameExpressionOptions = (containerPath?: string): Promise<GetNameExpressionOptionsResponse> => {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getNameExpressionOptions'),
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getNameExpressionOptions.api', undefined, {
+                container: containerPath,
+            }),
             success: Utils.getCallbackWrapper(response => resolve(response)),
             failure: handleRequestFailure(reject, 'Failed to get name expression options.'),
         });

--- a/packages/components/src/internal/components/settings/actions.ts
+++ b/packages/components/src/internal/components/settings/actions.ts
@@ -4,7 +4,11 @@ import { buildURL } from '../../url/AppURL';
 import { handleRequestFailure } from '../../util/utils';
 import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
-export const saveNameExpressionOptions = (key: string, value: string | boolean, containerPath?: string): Promise<null> => {
+export const saveNameExpressionOptions = (
+    key: string,
+    value: string | boolean,
+    containerPath?: string
+): Promise<null> => {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'setNameExpressionOptions.api', undefined, {

--- a/packages/components/src/internal/mock.tsx
+++ b/packages/components/src/internal/mock.tsx
@@ -605,7 +605,7 @@ export function initQueryGridMocks(delayMs = undefined) {
 }
 
 export function initDomainPropertiesMocks() {
-    mock.get(/.*\/security\/?.*\/GetMaxPhiLevel.*/, jsonResponse(getMaxPhiLevelJson));
+    mock.get(/.*\/security\/?.*\/getMaxPhiLevel.*/, jsonResponse(getMaxPhiLevelJson));
 
     mock.get(/.*\/assay\/?.*\/getValidPublishTargets.*/, jsonResponse(getValidPublishTargetsJson));
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -906,7 +906,7 @@ export function getContainerFilter(): Query.ContainerFilter {
     }
 
     if (container.parentPath === '/') {
-        return Query.ContainerFilter.currentAndSubfolders;
+        return Query.ContainerFilter.currentAndSubfoldersPlusShared;
     }
 
     return Query.ContainerFilter.currentPlusProjectAndShared;

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -898,14 +898,25 @@ export function processRequest(response: any, request: any, reject: (reason?: an
     return false;
 }
 
+/**
+ * Provides the default ContainerFilter to utilize when requesting data cross-folder.
+ * This ContainerFilter is applied to all `executeSql` and `selectRows` requests made via the methods
+ * provided by `@labkey/components`.
+ * @private
+ */
 export function getContainerFilter(): Query.ContainerFilter {
+    // Check experimental flag to see if cross-folder data support is enabled.
     if (!isSubfolderDataEnabled()) {
         return undefined;
     }
 
+    // When requesting data from a top-level folder context the ContainerFilter filters
+    // "down" the folder hierarchy for data.
     if (getServerContext().container.parentPath === '/') {
         return Query.ContainerFilter.currentAndSubfoldersPlusShared;
     }
 
+    // When requesting data from a sub-folder context the ContainerFilter filters
+    // "up" the folder hierarchy for data.
     return Query.ContainerFilter.currentPlusProjectAndShared;
 }

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -19,7 +19,7 @@ import { AuditBehaviorTypes, Filter, getServerContext, Query, QueryDOM } from '@
 
 import { getQueryMetadata } from '../global';
 import { resolveKeyFromJson } from '../../public/SchemaQuery';
-import { biologicsIsPrimaryApp } from '../app/utils';
+import { isSubfolderDataEnabled } from '../app/utils';
 import {
     caseInsensitive,
     QueryColumn,
@@ -899,13 +899,11 @@ export function processRequest(response: any, request: any, reject: (reason?: an
 }
 
 export function getContainerFilter(): Query.ContainerFilter {
-    const { container, moduleContext } = getServerContext();
-
-    if (!biologicsIsPrimaryApp(moduleContext)) {
+    if (!isSubfolderDataEnabled()) {
         return undefined;
     }
 
-    if (container.parentPath === '/') {
+    if (getServerContext().container.parentPath === '/') {
         return Query.ContainerFilter.currentAndSubfoldersPlusShared;
     }
 

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -225,9 +225,6 @@ export class AppURL extends Record({
  */
 export function spliceURL(parts: any[], newParts: any[], startIndex: number, numToReplace?: number): AppURL {
     parts.splice(startIndex, numToReplace === undefined ? 1 : numToReplace, ...newParts);
-    const decodedParts = [];
-    for (var i = 0; i < parts.length; i++) {
-        decodedParts.push(decodeURIComponent(parts[i]));
-    }
+    const decodedParts = parts.map(p => decodeURIComponent(p)).filter(p => !!p);
     return AppURL.create(...decodedParts);
 }

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -19,8 +19,9 @@ import { ActionURL, Experiment, Filter, getServerContext } from '@labkey/api';
 import { AppURL, createProductUrl } from '../..';
 import { LineageLinkMetadata } from '../components/lineage/types';
 
-import { AppRouteResolver } from './AppURLResolver';
 import { FREEZER_MANAGER_APP_PROPERTIES } from '../app/constants';
+
+import { AppRouteResolver } from './AppURLResolver';
 
 const ADD_TABLE_ROUTE = 'application/routing/add-table-route';
 
@@ -466,28 +467,27 @@ export const PICKLIST_MAPPER = new ActionMapper('picklist', 'grid', row => {
     return false;
 });
 
-export const FREEZER_ITEM_SAMPLE_MAPPER =
-    new ActionMapper('query', 'executeQuery', row => {
-        const url = row.get('url');
-        if (url) {
-            const materialIdKey = 'query.MaterialId~eq';
-            const params = ActionURL.getParameters(url);
-            if (
-                params.schemaName &&
-                params.schemaName.toLowerCase() === 'inventory' &&
-                params.queryName &&
-                params.queryName.toLowerCase() === 'item' &&
-                params[materialIdKey] !== undefined
-            ) {
-                return createProductUrl(
-                    FREEZER_MANAGER_APP_PROPERTIES.productId,
-                    undefined,
-                    AppURL.create('rd', 'sampleItem', params[materialIdKey])
-                );
-            }
+export const FREEZER_ITEM_SAMPLE_MAPPER = new ActionMapper('query', 'executeQuery', row => {
+    const url = row.get('url');
+    if (url) {
+        const materialIdKey = 'query.MaterialId~eq';
+        const params = ActionURL.getParameters(url);
+        if (
+            params.schemaName &&
+            params.schemaName.toLowerCase() === 'inventory' &&
+            params.queryName &&
+            params.queryName.toLowerCase() === 'item' &&
+            params[materialIdKey] !== undefined
+        ) {
+            return createProductUrl(
+                FREEZER_MANAGER_APP_PROPERTIES.productId,
+                undefined,
+                AppURL.create('rd', 'sampleItem', params[materialIdKey])
+            );
         }
-        return false;
-    });
+    }
+    return false;
+});
 
 export const URL_MAPPERS = {
     ASSAY_MAPPERS,

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -212,9 +212,6 @@ class LookupMapper implements URLMapper {
                 }
             }
 
-            if (lookup.get('containerPath') && lookup.get('containerPath') !== getServerContext().container.path)
-                return undefined;
-
             const parts = [
                 this.defaultPrefix,
                 lookup.get('schemaName'),

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -18,6 +18,7 @@ export class QueryInfo extends Record({
     // canEditSharedViews: false,
     columns: OrderedMap<string, QueryColumn>(),
     description: undefined,
+    domainContainerPath: undefined,
     // editDefinitionUrl: undefined,
     importTemplates: List<any>(),
     // indices: Map<string, any>(),
@@ -59,6 +60,7 @@ export class QueryInfo extends Record({
     // declare canEditSharedViews: boolean;
     declare columns: OrderedMap<string, QueryColumn>;
     declare description: string;
+    declare domainContainerPath: string;
     // declare editDefinitionUrl: string;
     declare iconURL: string;
     declare importTemplates: List<any>;

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -18,12 +18,13 @@ import {
     updateRows,
 } from '../..';
 
-interface Props extends RequiresModelAndActions {
+export interface EditableDetailPanelProps extends RequiresModelAndActions {
     appEditable?: boolean;
     asSubPanel?: boolean;
     auditBehavior?: AuditBehaviorTypes;
     cancelText?: string;
     canUpdate: boolean;
+    containerPath?: string;
     detailEditRenderer?: DetailRenderer;
     detailHeader?: ReactNode;
     detailRenderer?: DetailRenderer;
@@ -33,7 +34,7 @@ interface Props extends RequiresModelAndActions {
     queryColumns?: QueryColumn[];
     submitText?: string;
     title?: string;
-    useEditIcon: boolean;
+    useEditIcon?: boolean;
 }
 
 interface State {
@@ -43,7 +44,7 @@ interface State {
     warning: string;
 }
 
-export class EditableDetailPanel extends PureComponent<Props, State> {
+export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps, State> {
     static defaultProps = {
         useEditIcon: true,
         cancelText: 'Cancel',
@@ -84,7 +85,7 @@ export class EditableDetailPanel extends PureComponent<Props, State> {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleSubmit = async (values: Record<string, any>): Promise<void> => {
-        const { auditBehavior, model, onEditToggle, onUpdate } = this.props;
+        const { auditBehavior, containerPath, model, onEditToggle, onUpdate } = this.props;
         const { queryInfo } = model;
         const row = model.getRow();
         const updatedValues = extractChanges(queryInfo, fromJS(model.getRow()), values);
@@ -111,7 +112,12 @@ export class EditableDetailPanel extends PureComponent<Props, State> {
         });
 
         try {
-            await updateRows({ auditBehavior, rows: [updatedValues], schemaQuery: queryInfo.schemaQuery });
+            await updateRows({
+                auditBehavior,
+                containerPath,
+                rows: [updatedValues],
+                schemaQuery: queryInfo.schemaQuery,
+            });
 
             this.setState({ editing: false }, () => {
                 onUpdate?.(); // eslint-disable-line no-unused-expressions

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -503,6 +503,15 @@ export class QueryModel {
     }
 
     /**
+     * An array of load-related errors on this model. This specifically targets errors related to initializing and/or
+     * loading data. Subsequent errors that can occur (e.g. charting errors, selection errors, etc) are not included
+     * as those are intended to be handled explicitly.
+     */
+    get loadErrors(): string[] {
+        return [this.queryInfoError, this.rowsError].filter(e => !!e);
+    }
+
+    /**
      * Comma-delimited string of sorts from the [[QueryInfo]] sorts property. If the view has defined sorts, they
      * will be concatenated with the sorts property.
      */
@@ -694,6 +703,11 @@ export class QueryModel {
      */
     get hasData(): boolean {
         return this.rows !== undefined;
+    }
+
+    /** True if there are any load errors. */
+    get hasLoadErrors(): boolean {
+        return this.loadErrors.length > 0;
     }
 
     /**

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -3,6 +3,7 @@ import { Draft, immerable, produce } from 'immer';
 import { Filter, Query } from '@labkey/api';
 
 import {
+    caseInsensitive,
     GRID_CHECKBOX_OPTIONS,
     isLoading,
     LoadingState,
@@ -646,6 +647,14 @@ export class QueryModel {
 
         const row = this.rows[key];
         return flattenValues ? flattenValuesFromRow(row, this.queryInfo.getColumnFieldKeys()) : row;
+    }
+
+    /**
+     * Returns the value of a specific column in the first row.
+     * @param columnName Case insensitive name of the column.
+     */
+    getRowValue(columnName: string): any {
+        return caseInsensitive(this.getRow(), columnName)?.value;
     }
 
     /**

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -738,10 +738,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.9":
-  version "1.6.9"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.9.tgz#7f054750358357d667e3a6efd77c8173456eed77"
-  integrity sha1-fwVHUDWDV9Zn46bv13yBc0Vu7Xc=
+"@labkey/api@1.6.9-fb-subfolder-perms.0":
+  version "1.6.9-fb-subfolder-perms.0"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.9-fb-subfolder-perms.0.tgz#18296851a01a17d83db860e5bcda61d0a960c94d"
+  integrity sha1-GCloUaAaF9g9uGDlvNph0KlgyU0=
 
 "@labkey/eslint-config-base@0.0.11-fb-discussions.2":
   version "0.0.11-fb-discussions.2"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -738,10 +738,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.6.9-fb-subfolder-perms.0":
-  version "1.6.9-fb-subfolder-perms.0"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.9-fb-subfolder-perms.0.tgz#18296851a01a17d83db860e5bcda61d0a960c94d"
-  integrity sha1-GCloUaAaF9g9uGDlvNph0KlgyU0=
+"@labkey/api@1.6.10":
+  version "1.6.10"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.10.tgz#4532eb82d541c5a8a004592035cde18601bcc7d7"
+  integrity sha1-RTLrgtVBxaigBFkgNc3hhgG8x9c=
 
 "@labkey/eslint-config-base@0.0.11-fb-discussions.2":
   version "0.0.11-fb-discussions.2"


### PR DESCRIPTION
#### Rationale
This PR adds support for cross-folder viewing and interaction with Sample Type domains and data. These changes primarily fall into the following categories:

1. Supporting fetching container/user metadata cross-folder.
1. Editing Sample Type Domains cross-folder.
1. Interacting with Lineage components with samples that are cross-folder.

[Specification](https://docs.google.com/document/d/10H74scuWW7BV3xC2ks6MvHsdvsv8Oqm36Lb2NK6cu3k/edit)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2802
* https://github.com/LabKey/labkey-api-js/pull/116
* https://github.com/LabKey/labkey-ui-components/pull/679
* https://github.com/LabKey/sampleManagement/pull/761
* https://github.com/LabKey/biologics/pull/1070

#### Changes
* Add `getContainerFilter()` for resolving default container filter based on folder context.
* Add `SecurityAPIWrapper` to support fetching containers. This is provided to components via `AppContext`.
* Specify React hooks exported by `@labkey/components` on a `Hooks` object for easier mocking.
* Update `ParentEntityEditPanel` to fetch and persist parent metadata. This allows the component to operate independent of the configuration of the model as supplied by the caller.
* Update `EditableDetailPanel` to accept `containerPath`.
* QueryModel
  * Add `loadErrors` and `hasLoadErrors()` utilities to `QueryModel` to reduce the number of checks callers need to do to ensure errors are handled.
  * Add `getRowValue()` utility method to `QueryModel` which allows for fetching the specific value of a row by column name (case-insensitive).
* Domain Editing
  * Add `domainContainerPath` prop to `QueryInfo` as now specified by `query-getQueryDetails.api` endpoint.
  * Support requesting PHI level cross-folder.
  * Make domain save requests against domain's folder.