### PR TITLE
44544: Sample type dataset definitions should be locked similar to assays

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.137.3",
+  "version": "2.137.4-fb-issue-44544.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.137.4
+* Item 44544: Sample type dataset definitions should be locked similar to assays
+  * Generalize IDatasetModel.isFromAssay to isFromLinkedSource to handle both assay and sample type datasets
+
 ### version 2.137.3
 *Released*: 24 February 2022
 * Item 9968: Show FM Freezer List on LKB and LKSM dashboards

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
@@ -538,8 +538,8 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
                     fieldsAdditionalRenderer={this.renderColumnMappingSection}
                     successBsStyle={successBsStyle}
                     domainFormDisplayOptions={{
-                        isDragDisabled: model.isFromAssay(),
-                        hideAddFieldsButton: model.isFromAssay(),
+                        isDragDisabled: model.isFromLinkedSource(),
+                        hideAddFieldsButton: model.isFromLinkedSource(),
                         hideImportData: model.definitionIsShared, // Shared (Dataspace) study does not have permission to import data. See study-importAction.validatePermission
                         retainReservedFields: true, // reserved fields are used for mapping the participant and visit columns.
                     }}

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanelFormElements.tsx
@@ -112,7 +112,7 @@ export class BasicPropertiesFields extends React.PureComponent<BasicPropertiesIn
                     helpTip={this.getHelpTipElement('name')}
                     value={model.name}
                     placeholder="Enter a name for this dataset"
-                    disabled={model.isFromAssay()}
+                    disabled={model.isFromLinkedSource()}
                     onValueChange={onInputChange}
                     showInAdvancedSettings={false}
                     required={true}
@@ -255,7 +255,7 @@ export class DataRowUniquenessContainer extends React.PureComponent<DataRowUniqu
         const domain = model.domain;
         const additionalKeyFields = getAdditionalKeyFields(domain);
         const dataRowSetting = model.getDataRowSetting();
-        const showAdditionalKeyField = dataRowSetting === 2 || model.isFromAssay();
+        const showAdditionalKeyField = dataRowSetting === 2 || model.isFromLinkedSource();
 
         let keyPropertyName = model.keyPropertyName;
         if (model.useTimeKeyField) {
@@ -272,7 +272,7 @@ export class DataRowUniquenessContainer extends React.PureComponent<DataRowUniqu
         const keyPropertyManagedCls =
             showAdditionalKeyField && validKeyField ? 'dataset_data_row_element_show' : 'dataset_data_row_element_hide';
 
-        const managedKeyDisabled = !showAdditionalKeyField || !validKeyField || model.isFromAssay();
+        const managedKeyDisabled = !showAdditionalKeyField || !validKeyField || model.isFromLinkedSource();
 
         return (
             <>
@@ -281,7 +281,7 @@ export class DataRowUniquenessContainer extends React.PureComponent<DataRowUniqu
                 <DataRowUniquenessElements
                     onRadioChange={onRadioChange}
                     dataRowSetting={dataRowSetting}
-                    isFromAssay={model.isFromAssay()}
+                    isFromAssay={model.isFromLinkedSource()}
                 />
 
                 <div className={showAdditionalKeyFieldCls}>
@@ -291,7 +291,7 @@ export class DataRowUniquenessContainer extends React.PureComponent<DataRowUniqu
                         selectOptions={additionalKeyFields.toArray()}
                         onSelectChange={onSelectChange}
                         selectedValue={keyPropertyName}
-                        disabled={!showAdditionalKeyField || model.isFromAssay()}
+                        disabled={!showAdditionalKeyField || model.isFromLinkedSource()}
                         helpTip={this.getHelpTipForAdditionalField()}
                         clearable={false}
                     />

--- a/packages/components/src/internal/components/domainproperties/dataset/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/models.spec.ts
@@ -197,10 +197,10 @@ describe('DatasetModel', () => {
         expect(DatasetModel.create({ name: 'test' }).getDomainKind()).toBe('StudyDatasetVisit');
     });
 
-    test('isFromAssay', () => {
-        expect(DatasetModel.create({ name: 'test' }).isFromAssay()).toBeFalsy();
-        expect(DatasetModel.create({ name: 'test', sourceAssayName: undefined }).isFromAssay()).toBeFalsy();
-        expect(DatasetModel.create({ name: 'test', sourceAssayName: null }).isFromAssay()).toBeFalsy();
-        expect(DatasetModel.create({ name: 'test', sourceAssayName: 'test' }).isFromAssay()).toBeTruthy();
+    test('isFromLinkedSource', () => {
+        expect(DatasetModel.create({ name: 'test' }).isFromLinkedSource()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', sourceName: undefined }).isFromLinkedSource()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', sourceName: null }).isFromLinkedSource()).toBeFalsy();
+        expect(DatasetModel.create({ name: 'test', sourceName: 'test' }).isFromLinkedSource()).toBeTruthy();
     });
 });

--- a/packages/components/src/internal/components/domainproperties/dataset/models.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/models.ts
@@ -53,8 +53,9 @@ export interface IDatasetModel {
     description?: string;
     dataSharing?: string;
     definitionIsShared?: boolean;
-    sourceAssayName?: string;
-    sourceAssayUrl?: string;
+    sourceName?: string;
+    sourceUrl?: string;
+    sourceType?: string;
     useTimeKeyField?: boolean;
 }
 
@@ -79,8 +80,9 @@ export class DatasetModel implements IDatasetModel {
     readonly description?: string;
     readonly dataSharing?: string;
     readonly definitionIsShared?: boolean;
-    readonly sourceAssayName?: string;
-    readonly sourceAssayUrl?: string;
+    readonly sourceName?: string;
+    readonly sourceUrl?: string;
+    readonly sourceType?: string;
     readonly useTimeKeyField?: boolean;
 
     constructor(datasetModel: IDatasetModel) {
@@ -95,8 +97,8 @@ export class DatasetModel implements IDatasetModel {
             const domain = DomainDesign.create(raw.domainDesign);
             let model = new DatasetModel({ ...raw.options, domain });
 
-            // if the dataset is from an assay source, disable/lock the fields
-            if (model.isFromAssay()) {
+            // if the dataset is from a linked source, disable/lock the fields
+            if (model.isFromLinkedSource()) {
                 const newDomain = domain.merge({
                     fields: domain.fields
                         .map((field: DomainField) => {
@@ -186,7 +188,7 @@ export class DatasetModel implements IDatasetModel {
         return this.hasValidProperties() && !this.domain.hasInvalidFields();
     }
 
-    isFromAssay(): boolean {
-        return this.sourceAssayName !== undefined && this.sourceAssayName !== null;
+    isFromLinkedSource(): boolean {
+        return this.sourceName !== undefined && this.sourceName !== null;
     }
 }


### PR DESCRIPTION
#### Rationale
In 21.7 we added the ability to link sample type data to studies. The dataset designer restricts what properties are editable for linked source type datasets (additional key fields, name, etc). However this was only happening for assays and not sample types.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/3098

#### Changes
- generalize `IDatasetMode.isFromAssay` to `isFromLinkedSource`
- store `sourceName`, `sourceUrl`, and `sourceType` in the model
