### PR TITLE
Issue 44740: Add client side metrics to track if samples/sources are being created via the grid or from file import

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.129.0-fb-smEntityCreateMetric.0",
+  "version": "2.129.0-fb-smEntityCreateMetric.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.129.0",
+  "version": "2.129.0-fb-smEntityCreateMetric.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.129.0-fb-smEntityCreateMetric.1",
+  "version": "2.129.0-fb-smEntityCreateMetric.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.129.0-fb-smEntityCreateMetric.2",
+  "version": "2.130.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,8 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.130.0
 *Released*: 8 February 2022
 * Issue 44740: Add client side metrics to track if samples/sources are being created via the grid or from file import
-* Update incrementClientSideMetricCount() so that even on failure it calls resolve() since we don't want to interrupt the app execution
-* Update calls to incrementClientSideMetricCount() to use async/await
+* Update incrementClientSideMetricCount() so it does not return a Promise but is only used asynchronously
 
 ### version 2.129.0
 *Released*: 3 February 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.130
+### version 2.130.0
 *Released*: 8 February 2022
 * Issue 44740: Add client side metrics to track if samples/sources are being created via the grid or from file import
 * Update incrementClientSideMetricCount() so that even on failure it calls resolve() since we don't want to interrupt the app execution

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD February 2022
 * Issue 44740: Add client side metrics to track if samples/sources are being created via the grid or from file import
+* Update incrementClientSideMetricCount() so that even on failure it calls resolve() since we don't want to interrupt the app execution
+* Update calls to incrementClientSideMetricCount() to use async/await
 
 ### version 2.129.0
 *Released*: 3 February 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD February 2022
+* Issue 44740: Add client side metrics to track if samples/sources are being created via the grid or from file import
+
 ### version 2.129.0
 *Released*: 3 February 2022
 * **AliasInput**

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD February 2022
+### version 2.130
+*Released*: 8 February 2022
 * Issue 44740: Add client side metrics to track if samples/sources are being created via the grid or from file import
 * Update incrementClientSideMetricCount() so that even on failure it calls resolve() since we don't want to interrupt the app execution
 * Update calls to incrementClientSideMetricCount() to use async/await

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2399,11 +2399,7 @@ function pasteCellLoad(
                 let msg: CellMessage;
 
                 if (col && col.isPublicLookup()) {
-                    const { message, values } = parsePasteCellLookup(
-                        col,
-                        lookupDescriptorMap[col.lookupKey],
-                        value
-                    );
+                    const { message, values } = parsePasteCellLookup(col, lookupDescriptorMap[col.lookupKey], value);
                     cv = values;
 
                     if (message) {
@@ -2681,10 +2677,7 @@ export function createQueryConfigFilteredBySample(
  * @param featureArea
  * @param metricName
  */
-export function incrementClientSideMetricCount(
-    featureArea: string,
-    metricName: string
-): void {
+export function incrementClientSideMetricCount(featureArea: string, metricName: string): void {
     if (!featureArea || !metricName || getServerContext().user.isGuest) {
         return;
     } else {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2673,7 +2673,7 @@ export function createQueryConfigFilteredBySample(
     };
 }
 
-interface IClientSideMetricCountResponse {
+export interface IClientSideMetricCountResponse {
     count: number;
 }
 
@@ -2698,7 +2698,7 @@ export function incrementClientSideMetricCount(
                 failure: Utils.getCallbackWrapper(
                     response => {
                         console.error(response);
-                        reject(response);
+                        resolve(response); // still resolve here so this call doesn't prevent callers from proceeding as usual
                     },
                     this,
                     true

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -1516,6 +1516,7 @@ exports[`DataClassDesigner initModel 1`] = `
         "query": QueryServerAPIWrapper {
           "getEntityTypeOptions": [Function],
           "getQueryDetails": [Function],
+          "incrementClientSideMetricCount": [Function],
         },
         "samples": SamplesServerAPIWrapper {
           "getFieldLookupFromSelection": [Function],

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -1097,6 +1097,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
         "query": QueryServerAPIWrapper {
           "getEntityTypeOptions": [Function],
           "getQueryDetails": [Function],
+          "incrementClientSideMetricCount": [Function],
         },
         "samples": SamplesServerAPIWrapper {
           "getFieldLookupFromSelection": [Function],

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -1074,7 +1074,10 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             );
 
             this.setSubmitting(false);
-            api.query.incrementClientSideMetricCount(ENTITY_CREATION_METRIC, nounPlural + 'FileImport' + (isMerge ? 'WithMerge' : 'WithoutMerge'));
+            api.query.incrementClientSideMetricCount(
+                ENTITY_CREATION_METRIC,
+                nounPlural + 'FileImport' + (isMerge ? 'WithMerge' : 'WithoutMerge')
+            );
             onDataChange?.(false);
 
             if (useAsync) {

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -738,7 +738,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             this.setSubmitting(false);
 
             if (response?.rows) {
-                await api.query.incrementClientSideMetricCount(ENTITY_CREATION_METRIC, nounPlural + 'CreationFromGrid');
+                api.query.incrementClientSideMetricCount(ENTITY_CREATION_METRIC, nounPlural + 'CreationFromGrid');
                 this.props.onDataChange?.(false);
                 this.props.afterEntityCreation?.(
                     insertModel.getTargetEntityTypeLabel(),
@@ -1074,9 +1074,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             );
 
             this.setSubmitting(false);
+            api.query.incrementClientSideMetricCount(ENTITY_CREATION_METRIC, nounPlural + 'FileImport' + (isMerge ? 'WithMerge' : 'WithoutMerge'));
             onDataChange?.(false);
-
-            await api.query.incrementClientSideMetricCount(ENTITY_CREATION_METRIC, nounPlural + 'FileImport' + (isMerge ? 'WithMerge' : 'WithoutMerge'));
 
             if (useAsync) {
                 onBackgroundJobStart?.(insertModel.getTargetEntityTypeLabel(), file.name, response.jobId);

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -106,6 +106,8 @@ import {
     EntityParentTypeSelectors,
     removeEntityParentType,
 } from './EntityParentTypeSelectors';
+import { incrementClientSideMetricCount } from '../../actions';
+import { ENTITY_CREATION_METRIC } from './constants';
 
 const ALIQUOT_FIELD_COLS = ['aliquotedfrom', 'name', 'description', 'samplestate'];
 const ALIQUOT_NOUN_SINGULAR = 'Aliquot';
@@ -707,7 +709,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
     insertRowsFromGrid = async (): Promise<void> => {
         const { insertModel, creationType } = this.state;
-        const { entityDataType } = this.props;
+        const { entityDataType, nounPlural } = this.props;
         const queryGridModel = this.getQueryGridModel();
         const editorModel = getEditorModel(queryGridModel.getId());
         const errors = editorModel.getValidationErrors(queryGridModel, entityDataType.uniqueFieldKey);
@@ -734,6 +736,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             this.setSubmitting(false);
 
             if (response?.rows) {
+                await incrementClientSideMetricCount(ENTITY_CREATION_METRIC, nounPlural + 'CreationFromGrid');
                 this.props.onDataChange?.(false);
                 this.props.afterEntityCreation?.(
                     insertModel.getTargetEntityTypeLabel(),
@@ -1069,6 +1072,9 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
             this.setSubmitting(false);
             onDataChange?.(false);
+
+            await incrementClientSideMetricCount(ENTITY_CREATION_METRIC, nounPlural + 'FileImport' + (isMerge ? 'WithMerge' : ''));
+
             if (useAsync) {
                 onBackgroundJobStart?.(insertModel.getTargetEntityTypeLabel(), file.name, response.jobId);
             } else {

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -10,6 +10,7 @@ import { EntityDataType } from './models';
 
 export const DATA_DELETE_CONFIRMATION_ACTION = 'getDataDeleteConfirmationData.api';
 export const SAMPLE_DELETE_CONFIRMATION_ACTION = 'getMaterialOperationConfirmationData.api';
+export const ENTITY_CREATION_METRIC = 'entityCreation';
 
 export const SampleTypeDataType: EntityDataType = {
     typeListingSchemaQuery: SCHEMAS.EXP_TABLES.SAMPLE_SETS,

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -501,7 +501,7 @@ export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo(props => {
                 setSelKey(undefined);
             }
         })();
-    }, [sampleFieldKey, queryModel,]);
+    }, [sampleFieldKey, queryModel]);
 
     useEffect(() => {
         getPicklists()

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -12,8 +12,6 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 import { ColorIcon } from '../base/ColorIcon';
 import { createNotification } from '../notifications/actions';
 
-import { incrementClientSideMetricCount } from '../../actions';
-
 import { SampleOperation } from '../samples/constants';
 import { OperationConfirmationData } from '../entities/models';
 import { getOperationNotPermittedMessage } from '../samples/utils';
@@ -292,7 +290,7 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
                 const insertResponse = await addSamplesToPicklist(activeItem.name, statusData, selectionKey, sampleIds);
                 setError(undefined);
                 setSubmitting(false);
-                incrementClientSideMetricCount(metricFeatureArea, 'addSamplesToPicklist');
+                await api.query.incrementClientSideMetricCount(metricFeatureArea, 'addSamplesToPicklist');
                 createNotification({
                     message: () => (
                         <AddedToPicklistNotification

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -290,7 +290,7 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
                 const insertResponse = await addSamplesToPicklist(activeItem.name, statusData, selectionKey, sampleIds);
                 setError(undefined);
                 setSubmitting(false);
-                await api.query.incrementClientSideMetricCount(metricFeatureArea, 'addSamplesToPicklist');
+                api.query.incrementClientSideMetricCount(metricFeatureArea, 'addSamplesToPicklist');
                 createNotification({
                     message: () => (
                         <AddedToPicklistNotification

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -174,7 +174,7 @@ export const PicklistEditModalDisplay: FC<Props> = memo(props => {
                     selectionKey,
                     sampleIds
                 );
-                await api.query.incrementClientSideMetricCount(metricFeatureArea, 'createPicklist');
+                api.query.incrementClientSideMetricCount(metricFeatureArea, 'createPicklist');
             }
             reset();
             if (showNotification) {

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -60,7 +60,7 @@ export const PicklistEditModal: FC<Props> = memo(props => {
                 setSelKey(undefined);
             }
         })();
-    }, [api, sampleFieldKey, queryModel,]);
+    }, [api, sampleFieldKey, queryModel]);
 
     return <PicklistEditModalDisplay {...props} selectionKey={selKey} sampleIds={ids} />;
 });

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -12,12 +12,10 @@ import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainpr
 
 import { createNotification } from '../notifications/actions';
 
-import { incrementClientSideMetricCount } from '../../actions';
 import { SampleOperation } from '../samples/constants';
 import { OperationConfirmationData } from '../entities/models';
 import { getOperationNotPermittedMessage } from '../samples/utils';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-import { SchemaQuery } from '../../../public/SchemaQuery';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
@@ -176,7 +174,7 @@ export const PicklistEditModalDisplay: FC<Props> = memo(props => {
                     selectionKey,
                     sampleIds
                 );
-                incrementClientSideMetricCount(metricFeatureArea, 'createPicklist');
+                await api.query.incrementClientSideMetricCount(metricFeatureArea, 'createPicklist');
             }
             reset();
             if (showNotification) {

--- a/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
@@ -33,18 +33,18 @@ export const ProductLKSDrawer: FC<ProductLKSDrawerProps> = memo(props => {
         setTimeout(() => setTransition(false), 10);
     }, []);
 
-    const onTabClick = useCallback(async () => {
-        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_TAB_METRIC);
+    const onTabClick = useCallback(() => {
+        api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_TAB_METRIC);
     }, []);
 
     const visibleTabs = tabs.filter(tab => !tab.disabled);
 
-    const onHomeClick = useCallback(async () => {
-        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_HOME_METRIC);
+    const onHomeClick = useCallback(() => {
+        api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_HOME_METRIC);
     }, []);
 
-    const onContainerClick = useCallback(async () => {
-        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_CONTAINER_METRIC);
+    const onContainerClick = useCallback(() => {
+        api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_CONTAINER_METRIC);
     }, []);
 
     return (

--- a/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
@@ -101,7 +101,7 @@ export const ProductLKSDrawer: FC<ProductLKSDrawerProps> = memo(props => {
 
 ProductLKSDrawer.defaultProps = {
     api: getDefaultAPIWrapper(),
-}
+};
 
 // exported for jest testing
 export function getProjectBeginUrl(container: string): string {

--- a/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
@@ -3,7 +3,7 @@ import { getServerContext } from '@labkey/api';
 
 import classNames from 'classnames';
 
-import { buildURL, incrementClientSideMetricCount } from '../../..';
+import { buildURL } from '../../..';
 
 import { ContainerTabModel } from './models';
 import {
@@ -14,15 +14,17 @@ import {
     TO_LKS_TAB_METRIC,
 } from './constants';
 import { ProductClickableItem } from './ProductClickableItem';
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface ProductLKSDrawerProps {
+    api?: ComponentsAPIWrapper;
     showHome: boolean;
     disableLKSContainerLink?: boolean;
     tabs: ContainerTabModel[];
 }
 
 export const ProductLKSDrawer: FC<ProductLKSDrawerProps> = memo(props => {
-    const { tabs, disableLKSContainerLink, showHome } = props;
+    const { tabs, disableLKSContainerLink, showHome, api } = props;
     const { container, homeContainer, user } = getServerContext();
     const isHomeContainer = useMemo(() => container.path === '/home', [container]);
     const [transition, setTransition] = useState<boolean>(true);
@@ -31,18 +33,18 @@ export const ProductLKSDrawer: FC<ProductLKSDrawerProps> = memo(props => {
         setTimeout(() => setTransition(false), 10);
     }, []);
 
-    const onTabClick = useCallback(() => {
-        incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_TAB_METRIC);
+    const onTabClick = useCallback(async () => {
+        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_TAB_METRIC);
     }, []);
 
     const visibleTabs = tabs.filter(tab => !tab.disabled);
 
-    const onHomeClick = useCallback(() => {
-        incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_HOME_METRIC);
+    const onHomeClick = useCallback(async () => {
+        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_HOME_METRIC);
     }, []);
 
-    const onContainerClick = useCallback(() => {
-        incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_CONTAINER_METRIC);
+    const onContainerClick = useCallback(async () => {
+        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, TO_LKS_CONTAINER_METRIC);
     }, []);
 
     return (
@@ -96,6 +98,10 @@ export const ProductLKSDrawer: FC<ProductLKSDrawerProps> = memo(props => {
         </div>
     );
 });
+
+ProductLKSDrawer.defaultProps = {
+    api: getDefaultAPIWrapper(),
+}
 
 // exported for jest testing
 export function getProjectBeginUrl(container: string): string {

--- a/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
@@ -29,7 +29,7 @@ interface ProductAppsDrawerProps {
 }
 
 export const ProductSectionsDrawer: FC<ProductAppsDrawerProps> = memo(props => {
-    const { product, onCloseMenu } = props;
+    const { product } = props;
     const currentContainer = getServerContext().container;
     const [error, setError] = useState<string>();
     const [sections, setSections] = useState<ProductSectionModel[]>();
@@ -78,8 +78,8 @@ export const ProductSectionsDrawerImpl: FC<ProductSectionsDrawerImplProps> = mem
         setTimeout(() => setTransition(false), 10);
     }, []);
 
-    const navigate = useCallback(async (section: ProductSectionModel) => {
-        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, product.navigationMetric);
+    const navigate = useCallback((section: ProductSectionModel) => {
+        api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, product.navigationMetric);
         onCloseMenu?.();
     }, []);
 

--- a/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
@@ -2,24 +2,14 @@ import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'reac
 import { List } from 'immutable';
 import { ActionURL, getServerContext } from '@labkey/api';
 
-import {
-    Alert,
-    AppURL,
-    createProductUrl,
-    MenuSectionModel,
-    ProductMenuModel,
-} from '../../..';
-import {
-    FREEZERS_KEY,
-    MEDIA_KEY,
-    NOTEBOOKS_KEY,
-    WORKFLOW_KEY
-} from '../../app/constants';
+import { Alert, AppURL, createProductUrl, MenuSectionModel, ProductMenuModel } from '../../..';
+import { FREEZERS_KEY, MEDIA_KEY, NOTEBOOKS_KEY, WORKFLOW_KEY } from '../../app/constants';
+
+import { getAppProductIds } from '../../app/utils';
 
 import { ProductModel, ProductSectionModel } from './models';
 import { APPLICATION_NAVIGATION_METRIC, SECTION_KEYS_TO_SKIP } from './constants';
 import { ProductClickableItem } from './ProductClickableItem';
-import { getAppProductIds } from '../../app/utils';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface ProductAppsDrawerProps {
@@ -35,11 +25,10 @@ export const ProductSectionsDrawer: FC<ProductAppsDrawerProps> = memo(props => {
     const [sections, setSections] = useState<ProductSectionModel[]>();
 
     const productIds = useMemo((): List<string> => {
-       return getAppProductIds(product.productId)
+        return getAppProductIds(product.productId);
     }, [product.productId]);
 
     useEffect(() => {
-
         const model = new ProductMenuModel({
             currentProductId: product.productId,
             userMenuProductId: product.productId,
@@ -61,7 +50,7 @@ export const ProductSectionsDrawer: FC<ProductAppsDrawerProps> = memo(props => {
 
 ProductSectionsDrawer.defaultProps = {
     api: getDefaultAPIWrapper(),
-}
+};
 
 interface ProductSectionsDrawerImplProps extends ProductAppsDrawerProps {
     error: string;

--- a/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
@@ -6,17 +6,13 @@ import {
     Alert,
     AppURL,
     createProductUrl,
-    incrementClientSideMetricCount,
     MenuSectionModel,
     ProductMenuModel,
 } from '../../..';
 import {
-    BIOLOGICS_APP_PROPERTIES,
-    FREEZER_MANAGER_APP_PROPERTIES,
     FREEZERS_KEY,
     MEDIA_KEY,
     NOTEBOOKS_KEY,
-    SAMPLE_MANAGER_APP_PROPERTIES,
     WORKFLOW_KEY
 } from '../../app/constants';
 
@@ -24,8 +20,10 @@ import { ProductModel, ProductSectionModel } from './models';
 import { APPLICATION_NAVIGATION_METRIC, SECTION_KEYS_TO_SKIP } from './constants';
 import { ProductClickableItem } from './ProductClickableItem';
 import { getAppProductIds } from '../../app/utils';
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface ProductAppsDrawerProps {
+    api?: ComponentsAPIWrapper;
     product: ProductModel;
     onCloseMenu?: () => void;
 }
@@ -58,19 +56,21 @@ export const ProductSectionsDrawer: FC<ProductAppsDrawerProps> = memo(props => {
             });
     }, [product]);
 
-    return <ProductSectionsDrawerImpl error={error} product={product} sections={sections} onCloseMenu={onCloseMenu} />;
+    return <ProductSectionsDrawerImpl {...props} error={error} sections={sections} />;
 });
 
-interface ProductSectionsDrawerImplProps {
+ProductSectionsDrawer.defaultProps = {
+    api: getDefaultAPIWrapper(),
+}
+
+interface ProductSectionsDrawerImplProps extends ProductAppsDrawerProps {
     error: string;
-    product: ProductModel;
     sections: ProductSectionModel[];
-    onCloseMenu?: () => void;
 }
 
 // exported for jest testing
 export const ProductSectionsDrawerImpl: FC<ProductSectionsDrawerImplProps> = memo(props => {
-    const { sections, error, onCloseMenu, product } = props;
+    const { api, sections, error, onCloseMenu, product } = props;
 
     const [transition, setTransition] = useState<boolean>(true);
     useEffect(() => {
@@ -78,8 +78,8 @@ export const ProductSectionsDrawerImpl: FC<ProductSectionsDrawerImplProps> = mem
         setTimeout(() => setTransition(false), 10);
     }, []);
 
-    const navigate = useCallback((section: ProductSectionModel) => {
-        incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, product.navigationMetric);
+    const navigate = useCallback(async (section: ProductSectionModel) => {
+        await api.query.incrementClientSideMetricCount(APPLICATION_NAVIGATION_METRIC, product.navigationMetric);
         onCloseMenu?.();
     }, []);
 

--- a/packages/components/src/internal/components/search/FindByIdsModal.tsx
+++ b/packages/components/src/internal/components/search/FindByIdsModal.tsx
@@ -144,4 +144,4 @@ export const FindByIdsModal: FC<Props> = memo(props => {
 
 FindByIdsModal.defaultProps = {
     api: getDefaultAPIWrapper(),
-}
+};

--- a/packages/components/src/internal/components/search/FindByIdsModal.tsx
+++ b/packages/components/src/internal/components/search/FindByIdsModal.tsx
@@ -6,9 +6,9 @@ import { FindField } from '../samples/models';
 import { capitalizeFirstChar } from '../../util/utils';
 import { SAMPLE_ID_FIND_FIELD, UNIQUE_ID_FIND_FIELD } from '../samples/constants';
 import { saveIdsToFind } from '../samples/actions';
-import { incrementClientSideMetricCount } from '../../actions';
 import { resolveErrorMessage } from '../../util/messaging';
 import { Alert } from '../base/Alert';
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 // exported for Jest testing
 export const FindFieldOption: FC<{
@@ -37,6 +37,7 @@ export const FindFieldOption: FC<{
 });
 
 interface Props {
+    api?: ComponentsAPIWrapper;
     show: boolean;
     onCancel: () => void;
     onFind: (sessionKey: string) => void;
@@ -46,7 +47,7 @@ interface Props {
 }
 
 export const FindByIdsModal: FC<Props> = memo(props => {
-    const { show, onCancel, onFind, nounPlural, sessionKey, initialField } = props;
+    const { show, onCancel, onFind, nounPlural, sessionKey, initialField, api } = props;
 
     const [fieldType, setFieldType] = useState<FindField>(initialField || UNIQUE_ID_FIND_FIELD);
     const [idString, setIdString] = useState<string>(undefined);
@@ -78,10 +79,10 @@ export const FindByIdsModal: FC<Props> = memo(props => {
             .map(id => id.trim())
             .filter(id => id.length > 0);
         if (ids.length > 0) {
-            incrementClientSideMetricCount('find' + capitalNounPlural + 'ById', 'findCount');
             setSubmitting(true);
             try {
                 const _sessionKey = await saveIdsToFind(fieldType, ids, sessionKey);
+                await api.query.incrementClientSideMetricCount('find' + capitalNounPlural + 'ById', 'findCount');
                 setSubmitting(false);
                 reset();
                 onFind(_sessionKey);
@@ -140,3 +141,7 @@ export const FindByIdsModal: FC<Props> = memo(props => {
         </Modal>
     );
 });
+
+FindByIdsModal.defaultProps = {
+    api: getDefaultAPIWrapper(),
+}

--- a/packages/components/src/internal/components/search/FindByIdsModal.tsx
+++ b/packages/components/src/internal/components/search/FindByIdsModal.tsx
@@ -82,7 +82,7 @@ export const FindByIdsModal: FC<Props> = memo(props => {
             setSubmitting(true);
             try {
                 const _sessionKey = await saveIdsToFind(fieldType, ids, sessionKey);
-                await api.query.incrementClientSideMetricCount('find' + capitalNounPlural + 'ById', 'findCount');
+                api.query.incrementClientSideMetricCount('find' + capitalNounPlural + 'ById', 'findCount');
                 setSubmitting(false);
                 reset();
                 onFind(_sessionKey);

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -5,6 +5,7 @@ import { EntityDataType, IEntityTypeOption } from '../components/entities/models
 import { getEntityTypeOptions } from '../components/entities/actions';
 
 import { getQueryDetails, GetQueryDetailsOptions } from './api';
+import { incrementClientSideMetricCount, IClientSideMetricCountResponse } from '../actions';
 
 export interface QueryAPIWrapper {
     getEntityTypeOptions: (
@@ -12,11 +13,13 @@ export interface QueryAPIWrapper {
         containerPath?: string
     ) => Promise<Map<string, List<IEntityTypeOption>>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
+    incrementClientSideMetricCount: (featureArea: string, metricName: string) => Promise<IClientSideMetricCountResponse>
 }
 
 export class QueryServerAPIWrapper implements QueryAPIWrapper {
     getEntityTypeOptions = getEntityTypeOptions;
     getQueryDetails = getQueryDetails;
+    incrementClientSideMetricCount = incrementClientSideMetricCount;
 }
 
 /**
@@ -29,6 +32,7 @@ export function getQueryTestAPIWrapper(
     return {
         getEntityTypeOptions: mockFn(),
         getQueryDetails: mockFn(),
+        incrementClientSideMetricCount: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -4,8 +4,9 @@ import { QueryInfo } from '../../public/QueryInfo';
 import { EntityDataType, IEntityTypeOption } from '../components/entities/models';
 import { getEntityTypeOptions } from '../components/entities/actions';
 
-import { getQueryDetails, GetQueryDetailsOptions } from './api';
 import { incrementClientSideMetricCount } from '../actions';
+
+import { getQueryDetails, GetQueryDetailsOptions } from './api';
 
 export interface QueryAPIWrapper {
     getEntityTypeOptions: (
@@ -13,7 +14,7 @@ export interface QueryAPIWrapper {
         containerPath?: string
     ) => Promise<Map<string, List<IEntityTypeOption>>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
-    incrementClientSideMetricCount: (featureArea: string, metricName: string) => void
+    incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
 }
 
 export class QueryServerAPIWrapper implements QueryAPIWrapper {

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -5,7 +5,7 @@ import { EntityDataType, IEntityTypeOption } from '../components/entities/models
 import { getEntityTypeOptions } from '../components/entities/actions';
 
 import { getQueryDetails, GetQueryDetailsOptions } from './api';
-import { incrementClientSideMetricCount, IClientSideMetricCountResponse } from '../actions';
+import { incrementClientSideMetricCount } from '../actions';
 
 export interface QueryAPIWrapper {
     getEntityTypeOptions: (
@@ -13,7 +13,7 @@ export interface QueryAPIWrapper {
         containerPath?: string
     ) => Promise<Map<string, List<IEntityTypeOption>>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
-    incrementClientSideMetricCount: (featureArea: string, metricName: string) => Promise<IClientSideMetricCountResponse>
+    incrementClientSideMetricCount: (featureArea: string, metricName: string) => void
 }
 
 export class QueryServerAPIWrapper implements QueryAPIWrapper {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44740

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/727
* https://github.com/LabKey/biologics/pull/1146
* https://github.com/LabKey/sampleManagement/pull/827
* https://github.com/LabKey/inventory/pull/375

#### Changes
* add calls to `incrementClientSideMetricCount()` in `EntityInsertPanel` component after successful file import and grid row submission
