### PR TITLE
Item 9970: QueryFormInput change showQuerySelectPreviewOptions default prop value to false

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.121.3",
+  "version": "2.121.3-fb-smLookupPreviewOptions.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.121.3-fb-smLookupPreviewOptions.0",
+  "version": "2.121.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.121.4
+*Released*: 28 January 2022
 * Item 9970: QueryFormInput change showQuerySelectPreviewOptions default prop value to false
   * Update SampleStatusInput component QuerySelect previewOptions prop to false as well
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 9970: QueryFormInput change showQuerySelectPreviewOptions default prop value to false
+  * Update SampleStatusInput component QuerySelect previewOptions prop to false as well
+
 ### version 2.121.3
 *Released*: 27 January 2022
 * Merge release21.11-SNAPSHOT to develop (part 2)

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -82,7 +82,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
         allowFieldDisable: false,
         initiallyDisableFields: false,
         disabledFields: List<string>(),
-        showQuerySelectPreviewOptions: true,
+        showQuerySelectPreviewOptions: false,
     };
 
     private _fieldEnabledCount = 0;

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -148,7 +148,6 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
                 onQSChange={onChange}
                 onToggleDisable={onToggleDisable}
                 placeholder="Select or type to search..."
-                previewOptions={true}
                 required={col.required}
                 schemaQuery={col.lookup?.schemaQuery}
                 showLabel


### PR DESCRIPTION
#### Rationale
In LKSM and LKB, having a field that is a lookup (e.g., sample status) automatically shows a subset of the columns and data associated with that lookup (e.g., rowid, container) in the Bulk Update modal and some other form inputs. We’d prefer to just have all lookups be a display value option. 

This PR changes the default prop value in the QueryFormInput component so that it defaults to NOT showing those additional preview options. Note that there are still four places in the apps that set this property to TRUE and those were not affected by this change.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/721
* https://github.com/LabKey/sampleManagement/pull/816
* https://github.com/LabKey/biologics/pull/1136
* https://github.com/LabKey/inventory/pull/370

#### Changes
* QueryFormInput change showQuerySelectPreviewOptions default prop value to false
* Update SampleStatusInput component QuerySelect previewOptions prop to false as well
