### PR TITLE
Item 9627: TextChoiceValidator and usage for rendering select input for LKS insert/update form and app update forms

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.102.0-fb-lksTextChoiceValidator.1",
+  "version": "2.103.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.102.0-fb-lksTextChoiceValidator.0",
+  "version": "2.102.0-fb-lksTextChoiceValidator.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.102.0",
+  "version": "2.102.0-fb-lksTextChoiceValidator.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.TBD
-*Released*: TBD December 2021
+### version 2.103.0
+*Released*: 10 December 2021
 * Item 9627: TextChoiceInput and usage for rendering select input for DetailEditRenderer, QueryFormInputs, and EditableGrid cell
 
 ### version 2.102.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.103.0
 *Released*: 10 December 2021
-* Item 9627: TextChoiceInput and usage for rendering select input for DetailEditRenderer, QueryFormInputs, and EditableGrid cell
+* Item 9627: TextChoiceInput and usage for rendering select input for DetailEditRenderer and QueryFormInputs
 
 ### version 2.102.0
 *Released*: 1 December 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.TBD
+*Released*: TBD December 2021
+* Item 9627: TextChoiceInput and usage for rendering select input for DetailEditRenderer, QueryFormInputs, and EditableGrid cell
+
 ### version 2.102.0
 *Released*: 1 December 2021
 * Rename EditableGridPanel to EditableGridPanelDeprecated

--- a/packages/components/src/internal/components/forms/QueryFormInputs.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.spec.tsx
@@ -28,8 +28,8 @@ import { TextInput } from './input/TextInput';
 import { CheckboxInput } from './input/CheckboxInput';
 import { FileInput } from './input/FileInput';
 import { SelectInput } from './input/SelectInput';
-
 import { DatePickerInput } from './input/DatePickerInput';
+import { TextChoiceInput } from './input/TextChoiceInput';
 import { FieldLabel } from './FieldLabel';
 
 beforeAll(() => {
@@ -51,10 +51,11 @@ describe('QueryFormInputs', () => {
             );
 
             expect(formWrapper.find('input').findWhere(input => input.prop('disabled'))).toHaveLength(0);
-            expect(formWrapper.find(TextInput)).toHaveLength(4);
+            expect(formWrapper.find(TextInput)).toHaveLength(3);
             expect(formWrapper.find(DatePickerInput)).toHaveLength(1);
             expect(formWrapper.find(CheckboxInput)).toHaveLength(1);
-            expect(formWrapper.find(SelectInput)).toHaveLength(0);
+            expect(formWrapper.find(TextChoiceInput)).toHaveLength(1);
+            expect(formWrapper.find(SelectInput)).toHaveLength(1); // this is from the TextChoiceInput
             // default properties don't render file inputs
             expect(formWrapper.find(FileInput)).toHaveLength(0);
 
@@ -71,8 +72,8 @@ describe('QueryFormInputs', () => {
                 <Formsy>
                     <QueryFormInputs
                         queryInfo={queryInfo}
-                        renderFieldLabel={(queryColumn: QueryColumn) => {
-                            return <div className="jest-field-label-test">{queryColumn.name}</div>;
+                        renderFieldLabel={(queryColumn: QueryColumn, label: string) => {
+                            return <div className="jest-field-label-test">{queryColumn?.name || label}</div>;
                         }}
                     />
                 </Formsy>
@@ -129,7 +130,7 @@ describe('QueryFormInputs', () => {
                 </Formsy>
             );
 
-            expect(formWrapper.find('input').findWhere(input => !input.prop('disabled'))).toHaveLength(5);
+            expect(formWrapper.find('input').findWhere(input => !input.prop('disabled'))).toHaveLength(6);
             expect(formWrapper.find('input').findWhere(input => input.prop('disabled'))).toHaveLength(1);
 
             formWrapper.unmount();

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -29,8 +29,8 @@ import { QueryDateInput } from './input/QueryDateInput';
 import { CheckboxInput } from './input/CheckboxInput';
 import { TextAreaInput } from './input/TextAreaInput';
 import { FileInput } from './input/FileInput';
-
 import { DatePickerInput } from './input/DatePickerInput';
+import { TextChoiceInput } from './input/TextChoiceInput';
 
 const LABEL_FIELD_SUFFIX = '::label';
 
@@ -268,6 +268,22 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 </React.Fragment>
                             );
                         }
+                    }
+
+                    if (col.validValues) {
+                        return (
+                            <TextChoiceInput
+                                key={i}
+                                formsy
+                                queryColumn={col}
+                                value={value}
+                                addLabelAsterisk={showAsteriskSymbol}
+                                allowDisable={allowFieldDisable}
+                                initiallyDisabled={shouldDisableField}
+                                onToggleDisable={this.onToggleDisable}
+                                renderFieldLabel={renderFieldLabel}
+                            />
+                        );
                     }
 
                     if (col.inputType === 'textarea') {

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.spec.tsx
@@ -20,8 +20,8 @@ import {
 
 import { AssayRunReferenceRenderer } from '../../../renderers/AssayRunReferenceRenderer';
 import { AliasInput } from '../input/AliasInput';
-
 import { resolveDetailEditRenderer, resolveDetailRenderer, titleRenderer } from './DetailEditRenderer';
+import { TextChoiceInput } from '../input/TextChoiceInput';
 
 describe('titleRenderer', () => {
     test('editable', () => {
@@ -53,6 +53,7 @@ describe('resolveDetailEditRenderer', () => {
         expect(wrapper.find(DatePickerInput)).toHaveLength(count['datepickerinput'] ?? 0);
         expect(wrapper.find(QueryDateInput)).toHaveLength(count['dateinput'] ?? 0);
         expect(wrapper.find(FileInput)).toHaveLength(count['fileinput'] ?? 0);
+        expect(wrapper.find(TextChoiceInput)).toHaveLength(count['textchoiceinput'] ?? 0);
         expect(wrapper.find(Input)).toHaveLength(count['input'] ?? 0);
     }
 
@@ -139,6 +140,13 @@ describe('resolveDetailEditRenderer', () => {
         const col = new QueryColumn({ ...default_props });
         const wrapper = mount(<Formsy>{resolveDetailEditRenderer(col)(Map())}</Formsy>);
         validate(wrapper, { input: 1 });
+        wrapper.unmount();
+    });
+
+    test('validValues', () => {
+        const col = new QueryColumn({ ...default_props, validValues: ['a', 'b', 'c'] });
+        const wrapper = mount(<Formsy>{resolveDetailEditRenderer(col)(Map())}</Formsy>);
+        validate(wrapper, { textchoiceinput: 1 });
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.spec.tsx
@@ -20,8 +20,10 @@ import {
 
 import { AssayRunReferenceRenderer } from '../../../renderers/AssayRunReferenceRenderer';
 import { AliasInput } from '../input/AliasInput';
-import { resolveDetailEditRenderer, resolveDetailRenderer, titleRenderer } from './DetailEditRenderer';
+
 import { TextChoiceInput } from '../input/TextChoiceInput';
+
+import { resolveDetailEditRenderer, resolveDetailRenderer, titleRenderer } from './DetailEditRenderer';
 
 describe('titleRenderer', () => {
     test('editable', () => {

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -39,6 +39,7 @@ import { getUnFormattedNumber } from '../../../util/Date';
 
 import { _defaultRenderer, Renderer, RenderOptions } from './DetailDisplay';
 import { SampleStatusRenderer } from '../../../renderers/SampleStatusRenderer';
+import { TextChoiceInput } from '../input/TextChoiceInput';
 
 export function titleRenderer(col: QueryColumn): React.ReactNode {
     // If the column cannot be edited, return the label as is
@@ -108,6 +109,17 @@ export function resolveDetailEditRenderer(
                     />
                 );
             }
+        }
+
+        if (col.validValues) {
+            return (
+                <TextChoiceInput
+                    formsy
+                    inputClass="col-sm-12"
+                    queryColumn={col}
+                    value={value}
+                />
+            );
         }
 
         if (col.inputType === 'textarea') {

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -37,9 +37,10 @@ import { AssayRunReferenceRenderer } from '../../../renderers/AssayRunReferenceR
 
 import { getUnFormattedNumber } from '../../../util/Date';
 
-import { _defaultRenderer, Renderer, RenderOptions } from './DetailDisplay';
 import { SampleStatusRenderer } from '../../../renderers/SampleStatusRenderer';
 import { TextChoiceInput } from '../input/TextChoiceInput';
+
+import { _defaultRenderer, Renderer, RenderOptions } from './DetailDisplay';
 
 export function titleRenderer(col: QueryColumn): React.ReactNode {
     // If the column cannot be edited, return the label as is
@@ -112,14 +113,7 @@ export function resolveDetailEditRenderer(
         }
 
         if (col.validValues) {
-            return (
-                <TextChoiceInput
-                    formsy
-                    inputClass="col-sm-12"
-                    queryColumn={col}
-                    value={value}
-                />
-            );
+            return <TextChoiceInput formsy inputClass="col-sm-12" queryColumn={col} value={value} />;
         }
 
         if (col.inputType === 'textarea') {
@@ -243,7 +237,7 @@ export function resolveDetailRenderer(column: QueryColumn): Renderer {
                 renderer = d => <SourceTypeImportAliasRenderer data={d} />;
                 break;
             case 'samplestatusrenderer':
-                renderer = (d, r) => <SampleStatusRenderer row={r} />
+                renderer = (d, r) => <SampleStatusRenderer row={r} />;
                 break;
             default:
                 break;

--- a/packages/components/src/internal/components/forms/input/TextChoiceInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/TextChoiceInput.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { TextChoiceInput } from './TextChoiceInput';
+import { SelectInput } from './SelectInput';
+import { QueryColumn } from '../../../../public/QueryColumn';
+
+describe('TextChoiceInput', () => {
+    const DEFAULT_PROPS = {
+        queryColumn: new QueryColumn(),
+    };
+
+    function validate(wrapper: ReactWrapper, placeholder = 'Select or type to search...', options = []): void {
+        const input = wrapper.find(SelectInput);
+        expect(input).toHaveLength(1);
+        expect(input.prop('placeholder')).toBe(placeholder);
+        expect(input.prop('options')).toStrictEqual(options);
+    }
+
+    test('default props', () => {
+        const wrapper = mount(<TextChoiceInput {...DEFAULT_PROPS} />);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('placeholder', () => {
+        const wrapper = mount(
+            <TextChoiceInput {...DEFAULT_PROPS} placeholder="testing" />
+        );
+        validate(wrapper, 'testing');
+        wrapper.unmount();
+    });
+
+    test('validValues, undefined', () => {
+        const wrapper = mount(
+            <TextChoiceInput {...DEFAULT_PROPS} queryColumn={new QueryColumn({ validValues: undefined })} />
+        );
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('validValues, empty', () => {
+        const wrapper = mount(
+            <TextChoiceInput {...DEFAULT_PROPS} queryColumn={new QueryColumn({ validValues: [] })} />
+        );
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('validValues, with values', () => {
+        const wrapper = mount(
+            <TextChoiceInput
+                {...DEFAULT_PROPS}
+                placeholder="test"
+                queryColumn={new QueryColumn({ validValues: ['a', 'b', 'c'] })}
+            />
+        );
+        validate(wrapper, 'test', [{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }, { label: 'c', value: 'c' }]);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/forms/input/TextChoiceInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/TextChoiceInput.spec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
+import { QueryColumn } from '../../../../public/QueryColumn';
+
 import { TextChoiceInput } from './TextChoiceInput';
 import { SelectInput } from './SelectInput';
-import { QueryColumn } from '../../../../public/QueryColumn';
 
 describe('TextChoiceInput', () => {
     const DEFAULT_PROPS = {
@@ -24,9 +25,7 @@ describe('TextChoiceInput', () => {
     });
 
     test('placeholder', () => {
-        const wrapper = mount(
-            <TextChoiceInput {...DEFAULT_PROPS} placeholder="testing" />
-        );
+        const wrapper = mount(<TextChoiceInput {...DEFAULT_PROPS} placeholder="testing" />);
         validate(wrapper, 'testing');
         wrapper.unmount();
     });
@@ -55,7 +54,11 @@ describe('TextChoiceInput', () => {
                 queryColumn={new QueryColumn({ validValues: ['a', 'b', 'c'] })}
             />
         );
-        validate(wrapper, 'test', [{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }, { label: 'c', value: 'c' }]);
+        validate(wrapper, 'test', [
+            { label: 'a', value: 'a' },
+            { label: 'b', value: 'b' },
+            { label: 'c', value: 'c' },
+        ]);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
@@ -10,9 +10,9 @@ interface Props extends SelectInputProps {
 export class TextChoiceInput extends DisableableInput<Props, DisableableInputState> {
     render(): ReactNode {
         const { queryColumn, placeholder, ...inputProps } = this.props;
-        const inputOptions = queryColumn.validValues.map(val => {
+        const inputOptions = queryColumn.validValues?.map(val => {
             return { label: val, value: val };
-        });
+        }) ?? [];
 
         return (
             <SelectInput

--- a/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
@@ -1,0 +1,28 @@
+import React, { ReactNode } from 'react';
+import { SelectInput, SelectInputProps } from './SelectInput';
+import { QueryColumn } from '../../../../public/QueryColumn';
+import { DisableableInput, DisableableInputState } from './DisableableInput';
+
+interface Props extends SelectInputProps {
+    queryColumn: QueryColumn;
+}
+
+export class TextChoiceInput extends DisableableInput<Props, DisableableInputState> {
+    render(): ReactNode {
+        const { queryColumn, placeholder, ...inputProps } = this.props;
+        const inputOptions = queryColumn.validValues.map(val => {
+            return { label: val, value: val };
+        });
+
+        return (
+            <SelectInput
+                {...inputProps}
+                label={queryColumn.caption}
+                name={queryColumn.fieldKey}
+                options={inputOptions}
+                placeholder={placeholder || 'Select or type to search...'}
+                required={queryColumn.required}
+            />
+        );
+    }
+}

--- a/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from 'react';
-import { SelectInput, SelectInputProps } from './SelectInput';
+
 import { QueryColumn } from '../../../../public/QueryColumn';
+
+import { SelectInput, SelectInputProps } from './SelectInput';
 import { DisableableInput, DisableableInputState } from './DisableableInput';
 
 interface Props extends SelectInputProps {
@@ -10,9 +12,10 @@ interface Props extends SelectInputProps {
 export class TextChoiceInput extends DisableableInput<Props, DisableableInputState> {
     render(): ReactNode {
         const { queryColumn, placeholder, ...inputProps } = this.props;
-        const inputOptions = queryColumn.validValues?.map(val => {
-            return { label: val, value: val };
-        }) ?? [];
+        const inputOptions =
+            queryColumn.validValues?.map(val => {
+                return { label: val, value: val };
+            }) ?? [];
 
         return (
             <SelectInput

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -96,6 +96,7 @@ export class QueryColumn extends Record({
     // sqlType: undefined,
     type: undefined,
     userEditable: undefined,
+    validValues: undefined,
     // versionField: undefined,
 
     cell: undefined,
@@ -162,6 +163,7 @@ export class QueryColumn extends Record({
     // declare sqlType: string;
     declare type: string;
     declare userEditable: boolean;
+    declare validValues: string[];
     // declare versionField: boolean;
 
     declare cell: Function;

--- a/packages/components/src/test/data/assayGpatData-getQueryDetails.json
+++ b/packages/components/src/test/data/assayGpatData-getQueryDetails.json
@@ -174,7 +174,8 @@
       "queryName" : "c6d720_vial",
       "schemaName" : "specimentables",
       "table" : "c6d720_vial"
-    }
+    },
+    "validValues" : ["S1", "S2", "S3"]
   }, {
     "ext" : { },
     "name" : "ParticipantID",


### PR DESCRIPTION
#### Rationale
Part 1 of supporting a new field type for "Text Choice" as a light weight lookup which allows users to restrict data entry into text fields using a list of text choices. This PR adds the new TextChoiceInput shared component which can be used in the details panel renderers and the QueryFormInputs for a field with a TextChoiceValidator to show a select input with the valid values for that field (based on the validator expression).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2835
* https://github.com/LabKey/labkey-ui-components/pull/684
* https://github.com/LabKey/sampleManagement/pull/769
* https://github.com/LabKey/biologics/pull/1085

#### Changes
* add TextChoiceInput to wrap SelectInput and provide options based on the queryColumn validValues
* use TextChoiceInput in QueryFormInputs case and DetailEditRenderer case
* update QueryColumn props for new validValues property
