### PR TITLE
Issue 44397: Add new date util function, getJsonDateTimeFormatString(), to be used by DatePickerInput and EditableGrid insert/update case

### DIFF
--- a/packages/components/docs/localDev.md
+++ b/packages/components/docs/localDev.md
@@ -234,7 +234,7 @@ LabKey server. There are a few extra steps in this process, described below:
 1. Create the pull request from your new hotfix feature branch and set the target of the pull request to the release branch.
 1. After all code review and triage is complete and you are ready to merge, do the regular merge steps for
  `labkey-ui-components` (see the steps in the section above). Note that the new release version you will use for your changes
- will be the next patch version off of the target package version for that release. For example if the veresion was at
+ will be the next patch version off of the target package version for that release. For example, if the version was at
   `0.31.3` then you will publish version `0.31.4`.
 1. After any related LabKey module changes have been merged from their repo's release branch to develop,
  create a new branch in `labkey-ui-components` off of develop in order to merge forward your hotfix changes:

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.101.0-fb-dateTimezone44398.2",
+  "version": "2.101.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.101.0-fb-dateTimezone44398.1",
+  "version": "2.101.0-fb-dateTimezone44398.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.101.0-fb-dateTimezone44398.0",
+  "version": "2.101.0-fb-dateTimezone44398.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.101.0",
+  "version": "2.101.0-fb-dateTimezone44398.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.101.TBD
-*Released*: TBD
+### version 2.101.1
+*Released*: 7 December 2021
 * Issue 44397: Add new date util function, getJsonDateTimeFormatString(), to be used by DatePickerInput and EditableGrid insert/update case
 
 ### version 2.101.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.101.TBD
+*Released*: TBD
+* Issue 44397: Add new date util function, getJsonDateTimeFormatString(), to be used by DatePickerInput and EditableGrid insert/update case
+
 ### version 2.101.0
 *Released*: 30 November 2021
 * Add `getContainerFilter()` for resolving default container filter based on folder context.

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -25,6 +25,7 @@ import {
     datePlaceholder,
     getDateFormat,
     getDateTimeFormat,
+    getJsonDateTimeFormatString,
     getTimeFormat,
     isDateTimeCol,
     parseDate,
@@ -109,16 +110,18 @@ class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, DatePic
         return props.value ? parseDate(props.value) : undefined;
     }
 
-    onChange = (date): void => {
+    onChange = (date: Date): void => {
         this.setState(() => {
             return {
                 selectedDate: date,
             };
         });
 
-        if (this.props.onChange && Utils.isFunction(this.props.onChange)) this.props.onChange(date);
+        // Issue 44398: match JSON dateTime format provided by LK server when submitting date values back for insert/update
+        const _date = getJsonDateTimeFormatString(date);
 
-        if (this.props.formsy && Utils.isFunction(this.props.setValue)) this.props.setValue(date);
+        if (this.props.onChange && Utils.isFunction(this.props.onChange)) this.props.onChange(_date);
+        if (this.props.formsy && Utils.isFunction(this.props.setValue)) this.props.setValue(_date);
     };
 
     getDateFormat(): string {

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -33,7 +33,7 @@ import { getQueryColumnRenderers, getQueryMetadata } from './global';
 import { DefaultGridLoader } from './components/GridLoader';
 import { GRID_EDIT_INDEX } from './constants';
 import { IQueryGridModel } from './QueryGridModel';
-import { getDateTimeFormat, parseDate } from './util/Date';
+import { getDateTimeFormat, getJsonDateTimeFormatString, parseDate } from './util/Date';
 
 export function getStateModelId(gridId: string, schemaQuery: SchemaQuery, keyValue?: any): string {
     const parts = [gridId, resolveSchemaQuery(schemaQuery)];
@@ -454,7 +454,9 @@ export class EditorModel
                             dateVal = parseDate(values.first().raw, getDateTimeFormat());
                         }
                     }
-                    row = row.set(col.name, dateVal);
+
+                    // Issue 44398: match JSON dateTime format provided by LK server when submitting date values back for insert/update
+                    row = row.set(col.name, getJsonDateTimeFormatString(dateVal));
                 } else {
                     row = row.set(col.name, values.size === 1 ? values.first().raw?.toString().trim() : undefined);
                 }

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -15,7 +15,7 @@
  */
 import { initUnitTests } from '../testHelpers';
 
-import { formatDate, formatDateTime, generateNameWithTimestamp } from './Date';
+import { formatDate, formatDateTime, generateNameWithTimestamp, getJsonDateTimeFormatString } from './Date';
 
 beforeAll(() => {
     initUnitTests();
@@ -72,5 +72,17 @@ describe('formatDateTime', () => {
     test('supports custom format', () => {
         expect(formatDateTime(datePOSIX, 'America/New_York', 'DDYYYYMM')).toBe('06202008');
         expect(formatDateTime(testDate, 'America/New_York', 'DDYYYYMM')).toBe('06202008');
+    });
+});
+
+describe('getJsonDateTimeFormatString', () => {
+    test('without date', () => {
+        expect(getJsonDateTimeFormatString(undefined)).toBe(null);
+        expect(getJsonDateTimeFormatString(null)).toBe(null);
+    });
+
+    test('with date', () => {
+        expect(getJsonDateTimeFormatString(new Date('2021-12-03 00:00'))).toBe('2021-12-03 00:00:00');
+        expect(getJsonDateTimeFormatString(new Date('2021-12-03 23:59'))).toBe('2021-12-03 23:59:00');
     });
 });

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -77,8 +77,8 @@ describe('formatDateTime', () => {
 
 describe('getJsonDateTimeFormatString', () => {
     test('without date', () => {
-        expect(getJsonDateTimeFormatString(undefined)).toBe(null);
-        expect(getJsonDateTimeFormatString(null)).toBe(null);
+        expect(getJsonDateTimeFormatString(undefined)).toBe(undefined);
+        expect(getJsonDateTimeFormatString(null)).toBe(undefined);
     });
 
     test('with date', () => {

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -100,7 +100,6 @@ export function getUnFormattedNumber(n): number {
 // Issue 44398: see DateUtil.java getJsonDateTimeFormatString(), this function is to match the format, which is
 // provided by the LabKey server for the API response, from a JS Date object
 export function getJsonDateTimeFormatString(date: Date): string {
-    if (!date) return null;
     return _formatDate(date, 'YYYY-MM-dd HH:mm:ss');
 }
 

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -97,6 +97,16 @@ export function getUnFormattedNumber(n): number {
     return n ? numeral(n).value() : n;
 }
 
+// Issue 44398: see DateUtil.java getJsonDateTimeFormatString(), this function is to match the format, which is
+// provided by the LabKey server for the API response, from a JS Date object
+export function getJsonDateTimeFormatString(date: Date): string {
+    if (!date) return null;
+
+    const dateStr = date.toISOString().split('T')[0];
+    const timeStr = date.toTimeString().split(' ')[0];
+    return dateStr + ' ' + timeStr;
+}
+
 export function generateNameWithTimestamp(name: string): string {
     const date = new Date();
     const dateStr = date.toISOString().split('T')[0];

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -101,10 +101,7 @@ export function getUnFormattedNumber(n): number {
 // provided by the LabKey server for the API response, from a JS Date object
 export function getJsonDateTimeFormatString(date: Date): string {
     if (!date) return null;
-
-    const dateStr = date.toISOString().split('T')[0];
-    const timeStr = date.toTimeString().split(' ')[0];
-    return dateStr + ' ' + timeStr;
+    return _formatDate(date, 'YYYY-MM-dd HH:mm:ss');
 }
 
 export function generateNameWithTimestamp(name: string): string {

--- a/packages/components/src/internal/util/utils.spec.ts
+++ b/packages/components/src/internal/util/utils.spec.ts
@@ -921,7 +921,7 @@ describe('getUpdatedDataFromGrid', () => {
             Int: null,
             Bool: null,
             Data: null,
-            Date: new Date('2021-12-23 14:34'),
+            Date: '2021-12-23 14:34:00',
             RowId: '448',
         });
         expect(updatedData[1]).toStrictEqual({

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -22,7 +22,7 @@ import { QueryInfo } from '../../public/QueryInfo';
 
 import { encodePart } from '../../public/SchemaQuery';
 
-import { parseDate } from './Date';
+import { getJsonDateTimeFormatString, parseDate } from './Date';
 
 const emptyList = List<string>();
 
@@ -377,14 +377,16 @@ export function getUpdatedDataFromGrid(
                 // Lookup columns store a list but grid only holds a single value
                 else if (List.isList(originalValue) && !Array.isArray(value)) {
                     if (originalValue.get(0).value !== value) {
-                        row[key] = (isDate ? parseDate(value) : value) ?? null;
+                        // Issue 44398: match JSON dateTime format provided by LK server when submitting date values back for insert/update
+                        row[key] = (isDate ? getJsonDateTimeFormatString(parseDate(value)) : value) ?? null;
                     }
                 } else if (!(originalValue == undefined && value == undefined) && originalValue !== value) {
                     // - only update if the value has changed
                     // - if the value is 'undefined', it will be removed from the update rows, so in order to
                     // erase an existing value we set the value to null in our update data
 
-                    row[key] = (isDate ? parseDate(value) : value) ?? null;
+                    // Issue 44398: match JSON dateTime format provided by LK server when submitting date values back for insert/update
+                    row[key] = (isDate ? getJsonDateTimeFormatString(parseDate(value)) : value) ?? null;
                 }
                 return row;
             }, {});


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44398

See issues for full details, but the summary of the scenario is that if the LabKey server is running in a timezone that is different from the user's browser (i.e. server in PST and client in EST) then saving date values are getting unexpectedly adjusted from the user's point of view. 

For examples, if I am in EST and I enter a date of "2021-12-03" via the DatePickerInput or from an EditableGrid insert/update, the value that will show in the grid after save is "2021-12-02 09:00". The reason for this is because the ui-component client side code was posting the value as a JS Date object like "2021-12-03T05:00:00.000Z" which is reflecting the timezone of the browser. 

To fix this, we now convert the JS Date objects back to the ISO-like JSON date format that the LabKey server uses when we make a query/select API request (i.e."yyyy-MM-dd HH:mm:ss"). This means that the server will store the date that matches the input from the user. It is still a little confusing overall because the value we show in the grid like "2021-12-02 09:00" doesn't have any notion of timezone. The server is really meaning to say that the value is in the server's timezone, but from the user point of view that isn't clear.

There is discussion of future features that might help with these scenarios: 
1) a "Date" field type to go along with the "DateTime" field type
2) better support for displaying timezones in the LabKey UI (grid, date picker, etc.)

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/683
* https://github.com/LabKey/sampleManagement/pull/768
* https://github.com/LabKey/biologics/pull/1078

#### Changes
* Add new util function getJsonDateTimeFormatString() to convert JS Date to string
* Call getJsonDateTimeFormatString() onChange of DatePickerInput before passing value to onChange and formsy setValue prop
* Call getJsonDateTimeFormatString() when getting updated grid values in EditableGrid insert and update case
