### PR TITLE
Item 9875: Assay QC state option to require comment on QC state change for assay run

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.121.0",
+  "version": "2.121.0-fb-initFangElisa.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.121.0-fb-initFangElisa.0",
+  "version": "2.121.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.120.1",
+  "version": "2.120.1-fb-initFangElisa.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD January 2022
+### version 2.121.1
+*Released*: 24 January 2022
 * Item 9875: Add AssayDefinitionModel requireCommentOnQCStateChange prop
 
 ### version 2.121.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD January 2022
+* Item 9875: Add AssayDefinitionModel requireCommentOnQCStateChange prop
+
 ### version 2.120.1
 *Released*: 20 January 2022
 * Increase z-index of react-datepicker popover

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -39,6 +39,7 @@ export class AssayDefinitionModel extends Record({
     name: undefined,
     projectLevel: undefined,
     protocolSchemaName: undefined,
+    requireCommentOnQCStateChange: undefined,
     reRunSupport: undefined,
     templateLink: undefined,
     type: undefined,
@@ -54,6 +55,7 @@ export class AssayDefinitionModel extends Record({
     declare name: string;
     declare projectLevel: boolean;
     declare protocolSchemaName: string;
+    declare requireCommentOnQCStateChange: boolean;
     declare reRunSupport: string;
     declare templateLink: string;
     declare type: string;


### PR DESCRIPTION
#### Rationale
A client has an assay QC workflow that will be using Assay run QC states to track passing and failing plate/sample runs. The initial QC state for each run will be set during the file watcher pipeline import task, but users with proper permissions will be allowed to update QC states for a run after review within the LabKey UI. This story adds a feature so that an admin can set, via the Manage QC states page, that a comment is required when changing an assay run QC state.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2954
* https://github.com/LabKey/biologics/pull/1128
* https://github.com/LabKey/labkey-ui-components/pull/714

#### Changes
* Add AssayDefinitionModel requireCommentOnQCStateChange prop
