### PR TITLE
Issue 45009: Go back to using Inputs column instead of QueryableInputs for SampleFinder

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.6-noQueryableInputs.0",
+  "version": "2.138.6-noQueryableInputs.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.6-noQueryableInputs.1",
+  "version": "2.138.6-noQueryableInputs.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.6-noQueryableInputs.2",
+  "version": "2.138.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.5",
+  "version": "2.138.6-noQueryableInputs.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.138.6
+*Released*: 10 March 2022
 * Sample Finder Optimizations
   * Don't use expensive `QueryableInputs` now that we have the query for descendants
   * Don't load the grid until we have sample type names

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* Don't use expensive `QueryableInputs` now that we have the query for descendants
+* Sample Finder Optimizations
+  * Don't use expensive `QueryableInputs` now that we have the query for descendants
+  * Don't load the grid until we have sample type names
 
 ### version 2.138.5
 *Released*: 4 March 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Don't use expensive `QueryableInputs` now that we have the query for descendants
+
 ### version 2.138.5
 *Released*: 4 March 2022
 * Sample Finder Polish

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -354,7 +354,7 @@ const SampleFinderSamples: FC<SampleFinderSamplesProps> = memo(props => {
 
     if (errors) return <Alert>{errors}</Alert>;
 
-    if (!queryConfigs || sampleTypeNames.length == 0) return <LoadingSpinner />;
+    if (!queryConfigs || !sampleTypeNames) return <LoadingSpinner />;
 
     return (
         <SampleFinderSamplesWithQueryModels

--- a/packages/components/src/internal/components/search/SampleFinderSection.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSection.tsx
@@ -354,7 +354,7 @@ const SampleFinderSamples: FC<SampleFinderSamplesProps> = memo(props => {
 
     if (errors) return <Alert>{errors}</Alert>;
 
-    if (!queryConfigs) return <LoadingSpinner />;
+    if (!queryConfigs || sampleTypeNames.length == 0) return <LoadingSpinner />;
 
     return (
         <SampleFinderSamplesWithQueryModels

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -146,8 +146,8 @@ describe('getSampleFinderCommonConfigs', () => {
                 },
             ])
         ).toStrictEqual({
-            baseFilters: [Filter.create('QueryableInputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
-            requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'QueryableInputs/Materials/TestQuery'],
+            baseFilters: [Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
+            requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'Inputs/Materials/TestQuery'],
         });
     });
 
@@ -173,7 +173,7 @@ describe('getSampleFinderCommonConfigs', () => {
             ])
         ).toStrictEqual({
             baseFilters: [
-                Filter.create('QueryableInputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK),
+                Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK),
                 Filter.create(
                     '*',
                     'SELECT "TestQuery2".expObject() FROM Samples."TestQuery2" WHERE "TestColumn" = \'value\'',
@@ -182,9 +182,9 @@ describe('getSampleFinderCommonConfigs', () => {
             ],
             requiredColumns: [
                 ...SAMPLE_STATUS_REQUIRED_COLUMNS,
-                'QueryableInputs/Materials/TestQuery',
-                'QueryableInputs/Materials/TestQuery2',
-                'QueryableInputs/Materials/TestQuery2/TestColumn',
+                'Inputs/Materials/TestQuery',
+                'Inputs/Materials/TestQuery2',
+                'Inputs/Materials/TestQuery2/TestColumn',
             ],
         });
     });
@@ -237,8 +237,8 @@ describe('getSampleFinderQueryConfigs', () => {
                     SAMPLE_FINDER_VIEW_NAME
                 ),
                 omittedColumns: ['Run'],
-                baseFilters: [Filter.create('QueryableInputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
-                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'QueryableInputs/Materials/TestQuery'],
+                baseFilters: [Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
+                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'Inputs/Materials/TestQuery'],
             },
         });
     });
@@ -297,24 +297,24 @@ describe('getSampleFinderQueryConfigs', () => {
                     SAMPLE_FINDER_VIEW_NAME
                 ),
                 omittedColumns: ['checkedOutBy', 'Run'],
-                baseFilters: [Filter.create('QueryableInputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
-                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'QueryableInputs/Materials/TestQuery'],
+                baseFilters: [Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
+                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'Inputs/Materials/TestQuery'],
             },
             'uuid-1-testId|samples/Sample Type 1': {
                 id: 'uuid-1-testId|samples/Sample Type 1',
                 title: 'Sample Type 1',
                 schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 1', SAMPLE_FINDER_VIEW_NAME),
                 omittedColumns: ['checkedOutBy'],
-                baseFilters: [Filter.create('QueryableInputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
-                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'QueryableInputs/Materials/TestQuery'],
+                baseFilters: [Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
+                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'Inputs/Materials/TestQuery'],
             },
             'uuid-1-testId|samples/Sample Type 2': {
                 id: 'uuid-1-testId|samples/Sample Type 2',
                 title: 'Sample Type 2',
                 schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 2', SAMPLE_FINDER_VIEW_NAME),
                 omittedColumns: ['checkedOutBy'],
-                baseFilters: [Filter.create('QueryableInputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
-                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'QueryableInputs/Materials/TestQuery'],
+                baseFilters: [Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK)],
+                requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS, 'Inputs/Materials/TestQuery'],
             },
         });
     });
@@ -1010,7 +1010,7 @@ describe('getSampleFinderColumnNames', () => {
                 },
             ])
         ).toStrictEqual({
-            'QueryableInputs/Materials/query': 'Test Samples ID',
+            'Inputs/Materials/query': 'Test Samples ID',
         });
     });
 
@@ -1032,8 +1032,8 @@ describe('getSampleFinderColumnNames', () => {
                 },
             ])
         ).toStrictEqual({
-            'QueryableInputs/Materials/query': 'Test Samples ID',
-            'QueryableInputs/Materials/query/IntValue': 'Test Samples Integer',
+            'Inputs/Materials/query': 'Test Samples ID',
+            'Inputs/Materials/query/IntValue': 'Test Samples Integer',
         });
     });
 });

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -34,7 +34,8 @@ export function getFinderStartText(parentEntityDataTypes: EntityDataType[]): str
 }
 
 export function getFilterCardColumnName(entityDataType: EntityDataType, schemaQuery: SchemaQuery): string {
-    return entityDataType.inputColumnName.replace('Inputs', 'QueryableInputs').replace('First', schemaQuery.queryName);
+    return entityDataType.inputColumnName
+        .replace('First', schemaQuery.queryName);
 }
 
 const FIRST_COLUMNS_IN_VIEW = ['Name', 'SampleSet'];

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -176,16 +176,18 @@ export function getSampleFinderQueryConfigs(
         },
     };
 
-    for (const name of sampleTypeNames) {
-        const id = getSampleFinderConfigId(finderId, 'samples/' + name);
-        const schemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, name, SAMPLE_FINDER_VIEW_NAME);
-        configs[id] = {
-            id,
-            title: name,
-            schemaQuery,
-            omittedColumns,
-            ...commonConfig,
-        };
+    if (sampleTypeNames) {
+        for (const name of sampleTypeNames) {
+            const id = getSampleFinderConfigId(finderId, 'samples/' + name);
+            const schemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, name, SAMPLE_FINDER_VIEW_NAME);
+            configs[id] = {
+                id,
+                title: name,
+                schemaQuery,
+                omittedColumns,
+                ...commonConfig,
+            };
+        }
     }
     return configs;
 }


### PR DESCRIPTION
#### Rationale
Now that we have the lineage filtering done through the expdescendants of construct, we don't need to use the expensive `QueryableInputs` column for getting the display columns.

#### Related Pull Requests
* 

#### Changes
  * Don't use expensive `QueryableInputs` now that we have the query for descendants done differently
  * Don't load the grid until we have sample type names (avoids extra call to get the data for the All Samples grid.
