### PR TITLE
Item #9990: Adding search type ahead for ontology fields insert/update forms

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.135.0-fb-ontologyInputSearch.4",
+  "version": "2.136.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.131.0-fb-ontologyInputSearch.0",
+  "version": "2.131.0-fb-ontologyInputSearch.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.131.0-fb-ontologyInputSearch.1",
+  "version": "2.131.0-fb-ontologyInputSearch.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.131.0-fb-ontologyInputSearch.2",
+  "version": "2.131.0-fb-ontologyInputSearch.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.131.0",
+  "version": "2.131.0-fb-ontologyInputSearch.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 9992: Add ontology type ahead search to forms
+  * Split out `OntologySearchInput` from the existing `OntologyTreeSearchContainer`
+
 ### version 2.131.0
 *Released*: 8 February 2022
 * Issue 44711: Field editor update to show confirm modal on change of data type for saved field

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.136.0
+*Released*: 21 February 2022
 * Item 9992: Add ontology type ahead search to forms
   * Split out `OntologySearchInput` from the existing `OntologyTreeSearchContainer`
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -554,6 +554,7 @@ import { OntologyConceptPicker } from './internal/components/ontology/OntologyCo
 import { OntologyBrowserPage } from './internal/components/ontology/OntologyBrowserPanel';
 import { OntologyConceptOverviewPanel } from './internal/components/ontology/ConceptOverviewPanel';
 import { OntologyBrowserFilterPanel } from './internal/components/ontology/OntologyBrowserFilterPanel';
+import { OntologySearchInput } from './internal/components/ontology/OntologyTreeSearchContainer'
 import { AppModel, LogoutReason } from './internal/app/models';
 import { Picklist } from './internal/components/picklist/models';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';
@@ -1361,6 +1362,7 @@ export {
     OntologyConceptOverviewPanel,
     OntologyBrowserFilterPanel,
     OntologyConceptPicker,
+    OntologySearchInput,
     ConceptModel,
     // UserAvatars
     UserAvatar,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -554,7 +554,7 @@ import { OntologyConceptPicker } from './internal/components/ontology/OntologyCo
 import { OntologyBrowserPage } from './internal/components/ontology/OntologyBrowserPanel';
 import { OntologyConceptOverviewPanel } from './internal/components/ontology/ConceptOverviewPanel';
 import { OntologyBrowserFilterPanel } from './internal/components/ontology/OntologyBrowserFilterPanel';
-import { OntologySearchInput } from './internal/components/ontology/OntologyTreeSearchContainer'
+import { OntologySearchInput } from './internal/components/ontology/OntologyTreeSearchContainer';
 import { AppModel, LogoutReason } from './internal/app/models';
 import { Picklist } from './internal/components/picklist/models';
 import { PicklistCreationMenuItem } from './internal/components/picklist/PicklistCreationMenuItem';

--- a/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
@@ -12,11 +12,10 @@ interface Props {
     fieldLabel: string;
     fieldValue?: string;
     onConceptSelection: (concept: ConceptModel) => void;
-    showPickerListener?: (val:() => void) => void;
 }
 
 export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
-    const { ontologyId, conceptSubtree, fieldLabel, onConceptSelection, fieldValue = '', showPickerListener } = props;
+    const { ontologyId, conceptSubtree, fieldLabel, onConceptSelection, fieldValue = '' } = props;
     const [concept, setConcept] = useState<ConceptModel>();
     const [subtreePath, setSubtreePath] = useState<PathModel>();
     const [isLoadingSubtreePath, setIsLoadingSubtreePath] = useState<boolean>(!!conceptSubtree);
@@ -48,25 +47,9 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
         }
     }, [conceptSubtree]);
 
-    const showPickerModal = useCallback(()=>{
-        setShowPicker(true);
-    },[showPickerListener])
-
-    useEffect(() => {
-        const helper = () => {
-            return showPickerModal;
-        };
-        if (showPickerListener !== undefined)
-            showPickerListener(helper);
-
-        return () => {
-            showPickerListener?.(null);
-        };
-    }, [showPickerListener]);
-
     const togglePicker = useCallback(() => {
         setShowPicker(!showPicker);
-    }, [showPicker, setShowPicker]);
+    }, [showPicker]);
 
     const onApplyConcept = useCallback(
         (selectedPath: PathModel, selectedConcept: ConceptModel) => {
@@ -74,7 +57,7 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
             setShowPicker(false);
             onConceptSelection(selectedConcept);
         },
-        [setConcept, setShowPicker, onConceptSelection]
+        [onConceptSelection]
     );
 
     const label = concept?.label ?? null;

--- a/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptPicker.tsx
@@ -12,10 +12,11 @@ interface Props {
     fieldLabel: string;
     fieldValue?: string;
     onConceptSelection: (concept: ConceptModel) => void;
+    showPickerListener?: (val:() => void) => void;
 }
 
 export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
-    const { ontologyId, conceptSubtree, fieldLabel, onConceptSelection, fieldValue = '' } = props;
+    const { ontologyId, conceptSubtree, fieldLabel, onConceptSelection, fieldValue = '', showPickerListener } = props;
     const [concept, setConcept] = useState<ConceptModel>();
     const [subtreePath, setSubtreePath] = useState<PathModel>();
     const [isLoadingSubtreePath, setIsLoadingSubtreePath] = useState<boolean>(!!conceptSubtree);
@@ -46,6 +47,22 @@ export const OntologyConceptPicker: FC<Props> = memo((props: Props) => {
                 });
         }
     }, [conceptSubtree]);
+
+    const showPickerModal = useCallback(()=>{
+        setShowPicker(true);
+    },[showPickerListener])
+
+    useEffect(() => {
+        const helper = () => {
+            return showPickerModal;
+        };
+        if (showPickerListener !== undefined)
+            showPickerListener(helper);
+
+        return () => {
+            showPickerListener?.(null);
+        };
+    }, [showPickerListener]);
 
     const togglePicker = useCallback(() => {
         setShowPicker(!showPicker);

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { Alert } from '../../..';
+import { Alert, OntologySearchInput } from '../../..';
 
 import {
     getOntologySearchTerm,
@@ -9,6 +9,7 @@ import {
     OntologyTreeSearchContainer,
 } from './OntologyTreeSearchContainer';
 import { ConceptModel, OntologyModel } from './models';
+import { waitForLifecycle } from '../../testHelpers';
 
 const TEST_ONTOLOGY = new OntologyModel({
     abbreviation: 't',
@@ -31,14 +32,15 @@ const TEST_SEARCH_HITS = [
 ];
 
 describe('OntologyTreeSearchContainer', () => {
-    test('default props', () => {
+    test('default props', async () => {
         const wrapper = mount(
             <OntologyTreeSearchContainer ontology={TEST_ONTOLOGY} searchPathClickHandler={jest.fn} />
         );
         expect(wrapper.find('.concept-search-container')).toHaveLength(1);
         expect(wrapper.find('input')).toHaveLength(1);
         expect(wrapper.find('input').prop('placeholder')).toBe('Search t');
-        expect(wrapper.find(OntologySearchResultsMenu)).toHaveLength(1);
+        expect(wrapper.find(OntologySearchResultsMenu)).toHaveLength(0); // No initial search term, so no result element expected
+
         wrapper.unmount();
     });
 });
@@ -136,6 +138,7 @@ describe('OntologySearchResultsMenu', () => {
 describe('getOntologySearchTerm', () => {
     test('validate', () => {
         const ont = new OntologyModel({ abbreviation: 'abbr' });
-        expect(getOntologySearchTerm(ont, 'test')).toBe('+ontology:abbr AND test');
+        expect(getOntologySearchTerm(ont, 'test')).toBe('+ontology:abbr AND ("test" OR test)');
+        expect(getOntologySearchTerm(ont, 'test 123')).toBe('+ontology:abbr AND ("test 123" OR test 123)');
     });
 });

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { Alert, OntologySearchInput } from '../../..';
+import { Alert } from '../base/Alert';
 
 import {
     getOntologySearchTerm,
@@ -9,7 +9,6 @@ import {
     OntologyTreeSearchContainer,
 } from './OntologyTreeSearchContainer';
 import { ConceptModel, OntologyModel } from './models';
-import { waitForLifecycle } from '../../testHelpers';
 
 const TEST_ONTOLOGY = new OntologyModel({
     abbreviation: 't',

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -8,54 +8,6 @@ import { fetchAlternatePaths, getOntologyDetails } from './actions';
 const CONCEPT_CATEGORY = 'concept';
 const SEARCH_LIMIT = 20;
 
-interface OntologySearchInputProps extends Omit<OntologyTreeSearchContainerProps, 'ontology' | 'searchPathClickHandler' | 'onChangeListener'> {
-    ontologyId: string;
-    searchPathChangeHandler: (code: string) => void;
-}
-
-export const OntologySearchInput: FC<OntologySearchInputProps> = memo(props => {
-    const {ontologyId, searchPathChangeHandler, ...rest} = props;
-    const [ontologyModel, setOntologyModel] = useState<OntologyModel>();
-    const [error, setError] = useState<string>();
-
-    useEffect(() => {
-        if (ontologyId) {
-            getOntologyDetails(ontologyId)
-                .then((ontology: OntologyModel) => {
-                    setOntologyModel(ontology);
-                })
-                .catch(() => {
-                    setError('Error: unable to load ontology concept information for ' + ontologyId + '.');
-                });
-        } else {
-            setOntologyModel(undefined);
-        }
-    }, [ontologyId]);
-
-    const onSearchClickHandler = useCallback((path: PathModel) => {
-        searchPathChangeHandler(path.code)
-    }, [searchPathChangeHandler]);
-
-    const onChangeHandler = useCallback(
-        val => {
-            searchPathChangeHandler(val);
-        },
-        [searchPathChangeHandler]
-    );
-
-    return (
-        <>
-            <Alert>{error}</Alert>
-            {ontologyModel && <OntologyTreeSearchContainer
-                {...rest}
-                ontology={ontologyModel}
-                searchPathClickHandler={onSearchClickHandler}
-                onChangeListener={onChangeHandler}
-            />}
-        </>
-    );
-});
-
 interface OntologyTreeSearchContainerProps {
     ontology: OntologyModel;
     inputName?: string;
@@ -167,18 +119,18 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
 
     return (
         <div className="concept-search-container">
-                <input
-                    type="text"
-                    className={className}
-                    name={inputName}
-                    placeholder={'Search ' + ontology.abbreviation}
-                    onChange={onSearchChange}
-                    onFocus={onSearchFocus}
-                    onBlur={onSearchBlur}
-                    onKeyUp={keyHandler}
-                    value={searchTerm}
-                />
-            {showResults &&
+            <input
+                type="text"
+                className={className}
+                name={inputName}
+                placeholder={'Search ' + ontology.abbreviation}
+                onChange={onSearchChange}
+                onFocus={onSearchFocus}
+                onBlur={onSearchBlur}
+                onKeyUp={keyHandler}
+                value={searchTerm}
+            />
+            {showResults && (
                 <OntologySearchResultsMenu
                     searchHits={searchHits}
                     totalHits={totalHits}
@@ -186,7 +138,7 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
                     error={error}
                     onItemClick={onItemClick}
                 />
-            }
+            )}
         </div>
     );
 });
@@ -201,15 +153,15 @@ interface OntologySearchResultsMenuProps {
 
 // exported for jest testing
 export const OntologySearchResultsMenu: FC<OntologySearchResultsMenuProps> = memo(props => {
-    const { searchHits, isFocused, totalHits, error, onItemClick, } = props;
-    const showMenu = useMemo(() => isFocused && (searchHits !== undefined || error !== undefined), [
-        isFocused,
-        searchHits,
-        error,
-    ]);
-    const hitsHaveDescriptions = useMemo(() => searchHits?.findIndex(hit => hit.description !== undefined) > -1, [
-        searchHits,
-    ]);
+    const { searchHits, isFocused, totalHits, error, onItemClick } = props;
+    const showMenu = useMemo(
+        () => isFocused && (searchHits !== undefined || error !== undefined),
+        [isFocused, searchHits, error]
+    );
+    const hitsHaveDescriptions = useMemo(
+        () => searchHits?.findIndex(hit => hit.description !== undefined) > -1,
+        [searchHits]
+    );
 
     if (!showMenu) {
         return null;
@@ -250,6 +202,58 @@ export const OntologySearchResultsMenu: FC<OntologySearchResultsMenuProps> = mem
                 )}
             </ul>
         </div>
+    );
+});
+
+interface OntologySearchInputProps
+    extends Omit<OntologyTreeSearchContainerProps, 'ontology' | 'searchPathClickHandler' | 'onChangeListener'> {
+    ontologyId: string;
+    searchPathChangeHandler: (code: string) => void;
+}
+
+export const OntologySearchInput: FC<OntologySearchInputProps> = memo(props => {
+    const { ontologyId, searchPathChangeHandler, ...rest } = props;
+    const [ontologyModel, setOntologyModel] = useState<OntologyModel>();
+    const [error, setError] = useState<string>();
+
+    useEffect(() => {
+        if (ontologyId) {
+            getOntologyDetails(ontologyId)
+                .then((ontology: OntologyModel) => {
+                    setOntologyModel(ontology);
+                })
+                .catch(() => {
+                    setError('Error: unable to load ontology concept information for ' + ontologyId + '.');
+                });
+        }
+    }, [ontologyId]);
+
+    const onSearchClickHandler = useCallback(
+        (path: PathModel) => {
+            searchPathChangeHandler(path.code);
+        },
+        [searchPathChangeHandler]
+    );
+
+    const onChangeHandler = useCallback(
+        val => {
+            searchPathChangeHandler(val);
+        },
+        [searchPathChangeHandler]
+    );
+
+    return (
+        <>
+            <Alert>{error}</Alert>
+            {ontologyModel && (
+                <OntologyTreeSearchContainer
+                    {...rest}
+                    ontology={ontologyModel}
+                    searchPathClickHandler={onSearchClickHandler}
+                    onChangeListener={onChangeHandler}
+                />
+            )}
+        </>
     );
 });
 

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -33,10 +33,6 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
     const [error, setError] = useState<string>();
     const [showResults, setShowResults] = useState<boolean>(false);
 
-    useEffect(() => {
-        setSearchTerm(initCode);
-    }, [initCode]);
-
     const onSearchChange = useCallback(
         (evt: ChangeEvent<HTMLInputElement>) => {
             const { value } = evt.currentTarget;

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -1,9 +1,11 @@
 import React, { ChangeEvent, FC, memo, MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { Alert } from '../base/Alert';
+
+import { searchUsingIndex } from '../search/actions';
+
 import { ConceptModel, OntologyModel, PathModel } from './models';
 import { fetchAlternatePaths, getOntologyDetails } from './actions';
-import { Alert } from '../base/Alert';
-import { searchUsingIndex } from '../search/actions';
 
 const CONCEPT_CATEGORY = 'concept';
 const SEARCH_LIMIT = 20;
@@ -255,5 +257,6 @@ export const OntologySearchInput: FC<OntologySearchInputProps> = memo(props => {
 
 // exported for jest testing
 export function getOntologySearchTerm(ontology: OntologyModel, searchTerm: string): string {
-    return `+ontology:${ontology.abbreviation} AND ${searchTerm}`;
+    // Quotes are needed to escape the ':' and the open term allows more flexible search of multi-token terms, e.g. ABC T
+    return `+ontology:${ontology.abbreviation} AND ("${searchTerm}" OR ${searchTerm})`;
 }

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -1,9 +1,9 @@
-import React, { ChangeEvent, FC, memo, MouseEvent, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-
-import { Alert, searchUsingIndex } from '../../..';
+import React, { ChangeEvent, FC, memo, MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ConceptModel, OntologyModel, PathModel } from './models';
 import { fetchAlternatePaths, getOntologyDetails } from './actions';
+import { Alert } from '../base/Alert';
+import { searchUsingIndex } from '../search/actions';
 
 const CONCEPT_CATEGORY = 'concept';
 const SEARCH_LIMIT = 20;
@@ -89,8 +89,8 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
 
     const onItemClick = useCallback(
         async (evt: MouseEvent<HTMLLIElement>, code: string) => {
-            // for now we will just send the user to the first path for this concept, in the future we'll add in UI
-            // that lets the user select if more then one path exists for the concept
+            // for now, we will just send the user to the first path for this concept, in the future we'll add in UI
+            // that lets the user select if more than one path exists for the concept
             const codePaths = await fetchAlternatePaths(code);
             if (codePaths?.length > 0) {
                 searchPathClickHandler(codePaths[0], true);
@@ -255,5 +255,5 @@ export const OntologySearchInput: FC<OntologySearchInputProps> = memo(props => {
 
 // exported for jest testing
 export function getOntologySearchTerm(ontology: OntologyModel, searchTerm: string): string {
-    return '+ontology:' + ontology.abbreviation + ' AND ' + searchTerm;
+    return `+ontology:${ontology.abbreviation} AND ${searchTerm}`;
 }

--- a/packages/components/src/theme/ontologybrowser.scss
+++ b/packages/components/src/theme/ontologybrowser.scss
@@ -61,70 +61,70 @@
         height: 65vh;
     }
 
-    .concept-search-container {
-        padding-bottom: 30px;
-
-        input {
-            max-width: 450px;
-        }
-
-        .result-menu {
-            margin: 0;
-            padding: 0;
-            z-index: 1000;
-            position: absolute;
-            list-style: none;
-            background-color: $white;
-            border: 1px solid $gray-border;
-            box-shadow: 0 2px 2px 0 rgba(0,0,0,0.12);
-
-            max-height: 500px;
-            overflow-y: scroll;
-            min-width: 450px;
-            max-width: 800px;
-            width: 65vw;
-
-            li.selectable-item {
-                cursor: pointer;
-                &:hover {
-                    background-color: $gray-lighter;
-                }
-            }
-
-            li .row {
-                margin: 0;
-                border-bottom: 1px solid $gray-border;
-                display: flex;
-
-                .col {
-                    color: $gray-light;
-                    padding: 10px;
-                    border-right: 1px solid $gray-border;
-                    display: flex;
-                }
-
-                .bold {
-                    font-weight: bold;
-                }
-            }
-
-            li:last-child .row {
-                border-bottom: none;
-            }
-            li .row .col:last-child {
-                border-right: none;
-            }
-
-            .result-footer {
-                color: $gray-light;
-                font-size: 12px;
-                padding: 10px;
-            }
-        }
-    }
-
     .title {
         font-weight: bold;
+    }
+}
+
+.concept-search-container {
+    padding-bottom: 30px;
+
+    input {
+        max-width: 450px;
+    }
+
+    .result-menu {
+        margin: 0;
+        padding: 0;
+        z-index: 1000;
+        position: absolute;
+        list-style: none;
+        background-color: $white;
+        border: 1px solid $gray-border;
+        box-shadow: 0 2px 2px 0 rgba(0,0,0,0.12);
+
+        max-height: 500px;
+        overflow-y: scroll;
+        min-width: 450px;
+        max-width: 800px;
+        width: 65vw;
+
+        li.selectable-item {
+            cursor: pointer;
+            &:hover {
+                background-color: $gray-lighter;
+            }
+        }
+
+        li .row {
+            margin: 0;
+            border-bottom: 1px solid $gray-border;
+            display: flex;
+
+            .col {
+                color: $gray-light;
+                padding: 10px;
+                border-right: 1px solid $gray-border;
+                display: flex;
+            }
+
+            .bold {
+                font-weight: bold;
+            }
+        }
+
+        li:last-child .row {
+            border-bottom: none;
+        }
+        li .row .col:last-child {
+            border-right: none;
+        }
+
+        .result-footer {
+            color: $gray-light;
+            font-size: 12px;
+            padding: 10px;
+        }
     }
 }
 


### PR DESCRIPTION
#### Rationale
https://docs.google.com/document/d/1wdFrfVEUJMEKVQQTC3e2zB8MWUMVzLDfdflD55rLr3c/edit#
Use the Concept Picker's search element within the insert/update forms

#### Related Pull Requests
* https://github.com/LabKey/ontology/pull/73

#### Changes
* Split out and export a new ConceptSearchInput component
* Refactor ontology search elements accordingly
