### PR TITLE
Issue 44568: Update getRawData used when inserting via editable grid to use rowIds instead of names for parent columns

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.112.1-idVsName.1",
+  "version": "2.112.1-idVsName.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.112.1-idVsName.0",
+  "version": "2.112.1-idVsName.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.112.0",
+  "version": "2.112.1-idVsName.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.112.TBD
+*Released*: TBD
+* Issue 44568: SampleIds that are integers that match existing rowId defaults to the rowId in lineage updates
+  * Update `getRawData` to use the raw values (rowIds) when gathering data for parent inputs
+
 ### version 2.112.0
 *Released*: 30 December 2021
 * Item #9782: Text Choice data type support for field editor updates to in-use values

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -111,7 +111,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
         let value = chosenValue ?? undefined;
         if (!value && model?.hasData && parentLSIDs?.length > 0) {
             value = Object.values(model.rows)
-                .map(row => caseInsensitive(row, 'Name').value)
+                .map(row => caseInsensitive(row, 'RowId').value)
                 .join(DELIMITER);
         }
         let queryFilters = List<Filter.IFilter>();
@@ -161,7 +161,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
                             queryFilters={queryFilters}
                             showLoading
                             value={value}
-                            valueColumn="Name"
+                            valueColumn="RowId"
                         />
                         {!chosenValue && (
                             <div className="row top-spacing edit-parent-danger">

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -420,7 +420,20 @@ export class EditorModel
                 if (renderer?.getEditableRawValue) {
                     row = row.set(col.name, renderer.getEditableRawValue(values));
                 } else if (col.isLookup()) {
-                    if (col.isJunctionLookup() || col.isExpInput() || col.isAliquotParent()) {
+                    if (col.isExpInput() || col.isAliquotParent()) {
+                        let sep = '';
+                        row = row.set(
+                            col.name,
+                            values.reduce((str, vd) => {
+                                if (vd.raw !== undefined && vd.raw !== null) {
+                                    str += sep + vd.raw;
+                                    sep = ', ';
+                                }
+                                return str;
+                            }, '')
+                        );
+                    }
+                    else if (col.isJunctionLookup()) {
                         row = row.set(
                             col.name,
                             values.reduce((arr, vd) => {

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -420,19 +420,7 @@ export class EditorModel
                 if (renderer?.getEditableRawValue) {
                     row = row.set(col.name, renderer.getEditableRawValue(values));
                 } else if (col.isLookup()) {
-                    if (col.isExpInput() || col.isAliquotParent()) {
-                        let sep = '';
-                        row = row.set(
-                            col.name,
-                            values.reduce((str, vd) => {
-                                if (vd.display !== undefined && vd.display !== null) {
-                                    str += sep + vd.display;
-                                    sep = ', ';
-                                }
-                                return str;
-                            }, '')
-                        );
-                    } else if (col.isJunctionLookup()) {
+                    if (col.isJunctionLookup() || col.isExpInput() || col.isAliquotParent()) {
                         row = row.set(
                             col.name,
                             values.reduce((arr, vd) => {


### PR DESCRIPTION
#### Rationale
From our EditableGrid, we use insertRows to create samples and data class objects.  We have been passing through the names of parent samples provided in the grid as part of these insertRows updates.  Since we now (as of not too long ago) allow the names of these entities to be just strings of integers, they look very much like rowIds, and on the server side if we can parse the input value as an integer, we assume it is a rowId.  You can see the problem.  For **import** (from a file), we have a the `allowImportLookupByAlternateKey` property that can be set to allow finding values using other unique fields.  This is not used for insert (from a UI), however, presumably because we can always send through rowIds instead.  I'm not sure why we had been sending in the names instead of the rowIds for the parent fields, but this PR changes that behavior so we now send through rowIds for all lookups and the default logic on the server side will do the right thing of finding samples by RowId.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/795
* https://github.com/LabKey/biologics/pull/1117
* https://github.com/LabKey/platform/pull/2917


#### Changes
* Update `getRawData` to use the raw values (rowIds) when gathering data for parent inputs
