### PR TITLE
LKB: In-App Admin Settings and Profile

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.141.2-fb-inappadminlkb2-1.0",
+  "version": "2.142.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.141.1",
+  "version": "2.141.1-fb-inappadminlkb2-1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* TODO
+
 ### version 2.141.1
 *Released*: 11 March 2022
 * Merge release22.3-SNAPSHOT to develop again

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.142.0
+*Released*: 15 March 2022
 * Support In-App Admin across LKB and LKSM, adding admin & user settings page distinctions, as well as profile settings.
 
 ### version 2.141.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* TODO
+* Support In-App Admin across LKB and LKSM, adding admin & user settings page distinctions, as well as profile settings.
 
 ### version 2.141.2
 *Released*: 14 March 2022

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -422,6 +422,8 @@ import { ChangePasswordModal } from './internal/components/user/ChangePasswordMo
 import { UsersGridPanel } from './internal/components/user/UsersGridPanel';
 import { UserProvider, useUserProperties } from './internal/components/user/UserProvider';
 import { UserLink } from './internal/components/user/UserLink';
+import { AccountSubNav } from './internal/components/user/AccountSubNav';
+import { ProfilePage } from './internal/components/user/ProfilePage';
 import {
     DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
     DOMAIN_FIELD_REQUIRED,
@@ -942,6 +944,8 @@ export {
     UserDetailHeader,
     UserProfile,
     UserLink,
+    AccountSubNav,
+    ProfilePage,
     ChangePasswordModal,
     UsersGridPanel,
     InsufficientPermissionsAlert,
@@ -1468,7 +1472,6 @@ export type { SelectInputOption, SelectInputProps } from './internal/components/
 export type { PermissionsProviderProps } from './internal/components/permissions/models';
 export type { ISelectInitData } from './internal/components/forms/model';
 export type { QuerySelectOwnProps } from './internal/components/forms/QuerySelect';
-export type { UserProviderProps } from './internal/components/user/UserProvider';
 export type {
     SampleCreationTypeModel,
     GroupedSampleFields,

--- a/packages/components/src/internal/components/administration/AdministrationSubNav.tsx
+++ b/packages/components/src/internal/components/administration/AdministrationSubNav.tsx
@@ -21,7 +21,7 @@ export const getAdministrationSubNavTabs = (user: User): List<ITab> => {
         tabs = tabs.push('Permissions');
     }
     // Settings tab to be implemented in story 2 of In-App Admin
-    if (user.isAppAdmin() && !biologicsIsPrimaryApp()) {
+    if (user.isAppAdmin()) {
         tabs = tabs.push('Settings');
     }
 

--- a/packages/components/src/internal/components/administration/AdministrationSubNav.tsx
+++ b/packages/components/src/internal/components/administration/AdministrationSubNav.tsx
@@ -11,7 +11,6 @@ import { AppURL } from '../../url/AppURL';
 import { useServerContext } from '../base/ServerContext';
 
 import { User } from '../base/models/User';
-import { biologicsIsPrimaryApp } from '../../app/utils';
 
 export const getAdministrationSubNavTabs = (user: User): List<ITab> => {
     let tabs = List<string>();

--- a/packages/components/src/internal/components/user/AccountSubNav.tsx
+++ b/packages/components/src/internal/components/user/AccountSubNav.tsx
@@ -1,11 +1,12 @@
-import React from 'react'
-import { List } from 'immutable'
-import {ITab, SubNav} from "../navigation/SubNav";
-import {AppURL} from "../../url/AppURL";
+import React from 'react';
+import { List } from 'immutable';
+
+import { ITab, SubNav } from '../navigation/SubNav';
+import { AppURL } from '../../url/AppURL';
 
 const PARENT_TAB: ITab = {
     text: 'Dashboard',
-    url: AppURL.create('home')
+    url: AppURL.create('home'),
 };
 
 const TABS = List<string>(['Profile', 'Settings']);
@@ -14,11 +15,11 @@ export class AccountSubNav extends React.Component<any, any> {
     generateTabs(): List<ITab> {
         return TABS.map(text => ({
             text,
-            url: AppURL.create('account', text.toLowerCase())
-        })).toList()
+            url: AppURL.create('account', text.toLowerCase()),
+        })).toList();
     }
 
     render() {
-        return <SubNav tabs={this.generateTabs()} noun={PARENT_TAB}/>;
+        return <SubNav tabs={this.generateTabs()} noun={PARENT_TAB} />;
     }
 }

--- a/packages/components/src/internal/components/user/AccountSubNav.tsx
+++ b/packages/components/src/internal/components/user/AccountSubNav.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { List } from 'immutable'
+import {ITab, SubNav} from "../navigation/SubNav";
+import {AppURL} from "../../url/AppURL";
+
+const PARENT_TAB: ITab = {
+    text: 'Dashboard',
+    url: AppURL.create('home')
+};
+
+const TABS = List<string>(['Profile', 'Settings']);
+
+export class AccountSubNav extends React.Component<any, any> {
+    generateTabs(): List<ITab> {
+        return TABS.map(text => ({
+            text,
+            url: AppURL.create('account', text.toLowerCase())
+        })).toList()
+    }
+
+    render() {
+        return <SubNav tabs={this.generateTabs()} noun={PARENT_TAB}/>;
+    }
+}

--- a/packages/components/src/internal/components/user/ProfilePage.tsx
+++ b/packages/components/src/internal/components/user/ProfilePage.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import React, { FC, useState } from 'react';
+import { Button } from 'react-bootstrap';
+
+import { createNotification, withTimeout } from '../notifications/actions';
+import { queryGridInvalidate } from '../../actions';
+import { SCHEMAS } from '../../schemas';
+import { isLoginAutoRedirectEnabled } from '../administration/utils';
+import { InsufficientPermissionsPage } from '../permissions/InsufficientPermissionsPage';
+
+import { Page } from '../base/Page';
+
+import { Section } from '../base/Section';
+
+import { Notification } from '../notifications/Notification';
+
+import { UserDetailHeader } from './UserDetailHeader';
+import { getUserRoleDisplay } from './actions';
+
+import { UserProfile } from './UserProfile';
+import { ChangePasswordModal } from './ChangePasswordModal';
+import {AppURL} from "../../url/AppURL";
+import {useServerContext} from "../base/ServerContext";
+import {useUserProperties} from "./UserProvider";
+import {App} from "../../../index";
+
+// ToDo: This is copied from SM, and we only need a subset. Use withRouteLeave.
+interface CommonDispatchProps {
+    navigate: (url: string | AppURL) => any;
+    goBack: (n?: number) => any;
+    menuInit: () => any;
+    menuInvalidate: () => any;
+    setReloadRequired: () => any;
+}
+
+interface Props extends CommonDispatchProps {
+    updateUserDisplayName: (displayName: string) => any;
+}
+
+const TITLE = 'User Profile';
+
+const ProfilePageImpl: FC<Props> = props => {
+    const [showChangePassword, setShowChangePassword] = useState<boolean>(false);
+    const { user } = useServerContext();
+    const userProperties = useUserProperties(user);
+
+    if (!user.isSignedIn) {
+        return <InsufficientPermissionsPage title={TITLE} />;
+    }
+
+    const navigate = (result: {}, shouldReload: boolean): void => {
+        const { goBack, setReloadRequired, updateUserDisplayName } = props;
+        const successMsg = 'Successfully updated your user profile.';
+
+        if (shouldReload) {
+            createNotification(successMsg);
+            setReloadRequired();
+        } else if (result) {
+            queryGridInvalidate(SCHEMAS.CORE_TABLES.USERS);
+
+            // push any display name changes to the app state user object
+            if (result['updatedRows'].length === 1) {
+                const row = result['updatedRows'][0];
+                if (row.DisplayName !== undefined) {
+                    updateUserDisplayName(row.DisplayName);
+                }
+            }
+        }
+
+        goBack();
+        if (result && result['success']) {
+            withTimeout(() => {
+                createNotification(successMsg);
+            });
+        }
+    };
+
+    const onCancel = (): void => {
+        navigate(undefined, false);
+    };
+
+    const onChangePassword = (): void => {
+        createNotification('Successfully changed password.');
+    };
+
+    const toggleChangePassword = (): void => {
+        setShowChangePassword(!showChangePassword);
+    };
+
+    const allowChangePassword = !isLoginAutoRedirectEnabled();
+
+    return (
+        <Page title={TITLE} hasHeader>
+            <UserDetailHeader
+                userProperties={userProperties}
+                user={user}
+                title={user.displayName + "'s Profile"}
+                description={getUserRoleDisplay(user)}
+                dateFormat={App.getDateFormat().toUpperCase()}
+                renderButtons={
+                    allowChangePassword ? <Button onClick={toggleChangePassword}>Change Password</Button> : null
+                }
+            />
+            <Notification user={user} />
+            <Section>
+                <UserProfile userProperties={userProperties} user={user} onCancel={onCancel} onSuccess={navigate} />
+            </Section>
+            {allowChangePassword && showChangePassword && (
+                <ChangePasswordModal user={user} onHide={toggleChangePassword} onSuccess={onChangePassword} />
+            )}
+        </Page>
+    );
+};
+
+// export const ProfilePage = withRouteLeave(withRouter(ProfilePageImpl));
+export const ProfilePage = ProfilePageImpl;

--- a/packages/components/src/internal/components/user/ProfilePage.tsx
+++ b/packages/components/src/internal/components/user/ProfilePage.tsx
@@ -17,8 +17,6 @@ import { Section } from '../base/Section';
 
 import { Notification } from '../notifications/Notification';
 
-import { AppURL } from '../../url/AppURL';
-
 import { useServerContext } from '../base/ServerContext';
 
 import { App } from '../../../index';
@@ -31,22 +29,15 @@ import { ChangePasswordModal } from './ChangePasswordModal';
 
 import { useUserProperties } from './UserProvider';
 
-// ToDo: This is copied from SM, and we only need a subset. Use withRouteLeave.
-interface CommonDispatchProps {
-    navigate: (url: string | AppURL) => any;
-    goBack: (n?: number) => any;
-    menuInit: () => any;
-    menuInvalidate: () => any;
-    setReloadRequired: () => any;
-}
-
-interface Props extends CommonDispatchProps {
+interface Props {
     updateUserDisplayName: (displayName: string) => any;
+    setReloadRequired: () => any;
+    goBack: (n?: number) => any;
 }
 
 const TITLE = 'User Profile';
 
-const ProfilePageImpl: FC<Props> = props => {
+export const ProfilePage: FC<Props> = props => {
     const [showChangePassword, setShowChangePassword] = useState<boolean>(false);
     const { user } = useServerContext();
     const userProperties = useUserProperties(user);
@@ -118,6 +109,3 @@ const ProfilePageImpl: FC<Props> = props => {
         </Page>
     );
 };
-
-// export const ProfilePage = withRouteLeave(withRouter(ProfilePageImpl));
-export const ProfilePage = ProfilePageImpl;

--- a/packages/components/src/internal/components/user/ProfilePage.tsx
+++ b/packages/components/src/internal/components/user/ProfilePage.tsx
@@ -17,15 +17,19 @@ import { Section } from '../base/Section';
 
 import { Notification } from '../notifications/Notification';
 
+import { AppURL } from '../../url/AppURL';
+
+import { useServerContext } from '../base/ServerContext';
+
+import { App } from '../../../index';
+
 import { UserDetailHeader } from './UserDetailHeader';
 import { getUserRoleDisplay } from './actions';
 
 import { UserProfile } from './UserProfile';
 import { ChangePasswordModal } from './ChangePasswordModal';
-import {AppURL} from "../../url/AppURL";
-import {useServerContext} from "../base/ServerContext";
-import {useUserProperties} from "./UserProvider";
-import {App} from "../../../index";
+
+import { useUserProperties } from './UserProvider';
 
 // ToDo: This is copied from SM, and we only need a subset. Use withRouteLeave.
 interface CommonDispatchProps {

--- a/packages/components/src/internal/components/user/UserProvider.tsx
+++ b/packages/components/src/internal/components/user/UserProvider.tsx
@@ -14,8 +14,6 @@ interface State {
     userProperties: Record<string, any>;
 }
 
-export type UserProviderProps = Props & State;
-
 const Context = React.createContext<State>(undefined);
 const UserContextProvider = Context.Provider;
 export const UserContextConsumer = Context.Consumer;


### PR DESCRIPTION
#### Rationale
Currently in LabKey Biologics (LKB), to complete administrative tasks such as creating/deleting a user, deactivating/reactivating a user, or assigning user roles, the admin users have to navigate out of LKB to LKS, which is inconvenient. In order to bring more convenient and consistent user experiences to the LKB users, in-app administration functionality needs to be implemented.

As in-app admin is already present within LKSM, this work largely consists of refactoring existing code into ui-components to share across LKSM and LKB. LKB settings will also be refactored to delineate user vs admin settings, similar to what LKSM does.

The previous story covered the scope of the pages
- User icon > Administration > Users tab
- User icon > Administration > Permissions tab

This story covers the scope of the pages
- User icon > Administration > Settings tab
- User Icon > Profile
- User Icon > Settings

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1190
* https://github.com/LabKey/sampleManagement/pull/871
* https://github.com/LabKey/labkey-ui-components/pull/764

#### Changes
* Pull in AccountSubNav and ProfilePage from SM
* Refactor ProfilePage to be FC
* Delete now-unneeded code from refactor
