### PR TITLE
Item 9704: Sample Status Polish - Dashboard stacked bar chart and minor styling/wording updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.1-fb-smDashboardStackedBar.2",
+  "version": "2.99.1-fb-smDashboardStackedBar.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.94.0",
+  "version": "2.94.0-fb-smDashboardStackedBar.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.1",
+  "version": "2.99.1-fb-smDashboardStackedBar.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.1-fb-smDashboardStackedBar.5",
+  "version": "2.100.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.1-fb-smDashboardStackedBar.3",
+  "version": "2.99.1-fb-smDashboardStackedBar.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0",
+  "version": "2.95.0-fb-smDashboardStackedBar.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.1-fb-smDashboardStackedBar.4",
+  "version": "2.99.1-fb-smDashboardStackedBar.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.1-fb-smDashboardStackedBar.1",
+  "version": "2.99.1-fb-smDashboardStackedBar.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.96.0",
+  "version": "2.96.0-fb-smDashboardStackedBar.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.96.0-fb-smDashboardStackedBar.2",
+  "version": "2.96.0-fb-smDashboardStackedBar.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-smDashboardStackedBar.1",
+  "version": "2.95.0-fb-smDashboardStackedBar.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.96.0-fb-smDashboardStackedBar.0",
+  "version": "2.96.0-fb-smDashboardStackedBar.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.1-fb-smDashboardStackedBar.0",
+  "version": "2.99.1-fb-smDashboardStackedBar.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.95.0-fb-smDashboardStackedBar.0",
+  "version": "2.95.0-fb-smDashboardStackedBar.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.96.0-fb-smDashboardStackedBar.1",
+  "version": "2.96.0-fb-smDashboardStackedBar.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -9,6 +9,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   * other misc changes:
     * add vertical separator for manage sample statuses
     * update assay import sample status message to use warning instead of info alert display
+    * SamplesBulkUpdateForm update to only show aliquot-editable fields when any selected samples are aliquots
 
 ### version 2.95.0
 *Released*: 22 November 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Item 9703: Add support for LabKey Vis API stacked bar plot
   * supported groupPath for bar chart config
   * add legendData for group bar chart case
+  * other misc changes:
+    * add vertical separator for manage sample statuses
+    * update assay import sample status message to use warning instead of info alert display
 
 ### version 2.95.0
 *Released*: 22 November 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD November 2021
+* Item 9703: Add support for LabKey Vis API stacked bar plot
+  * supported groupPath for bar chart config
+  * add legendData for group bar chart case
+
 ### version 2.94.0
 *Released*: 17 November 2021
 * Item 9500: Improve Sample display when spanning types

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD November 2021
+### version 2.100.0
+*Released*: 29 November 2021
 * Item 9703: Add support for LabKey Vis API stacked bar plot
   * supported groupPath for bar chart config
   * add legendData for group bar chart case

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Item 9703: Add support for LabKey Vis API stacked bar plot
   * supported groupPath for bar chart config
   * add legendData for group bar chart case
+  * add sortFn and conditional margin values for the grouped plot legend text length
   * other misc changes:
     * add vertical separator for manage sample statuses
     * update assay import sample status message to use warning instead of info alert display

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -719,7 +719,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                         hasBatchProperties={model.batchColumns.size > 0}
                     />
                 )}
-                <Alert bsStyle="info">{sampleStatusWarning}</Alert>
+                <Alert bsStyle="warning">{sampleStatusWarning}</Alert>
                 <BatchPropertiesPanel
                     model={model}
                     showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -190,6 +190,7 @@ export class BarChartViewer extends PureComponent<Props, State> {
         } else {
             const { barFillColors, data } = processChartData(response, {
                 colorPath: selectedGroup.colorPath,
+                groupPath: selectedGroup.groupPath,
                 countPath: [currentChartOptions.name, 'value'],
             });
 
@@ -198,6 +199,7 @@ export class BarChartViewer extends PureComponent<Props, State> {
                     barFillColors={barFillColors}
                     data={data}
                     defaultBorderColor="#555"
+                    grouped={selectedGroup.groupPath !== undefined}
                     onClick={selectedGroup.getAppURL ? this.onBarClick : undefined}
                     title={`${selectedGroup.label} (${currentChartOptions.label})`}
                 />

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -89,8 +89,8 @@ export class BarChartViewer extends PureComponent<Props, State> {
                 const { itemCountFilters, itemCountSQ } = chartConfigs[currentGroup];
                 const itemCount = await fetchItemCount(itemCountSQ, itemCountFilters);
 
-                const { queryName, schemaName } = this.getSelectedChartGroup();
-                const response = await selectRows({ schemaName, queryName });
+                const { queryName, schemaName, sort } = this.getSelectedChartGroup();
+                const response = await selectRows({ schemaName, queryName, sort });
 
                 this.setState(state => ({
                     itemCounts: { ...state.itemCounts, [currentGroup]: itemCount },

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -118,7 +118,7 @@ export class BarChartViewer extends PureComponent<Props, State> {
             const chart = this.getSelectedChartGroupCharts()[this.state.currentChart];
 
             // apply the created date filter if the chart definition has one
-            let url = getAppURL(row);
+            let url = getAppURL(row, evt);
 
             if (chart.filter !== undefined) {
                 const dt = moment().add(chart.filter, 'days').format(getDateFormat().toUpperCase());

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -112,7 +112,7 @@ export class BarChartViewer extends PureComponent<Props, State> {
     };
 
     onBarClick = (evt: any, row: ChartData): void => {
-        const { getAppURL } = this.getSelectedChartGroup();
+        const { getAppURL, filterDataRegionName = 'query' } = this.getSelectedChartGroup();
 
         if (getAppURL) {
             const chart = this.getSelectedChartGroupCharts()[this.state.currentChart];
@@ -122,7 +122,7 @@ export class BarChartViewer extends PureComponent<Props, State> {
 
             if (chart.filter !== undefined) {
                 const dt = moment().add(chart.filter, 'days').format(getDateFormat().toUpperCase());
-                url = url.addParam('query.Created~dategte', dt);
+                url = url.addParam(filterDataRegionName + '.Created~dategte', dt);
             }
 
             this.props.navigate(url);

--- a/packages/components/src/internal/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/internal/components/chart/BaseBarChart.tsx
@@ -14,6 +14,7 @@ interface Props {
     defaultFillColor?: string;
     onClick?: (evt: any, row: any) => void;
     title: string;
+    grouped?: boolean;
 }
 
 export class BaseBarChart extends Component<Props> {
@@ -21,6 +22,7 @@ export class BaseBarChart extends Component<Props> {
         chartHeight: 350,
         defaultFillColor: '#236fa0',
         defaultBorderColor: '#236fa0',
+        grouped: false,
     };
 
     plotId: string;
@@ -55,7 +57,8 @@ export class BaseBarChart extends Component<Props> {
     };
 
     getPlotConfig = (): Record<string, any> => {
-        const { title, data, onClick, chartHeight, defaultFillColor, defaultBorderColor, barFillColors } = this.props;
+        const { title, data, onClick, chartHeight, defaultFillColor, defaultBorderColor, barFillColors, grouped } =
+            this.props;
 
         return getBarChartPlotConfig({
             renderTo: this.plotId,
@@ -67,6 +70,7 @@ export class BaseBarChart extends Component<Props> {
             onClick,
             data,
             barFillColors,
+            grouped,
         });
     };
 

--- a/packages/components/src/internal/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/internal/components/chart/BaseBarChart.tsx
@@ -64,7 +64,7 @@ export class BaseBarChart extends Component<Props> {
             renderTo: this.plotId,
             title,
             height: chartHeight,
-            width: this.getPlotElement().getBoundingClientRect().width + 50,
+            width: this.getPlotElement().getBoundingClientRect().width + (grouped ? 0 : 50),
             defaultFillColor,
             defaultBorderColor,
             onClick,

--- a/packages/components/src/internal/components/chart/configs.spec.ts
+++ b/packages/components/src/internal/components/chart/configs.spec.ts
@@ -6,9 +6,15 @@ describe('CHART_GROUPS', () => {
         let row = { x: 'x', xSub: 'xSub' } as ChartData;
         expect(CHART_GROUPS.Assays.getAppURL(row).toHref()).toBe('#/assays/general/x/overview');
         expect(CHART_GROUPS.Samples.getAppURL(row).toHref()).toBe('#/samples/x');
-        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'title' }}).toHref()).toBe('#/samples/xSub');
-        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'rect' }}).toHref()).toBe('#/samples/xSub?query.SampleState/Label~eq=x');
+        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'title' } }).toHref()).toBe(
+            '#/samples/xSub'
+        );
+        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'rect' } }).toHref()).toBe(
+            '#/samples/xSub?query.SampleState/Label~eq=x'
+        );
         row = { x: 'No Status', xSub: 'xSub' } as ChartData;
-        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'rect' }}).toHref()).toBe('#/samples/xSub?query.SampleState/Label~isblank=');
+        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'rect' } }).toHref()).toBe(
+            '#/samples/xSub?query.SampleState/Label~isblank='
+        );
     });
 });

--- a/packages/components/src/internal/components/chart/configs.spec.ts
+++ b/packages/components/src/internal/components/chart/configs.spec.ts
@@ -1,0 +1,14 @@
+import { CHART_GROUPS } from './configs';
+import { ChartData } from './types';
+
+describe('CHART_GROUPS', () => {
+    test('getAppURL', () => {
+        let row = { x: 'x', xSub: 'xSub' } as ChartData;
+        expect(CHART_GROUPS.Assays.getAppURL(row).toHref()).toBe('#/assays/general/x/overview');
+        expect(CHART_GROUPS.Samples.getAppURL(row).toHref()).toBe('#/samples/x');
+        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'title' }}).toHref()).toBe('#/samples/xSub');
+        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'rect' }}).toHref()).toBe('#/samples/xSub?query.SampleState/Label~eq=x');
+        row = { x: 'No Status', xSub: 'xSub' } as ChartData;
+        expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'rect' }}).toHref()).toBe('#/samples/xSub?query.SampleState/Label~isblank=');
+    });
+});

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -59,13 +59,16 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         groupPath: ['Status', 'value'],
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,
-        getAppURL: row => {
-            const url = AppURL.create(SAMPLES_KEY, row.subLabel);
-            if (row.label !== 'No Status') {
-                return url.addFilters(Filter.create('SampleState/Label', row.label));
-            } else {
-                return url.addFilters(Filter.create('SampleState/Label', null, Filter.Types.ISBLANK));
+        getAppURL: (row, evt) => {
+            let url = AppURL.create(SAMPLES_KEY, row.subLabel);
+            if (evt.target.tagName === 'rect') {
+                if (row.label !== 'No Status') {
+                    url = url.addFilters(Filter.create('SampleState/Label', row.label));
+                } else {
+                    url = url.addFilters(Filter.create('SampleState/Label', null, Filter.Types.ISBLANK));
+                }
             }
+            return url;
         },
         itemCountSQ: SCHEMAS.EXP_TABLES.SAMPLE_SETS,
         key: SAMPLES_KEY,

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -24,7 +24,7 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
             CHART_SELECTORS.Today,
         ],
         // TODO: Use redirect AppURL.create('assays', row.id, 'overview')
-        getAppURL: row => AppURL.create(ASSAYS_KEY, 'general', row.label, 'overview'),
+        getAppURL: row => AppURL.create(ASSAYS_KEY, 'general', row.x, 'overview'),
         itemCountSQ: SCHEMAS.ASSAY_TABLES.ASSAY_LIST,
         key: ASSAYS_KEY,
         label: 'Assay Run Count by Assay',
@@ -42,7 +42,7 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         colorPath: ['Color', 'value'],
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,
-        getAppURL: row => AppURL.create(SAMPLES_KEY, row.label),
+        getAppURL: row => AppURL.create(SAMPLES_KEY, row.x),
         itemCountSQ: SCHEMAS.EXP_TABLES.SAMPLE_SETS,
         key: SAMPLES_KEY,
         label: 'Sample Count by Sample Type',
@@ -60,10 +60,10 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,
         getAppURL: (row, evt) => {
-            let url = AppURL.create(SAMPLES_KEY, row.subLabel);
+            let url = AppURL.create(SAMPLES_KEY, row.xSub);
             if (evt.target.tagName === 'rect') {
-                if (row.label !== 'No Status') {
-                    url = url.addFilters(Filter.create('SampleState/Label', row.label));
+                if (row.x !== 'No Status') {
+                    url = url.addFilters(Filter.create('SampleState/Label', row.x));
                 } else {
                     url = url.addFilters(Filter.create('SampleState/Label', null, Filter.Types.ISBLANK));
                 }

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -50,6 +50,7 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
     SampleStatuses: {
         charts: [CHART_SELECTORS.All],
         colorPath: ['Color', 'value'],
+        groupPath: ['Status', 'value'],
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,
         // getAppURL: row => AppURL.create(SAMPLES_KEY),

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -60,10 +60,11 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,
         getAppURL: (row, evt) => {
-            let url = AppURL.create(SAMPLES_KEY, row.xSub);
+            let url = AppURL.create(SAMPLES_KEY, row.xSub || row['subLabel']);
             if (evt.target.tagName === 'rect') {
-                if (row.x !== 'No Status') {
-                    url = url.addFilters(Filter.create('SampleState/Label', row.x));
+                const val = row.x || row['label'];
+                if (val !== 'No Status') {
+                    url = url.addFilters(Filter.create('SampleState/Label', val));
                 } else {
                     url = url.addFilters(Filter.create('SampleState/Label', null, Filter.Types.ISBLANK));
                 }
@@ -75,6 +76,6 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         label: 'Sample Count by Status',
         queryName: 'SampleStatusCounts',
         schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
-        sort: '-Status,Name',
+        sort: '-Status',
     },
 };

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -1,3 +1,5 @@
+import { Filter } from '@labkey/api';
+
 import { AppURL, App, SCHEMAS } from '../../..';
 
 import { ASSAYS_KEY, SAMPLES_KEY } from '../../app/constants';
@@ -48,13 +50,23 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
     },
     SampleStatuses: {
-        charts: [CHART_SELECTORS.All],
+        charts: [
+            { name: 'TotalCount', label: 'All' },
+            { name: 'WithStatusCount', label: 'Only Samples with a Status' },
+        ],
         colorPath: ['Color', 'value'],
         groupPath: ['Status', 'value'],
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,
-        // getAppURL: row => AppURL.create(SAMPLES_KEY),
-        itemCountSQ: SCHEMAS.CORE_TABLES.DATA_STATES,
+        getAppURL: row => {
+            const url = AppURL.create(SAMPLES_KEY, row.subLabel);
+            if (row.label !== 'No Status') {
+                return url.addFilters(Filter.create('SampleState/Label', row.label));
+            } else {
+                return url.addFilters(Filter.create('SampleState/Label', null, Filter.Types.ISBLANK));
+            }
+        },
+        itemCountSQ: SCHEMAS.EXP_TABLES.SAMPLE_SETS,
         key: SAMPLES_KEY,
         label: 'Sample Count by Status',
         queryName: 'SampleStatusCounts',

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -51,8 +51,9 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
     },
     SampleStatuses: {
         charts: [
-            { name: 'TotalCount', label: 'All' },
-            { name: 'WithStatusCount', label: 'Only Samples with a Status' },
+            { name: 'TotalCount', label: 'All Statuses' },
+            { name: 'WithStatusCount', label: 'With a Status' },
+            { name: 'NoStatusCount', label: 'No Status' },
         ],
         colorPath: ['Color', 'value'],
         groupPath: ['Status', 'value'],

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -76,6 +76,5 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         label: 'Sample Count by Status',
         queryName: 'SampleStatusCounts',
         schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
-        sort: '-Status',
     },
 };

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -24,7 +24,8 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
             CHART_SELECTORS.Today,
         ],
         // TODO: Use redirect AppURL.create('assays', row.id, 'overview')
-        getAppURL: row => AppURL.create(ASSAYS_KEY, 'general', row.x, 'overview'),
+        getAppURL: row => AppURL.create(ASSAYS_KEY, 'general', row.x || row['label'], 'overview'),
+        filterDataRegionName: 'Runs',
         itemCountSQ: SCHEMAS.ASSAY_TABLES.ASSAY_LIST,
         key: ASSAYS_KEY,
         label: 'Assay Run Count by Assay',
@@ -42,7 +43,7 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         colorPath: ['Color', 'value'],
         createText: 'Create Samples',
         createURL: () => App.NEW_SAMPLES_HREF,
-        getAppURL: row => AppURL.create(SAMPLES_KEY, row.x),
+        getAppURL: row => AppURL.create(SAMPLES_KEY, row.x || row['label']),
         itemCountSQ: SCHEMAS.EXP_TABLES.SAMPLE_SETS,
         key: SAMPLES_KEY,
         label: 'Sample Count by Sample Type',

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -75,5 +75,6 @@ export const CHART_GROUPS: Record<string, ChartConfig> = {
         label: 'Sample Count by Status',
         queryName: 'SampleStatusCounts',
         schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
+        sort: '-Status,Name',
     },
 };

--- a/packages/components/src/internal/components/chart/types.ts
+++ b/packages/components/src/internal/components/chart/types.ts
@@ -18,6 +18,7 @@ export interface ChartSelector {
 export interface ChartConfig {
     charts: ChartSelector[];
     colorPath?: string[];
+    groupPath?: string[];
     createText?: string;
     createURL?: () => AppURL;
     emptyStateMsg?: ReactNode;

--- a/packages/components/src/internal/components/chart/types.ts
+++ b/packages/components/src/internal/components/chart/types.ts
@@ -23,6 +23,7 @@ export interface ChartConfig {
     createText?: string;
     createURL?: () => AppURL;
     emptyStateMsg?: ReactNode;
+    filterDataRegionName?: string;
     getAppURL?: (data: ChartData, evt?: any) => AppURL;
     itemCountFilters?: Filter.IFilter[];
     itemCountSQ: SchemaQuery;

--- a/packages/components/src/internal/components/chart/types.ts
+++ b/packages/components/src/internal/components/chart/types.ts
@@ -23,7 +23,7 @@ export interface ChartConfig {
     createText?: string;
     createURL?: () => AppURL;
     emptyStateMsg?: ReactNode;
-    getAppURL?: (data: ChartData) => AppURL;
+    getAppURL?: (data: ChartData, evt?: any) => AppURL;
     itemCountFilters?: Filter.IFilter[];
     itemCountSQ: SchemaQuery;
     key: string;

--- a/packages/components/src/internal/components/chart/types.ts
+++ b/packages/components/src/internal/components/chart/types.ts
@@ -31,4 +31,5 @@ export interface ChartConfig {
     namePath?: string[];
     queryName: string;
     schemaName: string;
+    sort?: string;
 }

--- a/packages/components/src/internal/components/chart/types.ts
+++ b/packages/components/src/internal/components/chart/types.ts
@@ -6,6 +6,7 @@ import { AppURL, SchemaQuery } from '../../..';
 export interface ChartData {
     count: number;
     label: string;
+    subLabel?: string;
     id?: string | number;
 }
 

--- a/packages/components/src/internal/components/chart/types.ts
+++ b/packages/components/src/internal/components/chart/types.ts
@@ -5,8 +5,8 @@ import { AppURL, SchemaQuery } from '../../..';
 
 export interface ChartData {
     count: number;
-    label: string;
-    subLabel?: string;
+    x: string;
+    xSub?: string;
     id?: string | number;
 }
 

--- a/packages/components/src/internal/components/chart/utils.spec.ts
+++ b/packages/components/src/internal/components/chart/utils.spec.ts
@@ -3,6 +3,10 @@ import AssayRunCountsRowsJson from '../../../test/data/AssayRunCounts-getQueryRo
 
 import { getBarChartPlotConfig } from './utils';
 
+beforeEach(() => {
+    LABKEY.vis = {};
+});
+
 describe('processChartData', () => {
     const response = {
         key: '0',
@@ -12,9 +16,9 @@ describe('processChartData', () => {
     test('with data', () => {
         const { data } = processChartData(response, { countPath: ['TotalCount', 'value'] });
         expect(data.length).toBe(4);
-        expect(data[0].label).toBe('GPAT 1');
+        expect(data[0].x).toBe('GPAT 1');
         expect(data[0].count).toBe(6);
-        expect(data[3].label).toBe('GPAT 25 with a longer name then the rest');
+        expect(data[3].x).toBe('GPAT 25 with a longer name then the rest');
         expect(data[3].count).toBe(1);
     });
 
@@ -29,7 +33,7 @@ describe('processChartData', () => {
             namePath: ['RowId', 'value'],
         });
         expect(data.length).toBe(4);
-        expect(data[0].label).toBe(5051);
+        expect(data[0].x).toBe(5051);
     });
 
     test('barFillColors without colorPath', () => {

--- a/packages/components/src/internal/components/chart/utils.spec.ts
+++ b/packages/components/src/internal/components/chart/utils.spec.ts
@@ -111,7 +111,7 @@ describe('getBarChartPlotConfig', () => {
         });
 
         expect(JSON.stringify(Object.keys(config.aes))).toBe('["x","y","color","xSub"]');
-        expect(JSON.stringify(Object.keys(config.scales))).toBe('["y","color","xSub"]');
+        expect(JSON.stringify(Object.keys(config.scales))).toBe('["y","color","x","xSub"]');
         expect(config.height).toBe(100);
         expect(config.width).toBe(100);
         expect(config.margins.top).toBe(50);

--- a/packages/components/src/internal/components/chart/utils.spec.ts
+++ b/packages/components/src/internal/components/chart/utils.spec.ts
@@ -10,11 +10,11 @@ beforeEach(() => {
 describe('processChartData', () => {
     const response = {
         key: '0',
-        models: {0: AssayRunCountsRowsJson},
+        models: { 0: AssayRunCountsRowsJson },
     } as ISelectRowsResult;
 
     test('with data', () => {
-        const {data} = processChartData(response, {countPath: ['TotalCount', 'value']});
+        const { data } = processChartData(response, { countPath: ['TotalCount', 'value'] });
         expect(data.length).toBe(4);
         expect(data[0].x).toBe('GPAT 1');
         expect(data[0].xSub).toBeUndefined();
@@ -25,12 +25,12 @@ describe('processChartData', () => {
     });
 
     test('without data', () => {
-        const {data} = processChartData(response, {countPath: ['TodayCount', 'value']});
+        const { data } = processChartData(response, { countPath: ['TodayCount', 'value'] });
         expect(data.length).toBe(0);
     });
 
     test('with alternate label field', () => {
-        const {data} = processChartData(response, {
+        const { data } = processChartData(response, {
             countPath: ['TotalCount', 'value'],
             namePath: ['RowId', 'value'],
         });
@@ -39,12 +39,12 @@ describe('processChartData', () => {
     });
 
     test('barFillColors without colorPath', () => {
-        const {barFillColors} = processChartData(response, {countPath: ['TodayCount', 'value']});
+        const { barFillColors } = processChartData(response, { countPath: ['TodayCount', 'value'] });
         expect(barFillColors).toBe(undefined);
     });
 
     test('barFillColors with colorPath', () => {
-        const {barFillColors} = processChartData(response, {
+        const { barFillColors } = processChartData(response, {
             colorPath: ['Color', 'value'],
             countPath: ['TotalCount', 'value'],
             namePath: ['Name', 'value'],

--- a/packages/components/src/internal/components/chart/utils.ts
+++ b/packages/components/src/internal/components/chart/utils.ts
@@ -122,7 +122,7 @@ export function getBarChartPlotConfig(props: BarChartPlotConfigProps): Record<st
 
         marginRight = Math.max(...Object.keys(barFillColors).map(text => text.length)) > 10 ? undefined : 125;
         legendPos = 'right';
-        legendData = Object.keys(barFillColors).map(text => {
+        legendData = Object.keys(barFillColors).sort().map(text => {
             return { text, color: barFillColors[text] };
         });
     }

--- a/packages/components/src/internal/components/chart/utils.ts
+++ b/packages/components/src/internal/components/chart/utils.ts
@@ -115,6 +115,13 @@ export function getBarChartPlotConfig(props: BarChartPlotConfigProps): Record<st
         aes['xSub'] = 'x';
         aes['color'] = 'x';
 
+        scales['x'] = {
+            scaleType: 'discrete',
+            sortFn: function (a, b) {
+                // reverse the sorting so that the stacked bar chart segments match the legend
+                return vis.discreteSortFn(b, a);
+            },
+        };
         scales['xSub'] = {
             scaleType: 'discrete',
             sortFn: vis.discreteSortFn,

--- a/packages/components/src/internal/components/chart/utils.ts
+++ b/packages/components/src/internal/components/chart/utils.ts
@@ -64,17 +64,8 @@ interface BarChartPlotConfigProps {
 
 export function getBarChartPlotConfig(props: BarChartPlotConfigProps): Record<string, any> {
     const vis = getServerContext().vis;
-    const {
-        renderTo,
-        data,
-        onClick,
-        height,
-        width,
-        defaultFillColor,
-        defaultBorderColor,
-        barFillColors,
-        grouped,
-    } = props;
+    const { renderTo, data, onClick, height, width, defaultFillColor, defaultBorderColor, barFillColors, grouped } =
+        props;
 
     let marginRight,
         legendPos = 'none',
@@ -129,9 +120,11 @@ export function getBarChartPlotConfig(props: BarChartPlotConfigProps): Record<st
 
         marginRight = Math.max(...Object.keys(barFillColors).map(text => text.length)) > 10 ? undefined : 125;
         legendPos = 'right';
-        legendData = Object.keys(barFillColors).sort().map(text => {
-            return { text, color: barFillColors[text] };
-        });
+        legendData = Object.keys(barFillColors)
+            .sort()
+            .map(text => {
+                return { text, color: barFillColors[text] };
+            });
     }
 
     return {
@@ -153,10 +146,15 @@ export function getBarChartPlotConfig(props: BarChartPlotConfigProps): Record<st
             stacked: grouped,
             clickFn: onClick,
             hoverFn: function (row) {
-                return (grouped ? row.subLabel + '\n' : '')
-                    + row.label + '\n'
-                    + 'Count: ' + row.value + '\n'
-                    + 'Click to view details';
+                return (
+                    (grouped ? row.subLabel + '\n' : '') +
+                    row.label +
+                    '\n' +
+                    'Count: ' +
+                    row.value +
+                    '\n' +
+                    'Click to view details'
+                );
             },
         },
         legendPos,

--- a/packages/components/src/internal/components/chart/utils.ts
+++ b/packages/components/src/internal/components/chart/utils.ts
@@ -109,6 +109,8 @@ export function getBarChartPlotConfig(props: BarChartPlotConfigProps): Record<st
     }
 
     if (grouped) {
+        // in the stacked bar chart case, we actually will end up using the xSub variable for the x-axis categories
+        // and the x variable for the secondary category and legend (i.e. the bar chart stacked segments)
         aes['x'] = 'xSub';
         aes['xSub'] = 'x';
         aes['color'] = 'x';

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -369,7 +369,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                 {!states && <LoadingSpinner />}
                 {states && !error && (
                     <div className="row choices-container">
-                        <div className="col-lg-4 col-md-6">
+                        <div className="col-lg-4 col-md-6 choices-container-left-panel">
                             <SampleStatusesList states={states} selected={selected} onSelect={onSetSelected} />
                             <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />
                         </div>

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
@@ -120,7 +120,7 @@ describe('SamplesBulkUpdateForm', () => {
         expect(queryInfo.columns.size).toBe(3);
         expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
         expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
-        expect(queryInfo.columns.get('meta')).toBe(COLUMN_META);
+        expect(queryInfo.columns.get('aliquotspecific')).toBe(COLUMN_ALIQUOT);
 
         wrapper.unmount();
     });
@@ -135,7 +135,7 @@ describe('SamplesBulkUpdateForm', () => {
         expect(queryInfo.columns.size).toBe(3);
         expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
         expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
-        expect(queryInfo.columns.get('meta')).toBe(COLUMN_META);
+        expect(queryInfo.columns.get('aliquotspecific')).toBe(COLUMN_ALIQUOT);
 
         wrapper.unmount();
     });
@@ -143,10 +143,9 @@ describe('SamplesBulkUpdateForm', () => {
 
 describe('SamplesBulkUpdateAlert', () => {
     const SINGLE_ALIQUOT_WARN =
-        '1 aliquot was among the selections. Aliquot data is inherited from the original sample and cannot be updated here. ';
+        'Since 1 aliquot was among the selected samples, only the aliquot-editable fields are shown below. ';
     const MULTI_ALIQUOTS_WARN =
-        '2 aliquots were among the selections. Aliquot data is inherited from the original sample and cannot be updated here. ';
-    const ALL_ALIQUOTS_WARN = 'Aliquot data inherited from the original sample cannot be updated here. ';
+        'Since 2 aliquots were among the selected samples, only the aliquot-editable fields are shown below. ';
     const ONE_LOCKED_WARN =
         'The current status of 1 selected sample prevents updating of its data. Either change the status here or remove these samples from your selection.';
     const TWO_LOCKED_WARN =
@@ -173,7 +172,7 @@ describe('SamplesBulkUpdateAlert', () => {
             <SamplesBulkUpdateAlert aliquots={[1, 2]} numSelections={2} editStatusData={undefined} />
         );
         expect(wrapper.find(Alert).exists()).toBeTruthy();
-        expect(wrapper.text()).toBe(ALL_ALIQUOTS_WARN);
+        expect(wrapper.text()).toBe(MULTI_ALIQUOTS_WARN);
         wrapper.unmount();
     });
 
@@ -201,7 +200,7 @@ describe('SamplesBulkUpdateAlert', () => {
             />
         );
         expect(wrapper.find(Alert).exists()).toBeTruthy();
-        expect(wrapper.text()).toBe(ALL_ALIQUOTS_WARN + ONE_LOCKED_WARN);
+        expect(wrapper.text()).toBe(MULTI_ALIQUOTS_WARN + ONE_LOCKED_WARN);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
@@ -38,20 +38,16 @@ interface UpdateAlertProps {
 
 // exported for jest testing
 export const SamplesBulkUpdateAlert: FC<UpdateAlertProps> = memo(props => {
-    const { numSelections, aliquots, editStatusData } = props;
+    const { aliquots, editStatusData } = props;
 
     let aliquotsMsg;
-    if (aliquots && aliquots.length > 0) {
-        if (aliquots.length < numSelections) {
-            aliquotsMsg = (
-                <>
-                    {aliquots.length} aliquot{aliquots.length > 1 ? 's were' : ' was'} among the selections. Aliquot
-                    data is inherited from the original sample and cannot be updated here.{' '}
-                </>
-            );
-        } else {
-            aliquotsMsg = <>Aliquot data inherited from the original sample cannot be updated here. </>;
-        }
+    if (aliquots?.length > 0) {
+        aliquotsMsg = (
+            <>
+                Since {aliquots.length} aliquot{aliquots.length > 1 ? 's were' : ' was'} among the selected samples,
+                only the aliquot-editable fields are shown below.{' '}
+            </>
+        );
     }
 
     if (!aliquotsMsg && (!editStatusData || editStatusData.allAllowed)) return null;
@@ -82,8 +78,8 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props> {
 
         let columns = OrderedMap<string, QueryColumn>();
 
-        // if all are aliquots, only show pk, aliquot specific and description/samplestate columns
-        if (aliquots && aliquots.length === this.getGridSelectionSize()) {
+        // if the selection includes any aliquots, only show pk, aliquot specific and description/samplestate columns
+        if (aliquots?.length > 0) {
             originalQueryInfo.columns.forEach((column, key) => {
                 const isAliquotField = sampleTypeDomainFields.aliquotFields.indexOf(column.fieldKey.toLowerCase()) > -1;
                 if (

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -2,6 +2,13 @@
     margin-top: 16px;
 }
 
+@media (min-width: 992px) {
+    .choices-container-left-panel {
+        border-right: 1px solid $gray-lighter;
+        min-height: 220px;
+    }
+}
+
 .choice-details-section {
     margin-top: 16px;
 }


### PR DESCRIPTION
#### Rationale
LKSM and LKB app dashboards are adding a stacked bar chart for viewing the sample counts of sample types by status. This PR updates the shared bar chart viewer components accordingly and the shared chart configs that the app dashboard pages use. It also includes a few other minor sample status polish changes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2806
* https://github.com/LabKey/biologics/pull/1071
* https://github.com/LabKey/inventory/pull/335
* https://github.com/LabKey/sampleManagement/pull/762
* https://github.com/LabKey/labkey-ui-components/pull/680

#### Changes
* BarChartViewer and BaseBarChart update to support groupPath for bar chart config
* update bar chart confits for sample status to add chart options and clickFn AppURL generator
* getBarChartPlotConfig updates for stacked case to adjust margins, legend, sortFN, etc.
* other misc changes: add vertical separator for manage sample statuses, update assay import sample status message to use warning instead of info alert display, SamplesBulkUpdateForm update to only show aliquot-editable fields when any selected samples are aliquots
