### PR TITLE
Address UnhandledPromiseRejections in tests

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.115.1-fb-unhandled-tests.0",
+  "version": "2.115.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.115.1",
+  "version": "2.115.1-fb-unhandled-tests.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.115.#
-*Released*: # January 2022
+### version 2.115.2
+*Released*: 7 January 2022
 * Fix unhandled promises
   * most are addressed by adding test mock initialization
   * address <AssignmentOptions/> in Issues by refactoring how erroneous requests are handled

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.115.#
+*Released*: # January 2022
+* Fix unhandled promises
+  * most are addressed by adding test mock initialization
+  * address <AssignmentOptions/> in Issues by refactoring how erroneous requests are handled
+
 ### version 2.115.1
 *Released*: 5 January 2022
 * Escape typings of some built-in React HTML types

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
@@ -10,21 +10,16 @@ import { CheckboxInput } from '../forms/input/CheckboxInput';
 
 import { AssayWizardModel } from './AssayWizardModel';
 import { RunPropertiesPanel } from './RunPropertiesPanel';
+import { initUnitTestMocks } from '../../testHelperMocks';
 
 beforeAll(() => {
-    LABKEY.container = {
-        formats: {
-            dateFormat: 'yyyy-MM-dd',
-            dateTimeFormat: 'yyyy-MM-dd HH:mm',
-            numberFormat: null,
-        },
-    };
+    initUnitTestMocks();
 });
 
 describe('<RunPropertiesPanel/>', () => {
     test('model without run domain fields', () => {
         const model = ASSAY_WIZARD_MODEL.set('runColumns', OrderedMap<string, QueryColumn>()) as AssayWizardModel;
-        const component = <RunPropertiesPanel model={model} onChange={() => {}} />;
+        const component = <RunPropertiesPanel model={model} onChange={jest.fn} />;
 
         const wrapper = mount(component);
         expect(wrapper.find('.panel')).toHaveLength(1);
@@ -34,7 +29,7 @@ describe('<RunPropertiesPanel/>', () => {
     });
 
     test('check form input types', () => {
-        const component = <RunPropertiesPanel model={ASSAY_WIZARD_MODEL} onChange={() => {}} />;
+        const component = <RunPropertiesPanel model={ASSAY_WIZARD_MODEL} onChange={jest.fn} />;
 
         const wrapper = mount(component);
         expect(wrapper.find('.panel')).toHaveLength(1);

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 
 import { DomainDesign, DomainPanelStatus } from '../models';
 
+import { initUnitTestMocks } from '../../../testHelperMocks';
 import { AssayPropertiesPanel } from './AssayPropertiesPanel';
 import { AssayProtocolModel } from './models';
 
@@ -24,6 +25,10 @@ import {
     SaveScriptDataInput,
     TransformScriptsInput,
 } from './AssayPropertiesInput';
+
+beforeAll(() => {
+    initUnitTestMocks();
+});
 
 const BASE_PROPS = {
     panelStatus: 'NONE' as DomainPanelStatus,

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.spec.tsx
@@ -11,6 +11,11 @@ import getDomainDetailsJSON from '../../../../test/data/dataclass-getDomainDetai
 
 import { DataClassPropertiesPanel, DataClassPropertiesPanelImpl } from './DataClassPropertiesPanel';
 import { DataClassModel } from './models';
+import { initUnitTestMocks } from '../../../testHelperMocks';
+
+beforeAll(() => {
+    initUnitTestMocks();
+});
 
 const BASE_PROPS = {
     panelStatus: 'NONE' as DomainPanelStatus,

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -3,8 +3,6 @@ import { Col, FormControl, Row } from 'react-bootstrap';
 
 import { List } from 'immutable';
 
-import produce from 'immer';
-
 import { SectionHeading } from '../SectionHeading';
 
 import { DomainFieldLabel } from '../DomainFieldLabel';
@@ -59,38 +57,29 @@ export class BasicPropertiesFields extends PureComponent<IssuesListDefBasicPrope
 }
 
 export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, AssignmentOptionsState> {
-    constructor(props: any) {
-        super(props);
-
-        this.state = produce(
-            {
-                coreGroups: undefined,
-                coreUsers: undefined,
-            },
-            () => {}
-        );
-    }
-
-    handleGroupChange = (groupId: number) => {
-        this.getFilteredCoreUsers(groupId);
+    state: Readonly<AssignmentOptionsState> = {
+        coreGroups: undefined,
+        coreUsers: undefined,
     };
 
-    componentDidMount() {
-        getProjectGroups().then(coreGroupsData => {
-            this.setState(() => ({
-                coreGroups: coreGroupsData,
-            }));
-        });
+    componentDidMount = async (): Promise<void> => {
+        try {
+            const coreGroups = await getProjectGroups();
+            this.setState({ coreGroups });
+        } catch (e) {
+            console.error('AssignmentOptions: failed to load initialize project groups', e);
+        }
 
-        this.getFilteredCoreUsers(this.props.model.assignedToGroup);
-    }
+        await this.loadUsersForGroup(this.props.model.assignedToGroup);
+    };
 
-    getFilteredCoreUsers = (groupId: any): any => {
-        getUsersForGroup(groupId).then(coreUsersData => {
-            this.setState(() => ({
-                coreUsers: coreUsersData,
-            }));
-        });
+    loadUsersForGroup = async (groupId: number): Promise<void> => {
+        try {
+            const coreUsers = await getUsersForGroup(groupId);
+            this.setState({ coreUsers });
+        } catch (e) {
+            console.error(`AssignmentOptions: failed to load users for group ${groupId}`, e);
+        }
     };
 
     render() {
@@ -104,7 +93,7 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
                     model={model}
                     coreGroups={coreGroups}
                     onSelect={onSelect}
-                    onGroupChange={this.handleGroupChange}
+                    onGroupChange={this.loadUsersForGroup}
                 />
                 <DefaultUserAssignmentInput model={model} coreUsers={coreUsers} onSelect={onSelect} />
             </Col>

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -71,6 +71,12 @@ import {
     STRING_RANGE_URI,
     TEXT_CHOICE_CONCEPT_URI,
 } from './constants';
+import { initUnitTestMocks } from '../../testHelperMocks';
+import { initOnotologyMocks } from '../../mock';
+
+beforeAll(() => {
+    initUnitTestMocks([initOnotologyMocks]);
+});
 
 const GRID_DATA = DomainDesign.create({
     fields: [
@@ -521,7 +527,7 @@ describe('DomainDesign', () => {
 
     test('getDomainContainer', () => {
         const domain = DomainDesign.create({ name: 'Test Container' });
-        expect(domain.getDomainContainer()).toBe(undefined);
+        expect(domain.getDomainContainer()).toBe('testContainerEntityId');
 
         const domain2 = DomainDesign.create({ name: 'Test Container', container: 'SOMETHINGELSE' });
         expect(domain2.getDomainContainer()).toBe('SOMETHINGELSE');

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
@@ -28,6 +28,11 @@ import { DomainFieldLabel } from '../DomainFieldLabel';
 import { SampleTypePropertiesPanel } from './SampleTypePropertiesPanel';
 import { SampleTypeModel } from './models';
 import { UniqueIdBanner } from './UniqueIdBanner';
+import { initUnitTestMocks } from '../../../testHelperMocks';
+
+beforeAll(() => {
+    initUnitTestMocks();
+});
 
 const BASE_PROPS = {
     panelStatus: 'NONE' as DomainPanelStatus,

--- a/packages/components/src/internal/testHelperMocks.ts
+++ b/packages/components/src/internal/testHelperMocks.ts
@@ -16,8 +16,6 @@ export function initUnitTestMocks(extraMocks?: Array<() => void>, metadata?: Map
     initQueryGridMocks();
     initDomainPropertiesMocks();
     initUserPropsMocks();
-    if (extraMocks) {
-        extraMocks.forEach(extraMock => extraMock());
-    }
+    extraMocks?.forEach(extraMock => extraMock());
     mock.use(proxy);
 }


### PR DESCRIPTION
#### Rationale
Fix unhandled promise exceptions in unit tests. These are no longer avoidable in Node 16 (that's a good thing). I was able to trace down where requests were being made that were not being handled and it looks like I got all of them.

#### Changes
* Most are addressed by adding test mock initialization
* Address `AssignmentOptions` utilized by the Issue's domain designer by refactoring how erroneous requests are handled.
