### PR TITLE
OntologyConceptPicker fix to wait for subtreePath model to load before showing find link

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.99.0",
+  "version": "2.99.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.98.0",
+  "version": "2.98.0-fb-ontologyFetchPathModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD November 2021
+* OntologyConceptPicker fix to wait for subtreePath model to load before showing find link
+
 ### version 2.98.0
 *Released*: 24 November 2021
 * Add ExtendableAppContext

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD November 2021
+### version 2.99.1
+*Released*: 26 November 2021
 * OntologyConceptPicker fix to wait for subtreePath model to load before showing find link
 
 ### version 2.99.0

--- a/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
@@ -18,6 +18,7 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
     const { ontologyId, conceptSubtree, fieldLabel, onConceptSelection, fieldValue = '' } = props;
     const [concept, setConcept] = useState<ConceptModel>();
     const [subtreePath, setSubtreePath] = useState<PathModel>();
+    const [isLoadingSubtreePath, setIsLoadingSubtreePath] = useState<boolean>(conceptSubtree !== undefined);
     const [showPicker, setShowPicker] = useState<boolean>(false);
 
     useEffect(() => {
@@ -36,10 +37,12 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
     useEffect(() => {
         if (conceptSubtree) {
             fetchPathModel(conceptSubtree)
-                .then(setSubtreePath)
+                .then(pathModel => {
+                    setSubtreePath(pathModel);
+                    setIsLoadingSubtreePath(false);
+                })
                 .catch(() => {
-                    // using null to signal that loading is complete
-                    setSubtreePath(null);
+                    setIsLoadingSubtreePath(false);
                 });
         }
     }, [conceptSubtree]);
@@ -60,8 +63,7 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
     const label = concept?.label ?? null;
     const title = `Find ${fieldLabel} By Tree`;
 
-    // if we have a conceptSubtree prop, wait to show the find link until we finish loading the subtreePath model
-    if (conceptSubtree && subtreePath === undefined) {
+    if (isLoadingSubtreePath) {
         return null;
     }
 

--- a/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
@@ -35,7 +35,12 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
 
     useEffect(() => {
         if (conceptSubtree) {
-            fetchPathModel(conceptSubtree).then(setSubtreePath);
+            fetchPathModel(conceptSubtree)
+                .then(setSubtreePath)
+                .catch(() => {
+                    // using null to signal that loading is complete
+                    setSubtreePath(null);
+                });
         }
     }, [conceptSubtree]);
 
@@ -54,6 +59,11 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
 
     const label = concept?.label ?? null;
     const title = `Find ${fieldLabel} By Tree`;
+
+    // if we have a conceptSubtree prop, wait to show the find link until we finish loading the subtreePath model
+    if (conceptSubtree && subtreePath === undefined) {
+        return null;
+    }
 
     return (
         <>

--- a/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
@@ -18,7 +18,7 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
     const { ontologyId, conceptSubtree, fieldLabel, onConceptSelection, fieldValue = '' } = props;
     const [concept, setConcept] = useState<ConceptModel>();
     const [subtreePath, setSubtreePath] = useState<PathModel>();
-    const [isLoadingSubtreePath, setIsLoadingSubtreePath] = useState<boolean>(conceptSubtree !== undefined);
+    const [isLoadingSubtreePath, setIsLoadingSubtreePath] = useState<boolean>(!!conceptSubtree);
     const [showPicker, setShowPicker] = useState<boolean>(false);
 
     useEffect(() => {


### PR DESCRIPTION
#### Rationale
To fix the OntologyFieldAnnotationTest.testConceptSubtree test failure. This PR updates the OntologyConceptPicker component so that it doesn't show (and allow clicking on) the "find ..." link until the subtree path model is finished loading.

#### Related Pull Requests
* https://github.com/LabKey/ontology/pull/66

#### Changes
* OntologyConceptPicker fix to wait for subtreePath model to load before showing find link
