### PR TITLE
Item 9998: Update permissions for StorageEditor and StorageDesigner roles

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.4",
+  "version": "2.132.0-sampleSteward.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.130.0-sampleSteward.1",
+  "version": "2.130.0-sampleSteward.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.9",
+  "version": "2.132.0-sampleSteward.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.8",
+  "version": "2.132.0-sampleSteward.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.8.0",
+    "@labkey/api": "1.9.0-sampleSteward.0",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.129.0",
+  "version": "2.130.0-sampleSteward.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.7",
+  "version": "2.132.0-sampleSteward.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.130.0-sampleSteward.2",
+  "version": "2.130.0-sampleSteward.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.3",
+  "version": "2.132.0-sampleSteward.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.130.0-sampleSteward.0",
+  "version": "2.130.0-sampleSteward.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.6",
+  "version": "2.132.0-sampleSteward.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.10",
+  "version": "2.132.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -43,7 +43,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.9.0-sampleSteward.0",
+    "@labkey/api": "1.9.0",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.0-sampleSteward.5",
+  "version": "2.132.0-sampleSteward.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 9998: Add permissions for restricting read for assays and data classes
+  * Add utility methods for checking various read permissions
+  * update `assayPage` to check assay read permission
+
 ### version 2.129.0
 *Released*: 3 February 2022
 * **AliasInput**

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   * Add utility methods for checking various read permissions
   * update `assayPage` to check assay read permission
 * Update `SelectionMenuItem` to accept either an `onClick` or `href` property.
+* Don't show the option to discard samples when changing status if user doesn't have proper permissions
 
 ### version 2.129.0
 *Released*: 3 February 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Item 9998: Add permissions for restricting read for assays and data classes
   * Add utility methods for checking various read permissions
   * update `assayPage` to check assay read permission
+* Update `SelectionMenuItem` to accept either an `onClick` or `href` property.
 
 ### version 2.129.0
 *Released*: 3 February 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.132.0
+*Released*: 16 February 2022
 * Item 9998: Add permissions for restricting read for assays and data classes
   * Add utility methods for checking various read permissions
   * update `assayPage` to check assay read permission

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -208,7 +208,13 @@ import {
 import { getLocation, pushParameter, replaceParameter, replaceParameters, resetParameters } from './internal/util/URL';
 import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
 import { getHelpLink, HELP_LINK_REFERRER, HelpLink, SAMPLE_ALIQUOT_TOPIC } from './internal/util/helpLinks';
-import { AssayResolver, AssayRunResolver, ListResolver, SamplesResolver } from './internal/url/AppURLResolver';
+import {
+    AssayResolver,
+    AssayRunResolver,
+    ExperimentRunResolver,
+    ListResolver,
+    SamplesResolver
+} from './internal/url/AppURLResolver';
 import { QueryGridPanel } from './internal/components/QueryGridPanel';
 import { EditableGridPanelDeprecated } from './internal/components/editable/EditableGridPanelDeprecated';
 import { EditableGridPanelForUpdate } from './internal/components/editable/EditableGridPanelForUpdate';
@@ -849,6 +855,7 @@ export {
     AssayRunResolver,
     ListResolver,
     SamplesResolver,
+    ExperimentRunResolver,
     getLocation,
     pushParameter,
     replaceParameter,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -214,7 +214,7 @@ import {
     AssayRunResolver,
     ExperimentRunResolver,
     ListResolver,
-    SamplesResolver
+    SamplesResolver,
 } from './internal/url/AppURLResolver';
 import { QueryGridPanel } from './internal/components/QueryGridPanel';
 import { EditableGridPanelDeprecated } from './internal/components/editable/EditableGridPanelDeprecated';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -199,11 +199,11 @@ import {
     IMPORT_DATA_FORM_TYPES,
     MAX_EDITABLE_GRID_ROWS,
     NO_UPDATES_MESSAGE,
-    SHARED_CONTAINER_PATH,
     PIPELINE_JOB_NOTIFICATION_EVENT,
     PIPELINE_JOB_NOTIFICATION_EVENT_ERROR,
     PIPELINE_JOB_NOTIFICATION_EVENT_START,
     PIPELINE_JOB_NOTIFICATION_EVENT_SUCCESS,
+    SHARED_CONTAINER_PATH,
 } from './internal/constants';
 import { getLocation, pushParameter, replaceParameter, replaceParameters, resetParameters } from './internal/util/URL';
 import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
@@ -259,8 +259,8 @@ import {
     getUsersWithPermissions,
     handleInputTab,
     handleTabKeyOnTextArea,
-    useUsersWithPermissions,
     updateRowFieldValue,
+    useUsersWithPermissions,
 } from './internal/components/forms/actions';
 import { FormStep, FormTabs, withFormSteps } from './internal/components/forms/FormStep';
 import { GridAliquotViewSelector } from './internal/components/gridbar/GridAliquotViewSelector';
@@ -291,10 +291,10 @@ import {
     fetchSamples,
     getDeleteSharedSampleTypeUrl,
     getEditSharedSampleTypeUrl,
+    getFieldLookupFromSelection,
     getFindSamplesByIdData,
     getSampleSet,
     getSampleTypeDetails,
-    getFieldLookupFromSelection,
     getSampleTypes,
     getSelectedItemSamples,
     getSelectedSampleTypes,
@@ -324,10 +324,10 @@ import {
     getOmittedSampleTypeColumns,
     getOperationNotPermittedMessage,
     getSampleDeleteMessage,
+    getSampleSetMenuItem,
     getSampleStatus,
     getSampleStatusType,
     isSampleOperationPermitted,
-    getSampleSetMenuItem,
     isSamplesSchema,
     SamplesManageButtonSections,
 } from './internal/components/samples/utils';
@@ -368,9 +368,9 @@ import {
 } from './internal/components/assay/actions';
 import { BaseBarChart } from './internal/components/chart/BaseBarChart';
 import {
-    processChartData,
-    createPercentageBarData,
     createHorizontalBarLegendData,
+    createPercentageBarData,
+    processChartData,
 } from './internal/components/chart/utils';
 import { ReportItemModal, ReportList, ReportListItem } from './internal/components/report-list/ReportList';
 import {
@@ -509,17 +509,17 @@ import { makeTestActions, makeTestQueryModel } from './public/QueryModel/testUti
 import { QueryDetailPage } from './internal/components/listing/pages/QueryDetailPage';
 import { QueryListingPage } from './internal/components/listing/pages/QueryListingPage';
 import {
+    ACTIVE_JOB_INDICATOR_CLS,
     BACKGROUND_IMPORT_MIN_FILE_SIZE,
     BACKGROUND_IMPORT_MIN_ROW_SIZE,
     DATA_IMPORT_FILE_SIZE_LIMITS,
-    ACTIVE_JOB_INDICATOR_CLS,
 } from './internal/components/pipeline/constants';
 import { PipelineJobDetailPage } from './internal/components/pipeline/PipelineJobDetailPage';
 import { PipelineJobsListingPage } from './internal/components/pipeline/PipelineJobsListingPage';
 import { PipelineJobsPage } from './internal/components/pipeline/PipelineJobsPage';
 import { PipelineSubNav } from './internal/components/pipeline/PipelineSubNav';
 import { PipelineStatusDetailPage } from './internal/components/pipeline/PipelineStatusDetailPage';
-import { hasActivePipelineJob, getTitleDisplay } from './internal/components/pipeline/utils';
+import { getTitleDisplay, hasActivePipelineJob } from './internal/components/pipeline/utils';
 import {
     ALIQUOT_CREATION,
     CHILD_SAMPLE_CREATION,
@@ -594,6 +594,11 @@ import {
     userCanDesignSourceTypes,
     userCanEditStorageData,
     userCanManagePicklists,
+    userCanReadAssays,
+    userCanReadMedia,
+    userCanReadNotebooks,
+    userCanReadRegistry,
+    userCanReadSources,
 } from './internal/app/utils';
 import {
     doResetQueryGridState,
@@ -709,6 +714,11 @@ const App = {
     userCanEditStorageData,
     userCanDesignSourceTypes,
     userCanManagePicklists,
+    userCanReadAssays,
+    userCanReadNotebooks,
+    userCanReadMedia,
+    userCanReadRegistry,
+    userCanReadSources,
     userCanDeletePublicPicklists,
     SECURITY_LOGOUT,
     SECURITY_SERVER_UNAVAILABLE,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -91,6 +91,7 @@ import { SelectionMenuItem } from './internal/components/menus/SelectionMenuItem
 import { DisabledMenuItem } from './internal/components/menus/DisabledMenuItem';
 import { LoadingModal } from './internal/components/base/LoadingModal';
 import { LoadingSpinner } from './internal/components/base/LoadingSpinner';
+import { InsufficientPermissionsAlert } from './internal/components/permissions/InsufficientPermissionsAlert';
 import { InsufficientPermissionsPage } from './internal/components/permissions/InsufficientPermissionsPage';
 import { BasePermissionsCheckPage } from './internal/components/permissions/BasePermissionsCheckPage';
 import { APPLICATION_SECURITY_ROLES, SITE_SECURITY_ROLES } from './internal/components/permissions/constants';
@@ -928,6 +929,7 @@ export {
     UserLink,
     ChangePasswordModal,
     UsersGridPanel,
+    InsufficientPermissionsAlert,
     InsufficientPermissionsPage,
     APPLICATION_SECURITY_ROLES,
     SITE_SECURITY_ROLES,

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -589,7 +589,6 @@ describe('addSourcesSectionConfig', () => {
         expect(configs.size).toBe(0);
     });
 
-
     test('storage designer', () => {
         let configs = List<Map<string, MenuSectionConfig>>();
         configs = addSourcesSectionConfig(TEST_USER_STORAGE_DESIGNER, '/labkey/test/app.view', configs);

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -65,7 +65,7 @@ describe('getMenuSectionConfigs', () => {
                 productId: 'SampleManager',
             },
         };
-        const configs = getMenuSectionConfigs(new User(), 'sampleManager');
+        const configs = getMenuSectionConfigs(TEST_USER_EDITOR, 'sampleManager');
 
         expect(configs.size).toBe(4);
         expect(configs.hasIn([0, 'sources'])).toBeTruthy();
@@ -89,7 +89,7 @@ describe('getMenuSectionConfigs', () => {
                 productId: FREEZER_MANAGER_APP_PROPERTIES.productId,
             },
         };
-        const configs = getMenuSectionConfigs(new User(), FREEZER_MANAGER_APP_PROPERTIES.productId);
+        const configs = getMenuSectionConfigs(TEST_USER_EDITOR, FREEZER_MANAGER_APP_PROPERTIES.productId);
 
         expect(configs.size).toBe(2);
         expect(configs.hasIn([0, 'freezers'])).toBeTruthy();
@@ -111,7 +111,7 @@ describe('getMenuSectionConfigs', () => {
             },
         };
 
-        const configs = getMenuSectionConfigs(new User(), 'sampleManager');
+        const configs = getMenuSectionConfigs(TEST_USER_EDITOR, 'sampleManager');
         expect(configs.size).toBe(5);
         expect(configs.hasIn([0, 'sources'])).toBeTruthy();
         expect(configs.getIn([0, 'sources', 'seeAllURL'])).toEqual('#/sources?viewAs=grid');
@@ -144,7 +144,7 @@ describe('getMenuSectionConfigs', () => {
             },
         };
 
-        const configs = getMenuSectionConfigs(new User(), FREEZER_MANAGER_APP_PROPERTIES.productId);
+        const configs = getMenuSectionConfigs(TEST_USER_EDITOR, FREEZER_MANAGER_APP_PROPERTIES.productId);
         expect(configs.size).toBe(5);
         expect(configs.hasIn([0, 'sources'])).toBeTruthy();
         expect(configs.getIn([0, 'sources', 'seeAllURL'])).toEqual(
@@ -166,6 +166,33 @@ describe('getMenuSectionConfigs', () => {
         expect(configs.getIn([4, 'workflow', 'seeAllURL'])).toEqual('/labkey/samplemanager/app.view#/workflow');
 
         expect(configs.hasIn([4, 'user'])).toBeTruthy();
+    });
+
+    test('SM and FM enabled, SM current app, storage editor', () => {
+        LABKEY.moduleContext = {
+            api: {
+                moduleNames: ['samplemanagement', 'study', 'premium'],
+            },
+            samplemanagement: {
+                productId: SAMPLE_MANAGER_APP_PROPERTIES.productId,
+            },
+            inventory: {
+                productId: FREEZER_MANAGER_APP_PROPERTIES.productId,
+            },
+        };
+
+        const configs = getMenuSectionConfigs(TEST_USER_STORAGE_EDITOR, 'sampleManager');
+        expect(configs.size).toBe(3);
+        expect(configs.hasIn([0, 'samples'])).toBeTruthy();
+        expect(configs.getIn([0, 'samples', 'seeAllURL'])).toEqual('#/samples?viewAs=cards');
+
+        expect(configs.hasIn([1, 'freezers'])).toBeTruthy();
+        expect(configs.getIn([1, 'freezers', 'seeAllURL'])).toEqual('/labkey/freezermanager/app.view#/home');
+
+        expect(configs.hasIn([2, 'workflow'])).toBeTruthy();
+        expect(configs.getIn([2, 'workflow', 'seeAllURL'])).toEqual('#/workflow');
+
+        expect(configs.hasIn([2, 'user'])).toBeTruthy();
     });
 });
 
@@ -554,6 +581,19 @@ describe('addSourcesSectionConfig', () => {
         expect(sectionConfig.emptyText).toBe('No source types have been defined');
         expect(sectionConfig.emptyURL).toBe('/labkey/test/app.view#/sourceType/new');
         expect(sectionConfig.emptyURLText).toBe('Create a source type');
+    });
+
+    test('storage editor', () => {
+        let configs = List<Map<string, MenuSectionConfig>>();
+        configs = addSourcesSectionConfig(TEST_USER_STORAGE_EDITOR, '/labkey/test/app.view', configs);
+        expect(configs.size).toBe(0);
+    });
+
+
+    test('storage designer', () => {
+        let configs = List<Map<string, MenuSectionConfig>>();
+        configs = addSourcesSectionConfig(TEST_USER_STORAGE_DESIGNER, '/labkey/test/app.view', configs);
+        expect(configs.size).toBe(0);
     });
 });
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -266,8 +266,7 @@ export function addSourcesSectionConfig(
     appBase: string,
     sectionConfigs: List<Map<string, MenuSectionConfig>>
 ): List<Map<string, MenuSectionConfig>> {
-    if (!userCanReadSources(user))
-        return sectionConfigs;
+    if (!userCanReadSources(user)) return sectionConfigs;
 
     let sourcesMenuConfig = new MenuSectionConfig({
         emptyText: 'No source types have been defined',
@@ -313,8 +312,7 @@ export function addAssaysSectionConfig(
     appBase: string,
     sectionConfigs: List<Map<string, MenuSectionConfig>>
 ): List<Map<string, MenuSectionConfig>> {
-    if (!userCanReadAssays(user))
-        return sectionConfigs;
+    if (!userCanReadAssays(user)) return sectionConfigs;
 
     let assaysMenuConfig = new MenuSectionConfig({
         emptyText: 'No assays have been defined',
@@ -374,16 +372,15 @@ const REQUESTS_SECTION_CONFIG = new MenuSectionConfig({
     iconURL: imageURL('_images', 'default.svg'),
 });
 
-function getBioWorkflowNotebookMediaConfigs(appBase: string, user: User)
-{
-    let configs  = Map({
-        [WORKFLOW_KEY]: getWorkflowSectionConfig(appBase)
+function getBioWorkflowNotebookMediaConfigs(appBase: string, user: User) {
+    let configs = Map({
+        [WORKFLOW_KEY]: getWorkflowSectionConfig(appBase),
     });
     if (userCanReadMedia(user)) {
-        configs = configs.set(MEDIA_KEY, getMediaSectionConfig(appBase))
+        configs = configs.set(MEDIA_KEY, getMediaSectionConfig(appBase));
     }
     if (userCanReadNotebooks(user)) {
-        configs = configs.set(NOTEBOOKS_KEY, getNotebooksSectionConfig(appBase))
+        configs = configs.set(NOTEBOOKS_KEY, getNotebooksSectionConfig(appBase));
     }
     return configs;
 }
@@ -446,18 +443,13 @@ export function getMenuSectionConfigs(
             if (storageConfig) {
                 requestsCol = requestsCol.set(FREEZERS_KEY, storageConfig);
             }
-            sectionConfigs = sectionConfigs.push(
-                requestsCol,
-                getBioWorkflowNotebookMediaConfigs(appBase, user)
-            );
+            sectionConfigs = sectionConfigs.push(requestsCol, getBioWorkflowNotebookMediaConfigs(appBase, user));
         } else {
             if (storageConfig) {
                 sectionConfigs = sectionConfigs.push(Map({ [FREEZERS_KEY]: storageConfig }));
             }
 
-            sectionConfigs = sectionConfigs.push(
-                getBioWorkflowNotebookMediaConfigs(appBase, user)
-            );
+            sectionConfigs = sectionConfigs.push(getBioWorkflowNotebookMediaConfigs(appBase, user));
         }
     } else {
         if (storageConfig) {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -98,6 +98,30 @@ export function registerWebSocketListeners(
     }
 }
 
+export function userCanReadAssays(user: User): boolean {
+    return hasAllPermissions(user, [PermissionTypes.ReadAssay]);
+}
+
+export function userCanReadSources(user: User): boolean {
+    return userCanReadDataClasses(user);
+}
+
+export function userCanReadRegistry(user: User): boolean {
+    return userCanReadDataClasses(user);
+}
+
+function userCanReadDataClasses(user: User): boolean {
+    return hasAllPermissions(user, [PermissionTypes.ReadDataClass]);
+}
+
+export function userCanReadMedia(user: User): boolean {
+    return hasAllPermissions(user, [PermissionTypes.ReadMedia]);
+}
+
+export function userCanReadNotebooks(user: User): boolean {
+    return hasAllPermissions(user, [PermissionTypes.ReadNotebooks]);
+}
+
 export function userCanManagePicklists(user: User): boolean {
     return hasAllPermissions(user, [PermissionTypes.ManagePicklists]);
 }
@@ -242,6 +266,9 @@ export function addSourcesSectionConfig(
     appBase: string,
     sectionConfigs: List<Map<string, MenuSectionConfig>>
 ): List<Map<string, MenuSectionConfig>> {
+    if (!userCanReadDataClasses(user))
+        return sectionConfigs;
+
     let sourcesMenuConfig = new MenuSectionConfig({
         emptyText: 'No source types have been defined',
         iconURL: imageURL('_images', 'source_type.svg'),
@@ -286,6 +313,9 @@ export function addAssaysSectionConfig(
     appBase: string,
     sectionConfigs: List<Map<string, MenuSectionConfig>>
 ): List<Map<string, MenuSectionConfig>> {
+    if (!userCanReadAssays(user))
+        return sectionConfigs;
+
     let assaysMenuConfig = new MenuSectionConfig({
         emptyText: 'No assays have been defined',
         iconURL: imageURL('_images', 'assay.svg'),
@@ -344,6 +374,20 @@ const REQUESTS_SECTION_CONFIG = new MenuSectionConfig({
     iconURL: imageURL('_images', 'default.svg'),
 });
 
+function getBioWorkflowNotebookMediaConfigs(appBase: string, user: User)
+{
+    let configs  = Map({
+        [WORKFLOW_KEY]: getWorkflowSectionConfig(appBase)
+    });
+    if (userCanReadMedia(user)) {
+        configs = configs.set(MEDIA_KEY, getMediaSectionConfig(appBase))
+    }
+    if (userCanReadNotebooks(user)) {
+        configs = configs.set(NOTEBOOKS_KEY, getNotebooksSectionConfig(appBase))
+    }
+    return configs;
+}
+
 // exported for testing
 export function getMenuSectionConfigs(
     user: User,
@@ -365,7 +409,9 @@ export function getMenuSectionConfigs(
     if (inSMApp) {
         sectionConfigs = addSourcesSectionConfig(user, appBase, sectionConfigs);
     } else if (isBioPrimary) {
-        sectionConfigs = sectionConfigs.push(Map({ [REGISTRY_KEY]: getRegistrySectionConfig(appBase) }));
+        if (userCanReadDataClasses(user)) {
+            sectionConfigs = sectionConfigs.push(Map({ [REGISTRY_KEY]: getRegistrySectionConfig(appBase) }));
+        }
     }
     if (isBioOrSM) {
         sectionConfigs = addSamplesSectionConfig(user, appBase, sectionConfigs);
@@ -402,22 +448,15 @@ export function getMenuSectionConfigs(
             }
             sectionConfigs = sectionConfigs.push(
                 requestsCol,
-                Map({
-                    [WORKFLOW_KEY]: workflowConfig,
-                    [MEDIA_KEY]: getMediaSectionConfig(appBase),
-                    [NOTEBOOKS_KEY]: getNotebooksSectionConfig(appBase),
-                })
+                getBioWorkflowNotebookMediaConfigs(appBase, user)
             );
         } else {
             if (storageConfig) {
                 sectionConfigs = sectionConfigs.push(Map({ [FREEZERS_KEY]: storageConfig }));
             }
+
             sectionConfigs = sectionConfigs.push(
-                Map({
-                    [WORKFLOW_KEY]: workflowConfig,
-                    [MEDIA_KEY]: getMediaSectionConfig(appBase),
-                    [NOTEBOOKS_KEY]: getNotebooksSectionConfig(appBase),
-                })
+                getBioWorkflowNotebookMediaConfigs(appBase, user)
             );
         }
     } else {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -266,7 +266,7 @@ export function addSourcesSectionConfig(
     appBase: string,
     sectionConfigs: List<Map<string, MenuSectionConfig>>
 ): List<Map<string, MenuSectionConfig>> {
-    if (!userCanReadDataClasses(user))
+    if (!userCanReadSources(user))
         return sectionConfigs;
 
     let sourcesMenuConfig = new MenuSectionConfig({

--- a/packages/components/src/internal/components/assay/withAssayModels.tsx
+++ b/packages/components/src/internal/components/assay/withAssayModels.tsx
@@ -5,14 +5,17 @@ import { withRouter, WithRouterProps } from 'react-router';
 
 import {
     Alert,
+    App,
     AssayDefinitionModel,
     AssayProtocolModel,
     AssayStateModel,
     getActionErrorMessage,
+    InsufficientPermissionsPage,
     isLoading,
     LoadingPage,
     LoadingState,
     NotFound,
+    useServerContext,
 } from '../../..';
 
 import { fetchProtocol } from '../domainproperties/assay/actions';
@@ -264,7 +267,11 @@ export function assayPage<Props>(
         const { assayModel, params } = props;
         const assayName = params?.protocol;
         const hasProtocol = assayName !== undefined;
+        const { user } = useServerContext();
 
+        if (!App.userCanReadAssays(user)) {
+            return <InsufficientPermissionsPage title={"Assays"} />
+        }
         if (
             isLoading(assayModel.definitionsLoadingState) ||
             (hasProtocol && isLoading(assayModel.protocolLoadingState))

--- a/packages/components/src/internal/components/assay/withAssayModels.tsx
+++ b/packages/components/src/internal/components/assay/withAssayModels.tsx
@@ -270,7 +270,7 @@ export function assayPage<Props>(
         const { user } = useServerContext();
 
         if (!App.userCanReadAssays(user)) {
-            return <InsufficientPermissionsPage title={"Assays"} />
+            return <InsufficientPermissionsPage title="Assays" />;
         }
         if (
             isLoading(assayModel.definitionsLoadingState) ||

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -87,6 +87,8 @@ import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../
 
 import { SampleStatusLegend } from '../samples/SampleStatusLegend';
 
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
 import {
     EntityDataType,
     EntityIdCreationModel,
@@ -107,7 +109,6 @@ import {
     removeEntityParentType,
 } from './EntityParentTypeSelectors';
 import { ENTITY_CREATION_METRIC } from './constants';
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 const ALIQUOT_FIELD_COLS = ['aliquotedfrom', 'name', 'description', 'samplestate'];
 const ALIQUOT_NOUN_SINGULAR = 'Aliquot';

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
@@ -9,13 +9,14 @@ import { SampleState } from '../../samples/models';
 import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { DiscardConsumedSamplesPanel } from '../../samples/DiscardConsumedSamplesPanel';
-import { waitForLifecycle } from '../../../testHelpers';
+import { mountWithServerContext, waitForLifecycle } from '../../../testHelpers';
 
 import { getSamplesTestAPIWrapper } from '../../samples/APIWrapper';
 
 import { getTestAPIWrapper } from '../../../APIWrapper';
 
 import { SampleStatusInput } from './SampleStatusInput';
+import { TEST_USER_EDITOR, TEST_USER_STORAGE_EDITOR } from '../../../../test/data/users';
 
 const COLUMN_STATUS = new QueryColumn({
     fieldKey: 'samplestate',
@@ -57,7 +58,10 @@ const DEFAULT_PROPS = {
 
 describe('SampleStatusInput', () => {
     test('initial value is blank', async () => {
-        const component = mount(<SampleStatusInput {...DEFAULT_PROPS} formsy={false} />);
+        const component = mountWithServerContext(
+            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />,
+            { user: TEST_USER_STORAGE_EDITOR }
+        );
         await waitForLifecycle(component);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
@@ -65,7 +69,10 @@ describe('SampleStatusInput', () => {
     });
 
     test('initial value is Consumed', async () => {
-        const component = mount(<SampleStatusInput {...DEFAULT_PROPS} formsy={false} data={INIT_CONSUMED} />);
+        const component = mountWithServerContext(
+            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} data={INIT_CONSUMED} />,
+            { user: TEST_USER_STORAGE_EDITOR }
+        );
         await waitForLifecycle(component);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
@@ -73,7 +80,10 @@ describe('SampleStatusInput', () => {
     });
 
     test('show discard', async () => {
-        const component = mount(<SampleStatusInput {...DEFAULT_PROPS} formsy={false} forceShowDiscard={true} />);
+        const component = mountWithServerContext(
+            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} forceShowDiscard={true} />,
+            { user: TEST_USER_STORAGE_EDITOR }
+        );
 
         await waitForLifecycle(component);
 
@@ -84,8 +94,9 @@ describe('SampleStatusInput', () => {
     });
 
     test('show discard, with allowDisable true (bulk edit)', async () => {
-        const component = mount(
-            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} forceShowDiscard={true} allowDisable={true} />
+        const component = mountWithServerContext(
+            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} forceShowDiscard={true} allowDisable={true} />,
+            { user: TEST_USER_STORAGE_EDITOR }
         );
 
         await waitForLifecycle(component);

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
@@ -15,9 +15,10 @@ import { getSamplesTestAPIWrapper } from '../../samples/APIWrapper';
 
 import { getTestAPIWrapper } from '../../../APIWrapper';
 
-import { SampleStatusInput } from './SampleStatusInput';
 import { TEST_USER_EDITOR, TEST_USER_STORAGE_EDITOR } from '../../../../test/data/users';
 import { QuerySelect } from '../QuerySelect';
+
+import { SampleStatusInput } from './SampleStatusInput';
 
 const COLUMN_STATUS = new QueryColumn({
     fieldKey: 'samplestate',
@@ -59,10 +60,9 @@ const DEFAULT_PROPS = {
 
 describe('SampleStatusInput', () => {
     test('initial value is blank', async () => {
-        const component = mountWithServerContext(
-            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />,
-            { user: TEST_USER_STORAGE_EDITOR }
-        );
+        const component = mountWithServerContext(<SampleStatusInput {...DEFAULT_PROPS} formsy={false} />, {
+            user: TEST_USER_STORAGE_EDITOR,
+        });
         await waitForLifecycle(component);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
@@ -80,13 +80,9 @@ describe('SampleStatusInput', () => {
         expect(discardPanel).toHaveLength(0);
     });
 
-
     test('change to consumed status, editor', async () => {
-        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false}  allowDisable />;
-        const wrapper = mountWithServerContext(
-            component,
-            { user: TEST_USER_EDITOR }
-        );
+        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} allowDisable />;
+        const wrapper = mountWithServerContext(component, { user: TEST_USER_EDITOR });
 
         await waitForLifecycle(wrapper); // retrieve statuses
         wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined);
@@ -97,11 +93,8 @@ describe('SampleStatusInput', () => {
     });
 
     test('change to consumed status, storage editor, allow disable (bulk edit)', async () => {
-        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false}  allowDisable />;
-        const wrapper = mountWithServerContext(
-            component,
-            { user: TEST_USER_STORAGE_EDITOR }
-        );
+        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} allowDisable />;
+        const wrapper = mountWithServerContext(component, { user: TEST_USER_STORAGE_EDITOR });
 
         await waitForLifecycle(wrapper);
         wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined);
@@ -114,10 +107,7 @@ describe('SampleStatusInput', () => {
 
     test('change to consumed status, storage editor, no allowDisable', async () => {
         const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />;
-        const wrapper = mountWithServerContext(
-            component,
-            { user: TEST_USER_STORAGE_EDITOR }
-        );
+        const wrapper = mountWithServerContext(component, { user: TEST_USER_STORAGE_EDITOR });
 
         await waitForLifecycle(wrapper);
         wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined);
@@ -128,13 +118,9 @@ describe('SampleStatusInput', () => {
         expect(wrapper.find('.sample-bulk-update-discard-panel')).toHaveLength(0);
     });
 
-
     test('change to not consumed, storage editor', async () => {
         const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />;
-        const wrapper = mountWithServerContext(
-            component,
-            { user: TEST_USER_STORAGE_EDITOR }
-        );
+        const wrapper = mountWithServerContext(component, { user: TEST_USER_STORAGE_EDITOR });
 
         await waitForLifecycle(wrapper);
         wrapper.find(QuerySelect).prop('onQSChange')('name', 100, [], undefined);

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
@@ -17,6 +17,7 @@ import { getTestAPIWrapper } from '../../../APIWrapper';
 
 import { SampleStatusInput } from './SampleStatusInput';
 import { TEST_USER_EDITOR, TEST_USER_STORAGE_EDITOR } from '../../../../test/data/users';
+import { QuerySelect } from '../QuerySelect';
 
 const COLUMN_STATUS = new QueryColumn({
     fieldKey: 'samplestate',
@@ -79,31 +80,68 @@ describe('SampleStatusInput', () => {
         expect(discardPanel).toHaveLength(0);
     });
 
-    test('show discard', async () => {
-        const component = mountWithServerContext(
-            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} forceShowDiscard={true} />,
-            { user: TEST_USER_STORAGE_EDITOR }
+
+    test('change to consumed status, editor', async () => {
+        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false}  allowDisable />;
+        const wrapper = mountWithServerContext(
+            component,
+            { user: TEST_USER_EDITOR }
         );
 
-        await waitForLifecycle(component);
+        await waitForLifecycle(wrapper); // retrieve statuses
+        wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined);
 
-        const discardPanel = component.find(DiscardConsumedSamplesPanel);
-        expect(discardPanel).toHaveLength(1);
-
-        expect(component.find('.sample-bulk-update-discard-panel')).toHaveLength(0);
+        await waitForLifecycle(wrapper); // update after select
+        const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
+        expect(discardPanel).toHaveLength(0);
     });
 
-    test('show discard, with allowDisable true (bulk edit)', async () => {
-        const component = mountWithServerContext(
-            <SampleStatusInput {...DEFAULT_PROPS} formsy={false} forceShowDiscard={true} allowDisable={true} />,
+    test('change to consumed status, storage editor, allow disable (bulk edit)', async () => {
+        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false}  allowDisable />;
+        const wrapper = mountWithServerContext(
+            component,
             { user: TEST_USER_STORAGE_EDITOR }
         );
 
-        await waitForLifecycle(component);
-
-        const discardPanel = component.find(DiscardConsumedSamplesPanel);
+        await waitForLifecycle(wrapper);
+        wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined);
+        await waitForLifecycle(wrapper);
+        const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(1);
 
-        expect(component.find('.sample-bulk-update-discard-panel')).toHaveLength(1);
+        expect(wrapper.find('.sample-bulk-update-discard-panel')).toHaveLength(1);
+    });
+
+    test('change to consumed status, storage editor, no allowDisable', async () => {
+        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />;
+        const wrapper = mountWithServerContext(
+            component,
+            { user: TEST_USER_STORAGE_EDITOR }
+        );
+
+        await waitForLifecycle(wrapper);
+        wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined);
+        await waitForLifecycle(wrapper);
+        const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
+        expect(discardPanel).toHaveLength(1);
+
+        expect(wrapper.find('.sample-bulk-update-discard-panel')).toHaveLength(0);
+    });
+
+
+    test('change to not consumed, storage editor', async () => {
+        const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />;
+        const wrapper = mountWithServerContext(
+            component,
+            { user: TEST_USER_STORAGE_EDITOR }
+        );
+
+        await waitForLifecycle(wrapper);
+        wrapper.find(QuerySelect).prop('onQSChange')('name', 100, [], undefined);
+        await waitForLifecycle(wrapper);
+        const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
+        expect(discardPanel).toHaveLength(0);
+
+        expect(wrapper.find('.sample-bulk-update-discard-panel')).toHaveLength(0);
     });
 });

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -33,7 +33,6 @@ interface SampleStatusInputProps {
     onAdditionalFormDataChange?: (name: string, value: any) => any;
     inputClass?: string;
     formsy?: boolean; // for jest test
-    forceShowDiscard?: boolean; // workaround for jest test due to difficulty getting QuerySelect to work with jest
 }
 
 export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
@@ -167,7 +166,7 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
                 inputClass={inputClass}
             />
             {error && <Alert>{error}</Alert>}
-            {(showDiscardPanel || props.forceShowDiscard) && <>{discardPanel}</>}
+            {showDiscardPanel && <>{discardPanel}</>}
         </React.Fragment>
     );
 });

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -12,6 +12,8 @@ import { QueryColumn } from '../../../../public/QueryColumn';
 import { QuerySelect } from '../QuerySelect';
 import { SampleStateType } from '../../samples/constants';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../../APIWrapper';
+import { userCanEditStorageData } from '../../../app/utils';
+import { useServerContext } from '../../base/ServerContext';
 
 interface SampleStatusInputProps {
     api?: ComponentsAPIWrapper;
@@ -52,6 +54,7 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
         inputClass,
         formsy,
     } = props;
+    const { user } = useServerContext();
     const [consumedStatuses, setConsumedStatuses] = useState<number[]>(undefined);
     const [error, setError] = useState<string>(undefined);
     const [showDiscardPanel, setShowDiscardPanel] = useState<boolean>(false);
@@ -82,14 +85,15 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
     const onChange = useCallback(
         (name: string, newValue: any, items: any) => {
             onQSChange?.(name, newValue, items);
-
-            const isConsumed = consumedStatuses.indexOf(newValue) > -1 && value !== newValue;
-            const isInStorage = onAdditionalFormDataChange?.(
-                DISCARD_CONSUMED_CHECKBOX_FIELD,
-                shouldDiscard && isConsumed
-            );
-            const showPanel = isInStorage && isConsumed;
-            setShowDiscardPanel(showPanel);
+            if (userCanEditStorageData(user)) {
+                const isConsumed = consumedStatuses.indexOf(newValue) > -1 && value !== newValue;
+                const isInStorage = onAdditionalFormDataChange?.(
+                    DISCARD_CONSUMED_CHECKBOX_FIELD,
+                    shouldDiscard && isConsumed
+                );
+                const showPanel = isInStorage && isConsumed;
+                setShowDiscardPanel(showPanel);
+            }
         },
         [consumedStatuses, onAdditionalFormDataChange, onQSChange, shouldDiscard, value]
     );

--- a/packages/components/src/internal/components/menus/SelectionMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/menus/SelectionMenuItem.spec.tsx
@@ -96,8 +96,10 @@ describe('<SelectionMenuItem/>', () => {
             totalRows: 5,
             selectedIds: List(['1', '2', '3']),
         });
-        const href = "http://my.href.test";
-        const wrapper = mount(<SelectionMenuItem maxSelection={2} id="jest-test-1" model={model} text={text} href={href} />);
+        const href = 'http://my.href.test';
+        const wrapper = mount(
+            <SelectionMenuItem maxSelection={2} id="jest-test-1" model={model} text={text} href={href} />
+        );
         expect(wrapper.prop('href')).toBe(href);
         expect(wrapper.prop('onClick')).toBe(undefined);
     });

--- a/packages/components/src/internal/components/menus/SelectionMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/menus/SelectionMenuItem.spec.tsx
@@ -89,4 +89,16 @@ describe('<SelectionMenuItem/>', () => {
         expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
         wrapper.unmount();
     });
+
+    test('with href', () => {
+        const text = 'Menu Item Text';
+        const model = new QueryGridModel({
+            totalRows: 5,
+            selectedIds: List(['1', '2', '3']),
+        });
+        const href = "http://my.href.test";
+        const wrapper = mount(<SelectionMenuItem maxSelection={2} id="jest-test-1" model={model} text={text} href={href} />);
+        expect(wrapper.prop('href')).toBe(href);
+        expect(wrapper.prop('onClick')).toBe(undefined);
+    });
 });

--- a/packages/components/src/internal/components/menus/SelectionMenuItem.tsx
+++ b/packages/components/src/internal/components/menus/SelectionMenuItem.tsx
@@ -23,11 +23,12 @@ interface Props {
     model?: QueryGridModel;
     queryModel?: QueryModel;
     text: string;
-    onClick: () => void;
+    onClick?: () => void;
     disabledMsg: string;
     maxSelection?: number;
     maxSelectionDisabledMsg?: string;
     nounPlural: string;
+    href?: string;
 }
 
 export class SelectionMenuItem extends PureComponent<Props> {
@@ -55,10 +56,10 @@ export class SelectionMenuItem extends PureComponent<Props> {
     }
 
     render() {
-        const { id, text, onClick, disabledMsg, maxSelection, maxSelectionDisabledMsg, nounPlural } = this.props;
+        const { id, text, onClick, href, disabledMsg, maxSelection, maxSelectionDisabledMsg, nounPlural } = this.props;
         const { disabled, tooFewSelected } = this;
         const item = (
-            <MenuItem onClick={onClick} disabled={disabled}>
+            <MenuItem href={href} onClick={onClick} disabled={disabled}>
                 {text}
             </MenuItem>
         );

--- a/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductLKSDrawer.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames';
 
 import { buildURL } from '../../..';
 
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
 import { ContainerTabModel } from './models';
 import {
     APPLICATION_NAVIGATION_METRIC,
@@ -14,7 +16,6 @@ import {
     TO_LKS_TAB_METRIC,
 } from './constants';
 import { ProductClickableItem } from './ProductClickableItem';
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface ProductLKSDrawerProps {
     api?: ComponentsAPIWrapper;

--- a/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductSectionsDrawer.tsx
@@ -7,10 +7,11 @@ import { FREEZERS_KEY, MEDIA_KEY, NOTEBOOKS_KEY, WORKFLOW_KEY } from '../../app/
 
 import { getAppProductIds } from '../../app/utils';
 
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
 import { ProductModel, ProductSectionModel } from './models';
 import { APPLICATION_NAVIGATION_METRIC, SECTION_KEYS_TO_SKIP } from './constants';
 import { ProductClickableItem } from './ProductClickableItem';
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface ProductAppsDrawerProps {
     api?: ComponentsAPIWrapper;

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
@@ -9,6 +9,7 @@ import { OperationConfirmationData } from '../entities/models';
 
 import { SamplesBulkUpdateAlert, SamplesBulkUpdateFormBase } from './SamplesBulkUpdateForm';
 import { getSamplesTestAPIWrapper } from './APIWrapper';
+import { TEST_USER_EDITOR } from '../../../test/data/users';
 
 describe('SamplesBulkUpdateForm', () => {
     const COLUMN_DESCRIPTION = new QueryColumn({
@@ -84,6 +85,7 @@ describe('SamplesBulkUpdateForm', () => {
         onBulkUpdateComplete: jest.fn,
         editSelectionInGrid: jest.fn,
         api: getSamplesTestAPIWrapper(),
+        user: TEST_USER_EDITOR,
     };
 
     test('all selected are samples', () => {

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
@@ -7,9 +7,10 @@ import { Alert, BulkUpdateForm, makeTestQueryModel, QueryColumn, QueryInfo, Sche
 
 import { OperationConfirmationData } from '../entities/models';
 
+import { TEST_USER_EDITOR } from '../../../test/data/users';
+
 import { SamplesBulkUpdateAlert, SamplesBulkUpdateFormBase } from './SamplesBulkUpdateForm';
 import { getSamplesTestAPIWrapper } from './APIWrapper';
-import { TEST_USER_EDITOR } from '../../../test/data/users';
 
 describe('SamplesBulkUpdateForm', () => {
     const COLUMN_DESCRIPTION = new QueryColumn({

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
@@ -4,18 +4,19 @@ import { List, Map, OrderedMap } from 'immutable';
 import { AuditBehaviorTypes } from '@labkey/api';
 
 import {
+    Alert,
     BulkUpdateForm,
+    createNotification,
+    deleteRows,
     getOperationNotPermittedMessage,
     QueryColumn,
     QueryInfo,
     QueryModel,
+    resolveErrorMessage,
     SampleOperation,
     SchemaQuery,
-    Alert,
-    deleteRows,
     SCHEMAS,
-    createNotification,
-    resolveErrorMessage,
+    User,
 } from '../../..';
 
 import { OperationConfirmationData } from '../entities/models';
@@ -23,6 +24,7 @@ import { OperationConfirmationData } from '../entities/models';
 import { SamplesSelectionProviderProps, SamplesSelectionResultProps } from './models';
 import { SamplesSelectionProvider } from './SamplesSelectionContextProvider';
 import { DISCARD_CONSUMED_CHECKBOX_FIELD, DISCARD_CONSUMED_COMMENT_FIELD } from './DiscardConsumedSamplesPanel';
+import { userCanEditStorageData } from '../../app/utils';
 
 interface OwnProps {
     queryModel: QueryModel;
@@ -33,6 +35,7 @@ interface OwnProps {
     onBulkUpdateError: (message: string) => void;
     onBulkUpdateComplete: (data: any, submitForEdit) => void;
     editSelectionInGrid: (updateData: any, dataForSelection: Map<string, any>, dataIdsForSelection: List<any>) => any;
+    user: User;
 }
 
 type Props = OwnProps & SamplesSelectionProviderProps & SamplesSelectionResultProps;
@@ -164,9 +167,11 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
     };
 
     onDiscardConsumedPanelChange = (field: string, value: any) => {
-        const { sampleItems } = this.props;
+        const { sampleItems, user } = this.props;
 
-        if (!sampleItems || Object.keys(sampleItems).length === 0) return false; // if no samples are in storage, skip showing discard panel
+        if (!sampleItems || Object.keys(sampleItems).length === 0 || !userCanEditStorageData(user)) {
+            return false; // if no samples are in storage or the user can't modify storage data, skip showing discard panel
+        }
 
         if (field === DISCARD_CONSUMED_CHECKBOX_FIELD) this.setState(() => ({ shouldDiscard: value }));
         else if (field === DISCARD_CONSUMED_COMMENT_FIELD) this.setState(() => ({ discardComment: value }));

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
@@ -21,10 +21,11 @@ import {
 
 import { OperationConfirmationData } from '../entities/models';
 
+import { userCanEditStorageData } from '../../app/utils';
+
 import { SamplesSelectionProviderProps, SamplesSelectionResultProps } from './models';
 import { SamplesSelectionProvider } from './SamplesSelectionContextProvider';
 import { DISCARD_CONSUMED_CHECKBOX_FIELD, DISCARD_CONSUMED_COMMENT_FIELD } from './DiscardConsumedSamplesPanel';
-import { userCanEditStorageData } from '../../app/utils';
 
 interface OwnProps {
     queryModel: QueryModel;

--- a/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
@@ -27,11 +27,12 @@ import {
 
 import { TabbedGridPanelProps } from '../../../public/QueryModel/TabbedGridPanel';
 
+import { userCanEditStorageData } from '../../app/utils';
+
 import { SamplesEditableGrid, SamplesEditableGridProps } from './SamplesEditableGrid';
 import { SamplesBulkUpdateForm } from './SamplesBulkUpdateForm';
 import { ALIQUOT_FILTER_MODE } from './SampleAliquotViewSelector';
 import { SampleGridButtonProps } from './models';
-import { userCanEditStorageData } from '../../app/utils';
 
 const EXPORT_TYPES_WITH_LABEL = Set.of(EXPORT_TYPES.CSV, EXPORT_TYPES.EXCEL, EXPORT_TYPES.TSV, EXPORT_TYPES.LABEL);
 

--- a/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
@@ -31,6 +31,7 @@ import { SamplesEditableGrid, SamplesEditableGridProps } from './SamplesEditable
 import { SamplesBulkUpdateForm } from './SamplesBulkUpdateForm';
 import { ALIQUOT_FILTER_MODE } from './SampleAliquotViewSelector';
 import { SampleGridButtonProps } from './models';
+import { userCanEditStorageData } from '../../app/utils';
 
 const EXPORT_TYPES_WITH_LABEL = Set.of(EXPORT_TYPES.CSV, EXPORT_TYPES.EXCEL, EXPORT_TYPES.TSV, EXPORT_TYPES.LABEL);
 
@@ -326,7 +327,8 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
                     onBulkUpdateComplete={onBulkUpdateComplete}
                     editSelectionInGrid={onEditSelectionInGrid}
                     updateRows={onUpdateRows}
-                    determineStorage // determine storage for discard consumed samples
+                    determineStorage={userCanEditStorageData(user)} // determine storage for discard consumed samples
+                    user={user}
                 />
             )}
         </>

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -115,6 +115,7 @@ export const SAMPLE_MANAGEMENT = {
     SAMPLE_TYPE_INSIGHTS: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'SampleTypeInsights'),
     SAMPLE_STATUS_COUNTS: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'SampleStatusCounts'),
     SOURCE_SAMPLES: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'SourceSamples'),
+    JOBS: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'Jobs'),
 };
 
 // STUDY

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -319,23 +319,23 @@ describe('App Route Resolvers', () => {
     });
 
     test('Should resolve /rd/run/### routes', () => {
-        const jobsResolver = new ExperimentRunResolver(new Set([4,5,10]));
+        const jobsResolver = new ExperimentRunResolver(new Set([4, 5, 10]));
 
         // test regex
         expect(jobsResolver.matches(undefined)).toBe(false);
-        expect(jobsResolver.matches("/rd/samples/4")).toBe(false);
-        expect(jobsResolver.matches("/rd/run/b")).toBe(false);
-        expect(jobsResolver.matches("/a/rd/run/b")).toBe(false);
-        expect(jobsResolver.matches("/rd/run/4")).toBe(true);
-        expect(jobsResolver.matches("/rd/run/141345")).toBe(true);
+        expect(jobsResolver.matches('/rd/samples/4')).toBe(false);
+        expect(jobsResolver.matches('/rd/run/b')).toBe(false);
+        expect(jobsResolver.matches('/a/rd/run/b')).toBe(false);
+        expect(jobsResolver.matches('/rd/run/4')).toBe(true);
+        expect(jobsResolver.matches('/rd/run/141345')).toBe(true);
 
         return Promise.all([
             jobsResolver.fetch(['rd', 'runs', 'notanumber']).then((result: boolean) => {
                 expect(result).toBe(true);
             }),
-            jobsResolver.fetch(['rd','runs', 4]).then((result: AppURL) => {
-                expect(result.toString()).toBe("/workflow/4");
-            })
+            jobsResolver.fetch(['rd', 'runs', 4]).then((result: AppURL) => {
+                expect(result.toString()).toBe('/workflow/4');
+            }),
         ]);
-    })
+    });
 });

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -15,7 +15,7 @@
  */
 import { fromJS, List, Map } from 'immutable';
 
-import { AppURL } from '../..';
+import { AppURL, ExperimentRunResolver } from '../..';
 
 import { initMockServerContext, registerDefaultURLMappers } from '../testHelpers';
 
@@ -317,4 +317,25 @@ describe('App Route Resolvers', () => {
             }),
         ]);
     });
+
+    test('Should resolve /rd/run/### routes', () => {
+        const jobsResolver = new ExperimentRunResolver(new Set([4,5,10]));
+
+        // test regex
+        expect(jobsResolver.matches(undefined)).toBe(false);
+        expect(jobsResolver.matches("/rd/samples/4")).toBe(false);
+        expect(jobsResolver.matches("/rd/run/b")).toBe(false);
+        expect(jobsResolver.matches("/a/rd/run/b")).toBe(false);
+        expect(jobsResolver.matches("/rd/run/4")).toBe(true);
+        expect(jobsResolver.matches("/rd/run/141345")).toBe(true);
+
+        return Promise.all([
+            jobsResolver.fetch(['rd', 'runs', 'notanumber']).then((result: boolean) => {
+                expect(result).toBe(true);
+            }),
+            jobsResolver.fetch(['rd','runs', 4]).then((result: AppURL) => {
+                expect(result.toString()).toBe("/workflow/4");
+            })
+        ]);
+    })
 });

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -318,13 +318,27 @@ export class SamplesResolver implements AppRouteResolver {
  * to the lineage page for a sample, but the URL here doesn't have any info about the related entity.
  */
 export class ExperimentRunResolver implements AppRouteResolver {
+
+    jobs: Set<number> // set of rowIds that are jobs
+
     static createURL(rowId: string | number): AppURL {
         return AppURL.create('rd','run', rowId);
+    }
+
+    constructor(jobs?: Set<number>) {
+        this.jobs = jobs !== undefined ? jobs : new Set();
     }
 
     fetch(parts: any[]): Promise<AppURL | boolean> {
         const rowId = parts[2];
 
+        if (isNaN(rowId)) {
+            // skip it
+            return Promise.resolve(true);
+        }
+        if (this.jobs.has(rowId)) {
+            return Promise.resolve(AppURL.create('workflow', rowId));
+        }
         return new Promise((resolve) => {
             return selectRows({
                 schemaName: SAMPLE_MANAGEMENT.JOBS.schemaName,

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -332,8 +332,7 @@ export class ExperimentRunResolver implements AppRouteResolver {
                 filterArray: [Filter.create('RowId', rowId)],
                 columns: 'RowId'
             }).then(result => {
-                const data = result.models[result.key];
-                if (data.rows) {
+                if (Object.keys(result.models[result.key]).length) {
                     resolve(AppURL.create('workflow', rowId))
                 }
                 resolve(true);

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -18,8 +18,9 @@ import { Filter } from '@labkey/api';
 
 import { AssayProtocolModel, caseInsensitive, fetchProtocol, getQueryDetails, SCHEMAS, selectRows } from '../..';
 
-import { AppURL, spliceURL } from './AppURL';
 import { SAMPLE_MANAGEMENT } from '../schemas';
+
+import { AppURL, spliceURL } from './AppURL';
 
 export interface AppRouteResolver {
     matches: (route: string) => boolean;
@@ -318,11 +319,10 @@ export class SamplesResolver implements AppRouteResolver {
  * to the lineage page for a sample, but the URL here doesn't have any info about the related entity.
  */
 export class ExperimentRunResolver implements AppRouteResolver {
-
-    jobs: Set<number> // set of rowIds that are jobs
+    jobs: Set<number>; // set of rowIds that are jobs
 
     static createURL(rowId: string | number): AppURL {
-        return AppURL.create('rd','run', rowId);
+        return AppURL.create('rd', 'run', rowId);
     }
 
     constructor(jobs?: Set<number>) {
@@ -345,7 +345,7 @@ export class ExperimentRunResolver implements AppRouteResolver {
                 schemaName: SAMPLE_MANAGEMENT.JOBS.schemaName,
                 queryName: SAMPLE_MANAGEMENT.JOBS.queryName,
                 filterArray: [Filter.create('RowId', rowId)],
-                columns: 'RowId'
+                columns: 'RowId',
             });
 
             if (Object.keys(result.models[result.key]).length) {
@@ -364,4 +364,3 @@ export class ExperimentRunResolver implements AppRouteResolver {
         return /\/rd\/run\/\d+$/.test(route);
     }
 }
-

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -330,7 +330,8 @@ export class ExperimentRunResolver implements AppRouteResolver {
     }
 
     fetch(parts: any[]): Promise<AppURL | boolean> {
-        const rowId = parts[2];
+        const rowIdIndex = 2;
+        const rowId = parseInt(parts[rowIdIndex], 10);
 
         if (isNaN(rowId)) {
             // skip it
@@ -347,6 +348,7 @@ export class ExperimentRunResolver implements AppRouteResolver {
                 columns: 'RowId'
             }).then(result => {
                 if (Object.keys(result.models[result.key]).length) {
+                    this.jobs.add(rowId);
                     resolve(AppURL.create('workflow', rowId))
                 }
                 resolve(true);

--- a/packages/components/src/test/data/users.ts
+++ b/packages/components/src/test/data/users.ts
@@ -81,6 +81,10 @@ export const TEST_USER_EDITOR = new User({
         PermissionTypes.Update,
         PermissionTypes.ManagePicklists,
         PermissionTypes.ManageSampleWorkflows,
+        PermissionTypes.ReadNotebooks,
+        PermissionTypes.ReadDataClass,
+        PermissionTypes.ReadAssay,
+        PermissionTypes.ReadMedia
     ]),
 });
 
@@ -131,6 +135,10 @@ export const TEST_USER_FOLDER_ADMIN = new User({
         PermissionTypes.ManagePicklists,
         PermissionTypes.ManageSampleWorkflows,
         PermissionTypes.Admin,
+        PermissionTypes.ReadNotebooks,
+        PermissionTypes.ReadDataClass,
+        PermissionTypes.ReadAssay,
+        PermissionTypes.ReadMedia,
     ]),
 });
 
@@ -163,6 +171,10 @@ export const TEST_USER_PROJECT_ADMIN = new User({
         PermissionTypes.ManageSampleWorkflows,
         PermissionTypes.Admin,
         PermissionTypes.AddUser,
+        PermissionTypes.ReadNotebooks,
+        PermissionTypes.ReadDataClass,
+        PermissionTypes.ReadAssay,
+        PermissionTypes.ReadMedia,
     ]),
 });
 
@@ -197,6 +209,10 @@ export const TEST_USER_APP_ADMIN = new User({
         PermissionTypes.UserManagement,
         PermissionTypes.ApplicationAdmin,
         PermissionTypes.AddUser,
+        PermissionTypes.ReadNotebooks,
+        PermissionTypes.ReadDataClass,
+        PermissionTypes.ReadAssay,
+        PermissionTypes.ReadMedia,
     ]),
 });
 

--- a/packages/components/src/test/data/users.ts
+++ b/packages/components/src/test/data/users.ts
@@ -90,7 +90,7 @@ export const TEST_USER_EDITOR = new User({
         PermissionTypes.ReadNotebooks,
         PermissionTypes.ReadDataClass,
         PermissionTypes.ReadAssay,
-        PermissionTypes.ReadMedia
+        PermissionTypes.ReadMedia,
     ]),
 });
 

--- a/packages/components/src/test/data/users.ts
+++ b/packages/components/src/test/data/users.ts
@@ -36,7 +36,13 @@ export const TEST_USER_READER = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([PermissionTypes.Read]),
+    permissionsList: List<string>([
+        PermissionTypes.Read,
+        PermissionTypes.ReadDataClass,
+        PermissionTypes.ReadAssay,
+        PermissionTypes.ReadMedia,
+        PermissionTypes.ReadNotebooks,
+    ]),
 });
 
 export const TEST_USER_AUTHOR = new User({

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -738,10 +738,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@labkey/api@1.8.0":
-  version "1.8.0"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.8.0.tgz#0e21a308ea610b6e6516c1b05f7042ee41a68657"
-  integrity sha1-DiGjCOphC25lFsGwX3BC7kGmhlc=
+"@labkey/api@1.9.0-sampleSteward.0":
+  version "1.9.0-sampleSteward.0"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.9.0-sampleSteward.0.tgz#f20b5d07abacbd18c40088bb45268bbd6d090cf4"
+  integrity sha1-8gtdB6usvRjEAIi7RSaLvW0JDPQ=
 
 "@labkey/eslint-config-base@0.0.11-fb-discussions.2":
   version "0.0.11-fb-discussions.2"


### PR DESCRIPTION
#### Rationale
The StorageEditor and StorageDesigner roles were created recently to be able to remove some capabilities from admins.  These roles did not provide any read access, however, because in some cases those who manage samples in storage are not meant to be able to read data about all types of entities.  In particular, assay, data class (registry or source), media, and LEN data may contain IP that not everyone is meant to be able to see.  We introduce new specific Read permissions for these types of data that can be granted separately from a general Read permission (needed for reading just the basic data needed for interacting with LKS and the applications on top of it).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3031
* https://github.com/LabKey/inventory/pull/376
* https://github.com/LabKey/biologics/pull/1150
* https://github.com/LabKey/labkey-api-js/pull/123
* https://github.com/LabKey/labbook/pull/142
* https://github.com/LabKey/recipe/pull/58
* https://github.com/LabKey/sampleManagement/pull/832

#### Changes
* Item 9998: Add permissions for restricting read for assays and data classes
  * Add utility methods for checking various read permissions
  * update `assayPage` to check assay read permission
* Update `SelectionMenuItem` to accept either an `onClick` or `href` property.
* Don't show the option to discard samples when changing status if user doesn't have proper permissions