### PR TITLE
Sample finder polish 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.1-sampleFinderPolishSusan.0",
+  "version": "2.138.1-sampleFinderPolishSusan.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.0",
+  "version": "2.138.1-sampleFinderPolishSusan.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.2-sampleFinderPolishSusan.3",
+  "version": "2.138.2-sampleFinderPolishSusan.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.1-sampleFinderPolishSusan.1",
+  "version": "2.138.1-sampleFinderPolishSusan.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.1-sampleFinderPolishSusan.2",
+  "version": "2.138.1-sampleFinderPolishSusan.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Sample Finder Polishing
   * Add `containerFilter` property to `EntityDataType` model
   * Assure grid is updated after sample actions are taken
+  * Update grid columns to always show parent id columns and add parent type name to column name
 
 ### version 2.138.0
 *Released*: 28 February 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.138.X
+*Released*: TBD
+* Sample Finder Polishing
+  * Add `containerFilter` property to `EntityDataType` model
+  * Assure grid is updated after sample actions are taken
+
 ### version 2.138.0
 *Released*: 28 February 2022
 * Item 10056: Sample Finder v1 - Wire up new lineage filters

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -19,6 +19,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   * Added getLabKeySqlWhere util
   * Added InExpAncestorsOfFilterType and InExpDescendantsOfFilterType
   * Enable non-text fields for EntityFieldFilterModal (Sample Finder)
+  * Add "showing all generations" message
 
 ### version 2.137.3
 *Released*: 24 February 2022

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -431,7 +431,7 @@ export function getEntityTypeOptions(
             queryName: typeListingSchemaQuery.queryName,
             columns: 'LSID,Name,RowId,Folder/Path',
             filterArray,
-            containerFilter: Query.containerFilter.currentPlusProjectAndShared,
+            containerFilter: entityDataType.containerFilter ?? Query.containerFilter.currentPlusProjectAndShared,
         })
             .then(result => {
                 const rows = fromJS(result.models[result.key]);

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AuditBehaviorTypes, Filter, Utils } from '@labkey/api';
+import { AuditBehaviorTypes, Filter, Query, Utils } from '@labkey/api';
 import { List, Map, OrderedMap, Record } from 'immutable';
 
 import { immerable } from 'immer';
@@ -570,6 +570,7 @@ export interface EntityDataType {
     isFromSharedContainer?: boolean; // if the data type is defined in /Shared project
     filterCardHeaderClass?: string; // css class to use for styling the header in the display of cards for Sample Finder
     exprColumnsWithSubSelect?: string[]; // A list of fields that are backed by ExprColumn and the ExprColumn's sql contain sub select clauses
+    containerFilter?: Query.ContainerFilter;
 }
 
 export class OperationConfirmationData {

--- a/packages/components/src/internal/components/search/EntityFieldFilterModal.tsx
+++ b/packages/components/src/internal/components/search/EntityFieldFilterModal.tsx
@@ -265,10 +265,6 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
         return filters;
     }, [dataTypeFilters, activeQuery, activeField, activeFieldKey]);
 
-    // TODO when populating types, adjust container filter to include the proper set of sample types
-    //  (current + project + shared, in most cases).  For LKB, check if we should filter out any of the
-    //  registry data types or the media types.
-
     return (
         <Modal show bsSize="lg" onHide={closeModal}>
             <Modal.Header closeButton>

--- a/packages/components/src/internal/components/search/EntityFieldFilterModal.tsx
+++ b/packages/components/src/internal/components/search/EntityFieldFilterModal.tsx
@@ -29,7 +29,7 @@ interface Props {
     api?: ComponentsAPIWrapper;
     entityDataType: EntityDataType;
     onCancel: () => void;
-    onFind: (schemaName: string, dataTypeFilters: { [key: string]: FieldFilter[] }) => void;
+    onFind: (schemaName: string, dataTypeFilters: { [key: string]: FieldFilter[] }, queryLabels: { [key: string]: string }) => void;
     queryName?: string;
     fieldKey?: string;
     cards?: FilterProps[];
@@ -199,7 +199,7 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
         });
         const filterErrors = getFieldFiltersValidationResult(validDataTypeFilters, queryLabels);
         if (!filterErrors) {
-            onFind(entityDataType.instanceSchemaName, validDataTypeFilters);
+            onFind(entityDataType.instanceSchemaName, validDataTypeFilters, queryLabels);
         } else {
             setFilterError(filterErrors);
             api.query.incrementClientSideMetricCount(metricFeatureArea, 'filterModalError');

--- a/packages/components/src/internal/components/search/FilterCards.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterCards.spec.tsx
@@ -30,6 +30,7 @@ describe('FilterCard', () => {
     test('empty filters', () => {
         const wrapper = mount(
             <FilterCard
+                dataTypeDisplayName="Parent"
                 entityDataType={TestTypeDataType}
                 schemaQuery={SchemaQuery.create('testSample', 'parent')}
                 filterArray={[]}
@@ -42,14 +43,14 @@ describe('FilterCard', () => {
         expect(header.prop('className').indexOf('without-secondary')).toBe(-1);
         expect(header.prop('className')).toContain(TestTypeDataType.filterCardHeaderClass);
         expect(header.find('.secondary-text').text()).toBe(capParentNoun);
-        expect(header.find('.primary-text').text()).toBe('parent');
+        expect(header.find('.primary-text').text()).toBe('Parent');
         expect(header.find('.fa-pencil').exists()).toBeTruthy();
         expect(header.find('.fa-trash').exists()).toBeTruthy();
 
         expect(wrapper.find('.filter-card__empty-content').exists()).toBeFalsy();
         const content = wrapper.find('.filter-card__card-content');
         expect(content.exists()).toBeTruthy();
-        expect(content.text().trim()).toBe('Showing all samples with parent test parents');
+        expect(content.text().trim()).toBe('Showing all samples with Parent test parents');
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/search/FilterCards.tsx
+++ b/packages/components/src/internal/components/search/FilterCards.tsx
@@ -15,7 +15,7 @@ interface FilterEditProps extends FilterProps {
 
 // exported for jest testing
 export const FilterCard: FC<FilterEditProps> = memo(props => {
-    const { entityDataType, filterArray, index, onAdd, onDelete, onEdit, schemaQuery, onFilterValueExpand } = props;
+    const { entityDataType, filterArray, index, onAdd, onDelete, onEdit, schemaQuery, onFilterValueExpand, dataTypeDisplayName } = props;
 
     const _onAdd = useCallback(() => {
         onAdd(entityDataType);
@@ -49,7 +49,7 @@ export const FilterCard: FC<FilterEditProps> = memo(props => {
                 <div className={'filter-card__header ' + entityDataType.filterCardHeaderClass}>
                     <div className="pull-left">
                         <div className="secondary-text">{capitalizeFirstChar(entityDataType.nounAsParentSingular)}</div>
-                        <div className="primary-text">{schemaQuery.queryName}</div>
+                        <div className="primary-text">{dataTypeDisplayName}</div>
                     </div>
                     <div className="pull-right actions">
                         {onEdit && <i className="fa fa-pencil action-icon" onClick={_onEdit} title="Edit filter" />}
@@ -59,11 +59,11 @@ export const FilterCard: FC<FilterEditProps> = memo(props => {
                     </div>
                 </div>
                 <div className="filter-card__card-content">
-                    {!filterArray?.length /* TODO: support finding by parent type without filters*/ && (
+                    {!filterArray?.length && (
                         <>
                             <hr />
                             <div>
-                                Showing all samples with {schemaQuery.queryName}{' '}
+                                Showing all samples with {dataTypeDisplayName}{' '}
                                 {entityDataType.nounAsParentSingular.toLowerCase()}s
                             </div>
                         </>

--- a/packages/components/src/internal/components/search/SampleFinderSection.spec.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.spec.tsx
@@ -49,7 +49,7 @@ describe('SampleFinderSection', () => {
         );
         const section = wrapper.find(Section);
         expect(section.prop('title')).toBe('Find Samples');
-        expect(section.prop('caption')).toBe('Find samples that meet all the criteria defined below');
+        expect(section.prop('caption')).toBe('Find all generations of samples that meet all the criteria defined below');
         expect(section.find('.filter-hint').exists()).toBeTruthy();
         const cards = wrapper.find(FilterCards);
         expect(cards.prop('className')).toBe('empty');

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -291,6 +291,10 @@ export const SampleFinderSamplesImpl: FC<SampleFinderSamplesGridProps & Injected
         };
     }, []);
 
+    const afterSampleActionComplete = useCallback((): void => {
+        actions.loadAllModels();
+    }, [actions]);
+
     if (isLoading) return <LoadingSpinner />;
 
     return (
@@ -298,6 +302,7 @@ export const SampleFinderSamplesImpl: FC<SampleFinderSamplesGridProps & Injected
             <SamplesTabbedGridPanel
                 {...props}
                 withTitle={false}
+                afterSampleActionComplete={afterSampleActionComplete}
                 asPanel={false}
                 actions={actions}
                 queryModels={queryModels}

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -46,7 +46,7 @@ import { EntityFieldFilterModal } from './EntityFieldFilterModal';
 import { FieldFilter, FilterProps } from './models';
 
 const SAMPLE_FINDER_TITLE = 'Find Samples';
-const SAMPLE_FINDER_CAPTION = 'Find samples that meet all the criteria defined below';
+const SAMPLE_FINDER_CAPTION = 'Find all generations of samples that meet all the criteria defined below';
 
 interface SampleFinderSamplesGridProps {
     columnDisplayNames?: {[key: string]: string}
@@ -353,19 +353,14 @@ const SampleFinderSamples: FC<SampleFinderSamplesProps> = memo(props => {
     if (!queryConfigs) return <LoadingSpinner />;
 
     return (
-        <>
-            <div className={"bottom-spacing filter-results__message"}>
-                Showing all generations of samples for the criteria given above.
-            </div>
-            <SampleFinderSamplesWithQueryModels
-                columnDisplayNames={getSampleFinderColumnNames(cards)}
-                sampleTypeNames={sampleTypeNames}
-                key={selectionKeyPrefix}
-                user={user}
-                {...gridProps}
-                autoLoad
-                queryConfigs={queryConfigs}
-            />
-        </>
+        <SampleFinderSamplesWithQueryModels
+            columnDisplayNames={getSampleFinderColumnNames(cards)}
+            sampleTypeNames={sampleTypeNames}
+            key={selectionKeyPrefix}
+            user={user}
+            {...gridProps}
+            autoLoad
+            queryConfigs={queryConfigs}
+        />
     );
 });

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -353,7 +353,9 @@ const SampleFinderSamples: FC<SampleFinderSamplesProps> = memo(props => {
 
     return (
         <>
-            <div className={"bottom-spacing filter-results__message"}>Showing all generations of samples for the criteria given above.</div>
+            <div className={"bottom-spacing filter-results__message"}>
+                Showing all generations of samples for the criteria given above.
+            </div>
             <SampleFinderSamplesWithQueryModels
                 columnDisplayNames={getSampleFinderColumnNames(cards)}
                 sampleTypeNames={sampleTypeNames}

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -34,7 +34,7 @@ import { removeFinderGridView, saveFinderGridView } from './actions';
 import { FilterCards } from './FilterCards';
 import {
     getFinderStartText,
-    getFinderViewColumnsConfig,
+    getFinderViewColumnsConfig, getSampleFinderColumnNames,
     getSampleFinderQueryConfigs,
     SAMPLE_FILTER_METRIC_AREA,
     searchFiltersFromJson,
@@ -48,6 +48,7 @@ const SAMPLE_FINDER_TITLE = 'Find Samples';
 const SAMPLE_FINDER_CAPTION = 'Find samples that meet all the criteria defined below';
 
 interface SampleFinderSamplesGridProps {
+    columnDisplayNames?: {[key: string]: string}
     user: User;
     getSampleAuditBehaviorType: () => AuditBehaviorTypes;
     samplesEditableGridProps: Partial<SamplesEditableGridProps>;
@@ -164,7 +165,7 @@ export const SampleFinderSection: FC<Props> = memo(props => {
     };
 
     const onFind = useCallback(
-        (schemaName: string, dataTypeFilters: { [key: string]: FieldFilter[] }) => {
+        (schemaName: string, dataTypeFilters: { [key: string]: FieldFilter[] },  queryLabels: { [key: string]: string }) => {
             const newFilterCards = [...filters].filter(filter => {
                 return filter.entityDataType.instanceSchemaName !== chosenEntityType.instanceSchemaName;
             });
@@ -173,6 +174,7 @@ export const SampleFinderSection: FC<Props> = memo(props => {
                     schemaQuery: SchemaQuery.create(schemaName, queryName),
                     filterArray: dataTypeFilters[queryName],
                     entityDataType: chosenEntityType,
+                    dataTypeDisplayName: queryLabels[queryName],
                 });
             });
 
@@ -247,7 +249,7 @@ interface SampleFinderSamplesProps extends SampleFinderSamplesGridProps {
 }
 
 export const SampleFinderSamplesImpl: FC<SampleFinderSamplesGridProps & InjectedQueryModels> = memo(props => {
-    const { actions, queryModels, gridButtons, excludedCreateMenuKeys } = props;
+    const { actions, columnDisplayNames, queryModels, gridButtons, excludedCreateMenuKeys } = props;
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
     useEffect(() => {
@@ -255,7 +257,7 @@ export const SampleFinderSamplesImpl: FC<SampleFinderSamplesGridProps & Injected
         if (allModelsLoaded && isLoading) {
             const promises = [];
             Object.values(queryModels).forEach(queryModel => {
-                const { hasUpdates, columns } = getFinderViewColumnsConfig(queryModel);
+                const { hasUpdates, columns } = getFinderViewColumnsConfig(queryModel, columnDisplayNames);
                 if (hasUpdates) {
                     promises.push(saveFinderGridView(queryModel.schemaQuery, columns));
                 }
@@ -351,6 +353,7 @@ const SampleFinderSamples: FC<SampleFinderSamplesProps> = memo(props => {
 
     return (
         <SampleFinderSamplesWithQueryModels
+            columnDisplayNames={getSampleFinderColumnNames(cards)}
             sampleTypeNames={sampleTypeNames}
             key={selectionKeyPrefix}
             user={user}

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -352,14 +352,17 @@ const SampleFinderSamples: FC<SampleFinderSamplesProps> = memo(props => {
     if (!queryConfigs) return <LoadingSpinner />;
 
     return (
-        <SampleFinderSamplesWithQueryModels
-            columnDisplayNames={getSampleFinderColumnNames(cards)}
-            sampleTypeNames={sampleTypeNames}
-            key={selectionKeyPrefix}
-            user={user}
-            {...gridProps}
-            autoLoad
-            queryConfigs={queryConfigs}
-        />
+        <>
+            <div className={"bottom-spacing filter-results__message"}>Showing all generations of samples for the criteria given above.</div>
+            <SampleFinderSamplesWithQueryModels
+                columnDisplayNames={getSampleFinderColumnNames(cards)}
+                sampleTypeNames={sampleTypeNames}
+                key={selectionKeyPrefix}
+                user={user}
+                {...gridProps}
+                autoLoad
+                queryConfigs={queryConfigs}
+            />
+        </>
     );
 });

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -34,7 +34,8 @@ import { removeFinderGridView, saveFinderGridView } from './actions';
 import { FilterCards } from './FilterCards';
 import {
     getFinderStartText,
-    getFinderViewColumnsConfig, getSampleFinderColumnNames,
+    getFinderViewColumnsConfig,
+    getSampleFinderColumnNames,
     getSampleFinderQueryConfigs,
     SAMPLE_FILTER_METRIC_AREA,
     searchFiltersFromJson,

--- a/packages/components/src/internal/components/search/models.ts
+++ b/packages/components/src/internal/components/search/models.ts
@@ -66,6 +66,7 @@ export interface FilterProps {
     entityDataType: EntityDataType;
     filterArray?: FieldFilter[]; // the filters to be used in conjunction with the schemaQuery
     schemaQuery?: SchemaQuery;
+    dataTypeDisplayName?: string;
     index?: number;
 }
 

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -12,7 +12,7 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SCHEMAS } from '../../schemas';
 
-import { JsonType, TEXT_TYPE } from '../domainproperties/PropDescType';
+import { TEXT_TYPE } from '../domainproperties/PropDescType';
 
 import { NOT_ANY_FILTER_TYPE } from '../../url/NotAnyFilterType';
 
@@ -29,7 +29,8 @@ import {
     getFilterValuesAsArray,
     getFinderStartText,
     getFinderViewColumnsConfig,
-    getLabKeySqlWhere, getSampleFinderColumnNames,
+    getLabKeySqlWhere,
+    getSampleFinderColumnNames,
     getSampleFinderCommonConfigs,
     getSampleFinderQueryConfigs,
     getUpdatedCheckedValues,

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -12,7 +12,7 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SCHEMAS } from '../../schemas';
 
-import { TEXT_TYPE } from '../domainproperties/PropDescType';
+import { JsonType, TEXT_TYPE } from '../domainproperties/PropDescType';
 
 import { NOT_ANY_FILTER_TYPE } from '../../url/NotAnyFilterType';
 
@@ -29,7 +29,7 @@ import {
     getFilterValuesAsArray,
     getFinderStartText,
     getFinderViewColumnsConfig,
-    getLabKeySqlWhere,
+    getLabKeySqlWhere, getSampleFinderColumnNames,
     getSampleFinderCommonConfigs,
     getSampleFinderQueryConfigs,
     getUpdatedCheckedValues,
@@ -40,6 +40,7 @@ import {
     searchFiltersToJson,
 } from './utils';
 import { FieldFilter } from './models';
+import { SampleTypeDataType } from '../entities/constants';
 
 test('getFinderStartText', () => {
     expect(getFinderStartText([])).toBe('Start by adding  properties.');
@@ -99,25 +100,25 @@ describe('getFinderViewColumnsConfig', () => {
         'test-samples'
     );
     test('no required columns', () => {
-        expect(getFinderViewColumnsConfig(model)).toStrictEqual({
+        expect(getFinderViewColumnsConfig(model, {})).toStrictEqual({
             hasUpdates: false,
-            columns: [{ fieldKey: 'Name' }],
+            columns: [{ fieldKey: 'Name', title: undefined }],
         });
     });
 
     test('no new required columns', () => {
         const modelUpdate = model.mutate({ requiredColumns: ['Name'] });
-        expect(getFinderViewColumnsConfig(modelUpdate)).toStrictEqual({
+        expect(getFinderViewColumnsConfig(modelUpdate, {})).toStrictEqual({
             hasUpdates: false,
-            columns: [{ fieldKey: 'Name' }],
+            columns: [{ fieldKey: 'Name', title: undefined }],
         });
     });
 
     test('with new required columns', () => {
         const modelUpdate = model.mutate({ requiredColumns: ['Name', 'ExtraField', 'SampleState'] });
-        expect(getFinderViewColumnsConfig(modelUpdate)).toStrictEqual({
+        expect(getFinderViewColumnsConfig(modelUpdate, {ExtraField: 'Extra Field Display'})).toStrictEqual({
             hasUpdates: true,
-            columns: [{ fieldKey: 'Name' }, { fieldKey: 'ExtraField' }],
+            columns: [{ fieldKey: 'Name', title: undefined }, { fieldKey: 'ExtraField', title: 'Extra Field Display' }],
         });
     });
 });
@@ -176,6 +177,7 @@ describe('getSampleFinderCommonConfigs', () => {
             requiredColumns: [
                 ...SAMPLE_STATUS_REQUIRED_COLUMNS,
                 'QueryableInputs/Materials/TestQuery',
+                'QueryableInputs/Materials/TestQuery2',
                 'QueryableInputs/Materials/TestQuery2/TestColumn',
             ],
         });
@@ -808,11 +810,11 @@ describe('getUpdatedChooseValuesFilter', () => {
 
 const datePOSIX = 1596750283812; // Aug 6, 2020 14:44 America/PST
 const testDate = new Date(datePOSIX);
-const dateStr = formatDate(testDate, 'America/PST', 'YYYY-MM-dd');
+const dateStr = formatDate(testDate, 'America/Los_Angeles', 'YYYY-MM-dd');
 
 const date2POSIX = 1597182283812; // Aug 11, 2020 14:44 America/PST
 const testDate2 = new Date(date2POSIX);
-const dateStr2 = formatDate(testDate2, 'America/PST', 'YYYY-MM-dd');
+const dateStr2 = formatDate(testDate2, 'America/Lost_Angeles', 'YYYY-MM-dd');
 
 const isBlankFilter = {
     fieldKey: 'String Field',
@@ -956,4 +958,56 @@ describe('getExpDescendantOfSelectClause', () => {
             'SELECT "Sample Type A".expObject() FROM Test."Sample Type A" WHERE "intField" = 1 AND "Boolean Field" = TRUE'
         );
     });
+});
+
+describe("getSampleFinderColumnNames", () => {
+
+   test("no cards", () => {
+       expect(getSampleFinderColumnNames(undefined)).toStrictEqual({});
+   });
+
+   test("empty cards", () => {
+      expect(getSampleFinderColumnNames([])).toStrictEqual({});
+   });
+
+   test("cards without dataTypeDisplayName", () => {
+       expect(getSampleFinderColumnNames([{
+           entityDataType: SampleTypeDataType,
+           schemaQuery: SchemaQuery.create("test", "query"),
+           filterArray: [{
+               fieldKey: "IntValue",
+               fieldCaption: "Integer",
+               filter: Filter.create("IntValue", 3, Filter.Types.GT),
+               jsonType: 'int'
+           }],
+       }])).toStrictEqual({});
+   });
+
+   test("cards without filters", () => {
+       expect(getSampleFinderColumnNames([{
+           entityDataType: SampleTypeDataType,
+           schemaQuery: SchemaQuery.create("test", "query"),
+           dataTypeDisplayName: "Test Samples",
+           filterArray: [],
+       }])).toStrictEqual({
+           'QueryableInputs/Materials/query': 'Test Samples ID',
+       });
+   });
+
+   test("cards with filters", () => {
+       expect(getSampleFinderColumnNames([{
+           entityDataType: SampleTypeDataType,
+           schemaQuery: SchemaQuery.create("test", "query"),
+           dataTypeDisplayName: "Test Samples",
+           filterArray: [{
+               fieldKey: "IntValue",
+               fieldCaption: "Integer",
+               filter: Filter.create("IntValue", 3, Filter.Types.GT),
+               jsonType: 'int'
+           }],
+       }])).toStrictEqual({
+           'QueryableInputs/Materials/query': 'Test Samples ID',
+           'QueryableInputs/Materials/query/IntValue': 'Test Samples Integer'
+       });
+   });
 });

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -815,7 +815,7 @@ const dateStr = formatDate(testDate, 'America/Los_Angeles', 'YYYY-MM-dd');
 
 const date2POSIX = 1597182283812; // Aug 11, 2020 14:44 America/PST
 const testDate2 = new Date(date2POSIX);
-const dateStr2 = formatDate(testDate2, 'America/Lost_Angeles', 'YYYY-MM-dd');
+const dateStr2 = formatDate(testDate2, 'America/Los_Angeles', 'YYYY-MM-dd');
 
 const isBlankFilter = {
     fieldKey: 'String Field',

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -189,10 +189,12 @@ export function getSampleFinderColumnNames(cards: FilterProps[]): {[key: string]
     const columnNames = {};
     cards?.forEach(card => {
         const cardColumnName = getFilterCardColumnName(card.entityDataType, card.schemaQuery);
-        columnNames[cardColumnName] = card.dataTypeDisplayName + " ID";
-        card.filterArray.forEach(filter => {
-            columnNames[cardColumnName + "/" + filter.fieldKey] = card.dataTypeDisplayName + " " + filter.fieldCaption
-        })
+        if (card.dataTypeDisplayName) {
+            columnNames[cardColumnName] = card.dataTypeDisplayName + " ID";
+            card.filterArray?.forEach(filter => {
+                columnNames[cardColumnName + "/" + filter.fieldKey] = card.dataTypeDisplayName + " " + filter.fieldCaption
+            });
+        }
     });
     return columnNames;
 }

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -38,7 +38,7 @@ export function getFilterCardColumnName(entityDataType: EntityDataType, schemaQu
 
 const FIRST_COLUMNS_IN_VIEW = ['Name', 'SampleSet'];
 
-export function getFinderViewColumnsConfig(queryModel: QueryModel): { hasUpdates: boolean; columns: any } {
+export function getFinderViewColumnsConfig(queryModel: QueryModel, columnDisplayNames: {[key: string]: string}): { hasUpdates: boolean; columns: any } {
     const defaultDisplayColumns = queryModel.queryInfo?.getDisplayColumns().toArray();
     const displayColumnKeys = defaultDisplayColumns.map(col => col.fieldKey);
     const columnKeys = [];
@@ -59,7 +59,7 @@ export function getFinderViewColumnsConfig(queryModel: QueryModel): { hasUpdates
             .filter(col => FIRST_COLUMNS_IN_VIEW.indexOf(col.fieldKey) === -1)
             .map(col => col.fieldKey)
     );
-    return { hasUpdates, columns: columnKeys.map(fieldKey => ({ fieldKey })) };
+    return { hasUpdates, columns: columnKeys.map(fieldKey => ({ fieldKey, title: columnDisplayNames[fieldKey] })) };
 }
 
 export const SAMPLE_FINDER_VIEW_NAME = 'Sample Finder';
@@ -183,6 +183,18 @@ export function getSampleFinderQueryConfigs(
         };
     }
     return configs;
+}
+
+export function getSampleFinderColumnNames(cards: FilterProps[]): {[key: string]: string } {
+    const columnNames = {};
+    cards?.forEach(card => {
+        const cardColumnName = getFilterCardColumnName(card.entityDataType, card.schemaQuery);
+        columnNames[cardColumnName] = card.dataTypeDisplayName + " ID";
+        card.filterArray.forEach(filter => {
+            columnNames[cardColumnName + "/" + filter.fieldKey] = card.dataTypeDisplayName + " " + filter.fieldCaption
+        })
+    });
+    return columnNames;
 }
 
 export const SAMPLE_SEARCH_FILTER_TYPES_TO_EXCLUDE = [

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -120,6 +120,7 @@ export function getSampleFinderCommonConfigs(cards: FilterProps[]): Partial<Quer
     cards.forEach(card => {
         const cardColumnName = getFilterCardColumnName(card.entityDataType, card.schemaQuery);
 
+        requiredColumns.push(cardColumnName);
         if (card.filterArray?.length) {
             const schemaQuery = card.schemaQuery;
             card.filterArray.forEach(f => {
@@ -138,7 +139,6 @@ export function getSampleFinderCommonConfigs(cards: FilterProps[]): Partial<Quer
                 baseFilters.push(filter);
             }
         } else {
-            requiredColumns.push(cardColumnName);
             baseFilters.push(Filter.create(cardColumnName + '/Name', null, Filter.Types.NONBLANK));
         }
     });

--- a/packages/components/src/theme/search.scss
+++ b/packages/components/src/theme/search.scss
@@ -225,3 +225,7 @@
     font-weight: bold;
     padding-bottom: 5px;
 }
+
+.filter-results__message {
+    font-style: italic;
+}


### PR DESCRIPTION
#### Rationale
We're releasing Sample Finder in 22.3 and just need to polish a few parts of it before we do that.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/858

#### Changes
  * Add `containerFilter` property to `EntityDataType` model
  * Assure grid is updated after sample actions are taken
  * Update grid columns to always show parent id columns and add parent type name to column name
  