### PR TITLE
Migrate subfolder data experimental flag to platform

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.3",
+  "version": "2.132.3-fb-subfolder-flag.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.3-fb-subfolder-flag.3",
+  "version": "2.132.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.3-fb-subfolder-flag.1",
+  "version": "2.132.3-fb-subfolder-flag.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.3-fb-subfolder-flag.2",
+  "version": "2.132.3-fb-subfolder-flag.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.3-fb-subfolder-flag.0",
+  "version": "2.132.3-fb-subfolder-flag.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.132.#
+*Released*: ## February 2022
+* Migrate subfolder data experimental flag to platform.
+
 ### version 2.132.3
 *Released*: 17 February 2022
 * Update to package to eliminate alpha version reference from node_modules

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.132.#
-*Released*: ## February 2022
+### version 2.132.4
+*Released*: 19 February 2022
 * Migrate subfolder data experimental flag to platform.
 
 ### version 2.132.3

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -157,7 +157,7 @@ export function isProductNavigationEnabled(productId: string): boolean {
 }
 
 export function isSubfolderDataEnabled(): boolean {
-    return getServerContext().moduleContext?.biologics?.isSubfolderDataEnabled === true;
+    return getServerContext().moduleContext?.query?.isSubfolderDataEnabled === true;
 }
 
 export function isSampleManagerEnabled(moduleContext?: any): boolean {


### PR DESCRIPTION
#### Rationale
Migrates the subfolder data experimental flag from LKB module to platform for use in other modules / packages.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3068
* https://github.com/LabKey/biologics/pull/1162
* https://github.com/LabKey/labkey-ui-components/pull/741

#### Changes
* Switch module context check from `biologics` to `query` module for subfolder data bit.
