### PR TITLE
Issue 44721: naturalSort, similaritySortFactory defensive against non-string values

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.121.1",
+  "version": "2.121.1-fb-fix-44721.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.121.1-fb-fix-44721.0",
+  "version": "2.121.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.12#.#
+*Released*: ## January 2022
+* Issue 44721: make sorting methods defensive against non-string values
+
 ### version 2.121.1
 *Released*: 24 January 2022
 * Item 9875: Add AssayDefinitionModel requireCommentOnQCStateChange prop

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.12#.#
-*Released*: ## January 2022
+### version 2.121.2
+*Released*: 25 January 2022
 * Issue 44721: make sorting methods defensive against non-string values
 
 ### version 2.121.1

--- a/packages/components/src/internal/util/similaritySortFactory.spec.tsx
+++ b/packages/components/src/internal/util/similaritySortFactory.spec.tsx
@@ -77,4 +77,12 @@ describe('similaritySortFactory', () => {
         result = getValues().sort(similaritySortFactory('s-1', true));
         expect(result[0]).toEqual('6S-1'); // degrade to natural sort
     });
+
+    test('non-string values', () => {
+        const nonStringValues = [42, 3.14, jest.fn(), true, [], {}, undefined, null, NaN];
+
+        // Don't particularly care how it sorts these ... just that it succeeds in processing them.
+        expect(nonStringValues.sort(similaritySortFactory('x')).length).toEqual(nonStringValues.length);
+        expect(nonStringValues.sort(similaritySortFactory('y', true)).length).toEqual(nonStringValues.length);
+    });
 });

--- a/packages/components/src/internal/util/similaritySortFactory.spec.tsx
+++ b/packages/components/src/internal/util/similaritySortFactory.spec.tsx
@@ -1,5 +1,6 @@
-import { contains, hasPrefix, similaritySortFactory } from './similaritySortFactory';
 import { naturalSort } from '../..';
+
+import { contains, hasPrefix, similaritySortFactory } from './similaritySortFactory';
 
 describe('contains', () => {
     test('Empty values', () => {

--- a/packages/components/src/internal/util/similaritySortFactory.ts
+++ b/packages/components/src/internal/util/similaritySortFactory.ts
@@ -3,8 +3,8 @@ import { naturalSort } from '../..';
 function indexOf(source: string, token: string, caseSensitive?: boolean): number {
     if (!source || !token) return -1;
 
-    const ss = caseSensitive === true ? source : source.toLowerCase();
-    const tt = caseSensitive === true ? token : token.toLowerCase();
+    const ss = caseSensitive === true ? source.toString() : source.toString().toLowerCase();
+    const tt = caseSensitive === true ? token.toString() : token.toString().toLowerCase();
 
     return ss.indexOf(tt);
 }
@@ -25,8 +25,8 @@ export function similaritySortFactory(token: string, caseSensitive?: boolean): (
         if (!rawA) return 1;
         if (!rawB) return -1;
 
-        const a = caseSensitive === true ? rawA : rawA.toLowerCase();
-        const b = caseSensitive === true ? rawB : rawB.toLowerCase();
+        const a = caseSensitive === true ? rawA.toString() : rawA.toString().toLowerCase();
+        const b = caseSensitive === true ? rawB.toString() : rawB.toString().toLowerCase();
 
         if (a === b) return 0;
         if (a === token && b !== token) return -1;

--- a/packages/components/src/public/sort.spec.ts
+++ b/packages/components/src/public/sort.spec.ts
@@ -1,6 +1,5 @@
 import { naturalSort } from './sort';
 
-
 describe('naturalSort', () => {
     test('alphabetic', () => {
         expect(naturalSort('', 'anything')).toBe(1);
@@ -22,5 +21,12 @@ describe('naturalSort', () => {
         expect(naturalSort('1.431', '14.31')).toBeLessThan(0);
         expect(naturalSort('10', '1.0')).toBeGreaterThan(0);
         expect(naturalSort('1.2ABC', '1.2XY')).toBeLessThan(0);
+    });
+
+    test('non-string values', () => {
+        const nonStringValues = [42, 3.14, jest.fn(), true, [], {}, undefined, null, NaN];
+
+        // Don't particularly care how it sorts these ... just that it succeeds in processing them.
+        expect(nonStringValues.sort(naturalSort).length).toEqual(nonStringValues.length);
     });
 });

--- a/packages/components/src/public/sort.ts
+++ b/packages/components/src/public/sort.ts
@@ -13,19 +13,17 @@ export function naturalSort(aso: any, bso: any): number {
     if (aso === undefined || aso === null || aso === '') return 1;
     if (bso === undefined || bso === null || bso === '') return -1;
 
-    let a,
-        b,
-        a1,
+    let a1,
         b1,
         i = 0,
-        n,
-        L,
-        rx = /(\.\d+)|(\d+(\.\d+)?)|([^\d.]+)|(\.\D+)|(\.$)/g;
+        n;
 
-    a = aso.toString().toLowerCase().match(rx);
-    b = bso.toString().toLowerCase().match(rx);
+    // If no matches are found in the group, then match() will return null
+    const rx = /(\.\d+)|(\d+(\.\d+)?)|([^\d.]+)|(\.\D+)|(\.$)/g;
+    const a = aso.toString().toLowerCase().match(rx) ?? [];
+    const b = bso.toString().toLowerCase().match(rx) ?? [];
 
-    L = a.length;
+    const L = a.length;
     while (i < L) {
         if (!b[i]) return 1;
         a1 = a[i];


### PR DESCRIPTION
#### Rationale
Addresses [Issue 44721](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44721) by making `naturalSort()` and `similaritySortFactory()` methods more defensive against non-string values.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1132

#### Changes
* Always call `toString()` on the raw value in `similaritySortFactory()` and `indexOf()`.
* Return `[]` for matches when no match is found against RegEx used in `naturalSort()`.
* Add unit test coverage.
