### PR TITLE
Cross-Folder Registry

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.128.0",
+  "version": "2.129.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,29 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.129.0
+*Released*: 3 February 2022
+* **AliasInput**
+    * Refactor `AliasInput` "value" processing to match what is expected. This fixes several bugs with how this component displays and persists state.
+    * Add unit tests.
+* **Data Classes**
+    * Support cross-folder domain editing for Data Classes.
+* **Details**
+    * Support `containerFilter` and `containerPath` for `Detail`, `DetailPanel`, `DetailEditRenderer`, and `EditableDetailPanel`.
+* **Lineage**
+    * Export `withLineage` and `InjectedLineage` for external use.
+    * Refactor how `sampleStats` are processed.
+* **Query APIs**
+    * Improve typings for `insertRows`, `deleteRows`, and `selectRows` to reduce duplication with `@labkey/api` and provide passthrough of all configuration options.
+    * Update `getContainerFilter` to process the `containerPath` provided to query configurations if provided.
+    * Introduce `getContainerFilterForInsert`. Supplies the container filter to be used when fetching data intended for insert.
+* **QuerySelect**
+    * Ensure all queries made by `QuerySelect` specify the same set of columns.
+    * Simplify and centralize `QuerySelectModel` initialization.
+    * Support specifying `containerFilter` on `QuerySelect`.
+* **SelectInput**
+    * Introduce `resolveFormValue` for component users to override how the input processes the selected options into a form value.
+
 ### version 2.128.0
 *Released*: 3 February 2022
 * Item 9815: Sample Finder v1 - Filter dialog field expression filters

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -178,6 +178,7 @@ import {
 import {
     deleteRows,
     getContainerFilter,
+    getContainerFilterForInsert,
     getQueryDetails,
     importData,
     InsertFormats,
@@ -780,6 +781,7 @@ export {
     initQueryGridState,
     initNotificationsState,
     getContainerFilter,
+    getContainerFilterForInsert,
     getStateQueryGridModel,
     getStateModelId,
     getQueryGridModel,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -376,7 +376,7 @@ import {
     getLineageFilterValue,
     invalidateLineageResults,
 } from './internal/components/lineage/actions';
-import { InjectedLineage, withLineage } from './internal/components/lineage/withLineage';
+import { withLineage } from './internal/components/lineage/withLineage';
 import { DEFAULT_LINEAGE_DISTANCE } from './internal/components/lineage/constants';
 import {
     LINEAGE_DIRECTIONS,
@@ -1089,7 +1089,6 @@ export {
     ReportList,
     // lineage
     DEFAULT_LINEAGE_DISTANCE,
-    InjectedLineage,
     LINEAGE_GROUPING_GENERATIONS,
     LINEAGE_DIRECTIONS,
     LineageDepthLimitMessage,
@@ -1463,3 +1462,4 @@ export type { ContainerUser, UseContainerUser } from './internal/components/cont
 export type { PageDetailHeaderProps } from './internal/components/forms/PageDetailHeader';
 export type { HorizontalBarData } from './internal/components/chart/HorizontalBarSection';
 export type { HorizontalBarLegendData } from './internal/components/chart/utils';
+export type { InjectedLineage } from './internal/components/lineage/withLineage';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -260,6 +260,7 @@ import {
     handleInputTab,
     handleTabKeyOnTextArea,
     useUsersWithPermissions,
+    updateRowFieldValue,
 } from './internal/components/forms/actions';
 import { FormStep, FormTabs, withFormSteps } from './internal/components/forms/FormStep';
 import { GridAliquotViewSelector } from './internal/components/gridbar/GridAliquotViewSelector';
@@ -662,7 +663,6 @@ import {
 import { Key, useEnterEscape } from './public/useEnterEscape';
 import { DateInput } from './internal/components/DateInput';
 import { EditInlineField } from './internal/components/EditInlineField';
-import { updateRowFieldValue } from './internal/components/forms/actions';
 import { FileAttachmentArea } from './internal/components/files/FileAttachmentArea';
 import { UserAvatar, UserAvatars } from './internal/components/UserAvatars';
 import { AnnouncementRenderType } from './internal/announcements/model';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -376,6 +376,7 @@ import {
     getLineageFilterValue,
     invalidateLineageResults,
 } from './internal/components/lineage/actions';
+import { InjectedLineage, withLineage } from './internal/components/lineage/withLineage';
 import { DEFAULT_LINEAGE_DISTANCE } from './internal/components/lineage/constants';
 import {
     LINEAGE_DIRECTIONS,
@@ -1088,6 +1089,7 @@ export {
     ReportList,
     // lineage
     DEFAULT_LINEAGE_DISTANCE,
+    InjectedLineage,
     LINEAGE_GROUPING_GENERATIONS,
     LINEAGE_DIRECTIONS,
     LineageDepthLimitMessage,
@@ -1100,6 +1102,7 @@ export {
     invalidateLineageResults,
     getImmediateChildLineageFilterValue,
     getLineageFilterValue,
+    withLineage,
     // Navigation
     MenuSectionConfig,
     ProductMenuModel,

--- a/packages/components/src/internal/components/domainproperties/APIWrapper.ts
+++ b/packages/components/src/internal/components/domainproperties/APIWrapper.ts
@@ -27,7 +27,8 @@ export interface DomainPropertiesAPIWrapper {
     hasExistingDomainData: (
         kindName: 'SampleSet' | 'DataClass',
         dataTypeLSID?: string,
-        rowId?: number
+        rowId?: number,
+        containerPath?: string
     ) => Promise<boolean>;
 }
 

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -170,7 +170,7 @@ export class DomainRowExpandedOptions extends React.Component<IDomainRowExpanded
                         index={index}
                         domainIndex={domainIndex}
                         label="Lookup Definition Options"
-                        lookupContainer={field.lookupContainer}
+                        lookupContainer={field.lookupContainer ?? domainContainerPath}
                         lookupSchema={field.lookupSchema}
                         lookupQueryValue={field.lookupQueryValue}
                         lookupValidator={field.lookupValidator}

--- a/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.tsx
@@ -8,6 +8,7 @@ import { isNotificationsEnabled } from '../notifications/global';
 
 export interface NameExpressionGenIdProps {
     api?: ComponentsAPIWrapper;
+    containerPath?: string;
     dataTypeName: string; // sampletype or dataclass name
     rowId: number;
     kindName: 'SampleSet' | 'DataClass';
@@ -15,7 +16,7 @@ export interface NameExpressionGenIdProps {
 }
 
 export const NameExpressionGenIdBanner: FC<NameExpressionGenIdProps> = props => {
-    const { api, rowId, kindName, dataTypeName, dataTypeLSID } = props;
+    const { api, containerPath, rowId, kindName, dataTypeName, dataTypeLSID } = props;
     const [currentGenId, setCurrentGenId] = useState<number>(undefined);
     const [newGenId, setNewGenId] = useState<number>(undefined);
     const [minNewGenId, setMinNewGenId] = useState<number>(undefined);
@@ -27,7 +28,7 @@ export const NameExpressionGenIdBanner: FC<NameExpressionGenIdProps> = props => 
     const init = async () => {
         if (rowId && kindName) {
             try {
-                const hasData = await api.domain.hasExistingDomainData(kindName, dataTypeLSID, rowId);
+                const hasData = await api.domain.hasExistingDomainData(kindName, dataTypeLSID, rowId, containerPath);
                 const canResetGen = !hasData;
                 setCanReset(canResetGen);
 

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -26,6 +26,7 @@ import {
     QueryColumn,
     SchemaDetails,
     SchemaQuery,
+    SCHEMAS,
 } from '../../..';
 
 import { processSchemas } from '../../schemas';
@@ -403,6 +404,7 @@ export function validateDomainNameExpressions(
         }
 
         Domain.validateNameExpressions({
+            containerPath: domain.container,
             options,
             domainDesign: DomainDesign.serialize(domain),
             kind,
@@ -1210,7 +1212,8 @@ export function getGenId(rowId: number, kindName: 'SampleSet' | 'DataClass', con
 export function hasExistingDomainData(
     kindName: 'SampleSet' | 'DataClass',
     dataTypeLSID?: string,
-    rowId?: number
+    rowId?: number,
+    containerPath?: string
 ): Promise<boolean> {
     let dataCountSql = 'SELECT COUNT(*) AS DataCount FROM ';
 
@@ -1222,7 +1225,8 @@ export function hasExistingDomainData(
 
     return new Promise((resolve, reject) => {
         Query.executeSql({
-            schemaName: 'exp',
+            containerPath,
+            schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
             sql: dataCountSql,
             success: async data => {
                 resolve(data.rows[0].DataCount !== 0);

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
@@ -69,9 +69,11 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
     state: Readonly<State> = { isValid: true, prefix: undefined, loadingError: undefined };
 
     componentDidMount = async (): Promise<void> => {
+        const { model } = this.props;
+
         if (isSampleManagerEnabled()) {
             try {
-                const response = await loadNameExpressionOptions();
+                const response = await loadNameExpressionOptions(model.containerPath);
                 this.setState({ prefix: response.prefix ?? null });
             } catch (error) {
                 this.setState({ loadingError: 'There was a problem retrieving the Naming Pattern prefix.' });
@@ -95,63 +97,13 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
     };
 
     onFormChange = (evt: any): void => {
-        const id = evt.target.id;
-        const value = evt.target.value;
+        const { id, value } = evt.target;
         this.onChange(id, value);
     };
 
     onChange = (id: string, value: any): void => {
         this.updateValidStatus(this.props.model.mutate({ [getFormNameFromId(id)]: value }));
     };
-
-    renderSampleTypeSelect(): ReactNode {
-        const { model, nounSingular } = this.props;
-
-        return (
-            <Row>
-                <Col xs={2}>
-                    <DomainFieldLabel
-                        label="Sample Type"
-                        helpTipBody={`The default Sample Type where new samples will be created for this ${nounSingular.toLowerCase()}.`}
-                    />
-                </Col>
-                <Col xs={10}>
-                    <QuerySelect
-                        componentId={FORM_IDS.SAMPLE_TYPE_ID}
-                        name={FORM_IDS.SAMPLE_TYPE_ID}
-                        schemaQuery={SCHEMAS.EXP_TABLES.SAMPLE_SETS}
-                        onQSChange={this.onChange}
-                        value={model.sampleSet}
-                        showLabel={false}
-                    />
-                </Col>
-            </Row>
-        );
-    }
-
-    renderCategorySelect(): ReactNode {
-        const { model } = this.props;
-
-        return (
-            <Row>
-                <Col xs={2}>
-                    <DomainFieldLabel label="Category" />
-                </Col>
-                <Col xs={10}>
-                    <QuerySelect
-                        componentId={FORM_IDS.CATEGORY}
-                        name={FORM_IDS.CATEGORY}
-                        schemaQuery={SCHEMAS.EXP_TABLES.DATA_CLASS_CATEGORY_TYPE}
-                        displayColumn="Value"
-                        valueColumn="Value"
-                        onQSChange={this.onChange}
-                        value={model.category}
-                        showLabel={false}
-                    />
-                </Col>
-            </Row>
-        );
-    }
 
     render(): ReactNode {
         const {
@@ -215,8 +167,45 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
                     onNameFieldHover={onNameFieldHover}
                     nameExpressionGenIdProps={nameExpressionGenIdProps}
                 />
-                {!appPropertiesOnly && this.renderCategorySelect()}
-                {!appPropertiesOnly && this.renderSampleTypeSelect()}
+                {!appPropertiesOnly && (
+                    <Row>
+                        <Col xs={2}>
+                            <DomainFieldLabel label="Category" />
+                        </Col>
+                        <Col xs={10}>
+                            <QuerySelect
+                                componentId={FORM_IDS.CATEGORY}
+                                name={FORM_IDS.CATEGORY}
+                                schemaQuery={SCHEMAS.EXP_TABLES.DATA_CLASS_CATEGORY_TYPE}
+                                displayColumn="Value"
+                                valueColumn="Value"
+                                onQSChange={this.onChange}
+                                value={model.category}
+                                showLabel={false}
+                            />
+                        </Col>
+                    </Row>
+                )}
+                {!appPropertiesOnly && (
+                    <Row>
+                        <Col xs={2}>
+                            <DomainFieldLabel
+                                label="Sample Type"
+                                helpTipBody={`The default Sample Type where new samples will be created for this ${nounSingular.toLowerCase()}.`}
+                            />
+                        </Col>
+                        <Col xs={10}>
+                            <QuerySelect
+                                componentId={FORM_IDS.SAMPLE_TYPE_ID}
+                                name={FORM_IDS.SAMPLE_TYPE_ID}
+                                schemaQuery={SCHEMAS.EXP_TABLES.SAMPLE_SETS}
+                                onQSChange={this.onChange}
+                                value={model.sampleSet}
+                                showLabel={false}
+                            />
+                        </Col>
+                    </Row>
+                )}
             </BasePropertiesPanel>
         );
     }

--- a/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
@@ -20,26 +20,27 @@ import { deleteEntityType } from '../../entities/actions';
 
 import { DataClassModel } from './models';
 
-export function fetchDataClass(queryName?: string, rowId?: number): Promise<DataClassModel> {
+export function fetchDataClass(queryName?: string, rowId?: number, containerPath?: string): Promise<DataClassModel> {
     if (rowId) {
-        return fetchDataClassProperties(rowId)
+        return fetchDataClassProperties(rowId, containerPath)
             .then(response => {
-                return _fetchDataClass(undefined, response.domainId);
+                return _fetchDataClass(undefined, response.domainId, containerPath);
             })
             .catch(error => {
                 return Promise.reject(error);
             });
     } else if (queryName) {
-        return _fetchDataClass(queryName);
+        return _fetchDataClass(queryName, undefined, containerPath);
     } else {
         // for the create case to get the domain details based on domainKind param only
         return _fetchDataClass();
     }
 }
 
-function _fetchDataClass(queryName?: string, domainId?: number): Promise<DataClassModel> {
+function _fetchDataClass(queryName?: string, domainId?: number, containerPath?: string): Promise<DataClassModel> {
     return new Promise((resolve, reject) => {
         return Domain.getDomainDetails({
+            containerPath,
             schemaName: SCHEMAS.DATA_CLASSES.SCHEMA,
             queryName,
             domainId,
@@ -58,11 +59,10 @@ function _fetchDataClass(queryName?: string, domainId?: number): Promise<DataCla
     });
 }
 
-function fetchDataClassProperties(rowId: number): Promise<any> {
+function fetchDataClassProperties(rowId: number, containerPath?: string): Promise<any> {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: ActionURL.buildURL('experiment', 'getDataClassProperties.api'),
-            method: 'GET',
+            url: ActionURL.buildURL('experiment', 'getDataClassProperties.api', containerPath),
             params: { rowId },
             scope: this,
             success: Utils.getCallbackWrapper(data => {

--- a/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
@@ -69,6 +69,10 @@ export class DataClassModel implements DataClassModelConfig {
         return new DataClassModel({ ...raw, domain });
     }
 
+    get containerPath(): string {
+        return this.domain?.container;
+    }
+
     get isNew(): boolean {
         return !this.rowId;
     }

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -735,6 +735,7 @@ class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDom
                     nameExpressionGenIdProps={
                         showGenIdBanner && options
                             ? {
+                                  containerPath: model.containerPath,
                                   dataTypeName: options.get('name'),
                                   dataTypeLSID: options.get('lsid'),
                                   rowId: options.get('rowId'),

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -137,6 +137,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
         return (
             <QuerySelect
                 autoFocus
+                containerFilter={lookup.containerFilter}
                 disabled={this.props.disabled}
                 queryFilters={queryFilters}
                 multiple={isMultiple}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -249,7 +249,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                         addLabelAsterisk={showAsteriskSymbol}
                                         allowDisable={allowFieldDisable}
                                         componentId={id}
-                                        containerFilter={containerFilter}
+                                        containerFilter={col.lookup.containerFilter ?? containerFilter}
                                         containerPath={col.lookup.containerPath}
                                         displayColumn={col.lookup.displayColumn}
                                         fireQSChangeOnInit={fireQSChangeOnInit}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -16,7 +16,7 @@
 import React, { ReactNode } from 'react';
 import { List, Map, OrderedMap } from 'immutable';
 import { Input } from 'formsy-react-components';
-import { Utils } from '@labkey/api';
+import { Query, Utils } from '@labkey/api';
 
 import { caseInsensitive, insertColumnFilter, QueryColumn, QueryInfo } from '../../..';
 
@@ -50,6 +50,8 @@ interface QueryFormInputsProps {
     checkRequiredFields?: boolean;
     columnFilter?: (col?: QueryColumn) => boolean;
     componentKey?: string; // unique key to add to QuerySelect to avoid duplication w/ transpose
+    /** A container filter that will be applied to all query-based inputs in this form */
+    containerFilter?: Query.ContainerFilter;
     disabledFields?: List<string>;
     fieldValues?: any;
     fireQSChangeOnInit?: boolean;
@@ -160,6 +162,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
         const {
             columnFilter,
             componentKey,
+            containerFilter,
             fieldValues,
             fireQSChangeOnInit,
             checkRequiredFields,
@@ -246,6 +249,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                         addLabelAsterisk={showAsteriskSymbol}
                                         allowDisable={allowFieldDisable}
                                         componentId={id}
+                                        containerFilter={containerFilter}
                                         containerPath={col.lookup.containerPath}
                                         displayColumn={col.lookup.displayColumn}
                                         fireQSChangeOnInit={fireQSChangeOnInit}

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -15,7 +15,7 @@
  */
 import React, { FC, PureComponent, ReactNode } from 'react';
 import { fromJS, List, Map } from 'immutable';
-import { Filter, Utils } from '@labkey/api';
+import { Filter, Query, Utils } from '@labkey/api';
 
 import { resolveErrorMessage, SchemaQuery } from '../../..';
 
@@ -124,6 +124,7 @@ type InheritedSelectInputProps = Omit<
 
 export interface QuerySelectOwnProps extends InheritedSelectInputProps {
     componentId: string;
+    containerFilter?: Query.ContainerFilter;
     /** The path to the LK container that the queries should be scoped to. */
     containerPath?: string;
     displayColumn?: string;

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -63,7 +63,7 @@ function initDisplayColumn(queryInfo: QueryInfo, column?: string): string {
 
 export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel> {
     return new Promise((resolve, reject) => {
-        const { componentId, schemaQuery, containerPath } = props;
+        const { componentId, schemaQuery, containerFilter, containerPath } = props;
 
         if (schemaQuery) {
             const { queryName, schemaName } = schemaQuery;
@@ -95,6 +95,7 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                         }
 
                         selectRows({
+                            containerFilter,
                             containerPath,
                             schemaName,
                             queryName,
@@ -231,6 +232,7 @@ export function fetchSearchResults(model: QuerySelectModel, input: any): Promise
     // 35112: Explicitly request exact matches -- can be disabled via QuerySelectModel.addExactFilter = false
     return searchRows(
         {
+            containerFilter: model.containerFilter,
             containerPath: model.containerPath,
             schemaName: schemaQuery.getSchema(),
             queryName: schemaQuery.getQuery(),

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo, ReactNode, useMemo } from 'react';
 import { List, OrderedMap } from 'immutable';
 import { Panel } from 'react-bootstrap';
+import { Query } from '@labkey/api';
 
 import { DefaultRenderer, LabelHelpTip, QueryColumn } from '../../../..';
 
@@ -17,6 +18,10 @@ import {
 export type Renderer = (data: any, row?: any) => ReactNode;
 
 export interface RenderOptions {
+    /** A container filter that will be applied to all query-based inputs in this form */
+    containerFilter?: Query.ContainerFilter;
+    /** A container path that will be applied to all query-based inputs on this form */
+    containerPath?: string;
     useDatePicker?: boolean;
 }
 
@@ -101,6 +106,8 @@ interface DetailDisplayProps extends DetailDisplaySharedProps {
 export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
     const {
         asPanel,
+        containerFilter,
+        containerPath,
         data,
         displayColumns,
         editingMode,
@@ -130,7 +137,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
             displayColumns,
             detailRenderer,
             titleRenderer,
-            { useDatePicker },
+            { containerFilter, containerPath, useDatePicker },
             fileInputRenderer,
             onAdditionalFormDataChange
         );

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -108,7 +108,8 @@ export function resolveDetailEditRenderer(
                 return (
                     <QuerySelect
                         componentId={col.fieldKey}
-                        containerPath={col.lookup.containerPath}
+                        containerFilter={options?.containerFilter}
+                        containerPath={options?.containerPath ?? col.lookup.containerPath}
                         displayColumn={col.lookup.displayColumn}
                         formsy
                         inputClass="col-sm-12"

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -109,7 +109,7 @@ export function resolveDetailEditRenderer(
                     <QuerySelect
                         componentId={col.fieldKey}
                         containerFilter={options?.containerFilter}
-                        containerPath={options?.containerPath ?? col.lookup.containerPath}
+                        containerPath={col.lookup.containerPath ?? options?.containerPath}
                         displayColumn={col.lookup.displayColumn}
                         formsy
                         inputClass="col-sm-12"

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -92,7 +92,7 @@ export function resolveDetailEditRenderer(
                     onAdditionalFormDataChange,
                     'col-sm-12',
                     options?.containerPath,
-                    options?.containerFilter,
+                    options?.containerFilter
                 );
             }
 

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -90,7 +90,9 @@ export function resolveDetailEditRenderer(
                     null,
                     false,
                     onAdditionalFormDataChange,
-                    'col-sm-12'
+                    'col-sm-12',
+                    options?.containerPath,
+                    options?.containerFilter,
                 );
             }
 
@@ -108,7 +110,7 @@ export function resolveDetailEditRenderer(
                 return (
                     <QuerySelect
                         componentId={col.fieldKey}
-                        containerFilter={options?.containerFilter}
+                        containerFilter={col.lookup.containerFilter ?? options?.containerFilter}
                         containerPath={col.lookup.containerPath ?? options?.containerPath}
                         displayColumn={col.lookup.displayColumn}
                         formsy

--- a/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { fromJS } from 'immutable';
+
+import { QueryColumn, SelectInput } from '../../../..';
+
+import { AliasInput } from './AliasInput';
+
+describe('AliasInput', () => {
+    const fieldKey = 'Alias';
+    const aliasColumn = QueryColumn.create({
+        caption: fieldKey,
+        fieldKey,
+        required: false,
+    });
+
+    test('value derived from "data"', () => {
+        const data = { [fieldKey.toLowerCase()]: [undefined, '', 'a', { displayValue: 'b' }, { foo: 'c' }, null] };
+
+        // No data
+        const wrapper = shallow(<AliasInput col={aliasColumn} />);
+        expect(wrapper.find(SelectInput).prop('value')).toEqual(undefined);
+
+        // Object data
+        wrapper.setProps({ data });
+        expect(wrapper.find(SelectInput).prop('value')).toEqual(['a', 'b']);
+
+        // Immutable data
+        wrapper.setProps({ data: fromJS(data) });
+        expect(wrapper.find(SelectInput).prop('value')).toEqual(['a', 'b']);
+    });
+
+    test('resolveFormValue', () => {
+        const wrapper = shallow(<AliasInput col={aliasColumn} />);
+        const resolveFormValue = wrapper.find(SelectInput).prop('resolveFormValue');
+
+        expect(resolveFormValue(undefined)).toEqual([]);
+        expect(resolveFormValue([])).toEqual([]);
+        expect(resolveFormValue([{ value: 'x', label: 'y' }])).toEqual(['y']);
+    });
+});

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo, ReactNode, ReactText, useCallback, useEffect, useState, useMemo } from 'react';
+import { Query } from '@labkey/api';
 
 import {
     DISCARD_CONSUMED_CHECKBOX_FIELD,
@@ -15,6 +16,8 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../../APIWrapper'
 interface SampleStatusInputProps {
     api?: ComponentsAPIWrapper;
     col: QueryColumn;
+    containerFilter?: Query.ContainerFilter;
+    containerPath?: string;
     data: any;
     key: ReactText;
     isDetailInput?: boolean;
@@ -37,6 +40,8 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
         showAsteriskSymbol,
         allowDisable,
         col,
+        containerFilter,
+        containerPath,
         key,
         initiallyDisabled,
         onToggleDisable,
@@ -86,7 +91,7 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
             const showPanel = isInStorage && isConsumed;
             setShowDiscardPanel(showPanel);
         },
-        [onQSChange, consumedStatuses]
+        [consumedStatuses, onAdditionalFormDataChange, onQSChange, shouldDiscard, value]
     );
 
     const onCommentChange = useCallback(
@@ -135,8 +140,9 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
                 addLabelAsterisk={showAsteriskSymbol}
                 allowDisable={allowDisable}
                 componentId={col.fieldKey + key}
-                containerPath={col.lookup?.containerPath}
-                displayColumn={col.lookup?.displayColumn}
+                containerFilter={col.lookup.containerFilter ?? containerFilter}
+                containerPath={col.lookup.containerPath ?? containerPath}
+                displayColumn={col.lookup.displayColumn}
                 formsy={formsy}
                 helpTipRenderer={col.helpTipRenderer}
                 initiallyDisabled={initiallyDisabled}
@@ -150,10 +156,10 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
                 onToggleDisable={onToggleDisable}
                 placeholder="Select or type to search..."
                 required={col.required}
-                schemaQuery={col.lookup?.schemaQuery}
+                schemaQuery={col.lookup.schemaQuery}
                 showLabel
                 value={value}
-                valueColumn={col.lookup?.keyColumn}
+                valueColumn={col.lookup.keyColumn}
                 inputClass={inputClass}
             />
             {error && <Alert>{error}</Alert>}

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -178,6 +178,7 @@ export interface SelectInputProps {
     promptTextCreator?: (filterText: string) => string;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
     required?: boolean;
+    resolveFormValue?: (selectedOptions: SelectInputOption | SelectInputOption[]) => any;
     saveOnBlur?: boolean;
     selectedOptions?: any;
     showLabel?: boolean;
@@ -353,7 +354,9 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
 
         let formValue;
 
-        if (selectedOptions !== undefined) {
+        if (this.props.resolveFormValue) {
+            formValue = this.props.resolveFormValue(selectedOptions);
+        } else if (selectedOptions !== undefined) {
             if (multiple) {
                 if (Array.isArray(selectedOptions)) {
                     formValue = selectedOptions.reduce((arr, option) => {

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -83,10 +83,6 @@ export class QuerySelectModel
     declare selectedItems: Map<string, any>;
     declare valueColumn: string;
 
-    constructor(values?: Partial<QuerySelectModelProps>) {
-        super(values);
-    }
-
     formatSavedResults(data?: Map<string, Map<string, any>>, token?: string): SelectInputOption[] {
         return actions.formatSavedResults(this, data, token);
     }

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { List, Map, Record } from 'immutable';
-import { Filter } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { ISelectRowsResult, QueryInfo, SchemaQuery } from '../../..';
 
@@ -23,6 +23,7 @@ import * as actions from './actions';
 
 export interface QuerySelectModelProps {
     allResults: Map<string, Map<string, any>>;
+    containerFilter?: Query.ContainerFilter;
     containerPath?: string;
     displayColumn: string;
     delimiter: string;
@@ -44,6 +45,7 @@ export class QuerySelectModel
     extends Record({
         addExactFilter: true,
         allResults: Map<string, Map<string, any>>(),
+        containerFilter: undefined,
         containerPath: undefined,
         displayColumn: undefined,
         delimiter: DELIMITER,
@@ -64,6 +66,7 @@ export class QuerySelectModel
 {
     declare addExactFilter: boolean;
     declare allResults: Map<string, Map<string, any>>;
+    declare containerFilter: Query.ContainerFilter;
     declare containerPath: string;
     declare displayColumn: string;
     declare delimiter: string;

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -108,7 +108,7 @@ const SampleStatusInputRenderer: InputRenderer = (
     onAdditionalFormDataChange?: (name: string, value: any) => any,
     inputClass?: string,
     containerPath?: string,
-    containerFilter?: Query.ContainerFilter,
+    containerFilter?: Query.ContainerFilter
 ) => {
     return (
         <SampleStatusInput

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -15,6 +15,7 @@
  */
 import React, { ReactNode, ReactText } from 'react';
 import { List, Map } from 'immutable';
+import { Query } from '@labkey/api';
 import { Input } from 'formsy-react-components';
 import { addValidationRule, validationRules } from 'formsy-react';
 
@@ -39,7 +40,9 @@ type InputRenderer = (
     renderLabelField?: (col: QueryColumn) => ReactNode,
     showAsteriskSymbol?: boolean,
     onAdditionalFormDataChange?: (name: string, value: any) => any,
-    inputClass?: string
+    inputClass?: string,
+    containerPath?: string,
+    containerFilter?: Query.ContainerFilter
 ) => ReactNode;
 
 const AliasInputRenderer: InputRenderer = (
@@ -103,7 +106,9 @@ const SampleStatusInputRenderer: InputRenderer = (
     renderLabelField?: (col: QueryColumn) => ReactNode,
     showAsteriskSymbol?: boolean,
     onAdditionalFormDataChange?: (name: string, value: any) => any,
-    inputClass?: string
+    inputClass?: string,
+    containerPath?: string,
+    containerFilter?: Query.ContainerFilter,
 ) => {
     return (
         <SampleStatusInput
@@ -119,6 +124,8 @@ const SampleStatusInputRenderer: InputRenderer = (
             showAsteriskSymbol={showAsteriskSymbol}
             onAdditionalFormDataChange={onAdditionalFormDataChange}
             inputClass={inputClass}
+            containerFilter={containerFilter}
+            containerPath={containerPath}
         />
     );
 };

--- a/packages/components/src/internal/components/forms/renderers.tsx
+++ b/packages/components/src/internal/components/forms/renderers.tsx
@@ -54,9 +54,9 @@ const AliasInputRenderer: InputRenderer = (
 ) => (
     <AliasInput
         col={col}
+        data={data}
         isDetailInput={isDetailInput}
         key={key}
-        value={value}
         allowDisable={allowFieldDisable}
         initiallyDisabled={initiallyDisabled}
         onToggleDisable={onToggleDisable}

--- a/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
+++ b/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
@@ -5,7 +5,7 @@
 import React, { FunctionComponent, PureComponent, ReactNode } from 'react';
 import { List } from 'immutable';
 
-import { Alert, Grid, GridColumn, LoadingSpinner } from '../../..';
+import { Grid, GridColumn } from '../../..';
 
 import { InjectedLineage, withLineage } from './withLineage';
 
@@ -27,18 +27,16 @@ class CountsWithLineageImpl extends PureComponent<InjectedLineage> {
 
     render(): ReactNode {
         const { lineage } = this.props;
+        const data = lineage?.sampleStats?.filter(stats => stats.getIn(['sampleCount', 'value']) > 0).toList();
 
-        if (!lineage || !lineage.isLoaded()) {
-            return <LoadingSpinner />;
-        }
-
-        if (lineage.error) {
-            return <Alert>{lineage.error}</Alert>;
-        }
-
-        const data = lineage.sampleStats.filter(stats => stats.getIn(['sampleCount', 'value']) > 0).toList();
-
-        return <Grid columns={this.columns} data={data} emptyText="No derived samples" />;
+        return (
+            <Grid
+                columns={this.columns}
+                data={data}
+                emptyText={lineage?.error ?? 'No derived samples'}
+                isLoading={!lineage?.isLoaded()}
+            />
+        );
     }
 }
 

--- a/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
+++ b/packages/components/src/internal/components/lineage/SampleTypeLineageCounts.tsx
@@ -36,7 +36,9 @@ class CountsWithLineageImpl extends PureComponent<InjectedLineage> {
             return <Alert>{lineage.error}</Alert>;
         }
 
-        return <Grid columns={this.columns} data={lineage.sampleStats} />;
+        const data = lineage.sampleStats.filter(stats => stats.getIn(['sampleCount', 'value']) > 0).toList();
+
+        return <Grid columns={this.columns} data={data} emptyText="No derived samples" />;
     }
 }
 

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -8,6 +8,7 @@ import { fromJS, Map, OrderedSet } from 'immutable';
 import { Experiment, Filter, getServerContext, Query } from '@labkey/api';
 
 import {
+    App,
     AppURL,
     caseInsensitive,
     ISelectRowsResult,
@@ -307,7 +308,7 @@ function computeSampleCounts(lineageResult: LineageResult, sampleSets: ISelectRo
 
         return {
             name: {
-                url: AppURL.create('samples', name).toHref(),
+                url: AppURL.create(App.SAMPLES_KEY, name).toHref(),
                 value: name,
             },
             sampleCount: {

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -494,7 +494,7 @@ export interface ILineage {
     error?: string;
     result: LineageResult;
     resultLoadingState?: LoadingState;
-    sampleStats: any;
+    sampleStats: List<Map<string, any>>;
     seed: string;
     seedResult: LineageResult;
     seedResultError?: string;
@@ -507,7 +507,7 @@ export class Lineage implements ILineage {
     readonly error?: string;
     readonly result: LineageResult;
     readonly resultLoadingState: LoadingState = LoadingState.INITIALIZED;
-    readonly sampleStats: any;
+    readonly sampleStats: List<Map<string, any>>;
     readonly seed: string;
     readonly seedResult: LineageResult;
     readonly seedResultError?: string;

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -252,7 +252,8 @@ export class LineageNode
         listURL: undefined,
         meta: undefined,
     })
-    implements LineageNodeConfig {
+    implements LineageNodeConfig
+{
     declare absolutePath: string;
     declare children: List<LineageLink>;
     declare container: string;

--- a/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
+++ b/packages/components/src/internal/components/samples/SampleDetailEditing.tsx
@@ -75,11 +75,11 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
     }
 
     init = async (): Promise<void> => {
-        const { sampleSet, api } = this.props;
+        const { sampleSet, api, model } = this.props;
 
         try {
             const sampleTypeDomainFields = await getGroupedSampleDomainFields(sampleSet);
-            const sampleStorageItemId = await api.samples.getSampleStorageId(this.getSampleId());
+            const sampleStorageItemId = await api.samples.getSampleStorageId(model.getRowValue('RowId'));
 
             this.setState({ sampleTypeDomainFields, sampleStorageItemId, hasError: false });
         } catch (e) {
@@ -89,11 +89,6 @@ export class SampleDetailEditing extends PureComponent<Props, State> {
 
     getRow = (): Record<string, any> => {
         return this.props.model.getRow() ?? {};
-    };
-
-    getSampleId = () => {
-        const row = this.getRow();
-        return caseInsensitive(row, 'RowId')?.value;
     };
 
     getUpdateDisplayColumns = (isAliquot: boolean): GroupedSampleDisplayColumns => {

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -232,6 +232,10 @@ function applyColumnMetadata(schemaQuery: SchemaQuery, rawColumn: any): QueryCol
             columnMetadata.detailRenderer = Renderers.applyDetailRenderer(columnMetadata, rawColumn, metadata);
             columnMetadata.inputRenderer = Renderers.applyInputRenderer(columnMetadata, rawColumn, metadata);
             columnMetadata.helpTipRenderer = Renderers.applyHelpTipRenderer(columnMetadata, rawColumn, metadata);
+
+            if (columnMetadata.lookup) {
+                columnMetadata.lookup = Object.assign({}, rawColumn.lookup, columnMetadata.lookup);
+            }
         }
     }
 

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -245,10 +245,10 @@ describe('App Route Resolvers', () => {
     });
 
     test('Should resolve /q/lists routes', () => {
-        const routes = Map<number, string>().asMutable();
-        routes.set(23, 'Jordan');
-        routes.set(8, 'KObE');
-        routes.set(7, 'PistolPete');
+        const routes = Map<string, string>().asMutable();
+        routes.set('/bulls|23', 'Jordan');
+        routes.set('/lakers|8', 'KObE');
+        routes.set('/jazz|7', 'PistolPete');
         const listResolver = new ListResolver(routes.asImmutable());
 
         // test regex
@@ -256,23 +256,29 @@ describe('App Route Resolvers', () => {
         expect(listResolver.matches(undefined)).toBe(false);
         expect(listResolver.matches('/q/lists/f23')).toBe(false);
         expect(listResolver.matches('/q/lists/2.3')).toBe(false);
-        expect(listResolver.matches('/q/lists/23')).toBe(true);
-        expect(listResolver.matches('/q/lists/3221/foo/bar')).toBe(true);
-        expect(listResolver.matches('/q/lists/919/foo/bar?bar=1')).toBe(true);
+        expect(listResolver.matches('/q/lists/$CPSpath$CPE/23')).toBe(true);
+        expect(listResolver.matches('/q/lists/$CPS1/23$CPE/3221/foo/bar')).toBe(true);
+        expect(listResolver.matches('/q/lists/$CPSq/we/ry$CPE/919/foo/bar?bar=1')).toBe(true);
 
         return Promise.all([
-            listResolver.fetch(['q', 'lists', 'jordan', 4]).then((result: boolean) => {
-                expect(result).toBe(true);
-            }),
-            listResolver.fetch(['q', 'lists', 23]).then((url: AppURL) => {
+            listResolver
+                .fetch(['q', 'lists', ListResolver.encodeResolverPath('/BULLS'), 'jordan', 4])
+                .then((result: boolean) => {
+                    expect(result).toBe(true);
+                }),
+            listResolver.fetch(['q', 'lists', ListResolver.encodeResolverPath('/BULLS'), 23]).then((url: AppURL) => {
                 expect(url.toString()).toBe('/q/lists/Jordan');
             }),
-            listResolver.fetch(['q', 'lists', '8', 'mamba']).then((url: AppURL) => {
-                expect(url.toString()).toBe('/q/lists/KObE/mamba');
-            }),
-            listResolver.fetch(['q', 'lists', '7', 17, '?']).then((url: AppURL) => {
-                expect(url.toString()).toBe('/q/lists/PistolPete/17/%3F');
-            }),
+            listResolver
+                .fetch(['q', 'lists', ListResolver.encodeResolverPath('/lakers'), '8', 'mamba'])
+                .then((url: AppURL) => {
+                    expect(url.toString()).toBe('/q/lists/KObE/mamba');
+                }),
+            listResolver
+                .fetch(['q', 'lists', ListResolver.encodeResolverPath('/JaZz'), '7', 17, '?'])
+                .then((url: AppURL) => {
+                    expect(url.toString()).toBe('/q/lists/PistolPete/17/%3F');
+                }),
         ]);
     });
 

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -16,7 +16,7 @@
 import { List, Map } from 'immutable';
 import { Filter } from '@labkey/api';
 
-import { AssayProtocolModel, fetchProtocol, getQueryDetails, SCHEMAS, selectRows } from '../..';
+import { AssayProtocolModel, caseInsensitive, fetchProtocol, getQueryDetails, SCHEMAS, selectRows } from '../..';
 
 import { AppURL, spliceURL } from './AppURL';
 
@@ -132,33 +132,46 @@ export class AssayRunResolver implements AppRouteResolver {
 
 /**
  * Resolves list routes dynamically
- * /q/lists/22/14/... -> /q/lists/listByName/14/...
+ * /q/lists/$CPS<container_path>$CPE/22/14/... -> /q/lists/listByName/14/...
  */
 export class ListResolver implements AppRouteResolver {
     fetched: boolean;
-    lists: Map<number, string>; // Map<listId, listName>
+    lists: Map<string, string>; // Map<containerPath|listId, listName>
 
-    constructor(lists?: Map<number, string>) {
+    static decodeResolverPath(resolverPath: string): string {
+        return resolverPath.replace('$CPS', '').replace('$CPE', '');
+    }
+
+    static encodeResolverPath(containerPath: string): string {
+        return ['$CPS', containerPath?.toLowerCase(), '$CPE'].join('');
+    }
+
+    constructor(lists?: Map<string, string>) {
         this.fetched = false;
-        this.lists = lists !== undefined ? lists : Map<number, string>();
+        this.lists = lists !== undefined ? lists : Map<string, string>();
     }
 
     matches(route: string): boolean {
-        return /\/q\/lists\/(\d+$|\d+\/)/.test(route);
+        return /\/q\/lists\/(\$CPS.+\$CPE)\/(\d+$|\d+)\/*/.test(decodeURIComponent(route));
     }
 
     async fetch(parts: any[]): Promise<AppURL | boolean> {
-        // ["q", "lists", "44", ...]
-        const listIdIndex = 2;
+        // ["q", "lists", "/container/path", "44", ...]
+        const containerPathIndex = 2;
+        const listIdIndex = 3;
         const listIdNum = parseInt(parts[listIdIndex], 10);
+        const containerPath = ListResolver.decodeResolverPath(
+            decodeURIComponent(parts[containerPathIndex])
+        )?.toLowerCase();
+        const key = [containerPath, listIdNum].join('|');
 
-        if (isNaN(listIdNum)) {
+        if (isNaN(listIdNum) || !containerPath) {
             // skip it
             return true;
-        } else if (this.lists.has(listIdNum)) {
+        } else if (this.lists.has(key)) {
             // resolve it
-            const newParts = [this.lists.get(listIdNum)];
-            return spliceURL(parts, newParts, listIdIndex);
+            const newParts = [this.lists.get(key)];
+            return spliceURL(parts, newParts, containerPathIndex, 2);
         } else if (this.fetched) {
             // skip it
             return true;
@@ -166,30 +179,31 @@ export class ListResolver implements AppRouteResolver {
 
         // fetch it
         try {
-            // TODO: Fetch "container" and incorporate into key. On the link construction side need to parse out the folder.
             const result = await selectRows({
                 schemaName: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER.schemaName,
                 queryName: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER.queryName,
-                columns: 'ListId,Name',
+                columns: 'ListId,Name,Container/Path',
             });
 
             this.fetched = true;
 
             // fulfill local cache
-            const allLists = Map<number, string>().asMutable();
-            const lists = result.models[result.key];
-            for (var i in lists) {
-                if (lists.hasOwnProperty(i)) {
-                    allLists.set(lists[i].ListId.value, lists[i].Name.value.toLowerCase());
-                }
-            }
-            this.lists = allLists.asImmutable();
+            this.lists = Object.values(result.models[result.key])
+                .reduce<Map<string, string>>((map, list) => {
+                    const _containerPath = caseInsensitive(list, 'Container/Path').value.toLowerCase();
+                    const _listId = caseInsensitive(list, 'ListId').value;
+                    const _name = caseInsensitive(list, 'Name').value.toLowerCase();
+
+                    const _key = [_containerPath, _listId].join('|');
+                    return map.set(_key, _name);
+                }, Map<string, string>().asMutable())
+                .asImmutable();
 
             // respond
-            if (this.lists.has(listIdNum)) {
+            if (this.lists.has(key)) {
                 // resolve it
-                const newParts = [this.lists.get(listIdNum)];
-                return spliceURL(parts, newParts, listIdIndex);
+                const newParts = [this.lists.get(key)];
+                return spliceURL(parts, newParts, containerPathIndex, 2);
             }
         } catch (e) {
             // skip it
@@ -202,7 +216,7 @@ export class ListResolver implements AppRouteResolver {
 
 /**
  * Resolves sample routes dynamically
- * rd/samples/14/... -> /samples/sampleSetByName/14/... || /media/batches/14
+ * /rd/samples/14/... -> /samples/sampleSetByName/14/... || /media/batches/14
  */
 export class SamplesResolver implements AppRouteResolver {
     samples: Map<number, List<string>>; // Map<SampleRowId, List<'samples' | 'media', sampleSetName | 'batches'>>

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -16,7 +16,7 @@
 import { fromJS, List, Map, OrderedSet } from 'immutable';
 import { ActionURL, Experiment, Filter, getServerContext } from '@labkey/api';
 
-import { AppURL, createProductUrl } from '../..';
+import { AppURL, createProductUrl, ListResolver } from '../..';
 import { LineageLinkMetadata } from '../components/lineage/types';
 
 import { FREEZER_MANAGER_APP_PROPERTIES } from '../app/constants';
@@ -379,20 +379,26 @@ const LIST_MAPPERS = [
     new ActionMapper('list', 'details', (row, column) => {
         if (!column.has('lookup')) {
             const params = ActionURL.getParameters(row.get('url'));
+            const urlParts = parsePathName(row.get('url'));
 
-            const parts = ['q', 'lists', params.listId, params.pk];
-
-            return AppURL.create(...parts);
+            if (params && urlParts?.containerPath) {
+                const resolverPath = ListResolver.encodeResolverPath(urlParts.containerPath);
+                const parts = ['q', 'lists', resolverPath, params.listId, params.pk];
+                return AppURL.create(...parts);
+            }
         }
     }),
 
     new ActionMapper('list', 'grid', (row, column) => {
         if (!column.has('lookup')) {
             const params = ActionURL.getParameters(row.get('url'));
+            const urlParts = parsePathName(row.get('url'));
 
-            const parts = ['q', 'lists', params.listId];
-
-            return AppURL.create(...parts);
+            if (params && urlParts?.containerPath) {
+                const resolverPath = ListResolver.encodeResolverPath(urlParts.containerPath);
+                const parts = ['q', 'lists', resolverPath, params.listId];
+                return AppURL.create(...parts);
+            }
         }
     }),
 ];

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -1,12 +1,14 @@
 // Consider having this implement Query.QueryColumn from @labkey/api
 // commented out attributes are not used in app
 import { Record } from 'immutable';
+import { Query } from '@labkey/api';
 
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../internal/components/domainproperties/constants';
 
 import { SchemaQuery } from './SchemaQuery';
 
 export class QueryLookup extends Record({
+    containerFilter: undefined,
     containerPath: undefined,
     displayColumn: undefined,
     isPublic: false,
@@ -18,6 +20,7 @@ export class QueryLookup extends Record({
     schemaQuery: undefined,
     table: undefined,
 }) {
+    declare containerFilter: Query.ContainerFilter;
     declare containerPath: string;
     declare displayColumn: string;
     declare isPublic: boolean;

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -78,7 +78,16 @@ interface DetailPanelWithModelProps extends DetailDisplaySharedProps {
 }
 
 export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props => {
-    const { asPanel, detailRenderer, editingMode, titleRenderer, useDatePicker, queryConfig } = props;
+    const {
+        asPanel,
+        containerFilter,
+        containerPath,
+        detailRenderer,
+        editingMode,
+        titleRenderer,
+        useDatePicker,
+        queryConfig,
+    } = props;
     const queryConfigs = useMemo(() => ({ model: queryConfig }), [queryConfig]);
     const { keyValue, schemaQuery } = queryConfig;
     const { schemaName, queryName } = schemaQuery;
@@ -89,6 +98,8 @@ export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props =>
         <DetailPanelWithModelBody
             asPanel={asPanel}
             autoLoad
+            containerFilter={containerFilter}
+            containerPath={containerPath}
             detailRenderer={detailRenderer}
             editingMode={editingMode}
             key={key}

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactNode } from 'react';
 import Formsy from 'formsy-react';
 import { fromJS } from 'immutable';
 import { Button } from 'react-bootstrap';
-import { AuditBehaviorTypes } from '@labkey/api';
+import { AuditBehaviorTypes, Query } from '@labkey/api';
 
 import { DetailPanelHeader } from '../../internal/components/forms/detail/DetailPanelHeader';
 import { DetailRenderer } from '../../internal/components/forms/detail/DetailDisplay';
@@ -24,6 +24,7 @@ export interface EditableDetailPanelProps extends RequiresModelAndActions {
     auditBehavior?: AuditBehaviorTypes;
     cancelText?: string;
     canUpdate: boolean;
+    containerFilter?: Query.ContainerFilter;
     containerPath?: string;
     detailEditRenderer?: DetailRenderer;
     detailHeader?: ReactNode;
@@ -136,6 +137,8 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
         const {
             actions,
             appEditable,
+            containerFilter,
+            containerPath,
             detailEditRenderer,
             detailHeader,
             detailRenderer,
@@ -175,6 +178,8 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
                         <DetailPanel
                             actions={actions}
+                            containerFilter={containerFilter}
+                            containerPath={containerPath}
                             detailEditRenderer={detailEditRenderer}
                             detailRenderer={detailRenderer}
                             editColumns={editColumns}


### PR DESCRIPTION
#### Rationale
Component updates in support of cross-folder registry in LKB.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/725
* https://github.com/LabKey/biologics/pull/1139
* https://github.com/LabKey/platform/pull/3001
* https://github.com/LabKey/sampleManagement/pull/823
* https://github.com/LabKey/inventory/pull/372

#### Changes
* **AliasInput**
	* Refactor `AliasInput` "value" processing to match what is expected. This fixes several bugs with how this component displays and persists state.
	* Add unit tests.
* **Data Classes**
	* Support cross-folder domain editing for Data Classes.
* **Details**
	* Support `containerFilter` and `containerPath` for `Detail`, `DetailPanel`, `DetailEditRenderer`, and `EditableDetailPanel`.
* **Lineage**
	* Export `withLineage` and `InjectedLineage` for external use.
	* Refactor how `sampleStats` are processed.
* **Query APIs**
	* Improve typings for `insertRows`, `deleteRows`, and `selectRows` to reduce duplication with `@labkey/api` and provide passthrough of all configuration options.
	* Update `getContainerFilter` to process the `containerPath` provided to query configurations if provided.
	* Introduce `getContainerFilterForInsert`. Supplies the container filter to be used when fetching data intended for insert.
* **QuerySelect**
	* Ensure all queries made by `QuerySelect` specify the same set of columns.
	* Simplify and centralize `QuerySelectModel` initialization.
	* Support specifying `containerFilter` on `QuerySelect`.
* **SelectInput**
	* Introduce `resolveFormValue` for component users to override how the input processes the selected options into a form value.
