### PR TITLE
Rename EditableGridPanel to EditableGridPanelDeprecated

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.102.0-fb-editable-grid-panel-deprecated.0",
+  "version": "2.102.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.101.0",
+  "version": "2.102.0-fb-editable-grid-panel-deprecated.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.102.0
+*Released*: ? December 2021
+* Rename EditableGridPanel to EditableGridPanelDeprecated
+  * There will be a new version in a future release, and the deprecated version will eventually be removed
+
 ### version 2.101.0
 *Released*: 30 November 2021
 * Add `getContainerFilter()` for resolving default container filter based on folder context.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.102.0
-*Released*: ? December 2021
+*Released*: 1 December 2021
 * Rename EditableGridPanel to EditableGridPanelDeprecated
   * There will be a new version in a future release, and the deprecated version will eventually be removed
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -205,7 +205,7 @@ import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/u
 import { getHelpLink, HELP_LINK_REFERRER, HelpLink, SAMPLE_ALIQUOT_TOPIC } from './internal/util/helpLinks';
 import { AssayResolver, AssayRunResolver, ListResolver, SamplesResolver } from './internal/url/AppURLResolver';
 import { QueryGridPanel } from './internal/components/QueryGridPanel';
-import { EditableGridPanel } from './internal/components/editable/EditableGridPanel';
+import { EditableGridPanelDeprecated } from './internal/components/editable/EditableGridPanelDeprecated';
 import { EditableGridPanelForUpdate } from './internal/components/editable/EditableGridPanelForUpdate';
 import { EditableGridLoader } from './internal/components/editable/EditableGridLoader';
 import { EditableGridLoaderFromSelection } from './internal/components/editable/EditableGridLoaderFromSelection';
@@ -776,7 +776,7 @@ export {
     MAX_EDITABLE_GRID_ROWS,
     EditableGridLoaderFromSelection,
     EditableGridLoader,
-    EditableGridPanel,
+    EditableGridPanelDeprecated,
     EditableGridPanelForUpdate,
     EditableGridModal,
     EditorModel,

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -21,7 +21,7 @@ import { Map } from 'immutable';
 import { Button } from 'react-bootstrap';
 
 import {
-    EditableGridPanel,
+    EditableGridPanelDeprecated,
     handleTabKeyOnTextArea,
     FormStep,
     FormTabs,
@@ -306,7 +306,7 @@ export class RunDataPanel extends React.Component<Props, State> {
                                         </Formsy>
                                     </FormStep>
                                     <FormStep stepIndex={AssayUploadTabs.Grid} trackActive={false}>
-                                        <EditableGridPanel
+                                        <EditableGridPanelDeprecated
                                             model={queryGridModelForEditor}
                                             isSubmitting={wizardModel.isSubmitting}
                                             disabled={currentStep !== AssayUploadTabs.Grid}

--- a/packages/components/src/internal/components/editable/EditableGridModal.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridModal.tsx
@@ -6,7 +6,7 @@ import { getQueryGridModel } from '../../global';
 
 import { QueryGridModel, WizardNavButtons } from '../../..';
 
-import { EditableGridPanel } from './EditableGridPanel';
+import { EditableGridPanelDeprecated } from './EditableGridPanelDeprecated';
 import { EditableGridProps } from './EditableGrid';
 
 import { AddRowsControlProps } from './Controls';
@@ -71,7 +71,7 @@ export class EditableGridModal extends React.PureComponent<Props, any> {
                 </Modal.Header>
 
                 <Modal.Body>
-                    <EditableGridPanel
+                    <EditableGridPanelDeprecated
                         addControlProps={this.props.addControlProps}
                         columnMetadata={this.props.columnMetadata}
                         notDeletable={this.props.notDeletable}

--- a/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
@@ -53,7 +53,7 @@ interface State {
     activeTab: number;
 }
 
-export class EditableGridPanel extends ReactN.Component<Props, State, GlobalAppState> {
+export class EditableGridPanelDeprecated extends ReactN.Component<Props, State, GlobalAppState> {
     constructor(props: Props) {
         // @ts-ignore // see https://github.com/CharlesStover/reactn/issues/126
         super(props);

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
@@ -8,7 +8,7 @@ import { capitalizeFirstChar, getUpdatedDataFromGrid } from '../../util/utils';
 
 import { getUniqueIdColumnMetadata } from '../entities/utils';
 
-import { EditableGridPanel } from './EditableGridPanel';
+import { EditableGridPanelDeprecated } from './EditableGridPanelDeprecated';
 
 interface Props {
     model: QueryGridModel | List<QueryGridModel>;
@@ -149,7 +149,7 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
 
         return (
             <>
-                <EditableGridPanel
+                <EditableGridPanelDeprecated
                     title={`Edit selected ${pluralNoun}`}
                     bsStyle="info"
                     models={model}

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -28,7 +28,7 @@ import {
     capitalizeFirstChar,
     DomainDetails,
     EditableColumnMetadata,
-    EditableGridPanel,
+    EditableGridPanelDeprecated,
     FileAttachmentForm,
     FileSizeLimitProps,
     FormStep,
@@ -895,7 +895,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                                 type={this.capTypeTextSingular}
                                 queryInfo={queryGridModel?.queryInfo}
                             />
-                            <EditableGridPanel
+                            <EditableGridPanelDeprecated
                                 addControlProps={{
                                     nounSingular: gridNounSingularCap,
                                     nounPlural: gridNounPluralCap,


### PR DESCRIPTION
#### Rationale
I am starting work on the EditableGrid refactor to support QueryModel and QueryGridModel, a future release will add a new EditableGridPanel which will be compatible with QueryModel.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2826
* https://github.com/LabKey/inventory/pull/337

#### Changes
* Rename EditableGridPanel to EditableGridPanelDeprecated
