### PR TITLE
Issue 44329: Import assay design XAR container select option

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.103.1-fb-44329-assay-xar-path.0",
+  "version": "2.104.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.103.0-fb-44329-assay-xar-path.3",
+  "version": "2.103.0-fb-44329-assay-xar-path.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.103.0",
+  "version": "2.103.0-fb-44329-assay-xar-path.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.104.0
+*Released*: 15 December 2021
+* Add container select support to assay picker XAR import
+
 ### version 2.103.1
 *Released*: 14 December 2021
 * Merge release21.12-SNAPSHOT to develop

--- a/packages/components/src/internal/components/assay/AssayDesignUploadPanel.tsx
+++ b/packages/components/src/internal/components/assay/AssayDesignUploadPanel.tsx
@@ -13,7 +13,7 @@ interface AssayDesignUploadPanelProps {
 }
 
 export const AssayDesignUploadPanel: FC<AssayDesignUploadPanelProps> = memo(props => {
-    const { onFileChange, onFileRemove } = props;
+    const { onFileChange, onFileRemove, children } = props;
 
     return (
         <div>
@@ -44,6 +44,7 @@ export const AssayDesignUploadPanel: FC<AssayDesignUploadPanelProps> = memo(prop
                     />
                 </Col>
             </Row>
+            {children}
             <Row>
                 <Col xs={6}>
                     <div className="margin-top margin-bottom">

--- a/packages/components/src/internal/components/assay/AssayPicker.spec.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.spec.tsx
@@ -22,7 +22,7 @@ describe('AssayPicker', () => {
         // Verify all three tabs shown and standard assay selected
         expect(wrapper.find('.nav-tabs li')).toHaveLength(3);
         expect(wrapper.find('.nav-tabs li.active a#assay-picker-tabs-tab-standard')).toHaveLength(1);
-        expect(wrapper.find('#assay-type-select-container')).toHaveLength(1);
+        expect(wrapper.find('#assay-type-select-container')).toHaveLength(2); // Specialty tab doesn't show this option if no providers
 
         // Click import tab and verify it's shown
         expect(wrapper.find('.nav-tabs li.active a#assay-picker-tabs-tab-import')).toHaveLength(0);

--- a/packages/components/src/internal/components/assay/AssayPicker.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.tsx
@@ -180,6 +180,18 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
         });
     }, []);
 
+    const containerSelect = useMemo(() => {
+        return (<Row>
+            <Col xs={6}>
+                <AssayContainerLocation
+                    locations={containers}
+                    selected={assaySelectionModel.container}
+                    onChange={onContainerChange}
+                />
+            </Col>
+        </Row>);
+    }, [containers, assaySelectionModel.container, onContainerChange]);
+
     return (
         <div>
             <Tab.Container
@@ -207,15 +219,7 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
                                 <StandardAssayPanel provider={standardProvider}>
                                     {showContainerSelect && (
                                         <div className="margin-top">
-                                            <Row>
-                                                <Col xs={6}>
-                                                    <AssayContainerLocation
-                                                        locations={containers}
-                                                        selected={assaySelectionModel.container}
-                                                        onChange={onContainerChange}
-                                                    />
-                                                </Col>
-                                            </Row>
+                                            {containerSelect}
                                         </div>
                                     )}
                                 </StandardAssayPanel>
@@ -232,15 +236,7 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
                                 >
                                     {showContainerSelect && providers?.length > 1 && (
                                         <div className="margin-top">
-                                            <Row>
-                                                <Col xs={6}>
-                                                    <AssayContainerLocation
-                                                        locations={containers}
-                                                        selected={assaySelectionModel.container}
-                                                        onChange={onContainerChange}
-                                                    />
-                                                </Col>
-                                            </Row>
+                                            {containerSelect}
                                         </div>
                                     )}
                                 </SpecialtyAssayPanel>
@@ -253,15 +249,7 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
                                     <AssayDesignUploadPanel onFileChange={onFileSelect} onFileRemove={onFileRemove} >
                                         {showContainerSelect && (
                                             <div className="margin-bottom">
-                                                <Row>
-                                                    <Col xs={6}>
-                                                        <AssayContainerLocation
-                                                            locations={containers}
-                                                            selected={assaySelectionModel.container}
-                                                            onChange={onContainerChange}
-                                                        />
-                                                    </Col>
-                                                </Row>
+                                                {containerSelect}
                                             </div>
                                         )}
                                     </AssayDesignUploadPanel>

--- a/packages/components/src/internal/components/assay/AssayPicker.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.tsx
@@ -250,7 +250,21 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
                                     className="margin-bottom margin-top"
                                     eventKey={AssayPickerTabs.XAR_IMPORT_TAB}
                                 >
-                                    <AssayDesignUploadPanel onFileChange={onFileSelect} onFileRemove={onFileRemove} />
+                                    <AssayDesignUploadPanel onFileChange={onFileSelect} onFileRemove={onFileRemove} >
+                                        {showContainerSelect && (
+                                            <div className="margin-bottom">
+                                                <Row>
+                                                    <Col xs={6}>
+                                                        <AssayContainerLocation
+                                                            locations={containers}
+                                                            selected={assaySelectionModel.container}
+                                                            onChange={onContainerChange}
+                                                        />
+                                                    </Col>
+                                                </Row>
+                                            </div>
+                                        )}
+                                    </AssayDesignUploadPanel>
                                 </Tab.Pane>
                             )}
                         </Tab.Content>

--- a/packages/components/src/internal/components/assay/__snapshots__/AssayPicker.spec.tsx.snap
+++ b/packages/components/src/internal/components/assay/__snapshots__/AssayPicker.spec.tsx.snap
@@ -1085,6 +1085,69 @@ exports[`AssayPicker AssayPicker 1`] = `
                                       </Col>
                                     </div>
                                   </Row>
+                                  <div
+                                    className="margin-bottom"
+                                  >
+                                    <Row
+                                      bsClass="row"
+                                      componentClass="div"
+                                    >
+                                      <div
+                                        className="row"
+                                      >
+                                        <Col
+                                          bsClass="col"
+                                          componentClass="div"
+                                          xs={6}
+                                        >
+                                          <div
+                                            className="col-xs-6"
+                                          >
+                                            <Memo()
+                                              locations={
+                                                Object {
+                                                  "ce3fb429-92f9-1038-8523-225b19648208": "Shared Folder",
+                                                  "ea7c355b-0b2e-1039-8359-225b19643884": "Current Folder (BiologicsAssayTest Project)",
+                                                }
+                                              }
+                                              onChange={[Function]}
+                                              selected="ea7c355b-0b2e-1039-8359-225b19643884"
+                                            >
+                                              <div
+                                                className="margin-bottom"
+                                              >
+                                                <b>
+                                                  Assay Location
+                                                </b>
+                                              </div>
+                                              <p>
+                                                Choose where the assay will be used and visible within subfolders.
+                                              </p>
+                                              <select
+                                                className="form-control"
+                                                id="assay-type-select-container"
+                                                onChange={[Function]}
+                                                value="ea7c355b-0b2e-1039-8359-225b19643884"
+                                              >
+                                                <option
+                                                  key="ea7c355b-0b2e-1039-8359-225b19643884"
+                                                  value="ea7c355b-0b2e-1039-8359-225b19643884"
+                                                >
+                                                  Current Folder (BiologicsAssayTest Project)
+                                                </option>
+                                                <option
+                                                  key="ce3fb429-92f9-1038-8523-225b19648208"
+                                                  value="ce3fb429-92f9-1038-8523-225b19648208"
+                                                >
+                                                  Shared Folder
+                                                </option>
+                                              </select>
+                                            </Memo()>
+                                          </div>
+                                        </Col>
+                                      </div>
+                                    </Row>
+                                  </div>
                                   <Row
                                     bsClass="row"
                                     componentClass="div"


### PR DESCRIPTION
#### Rationale
In the assay picker, standard and specialty assay tabs are able to select the container to create the assay in but XAR import is not.  This adds that capability to the assay picker.

#### Related Pull Requests
* TBD

#### Changes
* Add AssayContainerLocation to AssayDesignUploadPanel
