### PR TITLE
Issue #44567: Hide scannable option for floating point fields due to improper matching.

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0-fb-44567-hideScanFloat.0",
+  "version": "2.111.0-fb-44567-hideScanFloat.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0",
+  "version": "2.111.0-fb-44567-hideScanFloat.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0-fb-44567-hideScanFloat.1",
+  "version": "2.111.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.111.1
+*Released*: 29 December 2021
 * Issue #44567: Hide scannable option for floating point fields due to improper matching.
 
 ### version 2.111.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue #44567: Hide scannable option for floating point fields due to improper matching.
+
 ### version 2.111.0
 *Released*: 24 December 2021
 * Edit Sample Type and Data Class's Naming Pattern Prefix Expression alteration warning message

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -160,9 +160,10 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                         defaultScale={field.defaultScale}
                         onChange={onChange}
                         lockType={field.lockType}
-                        scannable={field.scannable}
-                        appPropertiesOnly={appPropertiesOnly}
-                        showScannableOption={domainFormDisplayOptions?.showScannableOption}
+                        ////Issue #44567: Hide scannable option due to matching issues with floating point representation.
+                        // scannable={field.scannable}
+                        // appPropertiesOnly={appPropertiesOnly}
+                        // showScannableOption={false}
                     />
                 );
             case 'lookup':

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -161,9 +161,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                         onChange={onChange}
                         lockType={field.lockType}
                         ////Issue #44567: Hide scannable option due to matching issues with floating point representation.
-                        // scannable={field.scannable}
-                        // appPropertiesOnly={appPropertiesOnly}
-                        // showScannableOption={false}
+                        showScannableOption={false}
                     />
                 );
             case 'lookup':

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
@@ -8030,7 +8030,6 @@ exports[`DomainRow decimal field 1`] = `
                                             label="Decimal Options"
                                             lockType="NotLocked"
                                             onChange={[Function]}
-                                            scannable={false}
                                           >
                                             <div>
                                               <Row
@@ -8292,7 +8291,6 @@ exports[`DomainRow decimal field 1`] = `
                                                 label="Decimal Options"
                                                 lockType="NotLocked"
                                                 onChange={[Function]}
-                                                scannable={false}
                                               />
                                             </div>
                                           </NumericFieldOptions>

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
@@ -8030,6 +8030,7 @@ exports[`DomainRow decimal field 1`] = `
                                             label="Decimal Options"
                                             lockType="NotLocked"
                                             onChange={[Function]}
+                                            showScannableOption={false}
                                           >
                                             <div>
                                               <Row
@@ -8291,6 +8292,7 @@ exports[`DomainRow decimal field 1`] = `
                                                 label="Decimal Options"
                                                 lockType="NotLocked"
                                                 onChange={[Function]}
+                                                showScannableOption={false}
                                               />
                                             </div>
                                           </NumericFieldOptions>


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44567
Hiding the scannable option due to mismatch between floating point representation and expected value 

#### Related Pull Requests
* Platform: https://github.com/LabKey/platform/pull/2900
* Biologics: https://github.com/LabKey/biologics/pull/1107
* SampleManager: https://github.com/LabKey/sampleManagement/pull/787
* Inventory: https://github.com/LabKey/inventory/pull/353

#### Changes
* Hide scannable option for floating point domain fields

