### PR TITLE
Item 9782: Text Choice data type support for field editor updates to in use values

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0-fb-textChoiceUpdates.0",
+  "version": "2.111.0-fb-textChoiceUpdates.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0-fb-textChoiceUpdates.1",
+  "version": "2.111.0-fb-textChoiceUpdates.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1-fb-textChoiceUpdates.5",
+  "version": "2.111.1-fb-textChoiceUpdates.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1-fb-textChoiceUpdates.0",
+  "version": "2.111.1-fb-textChoiceUpdates.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0",
+  "version": "2.111.0-fb-textChoiceUpdates.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0-fb-textChoiceUpdates.3",
+  "version": "2.111.0-fb-textChoiceUpdates.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1-fb-textChoiceUpdates.1",
+  "version": "2.111.1-fb-textChoiceUpdates.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1-fb-textChoiceUpdates.3",
+  "version": "2.111.1-fb-textChoiceUpdates.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.0-fb-textChoiceUpdates.2",
+  "version": "2.111.0-fb-textChoiceUpdates.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1-fb-textChoiceUpdates.4",
+  "version": "2.111.1-fb-textChoiceUpdates.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1-fb-textChoiceUpdates.2",
+  "version": "2.111.1-fb-textChoiceUpdates.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1-fb-textChoiceUpdates.6",
+  "version": "2.112.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.111.1",
+  "version": "2.111.1-fb-textChoiceUpdates.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,8 +3,12 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* Item #9782: Field editor "Text Choice" support for updating in use values
-  * ...
+* Item #9782: Text Choice data type support for field editor updates to in use values
+  * update to query to get in use text choice values so that it includes "locked" and row count
+  * provide SQL fragment from sample type domain for how to determine "locked" text choice values
+  * update text choice listing icons and selected value display for info on updates and hover text
+  * send text choice value updates for in use values to the server as part of post to update domain
+  * prevent text choice updates and add values modal apply for duplicates and empty strings
 
 ### version 2.111.0
 *Released*: 24 December 2021

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,11 +3,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* Item #9782: Text Choice data type support for field editor updates to in use values
-  * update to query to get in use text choice values so that it includes "locked" and row count
+* Item #9782: Text Choice data type support for field editor updates to in-use values
+  * update to query to get in-use text choice values so that it includes "locked" and row count
   * provide SQL fragment from sample type domain for how to determine "locked" text choice values
   * update text choice listing icons and selected value display for info on updates and hover text
-  * send text choice value updates for in use values to the server as part of post to update domain
+  * send text choice value updates for in-use values to the server as part of POST to update domain
   * prevent text choice updates and add values modal apply for duplicates and empty strings
 
 ### version 2.111.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item #9782: Field editor "Text Choice" support for updating in use values
+  * ...
+
 ### version 2.111.0
 *Released*: 24 December 2021
 * Edit Sample Type and Data Class's Naming Pattern Prefix Expression alteration warning message

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.112.0
+*Released*: 30 December 2021
 * Item #9782: Text Choice data type support for field editor updates to in-use values
   * update to query to get in-use text choice values so that it includes "locked" and row count
   * provide SQL fragment from sample type domain for how to determine "locked" text choice values

--- a/packages/components/src/internal/components/assay/AssayDesignUploadPanel.tsx
+++ b/packages/components/src/internal/components/assay/AssayDesignUploadPanel.tsx
@@ -1,11 +1,10 @@
-import React, { FC, memo, useMemo, useCallback, useState } from 'react';
+import React, { FC, memo } from 'react';
 import { Col, Row } from 'react-bootstrap';
 
 import { ActionURL } from '@labkey/api';
 import { Map } from 'immutable';
 
-import { FileAttachmentForm, getHelpLink } from '../../../index';
-import { DATA_CLASS_NAME_EXPRESSION_TOPIC } from '../../util/helpLinks';
+import { FileAttachmentForm, getHelpLink } from '../../..';
 
 interface AssayDesignUploadPanelProps {
     onFileChange: (files: Map<string, File>) => void;

--- a/packages/components/src/internal/components/base/LockIcon.spec.tsx
+++ b/packages/components/src/internal/components/base/LockIcon.spec.tsx
@@ -17,7 +17,7 @@ describe('<LockIcon/>', () => {
     });
 
     test('custom properties', () => {
-        const component = <LockIcon {...DEFAULT_PROPS} iconCls="jest-testing-cls" />;
+        const component = <LockIcon {...DEFAULT_PROPS} iconCls="jest-testing-cls" unlocked />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/components/src/internal/components/base/LockIcon.tsx
+++ b/packages/components/src/internal/components/base/LockIcon.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, PureComponent } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
-import { faLock } from '@fortawesome/free-solid-svg-icons';
+import { faLock, faLockOpen } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 interface Props {
@@ -8,11 +8,12 @@ interface Props {
     iconCls?: string;
     title: string;
     body: ReactNode;
+    unlocked?: boolean;
 }
 
 export class LockIcon extends PureComponent<Props> {
     render() {
-        const { id, title, iconCls, body } = this.props;
+        const { id, title, iconCls, body, unlocked = false } = this.props;
         return (
             <OverlayTrigger
                 placement="bottom"
@@ -23,7 +24,7 @@ export class LockIcon extends PureComponent<Props> {
                 }
             >
                 <span className={'domain-field-lock-icon' + (iconCls ? ' ' + iconCls : '')}>
-                    <FontAwesomeIcon icon={faLock} />
+                    <FontAwesomeIcon icon={unlocked ? faLockOpen : faLock} />
                 </span>
             </OverlayTrigger>
         );

--- a/packages/components/src/internal/components/base/LockIcon.tsx
+++ b/packages/components/src/internal/components/base/LockIcon.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, PureComponent } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
-import { faLock, faLockOpen } from '@fortawesome/free-solid-svg-icons';
+import { faLock, faUnlock } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 interface Props {
@@ -24,7 +24,7 @@ export class LockIcon extends PureComponent<Props> {
                 }
             >
                 <span className={'domain-field-lock-icon' + (iconCls ? ' ' + iconCls : '')}>
-                    <FontAwesomeIcon icon={unlocked ? faLockOpen : faLock} />
+                    <FontAwesomeIcon icon={unlocked ? faUnlock : faLock} />
                 </span>
             </OverlayTrigger>
         );

--- a/packages/components/src/internal/components/base/__snapshots__/LockIcon.spec.tsx.snap
+++ b/packages/components/src/internal/components/base/__snapshots__/LockIcon.spec.tsx.snap
@@ -11,8 +11,8 @@ exports[`<LockIcon/> custom properties 1`] = `
 >
   <svg
     aria-hidden="true"
-    className="svg-inline--fa fa-lock fa-w-14 "
-    data-icon="lock"
+    className="svg-inline--fa fa-unlock fa-w-14 "
+    data-icon="unlock"
     data-prefix="fas"
     focusable="false"
     role="img"
@@ -21,7 +21,7 @@ exports[`<LockIcon/> custom properties 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+      d="M400 256H152V152.9c0-39.6 31.7-72.5 71.3-72.9 40-.4 72.7 32.1 72.7 72v16c0 13.3 10.7 24 24 24h32c13.3 0 24-10.7 24-24v-16C376 68 307.5-.3 223.5 0 139.5.3 72 69.5 72 153.5V256H48c-26.5 0-48 21.5-48 48v160c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z"
       fill="currentColor"
       style={Object {}}
     />

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -160,7 +160,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                         defaultScale={field.defaultScale}
                         onChange={onChange}
                         lockType={field.lockType}
-                        ////Issue #44567: Hide scannable option due to matching issues with floating point representation.
+                        // Issue #44567: Hide scannable option due to matching issues with floating point representation.
                         showScannableOption={false}
                     />
                 );

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -224,6 +224,8 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                         onChange={onChange}
                         queryName={queryName}
                         schemaName={schemaName}
+                        lockedForDomain={domainFormDisplayOptions.textChoiceLockedForDomain}
+                        lockedSqlFragment={domainFormDisplayOptions.textChoiceLockedSqlFragment}
                     />
                 );
         }

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
@@ -15,7 +15,7 @@ describe('TextChoiceOptions', () => {
     const DEFAULT_PROPS = {
         label: 'Test Label',
         field: DomainField.create({}),
-        fieldValues: [],
+        fieldValues: {},
         loading: false,
         replaceValues: jest.fn,
         validValues: [],
@@ -120,7 +120,22 @@ describe('TextChoiceOptions', () => {
 
     test('with inUse values', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={['b']} />
+            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b:  false }} />
+        );
+        validate(wrapper, false, 2, 1);
+
+        // select the in use value and check right hand items
+        wrapper.find(ChoicesListItem).last().simulate('click');
+        await waitForLifecycle(wrapper);
+        validate(wrapper, false, 2, 1, true);
+        expect(wrapper.find('input').prop('disabled')).toBeFalsy();
+
+        wrapper.unmount();
+    });
+
+    test('with locked values', async () => {
+        const wrapper = mount(
+            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b:  true }} />
         );
         validate(wrapper, false, 2, 1);
 
@@ -135,7 +150,7 @@ describe('TextChoiceOptions', () => {
 
     test('delete button disabled', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={['b']} />
+            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b: false }} />
         );
         validate(wrapper, false, 2, 1);
 

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
@@ -128,7 +128,7 @@ describe('TextChoiceOptions', () => {
         );
         validate(wrapper, false, 2, 1);
 
-        // select the in use value and check right hand items
+        // select the in-use value and check right hand items
         wrapper.find(ChoicesListItem).last().simulate('click');
         await waitForLifecycle(wrapper);
         validate(wrapper, false, 2, 1, true);
@@ -147,7 +147,7 @@ describe('TextChoiceOptions', () => {
         );
         validate(wrapper, false, 2, 1);
 
-        // select the in use value and check right hand items
+        // select the locked value and check right hand items
         wrapper.find(ChoicesListItem).last().simulate('click');
         await waitForLifecycle(wrapper);
         validate(wrapper, false, 2, 1, true);

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
@@ -32,7 +32,7 @@ describe('TextChoiceOptions', () => {
         inUse = 0,
         hasSelection = false,
         hasValueUpdate = false,
-        hasValueError = false,
+        hasValueError = false
     ): void {
         expect(wrapper.find(SectionHeading)).toHaveLength(1);
         expect(wrapper.find(SectionHeading).prop('title')).toBe('Test Label');
@@ -162,7 +162,9 @@ describe('TextChoiceOptions', () => {
         await waitForLifecycle(wrapper);
 
         validate(wrapper, false, 2, 1, true, true);
-        expect(wrapper.find('.domain-text-choices-info').hostNodes().text()).toBe('1 row with value b will be updated to bb on save.');
+        expect(wrapper.find('.domain-text-choices-info').hostNodes().text()).toBe(
+            '1 row with value b will be updated to bb on save.'
+        );
 
         wrapper.unmount();
     });
@@ -187,12 +189,7 @@ describe('TextChoiceOptions', () => {
     });
 
     test('value update error checks', async () => {
-        const wrapper = mount(
-            <TextChoiceOptionsImpl
-                {...DEFAULT_PROPS}
-                validValues={['a', 'b']}
-            />
-        );
+        const wrapper = mount(<TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} />);
 
         wrapper.find(ChoicesListItem).last().simulate('click');
         await waitForLifecycle(wrapper);

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
@@ -120,7 +120,7 @@ describe('TextChoiceOptions', () => {
 
     test('with inUse values', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b:  false }} />
+            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b:  { locked: false, count: 1 } }} />
         );
         validate(wrapper, false, 2, 1);
 
@@ -135,7 +135,7 @@ describe('TextChoiceOptions', () => {
 
     test('with locked values', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b:  true }} />
+            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b: { locked: true, count: 1 } }} />
         );
         validate(wrapper, false, 2, 1);
 
@@ -150,7 +150,7 @@ describe('TextChoiceOptions', () => {
 
     test('delete button disabled', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b: false }} />
+            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b: { locked: false, count: 1 } }} />
         );
         validate(wrapper, false, 2, 1);
 

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.spec.tsx
@@ -120,7 +120,11 @@ describe('TextChoiceOptions', () => {
 
     test('with inUse values', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b:  { locked: false, count: 1 } }} />
+            <TextChoiceOptionsImpl
+                {...DEFAULT_PROPS}
+                validValues={['a', 'b']}
+                fieldValues={{ b: { locked: false, count: 1 } }}
+            />
         );
         validate(wrapper, false, 2, 1);
 
@@ -135,7 +139,11 @@ describe('TextChoiceOptions', () => {
 
     test('with locked values', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b: { locked: true, count: 1 } }} />
+            <TextChoiceOptionsImpl
+                {...DEFAULT_PROPS}
+                validValues={['a', 'b']}
+                fieldValues={{ b: { locked: true, count: 1 } }}
+            />
         );
         validate(wrapper, false, 2, 1);
 
@@ -150,7 +158,11 @@ describe('TextChoiceOptions', () => {
 
     test('delete button disabled', async () => {
         const wrapper = mount(
-            <TextChoiceOptionsImpl {...DEFAULT_PROPS} validValues={['a', 'b']} fieldValues={{ b: { locked: false, count: 1 } }} />
+            <TextChoiceOptionsImpl
+                {...DEFAULT_PROPS}
+                validValues={['a', 'b']}
+                fieldValues={{ b: { locked: false, count: 1 } }}
+            />
         );
         validate(wrapper, false, 2, 1);
 

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
@@ -285,7 +285,7 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
                                 </div>
                                 {fieldValueUpdates[selectedValue] !== undefined &&
                                     selectedValue !== fieldValueUpdates[selectedValue] && (
-                                        <Alert bsStyle="info">
+                                        <Alert bsStyle="info" className="domain-text-choices-info">
                                             {Utils.pluralize(
                                                 fieldValues[fieldValueUpdates[selectedValue]].count,
                                                 'row',

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
@@ -87,7 +87,7 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
     const [currentError, setCurrentError] = useState<string>();
     const [showAddValuesModal, setShowAddValuesModal] = useState<boolean>();
 
-    // keep a map from the updated values for the in use field values to their original values
+    // keep a map from the updated values for the in-use field values to their original values
     const [fieldValueUpdates, setFieldValueUpdates] = useState<Record<string, string>>({});
     useEffect(() => {
         setFieldValueUpdates(

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
@@ -10,6 +10,8 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 import { LockIcon } from '../base/LockIcon';
 import { DisableableButton } from '../buttons/DisableableButton';
 
+import { DisableableInput } from '../forms/DisableableInput';
+
 import { DOMAIN_VALIDATOR_TEXTCHOICE, MAX_VALID_TEXT_CHOICES } from './constants';
 import {
     DEFAULT_TEXT_CHOICE_VALIDATOR,
@@ -23,7 +25,6 @@ import { DomainFieldLabel } from './DomainFieldLabel';
 
 import { TextChoiceAddValuesModal } from './TextChoiceAddValuesModal';
 import { createFormInputId } from './actions';
-import { DisableableInput } from '../forms/DisableableInput';
 
 const HELP_TIP_BODY = <p>The set of values to be used as drop-down options to restrict data entry into this field.</p>;
 
@@ -99,11 +100,15 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
 
     const selectedValue = useMemo(() => validValues[selectedIndex], [validValues, selectedIndex]);
     const currentInUse = fieldValueUpdates.hasOwnProperty(selectedValue);
-    const currentLocked = currentInUse && (lockedForDomain || (fieldValues[fieldValueUpdates[selectedValue]]?.locked ?? false));
+    const currentLocked =
+        currentInUse && (lockedForDomain || (fieldValues[fieldValueUpdates[selectedValue]]?.locked ?? false));
 
-    const isValueDuplicate = useCallback((val: string): boolean => {
-        return validValues.indexOf(val) !== -1;
-    }, [validValues]);
+    const isValueDuplicate = useCallback(
+        (val: string): boolean => {
+            return validValues.indexOf(val) !== -1;
+        },
+        [validValues]
+    );
 
     const onSelect = useCallback(
         ind => {
@@ -114,15 +119,18 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
         [validValues]
     );
 
-    const onValueChange = useCallback(evt => {
-        const updatedVal = evt.target.value;
-        setCurrentValue(updatedVal);
-        setCurrentError(
-            updatedVal.trim() !== selectedValue && isValueDuplicate(updatedVal.trim())
-                ? `"${updatedVal.trim()}" already exists in the list of values.`
-                : undefined
-        );
-    }, [validValues, selectedIndex]);
+    const onValueChange = useCallback(
+        evt => {
+            const updatedVal = evt.target.value;
+            setCurrentValue(updatedVal);
+            setCurrentError(
+                updatedVal.trim() !== selectedValue && isValueDuplicate(updatedVal.trim())
+                    ? `"${updatedVal.trim()}" already exists in the list of values.`
+                    : undefined
+            );
+        },
+        [validValues, selectedIndex]
+    );
 
     const updateValue = useCallback(
         (updatedValue?: string) => {
@@ -207,7 +215,8 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
                             {validValues.map((value, ind) => {
                                 const inUse = fieldValueUpdates.hasOwnProperty(value);
                                 const locked =
-                                    inUse && (lockedForDomain || (fieldValues[fieldValueUpdates[value]]?.locked ?? false));
+                                    inUse &&
+                                    (lockedForDomain || (fieldValues[fieldValueUpdates[value]]?.locked ?? false));
 
                                 return (
                                     <ChoicesListItem
@@ -264,18 +273,28 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
                                     <Button
                                         bsStyle="success"
                                         className="pull-right"
-                                        disabled={currentError !== undefined || currentValue === selectedValue || currentValue === ''}
+                                        disabled={
+                                            currentError !== undefined ||
+                                            currentValue === selectedValue ||
+                                            currentValue === ''
+                                        }
                                         onClick={onApply}
                                     >
                                         Apply
                                     </Button>
                                 </div>
-                                {fieldValueUpdates[selectedValue] !== undefined && selectedValue !== fieldValueUpdates[selectedValue] && (
-                                    <Alert bsStyle="info">
-                                        {Utils.pluralize(fieldValues[fieldValueUpdates[selectedValue]].count, 'row', 'rows')}{' '}
-                                        with value <b>{fieldValueUpdates[selectedValue]}</b> will be updated to <b>{selectedValue}</b> on save.
-                                    </Alert>
-                                )}
+                                {fieldValueUpdates[selectedValue] !== undefined &&
+                                    selectedValue !== fieldValueUpdates[selectedValue] && (
+                                        <Alert bsStyle="info">
+                                            {Utils.pluralize(
+                                                fieldValues[fieldValueUpdates[selectedValue]].count,
+                                                'row',
+                                                'rows'
+                                            )}{' '}
+                                            with value <b>{fieldValueUpdates[selectedValue]}</b> will be updated to{' '}
+                                            <b>{selectedValue}</b> on save.
+                                        </Alert>
+                                    )}
                                 {currentError && <Alert bsStyle="danger">{currentError}</Alert>}
                             </>
                         )}
@@ -340,14 +359,14 @@ export const TextChoiceOptions: FC<Props> = memo(props => {
                     sql: `SELECT "${fieldName}", ${lockedSqlFragment} AS IsLocked, COUNT(*) AS RowCount FROM "${queryName}" WHERE "${fieldName}" IS NOT NULL GROUP BY "${fieldName}"`,
                     success: response => {
                         const values = response.rows
-                                .filter(row => isValidTextChoiceValue(row[fieldName]))
-                                .reduce((prev, current) => {
-                                    prev[current[fieldName]] = {
-                                        count: current['RowCount'],
-                                        locked: current['IsLocked'] === 1,
-                                    };
-                                    return prev;
-                                }, {});
+                            .filter(row => isValidTextChoiceValue(row[fieldName]))
+                            .reduce((prev, current) => {
+                                prev[current[fieldName]] = {
+                                    count: current['RowCount'],
+                                    locked: current['IsLocked'] === 1,
+                                };
+                                return prev;
+                            }, {});
                         setFieldValues(values);
 
                         // if this is new text choice validator (i.e. does not have a rowId) for an existing field

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
@@ -26,6 +26,7 @@ import { DomainFieldLabel } from './DomainFieldLabel';
 
 import { TextChoiceAddValuesModal } from './TextChoiceAddValuesModal';
 import { createFormInputId } from './actions';
+import { DisableableInput } from "../forms/DisableableInput";
 
 const HELP_TIP_BODY = <p>The set of values to be used as drop-down options to restrict data entry into this field.</p>;
 
@@ -182,13 +183,13 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
                                     <DomainFieldLabel label="Value" />
                                 </div>
                                 <div className="domain-field-padding-bottom">
-                                    <input
+                                    <DisableableInput
                                         className="form-control full-width"
-                                        disabled={currentInUse}
+                                        disabledMsg={currentLocked ? LOCKED_TIP : undefined}
                                         name="value"
                                         onChange={onValueChange}
                                         placeholder="Enter a text choice value"
-                                        type="text"
+                                        title={LOCKED_TITLE}
                                         value={currentValue ?? ''}
                                     />
                                 </div>

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
@@ -276,7 +276,7 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
                                         disabled={
                                             currentError !== undefined ||
                                             currentValue === selectedValue ||
-                                            currentValue === ''
+                                            currentValue.trim() === ''
                                         }
                                         onClick={onApply}
                                     >

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -135,29 +135,24 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
     getTextChoiceUpdatesValidMsg(): string {
         const { protocolModel } = this.state;
 
-        if (!protocolModel.editableRuns) {
-            const domain = protocolModel.getDomainByNameSuffix('Run');
-            const hasFieldValueUpdates =
-                domain.fields.find(field => {
-                    return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
-                }) !== undefined;
-            if (hasFieldValueUpdates) {
-                return 'Text choice value updates are not allowed when assay does not allow "Editable Runs".';
-            }
+        const runDomain = protocolModel.getDomainByNameSuffix('Run');
+        if (!protocolModel.editableRuns && this.domainHasTextChoiceUpdates(runDomain)) {
+            return 'Text choice value updates are not allowed when assay does not allow "Editable Runs".';
         }
 
-        if (!protocolModel.editableResults) {
-            const domain = protocolModel.getDomainByNameSuffix('Data');
-            const hasFieldValueUpdates =
-                domain.fields.find(field => {
-                    return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
-                }) !== undefined;
-            if (hasFieldValueUpdates) {
-                return 'Text choice value updates are not allowed when assay does not allow "Editable Results".';
-            }
+        const dataDomain = protocolModel.getDomainByNameSuffix('Data');
+        if (!protocolModel.editableResults && this.domainHasTextChoiceUpdates(dataDomain)) {
+            return 'Text choice value updates are not allowed when assay does not allow "Editable Results".';
         }
 
         return undefined;
+    }
+
+    domainHasTextChoiceUpdates(domain: DomainDesign): boolean {
+        return (
+            domain.fields.find(field => field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined) !==
+            undefined
+        );
     }
 
     onAssayPropertiesChange = (model: AssayProtocolModel) => {

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -137,9 +137,10 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
 
         if (!protocolModel.editableRuns) {
             const domain = protocolModel.getDomainByNameSuffix('Run');
-            const hasFieldValueUpdates = domain.fields.find(field => {
-                return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
-            }) !== undefined;
+            const hasFieldValueUpdates =
+                domain.fields.find(field => {
+                    return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
+                }) !== undefined;
             if (hasFieldValueUpdates) {
                 return 'Text choice value updates are not allowed when assay does not allow "Editable Runs".';
             }
@@ -147,9 +148,10 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
 
         if (!protocolModel.editableResults) {
             const domain = protocolModel.getDomainByNameSuffix('Data');
-            const hasFieldValueUpdates = domain.fields.find(field => {
-                return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
-            }) !== undefined;
+            const hasFieldValueUpdates =
+                domain.fields.find(field => {
+                    return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
+                }) !== undefined;
             if (hasFieldValueUpdates) {
                 return 'Text choice value updates are not allowed when assay does not allow "Editable Results".';
             }

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -86,12 +86,16 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
         const { setSubmitting } = this.props;
         const { protocolModel } = this.state;
         const appIsValidMsg = this.getAppIsValidMsg();
-        const isValid = protocolModel.isValid() && appIsValidMsg === undefined;
+        const textChoiceValidMsg = this.getTextChoiceUpdatesValidMsg();
+        const isValid = protocolModel.isValid() && textChoiceValidMsg === undefined && appIsValidMsg === undefined;
 
         this.props.onFinish(isValid, this.saveDomain);
 
         if (!isValid) {
-            const exception = appIsValidMsg !== undefined ? appIsValidMsg : protocolModel.getFirstDomainFieldError();
+            const exception =
+                appIsValidMsg !== undefined
+                    ? appIsValidMsg
+                    : textChoiceValidMsg ?? protocolModel.getFirstDomainFieldError();
             const updatedModel = protocolModel.set('exception', exception) as AssayProtocolModel;
             setSubmitting(false, () => {
                 this.setState(() => ({ protocolModel: updatedModel }));
@@ -126,6 +130,32 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
         const { protocolModel } = this.state;
 
         return !appIsValidMsg ? undefined : appIsValidMsg(protocolModel);
+    }
+
+    getTextChoiceUpdatesValidMsg(): string {
+        const { protocolModel } = this.state;
+
+        if (!protocolModel.editableRuns) {
+            const domain = protocolModel.getDomainByNameSuffix('Run');
+            const hasFieldValueUpdates = domain.fields.find(field => {
+                return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
+            }) !== undefined;
+            if (hasFieldValueUpdates) {
+                return 'Text choice value updates are not allowed when assay does not allow "Editable Runs".';
+            }
+        }
+
+        if (!protocolModel.editableResults) {
+            const domain = protocolModel.getDomainByNameSuffix('Data');
+            const hasFieldValueUpdates = domain.fields.find(field => {
+                return field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined;
+            }) !== undefined;
+            if (hasFieldValueUpdates) {
+                return 'Text choice value updates are not allowed when assay does not allow "Editable Results".';
+            }
+        }
+
+        return undefined;
     }
 
     onAssayPropertiesChange = (model: AssayProtocolModel) => {

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -136,12 +136,12 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
         const { protocolModel } = this.state;
 
         const runDomain = protocolModel.getDomainByNameSuffix('Run');
-        if (!protocolModel.editableRuns && this.domainHasTextChoiceUpdates(runDomain)) {
+        if (runDomain && !protocolModel.editableRuns && this.domainHasTextChoiceUpdates(runDomain)) {
             return 'Text choice value updates are not allowed when assay does not allow "Editable Runs".';
         }
 
         const dataDomain = protocolModel.getDomainByNameSuffix('Data');
-        if (!protocolModel.editableResults && this.domainHasTextChoiceUpdates(dataDomain)) {
+        if (dataDomain && !protocolModel.editableResults && this.domainHasTextChoiceUpdates(dataDomain)) {
             return 'Text choice value updates are not allowed when assay does not allow "Editable Results".';
         }
 

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -150,8 +150,10 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
 
     domainHasTextChoiceUpdates(domain: DomainDesign): boolean {
         return (
-            domain.fields.find(field => field.textChoiceValidator?.extraProperties?.valueUpdates !== undefined) !==
-            undefined
+            domain.fields.find(field => {
+                const valueUpdates = field.textChoiceValidator?.extraProperties?.valueUpdates ?? {};
+                return Object.keys(valueUpdates).length > 0;
+            }) !== undefined
         );
     }
 
@@ -238,9 +240,10 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
                         protocolModel.providerName !== 'General' || !domain.isNameSuffixMatch('Data');
                     const hideFilePropertyType = !domain.isNameSuffixMatch('Batch') && !domain.isNameSuffixMatch('Run');
                     const appDomainHeaderRenderer = this.getAppDomainHeaderRenderer(domain);
-                    const textChoiceLockedForDomain =
-                        (domain.isNameSuffixMatch('Run') && !protocolModel.editableRuns) ||
-                        (domain.isNameSuffixMatch('Data') && !protocolModel.editableResults);
+                    const textChoiceLockedForDomain = !(
+                        (domain.isNameSuffixMatch('Run') && protocolModel.editableRuns) ||
+                        (domain.isNameSuffixMatch('Data') && protocolModel.editableResults)
+                    );
 
                     return (
                         <DomainForm

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -211,6 +211,9 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
                         protocolModel.providerName !== 'General' || !domain.isNameSuffixMatch('Data');
                     const hideFilePropertyType = !domain.isNameSuffixMatch('Batch') && !domain.isNameSuffixMatch('Run');
                     const appDomainHeaderRenderer = this.getAppDomainHeaderRenderer(domain);
+                    const textChoiceLockedForDomain =
+                        (domain.isNameSuffixMatch('Run') && !protocolModel.editableRuns) ||
+                        (domain.isNameSuffixMatch('Data') && !protocolModel.editableResults);
 
                     return (
                         <DomainForm
@@ -246,6 +249,7 @@ class AssayDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDo
                                 domainKindDisplayName: 'assay design',
                                 hideFilePropertyType,
                                 hideInferFromFile,
+                                textChoiceLockedForDomain,
                             }}
                         >
                             <div>{domain.description}</div>

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -51,6 +51,7 @@ import {
     getValidValuesDetailStr,
     getValidValuesFromArray,
     isPropertyTypeAllowed,
+    isValidTextChoiceValue,
     PropertyValidatorProperties,
 } from './models';
 import {
@@ -1048,5 +1049,21 @@ describe('getValidValuesFromArray', () => {
 
     test('remove duplicates', () => {
         expect(getValidValuesFromArray(['a', 'a', 'a', 'b'])).toStrictEqual(['a', 'b']);
+    });
+});
+
+describe('isValidTextChoiceValue', () => {
+    test('empty', () => {
+        expect(isValidTextChoiceValue(undefined)).toBeFalsy();
+        expect(isValidTextChoiceValue(null)).toBeFalsy();
+        expect(isValidTextChoiceValue('')).toBeFalsy();
+        expect(isValidTextChoiceValue(' ')).toBeFalsy();
+    });
+
+    test('valid', () => {
+        expect(isValidTextChoiceValue('a')).toBeTruthy();
+        expect(isValidTextChoiceValue(' a')).toBeTruthy();
+        expect(isValidTextChoiceValue('a ')).toBeTruthy();
+        expect(isValidTextChoiceValue(' a ')).toBeTruthy();
     });
 });

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -62,6 +62,10 @@ import {
     DOMAIN_FIELD_PARTIALLY_LOCKED,
     INT_RANGE_URI,
     MULTILINE_RANGE_URI,
+    PHILEVEL_NOT_PHI,
+    PHILEVEL_FULL_PHI,
+    PHILEVEL_LIMITED_PHI,
+    PHILEVEL_RESTRICTED_PHI,
     SAMPLE_TYPE_CONCEPT_URI,
     STORAGE_UNIQUE_ID_CONCEPT_URI,
     STRING_RANGE_URI,
@@ -712,6 +716,13 @@ describe('DomainField', () => {
         expect(f2.isSaved()).toBeFalsy();
         const f3 = DomainField.create({ name: 'foo', rangeURI: TEXT_TYPE.rangeURI, propertyId: 1 });
         expect(f3.isSaved()).toBeTruthy();
+    });
+
+    test('isPHI', () => {
+        expect(DomainField.create({ name: 'foo', PHI: PHILEVEL_NOT_PHI }).isPHI()).toBeFalsy();
+        expect(DomainField.create({ name: 'foo', PHI: PHILEVEL_LIMITED_PHI }).isPHI()).toBeTruthy();
+        expect(DomainField.create({ name: 'foo', PHI: PHILEVEL_FULL_PHI }).isPHI()).toBeTruthy();
+        expect(DomainField.create({ name: 'foo', PHI: PHILEVEL_RESTRICTED_PHI }).isPHI()).toBeTruthy();
     });
 
     test('updateDefaultValues', () => {

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -670,6 +670,10 @@ export class PropertyValidator
                 delete pvs[i].properties.validValues;
             }
 
+            if (pvs[i]?.extraProperties && !pvs[i].extraProperties.valueUpdates) {
+                delete pvs[i].extraProperties;
+            }
+
             delete pvs[i].shouldShowWarning;
         }
 

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -551,17 +551,20 @@ export class ConditionalFormat
 export interface IPropertyValidatorProperties {
     failOnMatch: boolean;
     validValues: string[];
+    valueUpdates: Record<string, string>;
 }
 
 export class PropertyValidatorProperties
     extends Record({
         failOnMatch: false,
         validValues: undefined,
+        valueUpdates: undefined,
     })
     implements IPropertyValidatorProperties
 {
     declare failOnMatch: boolean;
     declare validValues: string[];
+    declare valueUpdates: Record<string, string>;
 
     constructor(values?: { [key: string]: any }) {
         if (typeof values?.failOnMatch === 'string') {
@@ -581,6 +584,7 @@ export interface IPropertyValidator {
     type: string;
     name: string;
     properties: PropertyValidatorProperties;
+    extraProperties: PropertyValidatorProperties;
     errorMessage?: string;
     description?: string;
     new: boolean;
@@ -594,6 +598,7 @@ export class PropertyValidator
         type: undefined,
         name: undefined,
         properties: new PropertyValidatorProperties(),
+        extraProperties: new PropertyValidatorProperties(),
         errorMessage: undefined,
         description: undefined,
         new: true,
@@ -606,6 +611,7 @@ export class PropertyValidator
     declare type: string;
     declare name: string;
     declare properties: PropertyValidatorProperties;
+    declare extraProperties: PropertyValidatorProperties;
     declare errorMessage?: string;
     declare description?: string;
     declare new: boolean;

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1209,9 +1209,13 @@ export class DomainField
     }
 }
 
+export function isValidTextChoiceValue(v: string): boolean {
+    return v !== null && v !== undefined && v.trim() !== '';
+}
+
 export function getValidValuesFromArray(validValues: string[]): string[] {
     // filter out any empty string values
-    const vals = validValues?.filter(v => v !== null && v !== undefined && v.trim() !== '') ?? [];
+    const vals = validValues?.filter(isValidTextChoiceValue) ?? [];
     // remove duplicates
     return [...new Set(vals)];
 }
@@ -1815,6 +1819,8 @@ export interface IDomainFormDisplayOptions {
     hideConditionalFormatting?: boolean;
     hideInferFromFile?: boolean;
     showScannableOption?: boolean;
+    textChoiceLockedForDomain?: boolean;
+    textChoiceLockedSqlFragment?: string;
 }
 
 export interface IDerivationDataScope {

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -42,6 +42,7 @@ import {
     FIELD_EMPTY_TEXT_CHOICE_WARNING_MSG,
     INT_RANGE_URI,
     MAX_TEXT_LENGTH,
+    PHILEVEL_NOT_PHI,
     SAMPLE_TYPE_CONCEPT_URI,
     SEVERITY_LEVEL_ERROR,
     SEVERITY_LEVEL_WARN,
@@ -1096,6 +1097,10 @@ export class DomainField
 
     isTextChoiceField(): boolean {
         return this.conceptURI === TEXT_CHOICE_CONCEPT_URI;
+    }
+
+    isPHI(): boolean {
+        return this.PHI !== PHILEVEL_NOT_PHI;
     }
 
     static hasRangeValidation(field: DomainField): boolean {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../..';
 
 import { DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS } from '../constants';
-import { addDomainField, getDomainPanelStatus, saveDomain, validateDomainNameExpressions } from '../actions';
+import { addDomainField, getDomainPanelStatus, saveDomain } from '../actions';
 import { initSampleSetSelects } from '../../samples/actions';
 import { DEFAULT_SAMPLE_FIELD_CONFIG } from '../../samples/constants';
 import { SAMPLE_SET_DISPLAY_TEXT } from '../../../constants';
@@ -752,6 +752,8 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
                         ...domainFormDisplayOptions,
                         hideStudyPropertyTypes: !_showLinkToStudy,
                         showScannableOption: true,
+                        textChoiceLockedSqlFragment:
+                            "MAX(CASE WHEN SampleState.StatusType = 'Locked' THEN 1 ELSE 0 END)",
                     }}
                 />
                 {error && <div className="domain-form-panel">{error && <Alert bsStyle="danger">{error}</Alert>}</div>}

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -2986,6 +2986,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
             "hideConditionalFormatting": true,
             "hideStudyPropertyTypes": true,
             "showScannableOption": true,
+            "textChoiceLockedSqlFragment": "MAX(CASE WHEN SampleState.StatusType = 'Locked' THEN 1 ELSE 0 END)",
           }
         }
         domainIndex={0}
@@ -3128,6 +3129,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                 "hideConditionalFormatting": true,
                 "hideStudyPropertyTypes": true,
                 "showScannableOption": true,
+                "textChoiceLockedSqlFragment": "MAX(CASE WHEN SampleState.StatusType = 'Locked' THEN 1 ELSE 0 END)",
               }
             }
             domainIndex={0}
@@ -3968,6 +3970,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                             "hideConditionalFormatting": true,
                                                             "hideStudyPropertyTypes": true,
                                                             "showScannableOption": true,
+                                                            "textChoiceLockedSqlFragment": "MAX(CASE WHEN SampleState.StatusType = 'Locked' THEN 1 ELSE 0 END)",
                                                           }
                                                         }
                                                         domainId={null}
@@ -4156,6 +4159,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                             "hideConditionalFormatting": true,
                                                                             "hideStudyPropertyTypes": true,
                                                                             "showScannableOption": true,
+                                                                            "textChoiceLockedSqlFragment": "MAX(CASE WHEN SampleState.StatusType = 'Locked' THEN 1 ELSE 0 END)",
                                                                           }
                                                                         }
                                                                         domainId={null}
@@ -4775,6 +4779,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                               "hideConditionalFormatting": true,
                                                                               "hideStudyPropertyTypes": true,
                                                                               "showScannableOption": true,
+                                                                              "textChoiceLockedSqlFragment": "MAX(CASE WHEN SampleState.StatusType = 'Locked' THEN 1 ELSE 0 END)",
                                                                             }
                                                                           }
                                                                           domainIndex={0}
@@ -5858,6 +5863,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                                         "hideConditionalFormatting": true,
                                                                                         "hideStudyPropertyTypes": true,
                                                                                         "showScannableOption": true,
+                                                                                        "textChoiceLockedSqlFragment": "MAX(CASE WHEN SampleState.StatusType = 'Locked' THEN 1 ELSE 0 END)",
                                                                                       }
                                                                                     }
                                                                                     domainIndex={0}

--- a/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RangeValidationOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RangeValidationOptions.spec.tsx.snap
@@ -28,6 +28,12 @@ exports[`RangeValidationOptions Range Validator - collapsed 1`] = `
       "properties": Immutable.Record {
         "failOnMatch": true,
         "validValues": undefined,
+        "valueUpdates": undefined,
+      },
+      "extraProperties": Immutable.Record {
+        "failOnMatch": false,
+        "validValues": undefined,
+        "valueUpdates": undefined,
       },
       "errorMessage": "Range validation failed",
       "description": "This is a range validator",
@@ -134,6 +140,12 @@ exports[`RangeValidationOptions Range Validator - expanded 1`] = `
       "properties": Immutable.Record {
         "failOnMatch": true,
         "validValues": undefined,
+        "valueUpdates": undefined,
+      },
+      "extraProperties": Immutable.Record {
+        "failOnMatch": false,
+        "validValues": undefined,
+        "valueUpdates": undefined,
       },
       "errorMessage": "Range validation failed",
       "description": "This is a range validator",

--- a/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RegexValidationOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RegexValidationOptions.spec.tsx.snap
@@ -28,6 +28,12 @@ exports[`RegexValidationOptions Regex Validator - collapsed 1`] = `
       "properties": Immutable.Record {
         "failOnMatch": true,
         "validValues": undefined,
+        "valueUpdates": undefined,
+      },
+      "extraProperties": Immutable.Record {
+        "failOnMatch": false,
+        "validValues": undefined,
+        "valueUpdates": undefined,
       },
       "errorMessage": "Test Validation Failure",
       "description": "This is my validator description",
@@ -134,6 +140,12 @@ exports[`RegexValidationOptions Regex Validator - expanded 1`] = `
       "properties": Immutable.Record {
         "failOnMatch": true,
         "validValues": undefined,
+        "valueUpdates": undefined,
+      },
+      "extraProperties": Immutable.Record {
+        "failOnMatch": false,
+        "validValues": undefined,
+        "valueUpdates": undefined,
       },
       "errorMessage": "Test Validation Failure",
       "description": "This is my validator description",

--- a/packages/components/src/internal/components/forms/DisableableInput.tsx
+++ b/packages/components/src/internal/components/forms/DisableableInput.tsx
@@ -1,0 +1,30 @@
+import React, { memo, FC } from 'react';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+
+interface Props {
+    className?: string;
+    disabledMsg?: string;
+    name: string;
+    placeholder?: string;
+    onChange: (evt: any) => void;
+    title?: string;
+    value: string;
+}
+
+export const DisableableInput: FC<Props> = memo(props => {
+    const { disabledMsg, title, ...inputProps } = props;
+
+    return (
+        <>
+            {disabledMsg ? (
+                <OverlayTrigger placement="bottom" overlay={<Popover title={title}>{disabledMsg}</Popover>}>
+                    <div className="disabled-button-with-tooltip full-width">
+                        <input {...inputProps} type="text" disabled />
+                    </div>
+                </OverlayTrigger>
+            ) : (
+                <input {...inputProps} type="text" />
+            )}
+        </>
+    );
+});

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -42,10 +42,6 @@
     margin: 0 !important;
 }
 
-.choices-list__locked-pad-right {
-    padding-right: 3px;
-}
-
 .choices-list .list-group-item .fa {
     margin-right: 6px;
 }

--- a/packages/components/src/theme/choiceList.scss
+++ b/packages/components/src/theme/choiceList.scss
@@ -42,6 +42,10 @@
     margin: 0 !important;
 }
 
+.choices-list__locked-pad-right {
+    padding-right: 3px;
+}
+
 .choices-list .list-group-item .fa {
     margin-right: 6px;
 }

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -776,3 +776,6 @@
 .domain-text-choices-error {
     color: $brand-danger;
 }
+.domain-text-choices-info {
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
#### Rationale
For this round of changes to the Text Choice data type epic, we are adding support for allowing updates to in use text choice values from within the field editor UI along with locking those values that are in use by a "locked" item (i.e. sample with a locked status). This PR also includes updates to the text choice value apply and add modal to prevent duplicates and empty strings from getting added to the list. Finally, it keeps track of the text choice value updates for in use values so that it can sent it to the server update domain API.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/697
* https://github.com/LabKey/platform/pull/2903
* https://github.com/LabKey/biologics/pull/1109
* https://github.com/LabKey/sampleManagement/pull/789

#### Changes
* update to query to get in use text choice values so that it includes "locked" and row count
* provide SQL fragment from sample type domain for how to determine "locked" text choice values
* update text choice listing icons and selected value display for info on updates and hover text
* send text choice value updates for in use values to the server as part of post to update domain
* prevent text choice updates and add values modal apply for duplicates and empty strings
