### PR TITLE
Item 9818: Lineage graph details panel updates to show object input/outputs and run step provenance map

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.4-fb-runDetailsProvenanceMap.3",
+  "version": "2.90.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.3",
+  "version": "2.90.4-fb-runDetailsProvenanceMap.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.4-fb-runDetailsProvenanceMap.2",
+  "version": "2.90.4-fb-runDetailsProvenanceMap.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.4-fb-runDetailsProvenanceMap.0",
+  "version": "2.90.4-fb-runDetailsProvenanceMap.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.90.4-fb-runDetailsProvenanceMap.1",
+  "version": "2.90.4-fb-runDetailsProvenanceMap.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.90.4
+*Released*: TBD
+* Item 9818: Lineage graph details panel updates to show object input/outputs and run step provenance map
+
 ### version 2.90.3
 *Released*: 10 November 2021
 * Issue 44250: Invalidate QueryInfo caches after change to NameIdSettings.allowUserSpecifiedNames

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.90.4
-*Released*: TBD
+*Released*: 21 January 2022
 * Item 9818: Lineage graph details panel updates to show object input/outputs and run step provenance map
   * update Lineage related models for provenanceMap, objectInputs, and objectOutputs
   * display Object Inputs and Object Outputs as collapsible details list (next to Material and Data Inputs/Outputs)

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.90.4
 *Released*: TBD
 * Item 9818: Lineage graph details panel updates to show object input/outputs and run step provenance map
+  * update Lineage related models for provenanceMap, objectInputs, and objectOutputs
+  * display Object Inputs and Object Outputs as collapsible details list (next to Material and Data Inputs/Outputs)
+  * use run step protocol name instead of step name for title
+  * update Run Step display to use tabs for Step Details and Provenance Map
+  * render Run Step provenance map as <Grid> with from/to info
 
 ### version 2.90.3
 *Released*: 10 November 2021

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -166,6 +166,8 @@ function applyLineageIOMetadata(
         dataOutputs: item.dataOutputs.map(_applyItem),
         materialInputs: item.materialInputs.map(_applyItem),
         materialOutputs: item.materialOutputs.map(_applyItem),
+        objectInputs: item.objectInputs.map(_applyItem),
+        objectOutputs: item.objectOutputs.map(_applyItem),
     };
 }
 

--- a/packages/components/src/internal/components/lineage/models.spec.ts
+++ b/packages/components/src/internal/components/lineage/models.spec.ts
@@ -1,4 +1,4 @@
-import {applyLineageOptions, LineageIO} from './models';
+import { applyLineageOptions, LineageIO } from './models';
 import { DEFAULT_LINEAGE_OPTIONS } from './constants';
 import { LineageFilter } from './types';
 
@@ -42,71 +42,119 @@ describe('LineageIO.applyConfig', () => {
         expect(LineageIO.applyConfig({}).dataInputs.length).toBe(0);
         expect(LineageIO.applyConfig({ dataInputs: undefined }).dataInputs.length).toBe(0);
         expect(LineageIO.applyConfig({ dataInputs: [] }).dataInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataInputs: [{...lineageObj}] }).dataInputs.length).toBe(1);
+        expect(LineageIO.applyConfig({ dataInputs: [{ ...lineageObj }] }).dataInputs.length).toBe(1);
     });
 
     it('dataOutputs', () => {
         expect(LineageIO.applyConfig({}).dataOutputs.length).toBe(0);
         expect(LineageIO.applyConfig({ dataOutputs: undefined }).dataOutputs.length).toBe(0);
         expect(LineageIO.applyConfig({ dataOutputs: [] }).dataOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataOutputs: [{...lineageObj}] }).dataOutputs.length).toBe(1);
+        expect(LineageIO.applyConfig({ dataOutputs: [{ ...lineageObj }] }).dataOutputs.length).toBe(1);
     });
 
     it('materialInputs', () => {
         expect(LineageIO.applyConfig({}).materialInputs.length).toBe(0);
         expect(LineageIO.applyConfig({ materialInputs: undefined }).materialInputs.length).toBe(0);
         expect(LineageIO.applyConfig({ materialInputs: [] }).materialInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialInputs: [{...lineageObj}] }).materialInputs.length).toBe(1);
+        expect(LineageIO.applyConfig({ materialInputs: [{ ...lineageObj }] }).materialInputs.length).toBe(1);
     });
 
     it('materialOutputs', () => {
         expect(LineageIO.applyConfig({}).materialOutputs.length).toBe(0);
         expect(LineageIO.applyConfig({ materialOutputs: undefined }).materialOutputs.length).toBe(0);
         expect(LineageIO.applyConfig({ materialOutputs: [] }).materialOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialOutputs: [{...lineageObj}] }).materialOutputs.length).toBe(1);
+        expect(LineageIO.applyConfig({ materialOutputs: [{ ...lineageObj }] }).materialOutputs.length).toBe(1);
     });
 
     it('objectInputs', () => {
         expect(LineageIO.applyConfig({}).objectInputs.length).toBe(0);
         expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectInputs.length).toBe(0);
         expect(LineageIO.applyConfig({ provenanceMap: [] }).objectInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: undefined,
-                to: {...lineageObj},
-        }] }).objectInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: undefined,
-                to: undefined,
-        }] }).objectInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: {...lineageObj},
-                to: undefined,
-        }] }).objectInputs.length).toBe(1);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: {...lineageObj},
-                to: {...lineageObj},
-        }] }).objectInputs.length).toBe(1);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: undefined,
+                        to: { ...lineageObj },
+                    },
+                ],
+            }).objectInputs.length
+        ).toBe(0);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: undefined,
+                        to: undefined,
+                    },
+                ],
+            }).objectInputs.length
+        ).toBe(0);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: { ...lineageObj },
+                        to: undefined,
+                    },
+                ],
+            }).objectInputs.length
+        ).toBe(1);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: { ...lineageObj },
+                        to: { ...lineageObj },
+                    },
+                ],
+            }).objectInputs.length
+        ).toBe(1);
     });
 
     it('objectOutputs', () => {
         expect(LineageIO.applyConfig({}).objectOutputs.length).toBe(0);
         expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectOutputs.length).toBe(0);
         expect(LineageIO.applyConfig({ provenanceMap: [] }).objectOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: undefined,
-                to: {...lineageObj},
-            }] }).objectOutputs.length).toBe(1);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: undefined,
-                to: undefined,
-            }] }).objectOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: {...lineageObj},
-                to: undefined,
-            }] }).objectOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [{
-                from: {...lineageObj},
-                to: {...lineageObj},
-            }] }).objectOutputs.length).toBe(1);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: undefined,
+                        to: { ...lineageObj },
+                    },
+                ],
+            }).objectOutputs.length
+        ).toBe(1);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: undefined,
+                        to: undefined,
+                    },
+                ],
+            }).objectOutputs.length
+        ).toBe(0);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: { ...lineageObj },
+                        to: undefined,
+                    },
+                ],
+            }).objectOutputs.length
+        ).toBe(0);
+        expect(
+            LineageIO.applyConfig({
+                provenanceMap: [
+                    {
+                        from: { ...lineageObj },
+                        to: { ...lineageObj },
+                    },
+                ],
+            }).objectOutputs.length
+        ).toBe(1);
     });
 });

--- a/packages/components/src/internal/components/lineage/models.spec.ts
+++ b/packages/components/src/internal/components/lineage/models.spec.ts
@@ -1,4 +1,4 @@
-import { applyLineageOptions } from './models';
+import {applyLineageOptions, LineageIO} from './models';
 import { DEFAULT_LINEAGE_OPTIONS } from './constants';
 import { LineageFilter } from './types';
 
@@ -19,5 +19,94 @@ describe('applyLineageOptions', () => {
 
     it('apply grouping options', () => {
         expect(applyLineageOptions({ grouping: { childDepth: 99 } })).toHaveProperty(['grouping', 'childDepth'], 99);
+    });
+});
+
+describe('LineageIO.applyConfig', () => {
+    const lineageObj = {
+        container: 'container',
+        created: '2022-01-20',
+        createdBy: 'me',
+        modified: '2022-01-21',
+        modifiedBy: 'me',
+        expType: 'type',
+        id: 1,
+        lsid: 'abc:123',
+        name: 'name',
+        pkFilters: [],
+        queryName: 'query',
+        schemaName: 'schema',
+    };
+
+    it('dataInputs', () => {
+        expect(LineageIO.applyConfig({}).dataInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ dataInputs: undefined }).dataInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ dataInputs: [] }).dataInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ dataInputs: [{...lineageObj}] }).dataInputs.length).toBe(1);
+    });
+
+    it('dataOutputs', () => {
+        expect(LineageIO.applyConfig({}).dataOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ dataOutputs: undefined }).dataOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ dataOutputs: [] }).dataOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ dataOutputs: [{...lineageObj}] }).dataOutputs.length).toBe(1);
+    });
+
+    it('materialInputs', () => {
+        expect(LineageIO.applyConfig({}).materialInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ materialInputs: undefined }).materialInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ materialInputs: [] }).materialInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ materialInputs: [{...lineageObj}] }).materialInputs.length).toBe(1);
+    });
+
+    it('materialOutputs', () => {
+        expect(LineageIO.applyConfig({}).materialOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ materialOutputs: undefined }).materialOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ materialOutputs: [] }).materialOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ materialOutputs: [{...lineageObj}] }).materialOutputs.length).toBe(1);
+    });
+
+    it('objectInputs', () => {
+        expect(LineageIO.applyConfig({}).objectInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [] }).objectInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: undefined,
+                to: {...lineageObj},
+        }] }).objectInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: undefined,
+                to: undefined,
+        }] }).objectInputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: {...lineageObj},
+                to: undefined,
+        }] }).objectInputs.length).toBe(1);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: {...lineageObj},
+                to: {...lineageObj},
+        }] }).objectInputs.length).toBe(1);
+    });
+
+    it('objectOutputs', () => {
+        expect(LineageIO.applyConfig({}).objectOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [] }).objectOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: undefined,
+                to: {...lineageObj},
+            }] }).objectOutputs.length).toBe(1);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: undefined,
+                to: undefined,
+            }] }).objectOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: {...lineageObj},
+                to: undefined,
+            }] }).objectOutputs.length).toBe(0);
+        expect(LineageIO.applyConfig({ provenanceMap: [{
+                from: {...lineageObj},
+                to: {...lineageObj},
+            }] }).objectOutputs.length).toBe(1);
     });
 });

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -182,8 +182,12 @@ export class LineageIO implements LineageItemWithMetadata {
             materialInputs: LineageIO.fromArray(values?.materialInputs),
             materialOutputs: LineageIO.fromArray(values?.materialOutputs),
             // convert the provenanceMap to the inputs and outputs array, filter for just those that have a from/to lsid value
-            objectInputs: LineageIO.fromArray(values?.provenanceMap?.map(prov => prov.from).filter(input => input?.lsid)),
-            objectOutputs: LineageIO.fromArray(values?.provenanceMap?.map(prov => prov.to).filter(input => input?.lsid)),
+            objectInputs: LineageIO.fromArray(
+                values?.provenanceMap?.map(prov => prov.from).filter(input => input?.lsid)
+            ),
+            objectOutputs: LineageIO.fromArray(
+                values?.provenanceMap?.map(prov => prov.to).filter(input => input?.lsid)
+            ),
         };
     }
 

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -94,11 +94,24 @@ export interface LineageItemWithMetadata extends Experiment.LineageItemBase {
     links: LineageLinkMetadata;
 }
 
-export interface LineageIOWithMetadata extends Experiment.LineageIOConfig {
+export interface ProvenanceMap {
+    from: Experiment.LineageItemBase;
+    to: Experiment.LineageItemBase;
+}
+
+interface LineageIOConfig extends Experiment.LineageIOConfig {
+    provenanceMap?: ProvenanceMap[];
+    objectInputs?: Experiment.LineageItemBase[];
+    objectOutputs?: Experiment.LineageItemBase[];
+}
+
+export interface LineageIOWithMetadata extends LineageIOConfig {
     dataInputs?: LineageItemWithMetadata[];
     dataOutputs?: LineageItemWithMetadata[];
     materialInputs?: LineageItemWithMetadata[];
     materialOutputs?: LineageItemWithMetadata[];
+    objectInputs?: LineageItemWithMetadata[];
+    objectOutputs?: LineageItemWithMetadata[];
 }
 
 export interface LineageItemWithIOMetadata extends LineageItemWithMetadata, LineageIOWithMetadata {}
@@ -126,6 +139,8 @@ export class LineageRunStep implements LineageRunStepConfig {
     readonly modified: string;
     readonly modifiedBy: string;
     readonly name: string;
+    readonly objectInputs: LineageIO[];
+    readonly objectOutputs: LineageIO[];
     readonly pkFilters: Experiment.LineagePKFilter[];
     readonly protocol: Experiment.LineageItemBase;
     readonly queryName: string;
@@ -160,12 +175,15 @@ export class LineageIO implements LineageItemWithMetadata {
         Object.assign(this, values);
     }
 
-    static applyConfig(values?: Experiment.LineageIOConfig): Experiment.LineageIOConfig {
+    static applyConfig(values?: LineageIOConfig): LineageIOConfig {
         return {
             dataInputs: LineageIO.fromArray(values?.dataInputs),
             dataOutputs: LineageIO.fromArray(values?.dataOutputs),
             materialInputs: LineageIO.fromArray(values?.materialInputs),
             materialOutputs: LineageIO.fromArray(values?.materialOutputs),
+            // convert the provenanceMap to the inputs and outputs array, filter for just those that have a from/to lsid value
+            objectInputs: LineageIO.fromArray(values?.provenanceMap?.map(prov => prov.from).filter(input => input?.lsid)),
+            objectOutputs: LineageIO.fromArray(values?.provenanceMap?.map(prov => prov.to).filter(input => input?.lsid)),
         };
     }
 
@@ -210,6 +228,8 @@ export class LineageNode
         modified: undefined,
         modifiedBy: undefined,
         name: undefined,
+        objectInputs: undefined,
+        objectOutputs: undefined,
         parents: undefined,
         pipelinePath: undefined,
         pkFilters: undefined,
@@ -246,6 +266,8 @@ export class LineageNode
     declare modified: string;
     declare modifiedBy: string;
     declare name: string;
+    declare objectInputs: LineageIO[];
+    declare objectOutputs: LineageIO[];
     declare parents: List<LineageLink>;
     declare pipelinePath: string;
     declare pkFilters: Experiment.LineagePKFilter[];

--- a/packages/components/src/internal/components/lineage/node/DetailsList.spec.tsx
+++ b/packages/components/src/internal/components/lineage/node/DetailsList.spec.tsx
@@ -3,12 +3,12 @@ import { mount, ReactWrapper } from 'enzyme';
 
 import lineageSampleData from '../../../../test/data/experiment-lineage-runSteps.json';
 
-import {DetailsList, DetailsListSteps} from './DetailsList';
-import {LineageNode} from "../models";
-import {LineageDataLink} from "../LineageDataLink";
+import { LineageNode } from '../models';
+import { LineageDataLink } from '../LineageDataLink';
+
+import { DetailsList, DetailsListSteps } from './DetailsList';
 
 describe('DetailsListSteps', () => {
-
     function validate(wrapper: ReactWrapper, stepCount: number): void {
         expect(wrapper.find(DetailsList)).toHaveLength(1);
         expect(wrapper.find('.lineage-sm-icon').hostNodes()).toHaveLength(stepCount);
@@ -17,28 +17,31 @@ describe('DetailsListSteps', () => {
     }
 
     test('not exp run', () => {
-        const wrapper = mount(<DetailsListSteps
-            node={LineageNode.create('abc:123', { expType: 'ProtocolApplication' })}
-            onSelect={jest.fn}
-        />);
+        const wrapper = mount(
+            <DetailsListSteps
+                node={LineageNode.create('abc:123', { expType: 'ProtocolApplication' })}
+                onSelect={jest.fn}
+            />
+        );
         expect(wrapper.find(DetailsList)).toHaveLength(0);
         wrapper.unmount();
     });
 
     test('no run steps', () => {
-        const wrapper = mount(<DetailsListSteps
-            node={LineageNode.create('abc:123', { expType: 'ExperimentRun' })}
-            onSelect={jest.fn}
-        />);
+        const wrapper = mount(
+            <DetailsListSteps node={LineageNode.create('abc:123', { expType: 'ExperimentRun' })} onSelect={jest.fn} />
+        );
         validate(wrapper, 0);
         wrapper.unmount();
     });
 
     test('with run steps', () => {
-        const wrapper = mount(<DetailsListSteps
-            node={LineageNode.create('abc:123', lineageSampleData.nodes[lineageSampleData.seed])}
-            onSelect={jest.fn}
-        />);
+        const wrapper = mount(
+            <DetailsListSteps
+                node={LineageNode.create('abc:123', lineageSampleData.nodes[lineageSampleData.seed])}
+                onSelect={jest.fn}
+            />
+        );
         validate(wrapper, 2);
         expect(wrapper.find('.lineage-sm-name').hostNodes().first().text()).toBe('RecordingOneStepOne');
         expect(wrapper.find('.lineage-sm-name').hostNodes().last().text()).toBe('RecordingOneStepTwo');

--- a/packages/components/src/internal/components/lineage/node/DetailsList.spec.tsx
+++ b/packages/components/src/internal/components/lineage/node/DetailsList.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import lineageSampleData from '../../../../test/data/experiment-lineage-runSteps.json';
+
+import {DetailsList, DetailsListSteps} from './DetailsList';
+import {LineageNode} from "../models";
+import {LineageDataLink} from "../LineageDataLink";
+
+describe('DetailsListSteps', () => {
+
+    function validate(wrapper: ReactWrapper, stepCount: number): void {
+        expect(wrapper.find(DetailsList)).toHaveLength(1);
+        expect(wrapper.find('.lineage-sm-icon').hostNodes()).toHaveLength(stepCount);
+        expect(wrapper.find('.lineage-sm-name').hostNodes()).toHaveLength(stepCount);
+        expect(wrapper.find(LineageDataLink)).toHaveLength(stepCount);
+    }
+
+    test('not exp run', () => {
+        const wrapper = mount(<DetailsListSteps
+            node={LineageNode.create('abc:123', { expType: 'ProtocolApplication' })}
+            onSelect={jest.fn}
+        />);
+        expect(wrapper.find(DetailsList)).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('no run steps', () => {
+        const wrapper = mount(<DetailsListSteps
+            node={LineageNode.create('abc:123', { expType: 'ExperimentRun' })}
+            onSelect={jest.fn}
+        />);
+        validate(wrapper, 0);
+        wrapper.unmount();
+    });
+
+    test('with run steps', () => {
+        const wrapper = mount(<DetailsListSteps
+            node={LineageNode.create('abc:123', lineageSampleData.nodes[lineageSampleData.seed])}
+            onSelect={jest.fn}
+        />);
+        validate(wrapper, 2);
+        expect(wrapper.find('.lineage-sm-name').hostNodes().first().text()).toBe('RecordingOneStepOne');
+        expect(wrapper.find('.lineage-sm-name').hostNodes().last().text()).toBe('RecordingOneStepTwo');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/lineage/node/DetailsList.tsx
+++ b/packages/components/src/internal/components/lineage/node/DetailsList.tsx
@@ -95,6 +95,8 @@ export class DetailsListLineageIO extends PureComponent<DetailsListLineageIOProp
                 <DetailsListLineageItems items={item.materialInputs} title="Material Inputs" />
                 <DetailsListLineageItems items={item.dataOutputs} title="Data Outputs" />
                 <DetailsListLineageItems items={item.materialOutputs} title="Material Outputs" />
+                <DetailsListLineageItems items={item.objectInputs} title="Object Inputs" />
+                <DetailsListLineageItems items={item.objectOutputs} title="Object Outputs" />
             </>
         );
     }
@@ -118,7 +120,7 @@ export class DetailsListSteps extends PureComponent<DetailsListStepProps> {
                 {node.steps.map((step, i) => (
                     <div className="lineage-name" key={`${node.lsid}.step.${i}`}>
                         <SVGIcon className="lineage-sm-icon" iconSrc={step.iconProps.iconURL} />
-                        <span className="spacer-right">{step.name}</span>
+                        <span className="spacer-right">{step.protocol?.name || step.name}</span>
                         <LineageDataLink
                             onClick={() => {
                                 onSelect(i);

--- a/packages/components/src/internal/components/lineage/node/DetailsList.tsx
+++ b/packages/components/src/internal/components/lineage/node/DetailsList.tsx
@@ -4,7 +4,7 @@ import { SVGIcon } from '../../../..';
 
 import { LineageItemWithMetadata, LineageIOWithMetadata, LineageNode } from '../models';
 import { LineageNodeCollection } from '../vis/VisGraphGenerator';
-import { getLineageNodeTitle } from '../utils';
+import { DEFAULT_ICON_URL, getLineageNodeTitle } from '../utils';
 import { NodeInteractionConsumer, WithNodeInteraction } from '../actions';
 import { LineageDataLink } from '../LineageDataLink';
 
@@ -119,8 +119,8 @@ export class DetailsListSteps extends PureComponent<DetailsListStepProps> {
             <DetailsList title="Run steps">
                 {node.steps.map((step, i) => (
                     <div className="lineage-name" key={`${node.lsid}.step.${i}`}>
-                        <SVGIcon className="lineage-sm-icon" iconSrc={step.iconProps.iconURL} />
-                        <span className="spacer-right">{step.protocol?.name || step.name}</span>
+                        <SVGIcon className="lineage-sm-icon" iconSrc={step.iconProps?.iconURL ?? DEFAULT_ICON_URL} />
+                        <span className="lineage-sm-name spacer-right">{step.protocol?.name || step.name}</span>
                         <LineageDataLink
                             onClick={() => {
                                 onSelect(i);
@@ -182,7 +182,7 @@ export class DetailsListLineageItems extends PureComponent<DetailsListLineageIte
                         style={{ fontWeight: highlightNode === item.lsid ? 'bold' : 'normal' }}
                         title={getLineageNodeTitle(item as LineageNode)}
                     >
-                        <SVGIcon className="lineage-sm-icon" iconSrc={item.iconProps.iconURL} />
+                        <SVGIcon className="lineage-sm-icon" iconSrc={item.iconProps?.iconURL ?? DEFAULT_ICON_URL} />
                         <NodeInteractionConsumer>
                             {(context: WithNodeInteraction) => {
                                 if (context.isNodeInGraph(item)) {

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-2020 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, memo, PureComponent, ReactNode, useCallback, useState } from 'react';
+import React, { FC, memo, PureComponent, ReactNode, useCallback, useState, useMemo } from 'react';
 import { Tab, Tabs } from 'react-bootstrap';
 import { List } from "immutable";
 
@@ -18,6 +18,7 @@ import { LineageDetail } from './LineageDetail';
 import { DetailHeader, NodeDetailHeader } from './NodeDetailHeader';
 import { DetailsListLineageIO, DetailsListNodes, DetailsListSteps } from './DetailsList';
 import { Grid, GridColumn } from "../../base/Grid";
+import { hasModule } from "../../../app/utils";
 
 interface LineageNodeDetailProps {
     highlightNode?: string;
@@ -170,6 +171,7 @@ const RunStepNodeDetail: FC<RunStepNodeDetailProps> = memo(props => {
     const [tabKey, setTabKey] = useState<number>(1);
     const step = node.steps.get(stepIdx);
     const stepName = step.protocol?.name || step.name;
+    const hasProvenanceModule = useMemo(() => hasModule('provenance'), []);
 
     const changeTab = useCallback((newTabKey: number) => {
         setTabKey(newTabKey);
@@ -194,9 +196,11 @@ const RunStepNodeDetail: FC<RunStepNodeDetailProps> = memo(props => {
                     <LineageDetail item={step} />
                     <DetailsListLineageIO item={step} />
                 </Tab>
-                <Tab eventKey={2} title="Provenance Map">
-                    <RunStepProvenanceMap item={step} />
-                </Tab>
+                {hasProvenanceModule && (
+                    <Tab eventKey={2} title="Provenance Map">
+                        <RunStepProvenanceMap item={step} />
+                    </Tab>
+                )}
             </Tabs>
         </div>
     );

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -195,7 +195,7 @@ const RunStepNodeDetail: FC<RunStepNodeDetailProps> = memo(props => {
                     <DetailsListLineageIO item={step} />
                 </Tab>
                 {hasProvenanceModule && (
-                    <Tab eventKey={2} title="Provenance Map">
+                    <Tab eventKey={2} title="Provenance Map" className="lineage-run-step-provenance-map">
                         <RunStepProvenanceMap item={step} />
                     </Tab>
                 )}

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -4,7 +4,7 @@
  */
 import React, { FC, memo, PureComponent, ReactNode, useCallback, useState, useMemo } from 'react';
 import { Tab, Tabs } from 'react-bootstrap';
-import { List } from "immutable";
+import { List } from 'immutable';
 
 import {
     createLineageNodeCollections,
@@ -14,11 +14,14 @@ import {
 import { LineageSummary } from '../LineageSummary';
 import { LineageIOWithMetadata, LineageNode } from '../models';
 import { LineageOptions } from '../types';
+
+import { Grid, GridColumn } from '../../base/Grid';
+
+import { hasModule } from '../../../app/utils';
+
 import { LineageDetail } from './LineageDetail';
 import { DetailHeader, NodeDetailHeader } from './NodeDetailHeader';
 import { DetailsListLineageIO, DetailsListNodes, DetailsListSteps } from './DetailsList';
-import { Grid, GridColumn } from "../../base/Grid";
-import { hasModule } from "../../../app/utils";
 
 interface LineageNodeDetailProps {
     highlightNode?: string;
@@ -186,12 +189,7 @@ const RunStepNodeDetail: FC<RunStepNodeDetailProps> = memo(props => {
                 <span className="spacer-left">&gt;</span>
                 <span className="spacer-left">{stepName}</span>
             </DetailHeader>
-            <Tabs
-                activeKey={tabKey}
-                defaultActiveKey={1}
-                id="lineage-run-step-tabs"
-                onSelect={changeTab as any}
-            >
+            <Tabs activeKey={tabKey} defaultActiveKey={1} id="lineage-run-step-tabs" onSelect={changeTab as any}>
                 <Tab eventKey={1} title="Step Details">
                     <LineageDetail item={step} />
                     <DetailsListLineageIO item={step} />
@@ -213,7 +211,7 @@ const provenanceCellRenderer = (data, row) => {
         return <a href={url}>{name}</a>;
     }
     return name;
-}
+};
 
 const PROVENANCE_MAP_COLS = List([
     new GridColumn({
@@ -233,7 +231,5 @@ export interface RunStepProvenanceMapProps {
 }
 
 const RunStepProvenanceMap: FC<RunStepProvenanceMapProps> = memo(({ item }) => {
-    return (
-        <Grid columns={PROVENANCE_MAP_COLS} data={item?.provenanceMap ?? []} />
-    )
+    return <Grid columns={PROVENANCE_MAP_COLS} data={item?.provenanceMap ?? []} />;
 });

--- a/packages/components/src/internal/components/lineage/utils.ts
+++ b/packages/components/src/internal/components/lineage/utils.ts
@@ -10,7 +10,7 @@ import { imageURL, SchemaQuery, SCHEMAS, Theme } from '../../..';
 import { LineageItemWithMetadata, LineageLink, LineageNode } from './models';
 import { LINEAGE_DIRECTIONS, LineageIconMetadata } from './types';
 
-const DEFAULT_ICON_URL = 'default';
+export const DEFAULT_ICON_URL = 'default';
 const BACKUP_IMAGE_ROOT = 'https://labkey.org/_images/';
 
 // The default vis-network icon shape to use for nodes in the lineage graph

--- a/packages/components/src/test/data/experiment-lineage-runSteps.json
+++ b/packages/components/src/test/data/experiment-lineage-runSteps.json
@@ -1,0 +1,1050 @@
+{
+  "nodes" : {
+    "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialTwoToRun" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:46:08.231",
+      "cpasType" : "Material",
+      "materialLineageType" : "RootMaterial",
+      "schemaName" : "exp",
+      "type" : "Material",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140507",
+      "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialTwoToRun",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 140507,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "InputMaterialTwoToRun",
+      "queryName" : "Materials",
+      "modified" : "2022-01-20 15:46:08.231",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140507,
+      "parents" : [ ]
+    },
+    "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepOne" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:46:08.276",
+      "cpasType" : "Material",
+      "materialLineageType" : "RootMaterial",
+      "schemaName" : "exp",
+      "type" : "Material",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140508",
+      "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepOne",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 140508,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "InputMaterialToStepOne",
+      "queryName" : "Materials",
+      "modified" : "2022-01-20 15:46:08.276",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140508,
+      "parents" : [ ]
+    },
+    "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:45:53.271",
+      "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+      "materialLineageType" : "RootMaterial",
+      "schemaName" : "samples",
+      "type" : "Sample",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140505",
+      "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:GeneralAssayRun.Folder-1456:9a963003-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 140505,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "Sample4",
+      "queryName" : "ScriptProcessSampleType",
+      "modified" : "2022-01-20 15:45:53.271",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140505,
+      "properties" : {
+        "name" : "Sample4"
+      },
+      "parents" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ]
+    },
+    "urn:lsid:labkey.com:GeneralAssayRun.Folder-1456:9a963003-5c5b-103a-b871-ea5aa9ea8b30" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "dataOutputs" : [ {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "created" : "2022-01-20 15:46:07.421",
+        "dataFileURL" : "file:///Users/corynathe/LabKey/trunk/build/deploy/files/Script%20Processes%20Test%20Project/@files/assaydata/Other_Assay-2022-01-20-154607.tmp",
+        "cpasType" : "Data",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showData.view?rowId=35468",
+        "lsid" : "urn:lsid:labkey.com:AssayRunTSVData.Folder-1456:9a963005-5c5b-103a-b871-ea5aa9ea8b30",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 35468,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Other_Assay-2022-01-20-154607.tmp",
+        "queryName" : "Data",
+        "modified" : "2022-01-20 15:46:07.814",
+        "absolutePath" : "/Users/corynathe/LabKey/trunk/build/deploy/files/Script Processes Test Project/@files/assaydata/Other_Assay-2022-01-20-154607.tmp",
+        "pipelinePath" : "assaydata/Other_Assay-2022-01-20-154607.tmp",
+        "expType" : "Data",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 35468
+      } ],
+      "dataInputs" : [ ],
+      "created" : "2022-01-20 15:46:07.375",
+      "cpasType" : "urn:lsid:labkey.com:GeneralAssayProtocol.Folder-1456:Other+Assay",
+      "materialInputs" : [ {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "inputSample",
+        "created" : "2022-01-20 15:45:53.271",
+        "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "samples",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140505",
+        "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140505,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Sample4",
+        "queryName" : "ScriptProcessSampleType",
+        "modified" : "2022-01-20 15:45:53.271",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140505,
+        "properties" : {
+          "name" : "Sample4"
+        }
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "inputSample",
+        "created" : "2022-01-20 15:45:53.271",
+        "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "samples",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140504",
+        "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample3",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140504,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Sample3",
+        "queryName" : "ScriptProcessSampleType",
+        "modified" : "2022-01-20 15:45:53.271",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140504,
+        "properties" : {
+          "name" : "Sample3"
+        }
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "inputSample",
+        "created" : "2022-01-20 15:45:53.271",
+        "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "samples",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140503",
+        "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample2",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140503,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Sample2",
+        "queryName" : "ScriptProcessSampleType",
+        "modified" : "2022-01-20 15:45:53.271",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140503,
+        "properties" : {
+          "name" : "Sample2"
+        }
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "inputSample",
+        "created" : "2022-01-20 15:45:53.271",
+        "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "samples",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140502",
+        "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140502,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Sample1",
+        "queryName" : "ScriptProcessSampleType",
+        "modified" : "2022-01-20 15:45:53.271",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140502,
+        "properties" : {
+          "name" : "Sample1"
+        }
+      } ],
+      "schemaName" : "assay.General.Other Assay",
+      "type" : "GeneralAssayRun",
+      "steps" : [ {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "dataOutputs" : [ {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "created" : "2022-01-20 15:46:07.421",
+          "dataFileURL" : "file:///Users/corynathe/LabKey/trunk/build/deploy/files/Script%20Processes%20Test%20Project/@files/assaydata/Other_Assay-2022-01-20-154607.tmp",
+          "cpasType" : "Data",
+          "schemaName" : "exp",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showData.view?rowId=35468",
+          "lsid" : "urn:lsid:labkey.com:AssayRunTSVData.Folder-1456:9a963005-5c5b-103a-b871-ea5aa9ea8b30",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 35468,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Other_Assay-2022-01-20-154607.tmp",
+          "queryName" : "Data",
+          "modified" : "2022-01-20 15:46:07.814",
+          "absolutePath" : "/Users/corynathe/LabKey/trunk/build/deploy/files/Script Processes Test Project/@files/assaydata/Other_Assay-2022-01-20-154607.tmp",
+          "pipelinePath" : "assaydata/Other_Assay-2022-01-20-154607.tmp",
+          "expType" : "Data",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 35468
+        } ],
+        "applicationType" : "ProtocolApplication",
+        "dataInputs" : [ ],
+        "created" : "2022-01-20 15:46:07.375",
+        "activitySequence" : 10,
+        "materialInputs" : [ {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "role" : "inputSample",
+          "created" : "2022-01-20 15:45:53.271",
+          "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+          "materialLineageType" : "RootMaterial",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140505",
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 140505,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample4",
+          "queryName" : "ScriptProcessSampleType",
+          "modified" : "2022-01-20 15:45:53.271",
+          "expType" : "Material",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 140505,
+          "properties" : {
+            "name" : "Sample4"
+          }
+        }, {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "role" : "inputSample",
+          "created" : "2022-01-20 15:45:53.271",
+          "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+          "materialLineageType" : "RootMaterial",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140504",
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample3",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 140504,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample3",
+          "queryName" : "ScriptProcessSampleType",
+          "modified" : "2022-01-20 15:45:53.271",
+          "expType" : "Material",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 140504,
+          "properties" : {
+            "name" : "Sample3"
+          }
+        }, {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "role" : "inputSample",
+          "created" : "2022-01-20 15:45:53.271",
+          "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+          "materialLineageType" : "RootMaterial",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140503",
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample2",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 140503,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample2",
+          "queryName" : "ScriptProcessSampleType",
+          "modified" : "2022-01-20 15:45:53.271",
+          "expType" : "Material",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 140503,
+          "properties" : {
+            "name" : "Sample2"
+          }
+        }, {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "role" : "inputSample",
+          "created" : "2022-01-20 15:45:53.271",
+          "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+          "materialLineageType" : "RootMaterial",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140502",
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 140502,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample1",
+          "queryName" : "ScriptProcessSampleType",
+          "modified" : "2022-01-20 15:45:53.271",
+          "expType" : "Material",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 140502,
+          "properties" : {
+            "name" : "Sample1"
+          }
+        } ],
+        "schemaName" : "exp",
+        "lsid" : "urn:lsid:labkey.com:ProtocolApplication.Run-26304:SimpleProtocol.CoreStep",
+        "protocol" : {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "created" : "2022-01-20 15:46:04.551",
+          "schemaName" : "exp",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-protocolDetails.view?rowId=5069",
+          "lsid" : "urn:lsid:labkey.com:GeneralAssayProtocol.Folder-1456:Other+Assay.Core",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 5069,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Other Assay - Core",
+          "queryName" : "Protocols",
+          "modified" : "2022-01-20 15:46:04.551",
+          "expType" : "Protocol",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 5069
+        },
+        "materialOutputs" : [ ],
+        "activityDate" : "2022-01-20 15:46:07.442",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 79358,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Other Assay",
+        "queryName" : "ProtocolApplications",
+        "modified" : "2022-01-20 15:46:07.824",
+        "expType" : "ProtocolApplication",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 79358
+      } ],
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showRunGraph.view?rowId=26304",
+      "lsid" : "urn:lsid:labkey.com:GeneralAssayRun.Folder-1456:9a963003-5c5b-103a-b871-ea5aa9ea8b30",
+      "materialOutputs" : [ ],
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ ],
+      "pkFilters" : [ {
+        "value" : 26304,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "OtherAssayRun",
+      "queryName" : "Runs",
+      "modified" : "2022-01-20 15:46:07.824",
+      "expType" : "ExperimentRun",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 26304,
+      "provenanceMap" : [ {
+        "from" : {
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 140502,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample1",
+          "queryName" : "ScriptProcessSampleType",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140502"
+        },
+        "to" : {
+          "lsid" : "urn:lsid:labkey.com:GeneralAssayResultRow.Protocol-5068:1",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 1,
+            "fieldKey" : "rowId"
+          } ],
+          "name" : "1",
+          "queryName" : "Data",
+          "schemaName" : "assay.General.Other Assay",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/assay-assayResults.view?rowId=5068&Data.rowId%7Eeq=1"
+        }
+      }, {
+        "from" : {
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 140502,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample1",
+          "queryName" : "ScriptProcessSampleType",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140502"
+        },
+        "to" : {
+          "lsid" : "urn:lsid:labkey.com:GeneralAssayResultRow.Protocol-5068:2",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 2,
+            "fieldKey" : "rowId"
+          } ],
+          "name" : "2",
+          "queryName" : "Data",
+          "schemaName" : "assay.General.Other Assay",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/assay-assayResults.view?rowId=5068&Data.rowId%7Eeq=2"
+        }
+      }, {
+        "from" : {
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample2",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 140503,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample2",
+          "queryName" : "ScriptProcessSampleType",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140503"
+        },
+        "to" : {
+          "lsid" : "urn:lsid:labkey.com:GeneralAssayResultRow.Protocol-5068:3",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 3,
+            "fieldKey" : "rowId"
+          } ],
+          "name" : "3",
+          "queryName" : "Data",
+          "schemaName" : "assay.General.Other Assay",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/assay-assayResults.view?rowId=5068&Data.rowId%7Eeq=3"
+        }
+      }, {
+        "from" : {
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample3",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 140504,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample3",
+          "queryName" : "ScriptProcessSampleType",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140504"
+        },
+        "to" : {
+          "lsid" : "urn:lsid:labkey.com:GeneralAssayResultRow.Protocol-5068:4",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 4,
+            "fieldKey" : "rowId"
+          } ],
+          "name" : "4",
+          "queryName" : "Data",
+          "schemaName" : "assay.General.Other Assay",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/assay-assayResults.view?rowId=5068&Data.rowId%7Eeq=4"
+        }
+      }, {
+        "from" : {
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 140505,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample4",
+          "queryName" : "ScriptProcessSampleType",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140505"
+        },
+        "to" : {
+          "lsid" : "urn:lsid:labkey.com:GeneralAssayResultRow.Protocol-5068:5",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 5,
+            "fieldKey" : "rowId"
+          } ],
+          "name" : "5",
+          "queryName" : "Data",
+          "schemaName" : "assay.General.Other Assay",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/assay-assayResults.view?rowId=5068&Data.rowId%7Eeq=5"
+        }
+      }, {
+        "from" : {
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 140505,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample4",
+          "queryName" : "ScriptProcessSampleType",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140505"
+        },
+        "to" : {
+          "lsid" : "urn:lsid:labkey.com:GeneralAssayResultRow.Protocol-5068:6",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 6,
+            "fieldKey" : "rowId"
+          } ],
+          "name" : "6",
+          "queryName" : "Data",
+          "schemaName" : "assay.General.Other Assay",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/assay-assayResults.view?rowId=5068&Data.rowId%7Eeq=6"
+        }
+      } ],
+      "parents" : [ {
+        "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+        "role" : "no role"
+      } ]
+    },
+    "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialOneToRun" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:46:08.208",
+      "cpasType" : "Material",
+      "materialLineageType" : "RootMaterial",
+      "schemaName" : "exp",
+      "type" : "Material",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140506",
+      "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialOneToRun",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 140506,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "InputMaterialOneToRun",
+      "queryName" : "Materials",
+      "modified" : "2022-01-20 15:46:08.208",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140506,
+      "parents" : [ ]
+    },
+    "urn:lsid:labkey.com:Transform.Folder-1456:9a963069-5c5b-103a-b871-ea5aa9ea8b30" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:46:08.478",
+      "dataFileURL" : null,
+      "cpasType" : "Data",
+      "schemaName" : "exp",
+      "type" : "Transform",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showData.view?rowId=35470",
+      "lsid" : "urn:lsid:labkey.com:Transform.Folder-1456:9a963069-5c5b-103a-b871-ea5aa9ea8b30",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 35470,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "file:///Users/corynathe/LabKey/trunk/build/deploy/files/Script%20Processes%20Test%20Project/@files",
+      "queryName" : "Data",
+      "modified" : "2022-01-20 15:46:08.478",
+      "expType" : "Data",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 35470,
+      "parents" : [ ]
+    },
+    "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepTwo" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:46:08.319",
+      "cpasType" : "Material",
+      "materialLineageType" : "RootMaterial",
+      "schemaName" : "exp",
+      "type" : "Material",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140510",
+      "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepTwo",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 140510,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "InputMaterialToStepTwo",
+      "queryName" : "Materials",
+      "modified" : "2022-01-20 15:46:08.319",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140510,
+      "parents" : [ ]
+    },
+    "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:45:53.271",
+      "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-1456:ScriptProcessSampleType",
+      "materialLineageType" : "RootMaterial",
+      "schemaName" : "samples",
+      "type" : "Sample",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140502",
+      "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 140502,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "Sample1",
+      "queryName" : "ScriptProcessSampleType",
+      "modified" : "2022-01-20 15:45:53.271",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140502,
+      "properties" : {
+        "name" : "Sample1"
+      },
+      "parents" : [ ]
+    },
+    "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialTwoFromRun" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:46:08.389",
+      "cpasType" : "Material",
+      "materialLineageType" : "Derivative",
+      "schemaName" : "exp",
+      "type" : "Material",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140513",
+      "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialTwoFromRun",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ ],
+      "pkFilters" : [ {
+        "value" : 140513,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "OutputMaterialTwoFromRun",
+      "queryName" : "Materials",
+      "modified" : "2022-01-20 15:46:08.526",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140513,
+      "parents" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ]
+    },
+    "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "dataOutputs" : [ ],
+      "dataInputs" : [ {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "created" : "2022-01-20 15:46:08.478",
+        "dataFileURL" : null,
+        "cpasType" : "Data",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showData.view?rowId=35470",
+        "lsid" : "urn:lsid:labkey.com:Transform.Folder-1456:9a963069-5c5b-103a-b871-ea5aa9ea8b30",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 35470,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "file:///Users/corynathe/LabKey/trunk/build/deploy/files/Script%20Processes%20Test%20Project/@files",
+        "queryName" : "Data",
+        "modified" : "2022-01-20 15:46:08.478",
+        "expType" : "Data",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 35470
+      } ],
+      "created" : "2022-01-20 15:46:08.456",
+      "cpasType" : "urn:lsid:labkey.org:Protocol:ProvenanceProtocol9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "materialInputs" : [ {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "Material",
+        "created" : "2022-01-20 15:46:08.319",
+        "cpasType" : "Material",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140510",
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepTwo",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140510,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "InputMaterialToStepTwo",
+        "queryName" : "Materials",
+        "modified" : "2022-01-20 15:46:08.319",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140510
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "Material",
+        "created" : "2022-01-20 15:46:08.276",
+        "cpasType" : "Material",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140508",
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepOne",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140508,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "InputMaterialToStepOne",
+        "queryName" : "Materials",
+        "modified" : "2022-01-20 15:46:08.276",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140508
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "Material",
+        "created" : "2022-01-20 15:46:08.208",
+        "cpasType" : "Material",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140506",
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialOneToRun",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140506,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "InputMaterialOneToRun",
+        "queryName" : "Materials",
+        "modified" : "2022-01-20 15:46:08.208",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140506
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "Material",
+        "created" : "2022-01-20 15:46:08.231",
+        "cpasType" : "Material",
+        "materialLineageType" : "RootMaterial",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140507",
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialTwoToRun",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140507,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "InputMaterialTwoToRun",
+        "queryName" : "Materials",
+        "modified" : "2022-01-20 15:46:08.231",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140507
+      } ],
+      "schemaName" : "exp",
+      "type" : "Run",
+      "steps" : [ {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "dataOutputs" : [ ],
+        "applicationType" : "ProtocolApplication",
+        "dataInputs" : [ ],
+        "created" : "2022-01-20 15:46:08.456",
+        "activitySequence" : 2,
+        "materialInputs" : [ {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "role" : "Material",
+          "created" : "2022-01-20 15:46:08.276",
+          "cpasType" : "Material",
+          "materialLineageType" : "RootMaterial",
+          "schemaName" : "exp",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140508",
+          "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepOne",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 140508,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "InputMaterialToStepOne",
+          "queryName" : "Materials",
+          "modified" : "2022-01-20 15:46:08.276",
+          "expType" : "Material",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 140508
+        } ],
+        "schemaName" : "exp",
+        "lsid" : "urn:lsid:labkey.com:ProtocolApplication.Folder-1456:9a96306a-5c5b-103a-b871-ea5aa9ea8b30",
+        "protocol" : {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "created" : "2022-01-20 15:46:08.405",
+          "schemaName" : "exp",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-protocolDetails.view?rowId=5071",
+          "lsid" : "urn:lsid:labkey.com:Protocol.Folder-1456:RecordingOneStepOne",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 5071,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "RecordingOneStepOne",
+          "queryName" : "Protocols",
+          "modified" : "2022-01-20 15:46:08.405",
+          "expType" : "Protocol",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 5071
+        },
+        "materialOutputs" : [ ],
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 79362,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Step One of Recording One",
+        "queryName" : "ProtocolApplications",
+        "modified" : "2022-01-20 15:46:08.456",
+        "expType" : "ProtocolApplication",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 79362
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "dataOutputs" : [ ],
+        "applicationType" : "ProtocolApplication",
+        "dataInputs" : [ ],
+        "created" : "2022-01-20 15:46:08.456",
+        "activitySequence" : 3,
+        "materialInputs" : [ {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "role" : "Material",
+          "created" : "2022-01-20 15:46:08.319",
+          "cpasType" : "Material",
+          "materialLineageType" : "RootMaterial",
+          "schemaName" : "exp",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140510",
+          "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepTwo",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 140510,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "InputMaterialToStepTwo",
+          "queryName" : "Materials",
+          "modified" : "2022-01-20 15:46:08.319",
+          "expType" : "Material",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 140510
+        } ],
+        "schemaName" : "exp",
+        "lsid" : "urn:lsid:labkey.com:ProtocolApplication.Folder-1456:9a96306c-5c5b-103a-b871-ea5aa9ea8b30",
+        "protocol" : {
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "created" : "2022-01-20 15:46:08.419",
+          "schemaName" : "exp",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-protocolDetails.view?rowId=5072",
+          "lsid" : "urn:lsid:labkey.com:Protocol.Folder-1456:RecordingOneStepTwo",
+          "createdBy" : "cnathe@labkey.com",
+          "pkFilters" : [ {
+            "value" : 5072,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "RecordingOneStepTwo",
+          "queryName" : "Protocols",
+          "modified" : "2022-01-20 15:46:08.419",
+          "expType" : "Protocol",
+          "modifiedBy" : "cnathe@labkey.com",
+          "id" : 5072
+        },
+        "materialOutputs" : [ ],
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 79363,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "Step Two of Recording One",
+        "queryName" : "ProtocolApplications",
+        "modified" : "2022-01-20 15:46:08.456",
+        "expType" : "ProtocolApplication",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 79363,
+        "provenanceMap" : [ {
+          "from" : {
+            "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample2",
+            "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+            "pkFilters" : [ {
+              "value" : 140503,
+              "fieldKey" : "RowId"
+            } ],
+            "name" : "Sample2",
+            "queryName" : "ScriptProcessSampleType",
+            "schemaName" : "samples",
+            "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140503"
+          },
+          "to" : {
+            "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample3",
+            "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+            "pkFilters" : [ {
+              "value" : 140504,
+              "fieldKey" : "RowId"
+            } ],
+            "name" : "Sample3",
+            "queryName" : "ScriptProcessSampleType",
+            "schemaName" : "samples",
+            "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140504"
+          }
+        } ]
+      } ],
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showRunGraph.view?rowId=26305",
+      "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+      "materialOutputs" : [ {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "Material",
+        "created" : "2022-01-20 15:46:08.366",
+        "cpasType" : "Material",
+        "materialLineageType" : "Derivative",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140512",
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialOneFromRun",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140512,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "OutputMaterialOneFromRun",
+        "queryName" : "Materials",
+        "modified" : "2022-01-20 15:46:08.537",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140512
+      }, {
+        "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "Material",
+        "created" : "2022-01-20 15:46:08.389",
+        "cpasType" : "Material",
+        "materialLineageType" : "Derivative",
+        "schemaName" : "exp",
+        "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140513",
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialTwoFromRun",
+        "createdBy" : "cnathe@labkey.com",
+        "pkFilters" : [ {
+          "value" : 140513,
+          "fieldKey" : "RowId"
+        } ],
+        "name" : "OutputMaterialTwoFromRun",
+        "queryName" : "Materials",
+        "modified" : "2022-01-20 15:46:08.526",
+        "expType" : "Material",
+        "modifiedBy" : "cnathe@labkey.com",
+        "id" : 140513
+      } ],
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+        "role" : "no role"
+      }, {
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialTwoFromRun",
+        "role" : "no role"
+      }, {
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialOneFromRun",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "value" : 26305,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "ScriptProcessesTestRun",
+      "queryName" : "Runs",
+      "modified" : "2022-01-20 15:46:08.456",
+      "expType" : "ExperimentRun",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 26305,
+      "provenanceMap" : [ {
+        "to" : {
+          "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample4",
+          "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+          "pkFilters" : [ {
+            "value" : 140505,
+            "fieldKey" : "RowId"
+          } ],
+          "name" : "Sample4",
+          "queryName" : "ScriptProcessSampleType",
+          "schemaName" : "samples",
+          "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140505"
+        }
+      } ],
+      "objectInputs" : [ "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1" ],
+      "parents" : [ {
+        "lsid" : "urn:lsid:labkey.com:Transform.Folder-1456:9a963069-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      }, {
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialTwoToRun",
+        "role" : "no role"
+      }, {
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepTwo",
+        "role" : "no role"
+      }, {
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialOneToRun",
+        "role" : "no role"
+      }, {
+        "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:InputMaterialToStepOne",
+        "role" : "no role"
+      }, {
+        "lsid" : "urn:lsid:labkey.com:Sample.1456.ScriptProcessSampleType:Sample1",
+        "role" : "no role"
+      } ]
+    },
+    "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialOneFromRun" : {
+      "container" : "9a962d04-5c5b-103a-b871-ea5aa9ea8b30",
+      "created" : "2022-01-20 15:46:08.366",
+      "cpasType" : "Material",
+      "materialLineageType" : "Derivative",
+      "schemaName" : "exp",
+      "type" : "Material",
+      "url" : "/labkey/Script%20Processes%20Test%20Project/experiment-showMaterial.view?rowId=140512",
+      "lsid" : "urn:lsid:labkey.com:Material.Folder-1456:OutputMaterialOneFromRun",
+      "createdBy" : "cnathe@labkey.com",
+      "children" : [ ],
+      "pkFilters" : [ {
+        "value" : 140512,
+        "fieldKey" : "RowId"
+      } ],
+      "name" : "OutputMaterialOneFromRun",
+      "queryName" : "Materials",
+      "modified" : "2022-01-20 15:46:08.537",
+      "expType" : "Material",
+      "modifiedBy" : "cnathe@labkey.com",
+      "id" : 140512,
+      "parents" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30",
+        "role" : "no role"
+      } ]
+    }
+  },
+  "seed" : "urn:lsid:labkey.com:Run.Folder-1456:9a963061-5c5b-103a-b871-ea5aa9ea8b30"
+}

--- a/packages/components/src/theme/lineage.scss
+++ b/packages/components/src/theme/lineage.scss
@@ -160,3 +160,8 @@
     padding-left: 0;
     margin-bottom: 0.5em;
 }
+
+.lineage-run-step-provenance-map {
+    max-height: 500px;
+    overflow: auto;
+}


### PR DESCRIPTION
#### Rationale
The provenance module allows for object inputs/outputs to be attached to a protocol application run step. This PR updates the Lineage Graph React display component side panels to show that provenance map information for the run steps.

<img width="631" alt="Screen Shot 2022-01-19 at 4 50 37 PM" src="https://user-images.githubusercontent.com/6411206/150231312-9043b2e8-560c-40c8-9d61-b404bd5b8d07.png">
<img width="628" alt="Screen Shot 2022-01-19 at 4 50 45 PM" src="https://user-images.githubusercontent.com/6411206/150231314-7605a048-19f3-4313-9b07-6d3e76f0b51d.png">

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/711
* https://github.com/LabKey/platform/pull/2961
* https://github.com/LabKey/provenance/pull/85

#### Changes
* update Lineage related models for provenanceMap, objectInputs, and objectOutputs
* display Object Inputs and Object Outputs as collapsible details list (next to Material and Data Inputs/Outputs)
* use run step protocol name instead of step name for title
* update Run Step display to use tabs for Step Details and Provenance Map
* render Run Step provenance map as <Grid> with from/to info
