### PR TITLE
Core components page update to use QueryModel based EditableGridPanel

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.133.0",
+  "version": "2.133.0-fb-coreComponentsEditableGrid.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.133.0-fb-coreComponentsEditableGrid.0",
+  "version": "2.134.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.131.0-fb-coreComponentsEditableGrid.1",
+  "version": "2.131.0-fb-coreComponentsEditableGrid.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.131.0-fb-coreComponentsEditableGrid.0",
+  "version": "2.131.0-fb-coreComponentsEditableGrid.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.131.0",
+  "version": "2.131.0-fb-coreComponentsEditableGrid.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,9 +3,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* ...
-  * factor loadEditorModelData() out of AssayWizardModel.ts
-  * export EditableGridPanel and loadEditorModelData from index.ts
+* Core components page update to use QueryModel based EditableGridPanel
+  * factor loadEditorModelData() out of AssayWizardModel.ts to editable/utils.ts
+  * export EditableGridPanel, loadEditorModelData, and EditorModelProps from index.ts
+  * AssayImportPanels.tsx fix for undefined location prop in core-components case
 
 ### version 2.131.0
 *Released*: 8 February 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.134.0
+*Released*: 21 February 2022
 * Core components page update to use QueryModel based EditableGridPanel
   * factor loadEditorModelData() out of AssayWizardModel.ts to editable/utils.ts
   * export EditableGridPanel, loadEditorModelData, and EditorModelProps from index.ts

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* ...
+  * factor loadEditorModelData() out of AssayWizardModel.ts
+  * export EditableGridPanel and loadEditorModelData from index.ts
+
 ### version 2.131.0
 *Released*: 8 February 2022
 * Issue 44711: Field editor update to show confirm modal on change of data type for saved field

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -210,6 +210,8 @@ import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/u
 import { getHelpLink, HELP_LINK_REFERRER, HelpLink, SAMPLE_ALIQUOT_TOPIC } from './internal/util/helpLinks';
 import { AssayResolver, AssayRunResolver, ListResolver, SamplesResolver } from './internal/url/AppURLResolver';
 import { QueryGridPanel } from './internal/components/QueryGridPanel';
+import { loadEditorModelData } from './internal/components/editable/utils';
+import { EditableGridPanel } from './internal/components/editable/EditableGridPanel';
 import { EditableGridPanelDeprecated } from './internal/components/editable/EditableGridPanelDeprecated';
 import { EditableGridPanelForUpdate } from './internal/components/editable/EditableGridPanelForUpdate';
 import { EditableGridLoader } from './internal/components/editable/EditableGridLoader';
@@ -821,9 +823,11 @@ export {
     invalidateQueryDetailsCache,
     invalidateQueryDetailsCacheKey,
     // editable grid related items
+    loadEditorModelData,
     MAX_EDITABLE_GRID_ROWS,
     EditableGridLoaderFromSelection,
     EditableGridLoader,
+    EditableGridPanel,
     EditableGridPanelDeprecated,
     EditableGridPanelForUpdate,
     EditableGridModal,
@@ -1410,7 +1414,7 @@ export type { MessageFunction, NotificationItemProps } from './internal/componen
 export type { VisGraphNode } from './internal/components/lineage/vis/VisGraphGenerator';
 export type { ITab } from './internal/components/navigation/SubNav';
 export type { NotificationCreatable } from './internal/components/notifications/actions';
-export type { IDataViewInfo } from './internal/models';
+export type { IDataViewInfo, EditorModelProps } from './internal/models';
 export type { HeatMapCell } from './internal/components/heatmap/HeatMap';
 export type { InjectedAssayModel, WithAssayModelProps } from './internal/components/assay/withAssayModels';
 export type { SearchResultCardData } from './internal/components/search/models';

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -221,7 +221,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
         const { schemaQuery } = this.state;
         let workflowTask;
 
-        if (location.query?.workflowTaskId) {
+        if (location?.query?.workflowTaskId) {
             const _workflowTask = parseInt(location.query?.workflowTaskId, 10);
             workflowTask = isNaN(_workflowTask) ? undefined : _workflowTask;
         }
@@ -514,8 +514,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
                     const backgroundUpload = assayProtocol?.backgroundUpload;
                     let forceAsync = false;
                     if (!backgroundUpload && assayProtocol?.allowBackgroundUpload) {
-                        const asyncFileSize = location.query?.useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_FILE_SIZE;
-                        const asyncRowSize = location.query?.useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_ROW_SIZE;
+                        const asyncFileSize = location?.query?.useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_FILE_SIZE;
+                        const asyncRowSize = location?.query?.useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_ROW_SIZE;
                         if (
                             (processedData.maxFileSize && processedData.maxFileSize >= asyncFileSize) ||
                             (processedData.maxRowCount && processedData.maxRowCount >= asyncRowSize)

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -477,15 +477,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
     };
 
     onFinish = (importAgain: boolean): void => {
-        const {
-            currentStep,
-            onSave,
-            maxRows,
-            beforeFinish,
-            jobNotificationProvider,
-            assayProtocol,
-            location,
-        } = this.props;
+        const { currentStep, onSave, maxRows, beforeFinish, jobNotificationProvider, assayProtocol, location } =
+            this.props;
         const { model } = this.state;
         let data = model.prepareFormData(currentStep, this.state.editorModel, this.state.dataModel);
 
@@ -514,7 +507,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
                     const backgroundUpload = assayProtocol?.backgroundUpload;
                     let forceAsync = false;
                     if (!backgroundUpload && assayProtocol?.allowBackgroundUpload) {
-                        const asyncFileSize = location?.query?.useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_FILE_SIZE;
+                        const asyncFileSize =
+                            location?.query?.useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_FILE_SIZE;
                         const asyncRowSize = location?.query?.useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_ROW_SIZE;
                         if (
                             (processedData.maxFileSize && processedData.maxFileSize >= asyncFileSize) ||

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -13,7 +13,7 @@ import {
 } from '../../..';
 import { AssayUploadTabs } from '../../constants';
 import { generateNameWithTimestamp } from '../../util/Date';
-import { loadEditorModelData } from "../editable/utils";
+import { loadEditorModelData } from '../editable/utils';
 
 // exported for jest testing
 export function parseDataTextToRunRows(rawData: string): any[] {
@@ -235,7 +235,7 @@ export class AssayWizardModel
         return assayData;
     }
 
-    getInitialQueryModelData(): { rows: { [key: string]: any }; orderedRows: string[], queryInfo: QueryInfo } {
+    getInitialQueryModelData(): { rows: { [key: string]: any }; orderedRows: string[]; queryInfo: QueryInfo } {
         const { assayDef, selectedSamples } = this;
         const sampleColumnData = assayDef.getSampleColumn();
         const sampleColInResults = sampleColumnData && sampleColumnData.domain === AssayDomainTypes.RESULT;

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -1,5 +1,5 @@
-import { fromJS, List, Map, OrderedMap, Record, Set } from 'immutable';
-import { AssayDOM, Utils } from '@labkey/api';
+import { fromJS, List, Map, OrderedMap, Record } from 'immutable';
+import { AssayDOM } from '@labkey/api';
 
 import {
     AppURL,
@@ -11,10 +11,9 @@ import {
     QueryInfo,
     QueryModel,
 } from '../../..';
-import { genCellKey, getLookupDisplayValue, getLookupValueDescriptors } from '../../actions';
 import { AssayUploadTabs } from '../../constants';
-import { ValueDescriptor } from '../../models';
 import { generateNameWithTimestamp } from '../../util/Date';
+import { loadEditorModelData } from "../editable/utils";
 
 // exported for jest testing
 export function parseDataTextToRunRows(rawData: string): any[] {
@@ -236,68 +235,14 @@ export class AssayWizardModel
         return assayData;
     }
 
-    getInitialQueryModelData(): { rows: { [key: string]: any }; orderedRows: string[] } {
+    getInitialQueryModelData(): { rows: { [key: string]: any }; orderedRows: string[], queryInfo: QueryInfo } {
         const { assayDef, selectedSamples } = this;
         const sampleColumnData = assayDef.getSampleColumn();
         const sampleColInResults = sampleColumnData && sampleColumnData.domain === AssayDomainTypes.RESULT;
         const hasSamples = sampleColInResults && selectedSamples;
         // We only care about passing samples to the data grid if there is a sample column in the results domain.
         const rows = hasSamples ? selectedSamples.toJS() : {};
-        return { rows, orderedRows: Object.keys(rows) };
-    }
-
-    // TODO: this method is essentially a duplicate of loadDataForEditor. We should probably make a version that can be
-    //  shared because we're going to need this outside of Assays when we convert more usages of
-    //  EditableGridPanelDeprecated
-    async getInitialEditorModelData(queryModelData: Partial<QueryModel>): Promise<Partial<EditorModel>> {
-        const { orderedRows, rows } = queryModelData;
-        const columns = this.queryInfo.getInsertColumns();
-        const lookupValueDescriptors = await getLookupValueDescriptors(
-            columns.toArray(),
-            fromJS(rows),
-            fromJS(orderedRows)
-        );
-        let cellValues = Map<string, List<ValueDescriptor>>();
-
-        // data is initialized in column order
-        columns.forEach((col, cn) => {
-            orderedRows.forEach((id, rn) => {
-                const row = rows[id];
-                const cellKey = genCellKey(cn, rn);
-                const value = row[col.fieldKey];
-
-                if (Array.isArray(value)) {
-                    // assume to be list of {displayValue, value} objects
-                    cellValues = cellValues.set(
-                        cellKey,
-                        value.reduce(
-                            (list, v) => list.push({ display: v.displayValue, raw: v.value }),
-                            List<ValueDescriptor>()
-                        )
-                    );
-                } else {
-                    let cellValue = List([{ display: value, raw: value }]);
-
-                    // Issue 37833: try resolving the value for the lookup to get the displayValue to show in the grid
-                    // cell
-                    if (col.isLookup() && Utils.isNumber(value)) {
-                        const descriptors = lookupValueDescriptors[col.lookupKey];
-                        if (descriptors) {
-                            cellValue = List(descriptors.filter(descriptor => descriptor.raw === value));
-                        }
-                    }
-
-                    cellValues = cellValues.set(cellKey, cellValue);
-                }
-            });
-        });
-
-        return {
-            cellValues,
-            colCount: columns.size,
-            deletedIds: Set<any>(),
-            rowCount: orderedRows.length,
-        };
+        return { rows, orderedRows: Object.keys(rows), queryInfo: this.queryInfo };
     }
 
     /**
@@ -306,7 +251,7 @@ export class AssayWizardModel
      */
     async getInitialGridData(): Promise<{ editorModel: Partial<EditorModel>; queryModel: Partial<QueryModel> }> {
         const queryModelData = this.getInitialQueryModelData();
-        const editorModelData = await this.getInitialEditorModelData(queryModelData);
+        const editorModelData = await loadEditorModelData(queryModelData);
         return { editorModel: editorModelData, queryModel: queryModelData };
     }
 }

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -16,6 +16,13 @@ interface Props extends SharedEditableGridProps {
     title?: string;
 }
 
+/**
+ * Note that there are some cases which will call the onChange callback prop back to back (i.e. see LookupCell.onInputChange)
+ * and pass through different sets of `editorModelChanges`. In that case, you will want to make sure that your onChange
+ * handler is getting the current state object before merging in the `editorModelChanges`. See example in platform/core
+ * (core/src/client/LabKeyUIComponentsPage/EditableGridPage.tsx) which uses the set state function which takes a function
+ * as the first parameter instead of the new state object.
+ */
 export const EditableGridPanel: FC<Props> = memo(props => {
     const { editorModel, model, onChange, title, ...gridProps } = props;
 

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -1,5 +1,6 @@
 import { fromJS, List, Map } from 'immutable';
 import React, { FC, memo, useMemo } from 'react';
+
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { EditorModel, EditorModelProps } from '../../models';
 

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -1,9 +1,9 @@
-import {fromJS, List, Map, Set} from "immutable";
-import {Utils} from "@labkey/api";
+import { fromJS, List, Map, Set } from 'immutable';
+import { Utils } from '@labkey/api';
 
-import {QueryModel} from "../../../public/QueryModel/QueryModel";
-import {EditorModel, ValueDescriptor} from "../../models";
-import {genCellKey, getLookupValueDescriptors} from "../../actions";
+import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { EditorModel, ValueDescriptor } from '../../models';
+import { genCellKey, getLookupValueDescriptors } from '../../actions';
 
 export const loadEditorModelData = async (queryModelData: Partial<QueryModel>): Promise<Partial<EditorModel>> => {
     const { orderedRows, rows, queryInfo } = queryModelData;
@@ -35,10 +35,12 @@ export const loadEditorModelData = async (queryModelData: Partial<QueryModel>): 
                 // assume to be a {displayValue, value} object
                 const raw = value?.value;
                 const display = value?.displayValue ?? raw;
-                let cellValue = List([{
-                    display: display !== null ? display : undefined,
-                    raw: raw !== null ? raw : undefined
-                }]);
+                let cellValue = List([
+                    {
+                        display: display !== null ? display : undefined,
+                        raw: raw !== null ? raw : undefined,
+                    },
+                ]);
 
                 // Issue 37833: try resolving the value for the lookup to get the displayValue to show in the grid cell
                 if (col.isLookup() && Utils.isNumber(raw)) {
@@ -59,4 +61,4 @@ export const loadEditorModelData = async (queryModelData: Partial<QueryModel>): 
         deletedIds: Set<any>(),
         rowCount: orderedRows.length,
     };
-}
+};

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -7,7 +7,7 @@ import {genCellKey, getLookupValueDescriptors} from "../../actions";
 
 export const loadEditorModelData = async (queryModelData: Partial<QueryModel>): Promise<Partial<EditorModel>> => {
     const { orderedRows, rows, queryInfo } = queryModelData;
-    const columns = queryInfo.getInsertColumns(); // TODO see inclusion of model.requiredColumns in loadDataForEditor
+    const columns = queryInfo.getInsertColumns();
     const lookupValueDescriptors = await getLookupValueDescriptors(
         columns.toArray(),
         fromJS(rows),

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -1,0 +1,62 @@
+import {fromJS, List, Map, Set} from "immutable";
+import {Utils} from "@labkey/api";
+
+import {QueryModel} from "../../../public/QueryModel/QueryModel";
+import {EditorModel, ValueDescriptor} from "../../models";
+import {genCellKey, getLookupValueDescriptors} from "../../actions";
+
+export const loadEditorModelData = async (queryModelData: Partial<QueryModel>): Promise<Partial<EditorModel>> => {
+    const { orderedRows, rows, queryInfo } = queryModelData;
+    const columns = queryInfo.getInsertColumns(); // TODO see inclusion of model.requiredColumns in loadDataForEditor
+    const lookupValueDescriptors = await getLookupValueDescriptors(
+        columns.toArray(),
+        fromJS(rows),
+        fromJS(orderedRows)
+    );
+    let cellValues = Map<string, List<ValueDescriptor>>();
+
+    // data is initialized in column order
+    columns.forEach((col, cn) => {
+        orderedRows.forEach((id, rn) => {
+            const row = rows[id];
+            const cellKey = genCellKey(cn, rn);
+            const value = row[col.fieldKey];
+
+            if (Array.isArray(value)) {
+                // assume to be list of {displayValue, value} objects
+                cellValues = cellValues.set(
+                    cellKey,
+                    value.reduce(
+                        (list, v) => list.push({ display: v.displayValue, raw: v.value }),
+                        List<ValueDescriptor>()
+                    )
+                );
+            } else {
+                // assume to be a {displayValue, value} object
+                const raw = value.value;
+                const display = value.displayValue ?? raw;
+                let cellValue = List([{
+                    display: display !== null ? display : undefined,
+                    raw: raw !== null ? raw : undefined
+                }]);
+
+                // Issue 37833: try resolving the value for the lookup to get the displayValue to show in the grid cell
+                if (col.isLookup() && Utils.isNumber(raw)) {
+                    const descriptors = lookupValueDescriptors[col.lookupKey];
+                    if (descriptors) {
+                        cellValue = List(descriptors.filter(descriptor => descriptor.raw === raw));
+                    }
+                }
+
+                cellValues = cellValues.set(cellKey, cellValue);
+            }
+        });
+    });
+
+    return {
+        cellValues,
+        colCount: columns.size,
+        deletedIds: Set<any>(),
+        rowCount: orderedRows.length,
+    };
+}

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -33,8 +33,8 @@ export const loadEditorModelData = async (queryModelData: Partial<QueryModel>): 
                 );
             } else {
                 // assume to be a {displayValue, value} object
-                const raw = value.value;
-                const display = value.displayValue ?? raw;
+                const raw = value?.value;
+                const display = value?.displayValue ?? raw;
                 let cellValue = List([{
                     display: display !== null ? display : undefined,
                     raw: raw !== null ? raw : undefined


### PR DESCRIPTION
#### Rationale
Alan completed the work in Jan for the QueryModel based EditableGridPanel component and converted over the usage in AssayImportPanels.tsx. This PR supports the conversion of another usage from the core-components.view.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/736
* https://github.com/LabKey/sampleManagement/pull/837
* https://github.com/LabKey/biologics/pull/1155
* https://github.com/LabKey/inventory/pull/381
* https://github.com/LabKey/platform/pull/3044
* https://github.com/LabKey/testAutomation/pull/1009

#### Changes
* factor loadEditorModelData() out of AssayWizardModel.ts to editable/utils.ts
* export EditableGridPanel, loadEditorModelData, and EditorModelProps from index.ts
* AssayImportPanels.tsx fix for undefined location prop in core-components case
