### PR TITLE
Allow test suites to override superagent, expose ServerContext

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/releaseNotes/test.md
+++ b/packages/test/releaseNotes/test.md
@@ -1,6 +1,12 @@
 # @labkey/test
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
+### version 1.1.0
+* Allow superagent to be overridden
+  * This allows test suites to use a different version of super agent e.g. superwsagent
+* Expose ServerContext
+  * This allows test suites to have access to the underlying agent if needed
+
 ### version 1.0.1
 * Regenerate lockfile so TC doesn't fail during install
 


### PR DESCRIPTION
#### Rationale
This PR lets users of `hookServer` override `superagent`. Most test suites will not do this, but in Biologics we want to use `superwsagent`, which is API compatible with `superagent`, and allows us to test WebSocket connections. This PR also exposes the ServerContext, which we need in order to access `superwsagent`'s `ws()` method.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1148
#### Changes
* Allow superagent to be overridden
  * This allows test suites to use a different version of super agent e.g. superwsagent
* Expose ServerContext
  * This allows test suites to have access to the underlying agent if needed

