### PR TITLE
Fix z-index issue for react-datepicker

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.120.0",
+  "version": "2.120.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.120.1
+*Released*: 20 January 2022
+* Increase z-index of react-datepicker popover
+
 ### version 2.120.0
 *Released*: 19 January 2022
 * Declare and export the `UPDATE_USER` redux action and wire up updates via reducer.

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -200,7 +200,11 @@ div.react-datepicker,
 div.react-datepicker__current-month {
     font-size: 14px;
 }
-
+.react-datepicker-popper {
+    // The default z-index is 1, but bootstrap sets the z-index for form inputs to 2, which means all form inputs render
+    // on top of the date-picker by default, which makes it hard to use in some situations.
+    z-index: 10;
+}
 .add-control--error-message {
     padding-top: 5px;
 }


### PR DESCRIPTION
#### Rationale
By default bootstrap form inputs have a z-index of 2, and the react-datepicker popoverh as a z-index of 1. If you get yourself into a situation where the popover overlaps with an input above or below the input will render above the popover.

![z-index-problem](https://user-images.githubusercontent.com/5341647/150430993-8d238030-9524-4834-a10f-c5fc474c2f19.png)

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1126

#### Changes
* Increase z-index of react-datepicker popover
