### PR TITLE
EHR URL Mappers

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.136.0-fb-ehr-sm-module.0",
+  "version": "2.136.0-fb-ehr-sm-module.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.3-fb-ehr-sm-module.0",
+  "version": "2.136.0-fb-ehr-sm-module.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.132.3",
+  "version": "2.132.3-fb-ehr-sm-module.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.136.0-fb-ehr-sm-module.2",
+  "version": "2.136.0-fb-ehr-sm-module.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -445,6 +445,14 @@ const EHR_MAPPERS = [
                 return false;
         }
     }),
+    new ActionMapper('query', 'detailsQueryRow', row => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
+            if (params.schemaName === 'ehr' || params.schemaName === 'ehr_lookups')
+                return false;
+        }
+    }),
     new ActionMapper('ehr', 'participantView', () => false),
 ];
 

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -445,14 +445,6 @@ const EHR_MAPPERS = [
                 return false;
         }
     }),
-    new ActionMapper('query', 'detailsQueryRow', row => {
-        const url = row.get('url');
-        if (url) {
-            const params = ActionURL.getParameters(url);
-            if (params.schemaName === 'ehr' || params.schemaName === 'ehr_lookups')
-                return false;
-        }
-    }),
     new ActionMapper('ehr', 'participantView', () => false),
 ];
 

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -436,6 +436,18 @@ const USER_DETAILS_MAPPERS = [
     new ActionMapper('user', 'attachmentDownload', () => false),
 ];
 
+const EHR_MAPPERS = [
+    new ActionMapper('query', 'detailsQueryRow', row => {
+        const url = row.get('url');
+        if (url) {
+            const params = ActionURL.getParameters(url);
+            if (params.schemaName === 'ehr' || params.schemaName === 'ehr_lookups')
+                return false;
+        }
+    }),
+    new ActionMapper('ehr', 'participantView', () => false),
+];
+
 const DOWNLOAD_FILE_LINK_MAPPER = new ActionMapper('core', 'downloadFileLink', () => false);
 
 const AUDIT_DETAILS_MAPPER = new ActionMapper('audit', 'detailedAuditChanges', () => false);
@@ -501,6 +513,7 @@ export const URL_MAPPERS = {
     SAMPLE_TYPE_MAPPERS,
     LIST_MAPPERS,
     PICKLIST_MAPPER,
+    EHR_MAPPERS,
     DETAILS_QUERY_ROW_MAPPER,
     EXECUTE_QUERY_MAPPER,
     USER_DETAILS_MAPPERS,


### PR DESCRIPTION
#### Rationale
Initially for use in EHR SM module, but will be needed else where as we do react forms in EHR. Preserve URLs coming from server.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/850

#### Changes
* Don't override EHR URLs from server
