### PR TITLE
Fix issue 44859

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.144.0-fb-issue-44859.1",
+  "version": "2.144.0-fb-issue-44859.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.145.0-fb-issue-44859.0",
+  "version": "2.145.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.144.0-fb-issue-44859.0",
+  "version": "2.144.0-fb-issue-44859.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.144.2",
+  "version": "2.144.0-fb-issue-44859.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.144.0-fb-issue-44859.2",
+  "version": "2.145.0-fb-issue-44859.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.145.0
+*Released*: ?? March 2022
+* Fix Issue 44859
+  * HeaderWrapper no longer scrolls to the top of the page during update
+  * Page component now scrolls to top of the page on mount
+* Remove circular dependency between Page and NotFound
+* Refactor NavigationBar to render HeaderWrapper and sticky class
+  * This eliminates duplicated code between our apps
+
 ### version 2.144.2
 *Released*: 21 March 2022
 * add `exportConfig` parameter to `getSampleTypeTemplateUrl` for better behavior for media templates

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.145.0
-*Released*: ?? March 2022
+*Released*: 22 March 2022
 * Fix Issue 44859
   * HeaderWrapper no longer scrolls to the top of the page during update
   * Page component now scrolls to top of the page on mount

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -412,7 +412,6 @@ import { LineageGrid, LineageGridFromLocation } from './internal/components/line
 import { EntityDeleteConfirmModal } from './internal/components/entities/EntityDeleteConfirmModal';
 import { EntityTypeDeleteConfirmModal } from './internal/components/entities/EntityTypeDeleteConfirmModal';
 import { SampleTypeLineageCounts } from './internal/components/lineage/SampleTypeLineageCounts';
-import { HeaderWrapper } from './internal/components/navigation/HeaderWrapper';
 import { NavigationBar } from './internal/components/navigation/NavigationBar';
 import { FindByIdsModal } from './internal/components/search/FindByIdsModal';
 import { ProductNavigationMenu } from './internal/components/productnavigation/ProductNavigationMenu';
@@ -1170,7 +1169,6 @@ export {
     ProductMenuModel,
     MenuSectionModel,
     MenuItemModel,
-    HeaderWrapper,
     NavigationBar,
     ProductNavigationMenu,
     FindByIdsModal,

--- a/packages/components/src/internal/components/base/Page.spec.tsx
+++ b/packages/components/src/internal/components/base/Page.spec.tsx
@@ -20,7 +20,6 @@ import { shallow } from 'enzyme';
 import { notificationInit } from '../../../test/setupUtils';
 
 import { Page } from './Page';
-import { NotFound } from './NotFound';
 import { PageHeader } from './PageHeader';
 
 beforeEach(() => {
@@ -66,7 +65,7 @@ describe('<Page /> document title', () => {
 describe('<Page />', () => {
     test('page not found', () => {
         const wrapper = shallow(<Page notFound={true} />);
-        expect(wrapper.find(NotFound)).toHaveLength(1);
+        expect(wrapper.find('h1').text()).toEqual('Not Found');
 
         const tree = renderer.create(<Page notFound={true} />).toJSON();
         expect(tree).toMatchSnapshot();

--- a/packages/components/src/internal/components/base/Page.tsx
+++ b/packages/components/src/internal/components/base/Page.tsx
@@ -16,7 +16,6 @@
 import React from 'react';
 
 import { PageHeader } from './PageHeader';
-import { NotFound } from './NotFound';
 
 export interface PageProps {
     notFound?: boolean;
@@ -33,11 +32,12 @@ export class Page extends React.Component<PageProps, any> {
     };
 
     componentDidMount() {
-        Page.setDocumentTitle(this.props);
+        this.setDocumentTitle();
+        window.scrollTo(0, 0);
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: PageProps): void {
-        Page.setDocumentTitle(nextProps);
+    componentDidUpdate(): void {
+        this.setDocumentTitle();
     }
 
     static getDocumentTitle(props: PageProps): string {
@@ -48,13 +48,13 @@ export class Page extends React.Component<PageProps, any> {
         return fullTitle;
     }
 
-    static setDocumentTitle(props: PageProps): void {
-        const fullTitle = Page.getDocumentTitle(props);
+    setDocumentTitle = (): void => {
+        const fullTitle = Page.getDocumentTitle(this.props);
 
-        if (document.title != fullTitle) {
+        if (document.title !== fullTitle) {
             document.title = fullTitle;
         }
-    }
+    };
 
     isHeader = (child): boolean => {
         // Dev/Prod builds require slightly different requirements for this check
@@ -62,20 +62,15 @@ export class Page extends React.Component<PageProps, any> {
     };
 
     render() {
-        const { children, notFound, showNotifications } = this.props;
-
-        if (notFound) {
-            return <NotFound />;
-        }
+        const { notFound, showNotifications } = this.props;
+        let { hasHeader } = this.props;
+        const children = notFound ? <h1>Not Found</h1> : this.props.children;
 
         if (children) {
-            let hasHeader = this.props.hasHeader;
             if (!hasHeader) {
                 React.Children.forEach(children, (child: any) => {
-                    if (!hasHeader && child && child.type) {
-                        if (this.isHeader(child)) {
-                            hasHeader = true;
-                        }
+                    if (!hasHeader && child && child.type && this.isHeader(child)) {
+                        hasHeader = true;
                     }
                 });
             }

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -16,6 +16,8 @@
 import React, { FC, memo, ReactNode, useCallback } from 'react';
 import { List, Map } from 'immutable';
 
+import { HeaderWrapper } from './HeaderWrapper';
+
 import { User } from '../../..';
 
 import { ServerNotifications } from '../notifications/ServerNotifications';
@@ -57,6 +59,7 @@ type Props = NavigationBarProps & UserMenuProps;
 export const NavigationBar: FC<Props> = memo(props => {
     const {
         brand,
+        children,
         extraDevItems,
         extraUserItems,
         menuSectionConfigs,
@@ -84,78 +87,84 @@ export const NavigationBar: FC<Props> = memo(props => {
     const _showProductNav = showProductNav !== false && shouldShowProductNavigation(user);
 
     return (
-        <nav className="navbar navbar-container test-loc-nav-header">
-            <div className="container">
-                <div className="row">
-                    <div className="navbar-left col-xs-8 col-md-7">
-                        <span className="navbar-item pull-left">{brand}</span>
-                        {showFolderMenu && (
-                            <span className="navbar-item">
-                                <FolderMenu />
-                            </span>
-                        )}
-                        {showNavMenu && !!model && (
-                            <span className="navbar-item">
-                                <ProductMenu model={model} sectionConfigs={menuSectionConfigs} />
-                            </span>
-                        )}
-                    </div>
-                    <div className="navbar-right col-xs-4 col-md-5">
-                        {!!user && (
-                            <div className="navbar-item pull-right">
-                                <UserMenu
-                                    extraDevItems={extraDevItems}
-                                    extraUserItems={extraUserItems}
-                                    model={model}
-                                    onSignIn={onSignIn}
-                                    onSignOut={onSignOut}
-                                    signOutUrl={signOutUrl}
-                                    user={user}
-                                />
+        <div className="sticky-on-top">
+            <HeaderWrapper>
+                <nav className="navbar navbar-container test-loc-nav-header">
+                    <div className="container">
+                        <div className="row">
+                            <div className="navbar-left col-xs-8 col-md-7">
+                                <span className="navbar-item pull-left">{brand}</span>
+                                {showFolderMenu && (
+                                    <span className="navbar-item">
+                                        <FolderMenu />
+                                    </span>
+                                )}
+                                {showNavMenu && !!model && (
+                                    <span className="navbar-item">
+                                        <ProductMenu model={model} sectionConfigs={menuSectionConfigs} />
+                                    </span>
+                                )}
                             </div>
-                        )}
-                        {_showNotifications && (
-                            <div className="navbar-item pull-right navbar-item-notification">
-                                <ServerNotifications {...notificationsConfig} />
-                            </div>
-                        )}
-                        {_showProductNav && (
-                            <div className="navbar-item pull-right navbar-item-product-navigation hidden-xs">
-                                <ProductNavigation />
-                            </div>
-                        )}
-                        {showSearchBox && (
-                            <div className="navbar-item pull-right">
-                                <div className="hidden-md hidden-sm hidden-xs">
-                                    <SearchBox
-                                        onSearch={onSearch}
-                                        placeholder={searchPlaceholder}
-                                        onFindByIds={onFindByIds}
-                                        findNounPlural="samples"
-                                    />
-                                </div>
-                                <div className="visible-md visible-sm visible-xs">
-                                    {onFindByIds ? (
-                                        <FindAndSearchDropdown
-                                            className="navbar__xs-find-dropdown"
-                                            title={<i className="fa fa-search navbar__xs-search-icon" />}
-                                            findNounPlural="samples"
-                                            onSearch={onSearchIconClick}
-                                            onFindByIds={onFindByIds}
+                            <div className="navbar-right col-xs-4 col-md-5">
+                                {!!user && (
+                                    <div className="navbar-item pull-right">
+                                        <UserMenu
+                                            extraDevItems={extraDevItems}
+                                            extraUserItems={extraUserItems}
+                                            model={model}
+                                            onSignIn={onSignIn}
+                                            onSignOut={onSignOut}
+                                            signOutUrl={signOutUrl}
+                                            user={user}
                                         />
-                                    ) : (
-                                        <i
-                                            className="fa fa-search navbar__xs-search-icon"
-                                            onClick={onSearchIconClick}
-                                        />
-                                    )}
-                                </div>
+                                    </div>
+                                )}
+                                {_showNotifications && (
+                                    <div className="navbar-item pull-right navbar-item-notification">
+                                        <ServerNotifications {...notificationsConfig} />
+                                    </div>
+                                )}
+                                {_showProductNav && (
+                                    <div className="navbar-item pull-right navbar-item-product-navigation hidden-xs">
+                                        <ProductNavigation />
+                                    </div>
+                                )}
+                                {showSearchBox && (
+                                    <div className="navbar-item pull-right">
+                                        <div className="hidden-md hidden-sm hidden-xs">
+                                            <SearchBox
+                                                onSearch={onSearch}
+                                                placeholder={searchPlaceholder}
+                                                onFindByIds={onFindByIds}
+                                                findNounPlural="samples"
+                                            />
+                                        </div>
+                                        <div className="visible-md visible-sm visible-xs">
+                                            {onFindByIds ? (
+                                                <FindAndSearchDropdown
+                                                    className="navbar__xs-find-dropdown"
+                                                    title={<i className="fa fa-search navbar__xs-search-icon" />}
+                                                    findNounPlural="samples"
+                                                    onSearch={onSearchIconClick}
+                                                    onFindByIds={onFindByIds}
+                                                />
+                                            ) : (
+                                                <i
+                                                    className="fa fa-search navbar__xs-search-icon"
+                                                    onClick={onSearchIconClick}
+                                                />
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
                             </div>
-                        )}
+                        </div>
                     </div>
-                </div>
-            </div>
-        </nav>
+                </nav>
+
+                {children}
+            </HeaderWrapper>
+        </div>
     );
 });
 

--- a/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
@@ -1,365 +1,397 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<NavigationBar/> default props 1`] = `
-<nav
-  className="navbar navbar-container test-loc-nav-header"
+<div
+  className="sticky-on-top"
 >
   <div
-    className="container"
+    className="app-header-wrapper"
   >
-    <div
-      className="row"
+    <nav
+      className="navbar navbar-container test-loc-nav-header"
     >
       <div
-        className="navbar-left col-xs-8 col-md-7"
+        className="container"
       >
-        <span
-          className="navbar-item pull-left"
-        />
+        <div
+          className="row"
+        >
+          <div
+            className="navbar-left col-xs-8 col-md-7"
+          >
+            <span
+              className="navbar-item pull-left"
+            />
+          </div>
+          <div
+            className="navbar-right col-xs-4 col-md-5"
+          />
+        </div>
       </div>
-      <div
-        className="navbar-right col-xs-4 col-md-5"
-      />
-    </div>
+    </nav>
   </div>
-</nav>
+</div>
 `;
 
 exports[`<NavigationBar/> with findByIds 1`] = `
-<nav
-  className="navbar navbar-container test-loc-nav-header"
+<div
+  className="sticky-on-top"
 >
   <div
-    className="container"
+    className="app-header-wrapper"
   >
-    <div
-      className="row"
+    <nav
+      className="navbar navbar-container test-loc-nav-header"
     >
       <div
-        className="navbar-left col-xs-8 col-md-7"
-      >
-        <span
-          className="navbar-item pull-left"
-        />
-      </div>
-      <div
-        className="navbar-right col-xs-4 col-md-5"
+        className="container"
       >
         <div
-          className="navbar-item pull-right"
+          className="row"
         >
           <div
-            className="hidden-md hidden-sm hidden-xs"
+            className="navbar-left col-xs-8 col-md-7"
           >
-            <form
-              className="navbar__search-form"
-              onSubmit={[Function]}
-            >
-              <div
-                className="form-group"
-              >
-                <i
-                  className="fa fa-search navbar__search-icon"
-                />
-                <span
-                  className="navbar__input-group input-group"
-                >
-                  <input
-                    className="form-control navbar__search-input"
-                    onChange={[Function]}
-                    placeholder="Enter Search Terms"
-                    size={34}
-                    type="text"
-                    value=""
-                  />
-                  <span
-                    className="input-group-btn"
-                  >
-                    <div
-                      className="dropdown btn-group"
-                    >
-                      <button
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        className="navbar__find-and-search-button undefined dropdown-toggle btn btn-default"
-                        disabled={false}
-                        id="find-and-search-menu"
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="button"
-                        type="button"
-                      >
-                         
-                        <span
-                          className="caret"
-                        />
-                      </button>
-                      <ul
-                        aria-labelledby="find-and-search-menu"
-                        className="dropdown-menu"
-                        role="menu"
-                      >
-                        <li
-                          className=""
-                          role="presentation"
-                        >
-                          <a
-                            href="#"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="menuitem"
-                            tabIndex="-1"
-                          >
-                            <i
-                              className="fa fa-barcode"
-                            />
-                             Find 
-                            Samples
-                             by Barcode
-                          </a>
-                        </li>
-                        <li
-                          className=""
-                          role="presentation"
-                        >
-                          <a
-                            href="#"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="menuitem"
-                            tabIndex="-1"
-                          >
-                            <i
-                              className="fa fa-hashtag"
-                            />
-                             Find 
-                            Samples
-                             by ID
-                          </a>
-                        </li>
-                        <li
-                          className=""
-                          role="presentation"
-                        >
-                          <a
-                            href="#/search/samplesByFilter"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="menuitem"
-                            tabIndex="-1"
-                          >
-                            <i
-                              className="fa fa-sitemap"
-                            />
-                             Sample Finder
-                          </a>
-                        </li>
-                      </ul>
-                    </div>
-                  </span>
-                </span>
-              </div>
-            </form>
+            <span
+              className="navbar-item pull-left"
+            />
           </div>
           <div
-            className="visible-md visible-sm visible-xs"
+            className="navbar-right col-xs-4 col-md-5"
           >
             <div
-              className="dropdown btn-group"
+              className="navbar-item pull-right"
             >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                className="navbar__find-and-search-button navbar__xs-find-dropdown dropdown-toggle btn btn-default"
-                disabled={false}
-                id="find-and-search-menu"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                role="button"
-                type="button"
+              <div
+                className="hidden-md hidden-sm hidden-xs"
               >
-                <i
-                  className="fa fa-search navbar__xs-search-icon"
-                />
-                 
-                <span
-                  className="caret"
-                />
-              </button>
-              <ul
-                aria-labelledby="find-and-search-menu"
-                className="dropdown-menu"
-                role="menu"
+                <form
+                  className="navbar__search-form"
+                  onSubmit={[Function]}
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <i
+                      className="fa fa-search navbar__search-icon"
+                    />
+                    <span
+                      className="navbar__input-group input-group"
+                    >
+                      <input
+                        className="form-control navbar__search-input"
+                        onChange={[Function]}
+                        placeholder="Enter Search Terms"
+                        size={34}
+                        type="text"
+                        value=""
+                      />
+                      <span
+                        className="input-group-btn"
+                      >
+                        <div
+                          className="dropdown btn-group"
+                        >
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            className="navbar__find-and-search-button undefined dropdown-toggle btn btn-default"
+                            disabled={false}
+                            id="find-and-search-menu"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="button"
+                            type="button"
+                          >
+                             
+                            <span
+                              className="caret"
+                            />
+                          </button>
+                          <ul
+                            aria-labelledby="find-and-search-menu"
+                            className="dropdown-menu"
+                            role="menu"
+                          >
+                            <li
+                              className=""
+                              role="presentation"
+                            >
+                              <a
+                                href="#"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                role="menuitem"
+                                tabIndex="-1"
+                              >
+                                <i
+                                  className="fa fa-barcode"
+                                />
+                                 Find 
+                                Samples
+                                 by Barcode
+                              </a>
+                            </li>
+                            <li
+                              className=""
+                              role="presentation"
+                            >
+                              <a
+                                href="#"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                role="menuitem"
+                                tabIndex="-1"
+                              >
+                                <i
+                                  className="fa fa-hashtag"
+                                />
+                                 Find 
+                                Samples
+                                 by ID
+                              </a>
+                            </li>
+                            <li
+                              className=""
+                              role="presentation"
+                            >
+                              <a
+                                href="#/search/samplesByFilter"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                role="menuitem"
+                                tabIndex="-1"
+                              >
+                                <i
+                                  className="fa fa-sitemap"
+                                />
+                                 Sample Finder
+                              </a>
+                            </li>
+                          </ul>
+                        </div>
+                      </span>
+                    </span>
+                  </div>
+                </form>
+              </div>
+              <div
+                className="visible-md visible-sm visible-xs"
               >
-                <li
-                  className=""
-                  role="presentation"
+                <div
+                  className="dropdown btn-group"
                 >
-                  <a
-                    href="#"
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="navbar__find-and-search-button navbar__xs-find-dropdown dropdown-toggle btn btn-default"
+                    disabled={false}
+                    id="find-and-search-menu"
                     onClick={[Function]}
                     onKeyDown={[Function]}
-                    role="menuitem"
-                    tabIndex="-1"
+                    role="button"
+                    type="button"
                   >
                     <i
-                      className="fa fa-barcode"
+                      className="fa fa-search navbar__xs-search-icon"
                     />
-                     Find 
-                    Samples
-                     by Barcode
-                  </a>
-                </li>
-                <li
-                  className=""
-                  role="presentation"
-                >
-                  <a
-                    href="#"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="menuitem"
-                    tabIndex="-1"
+                     
+                    <span
+                      className="caret"
+                    />
+                  </button>
+                  <ul
+                    aria-labelledby="find-and-search-menu"
+                    className="dropdown-menu"
+                    role="menu"
                   >
-                    <i
-                      className="fa fa-hashtag"
-                    />
-                     Find 
-                    Samples
-                     by ID
-                  </a>
-                </li>
-                <li
-                  className=""
-                  role="presentation"
-                >
-                  <a
-                    href="#/search/samplesByFilter"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="menuitem"
-                    tabIndex="-1"
-                  >
-                    <i
-                      className="fa fa-sitemap"
-                    />
-                     Sample Finder
-                  </a>
-                </li>
-                <li
-                  className=""
-                  role="presentation"
-                >
-                  <a
-                    href="#"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="menuitem"
-                    tabIndex="-1"
-                  >
-                    <i
-                      className="fa fa-search"
-                    />
-                     Search
-                  </a>
-                </li>
-              </ul>
+                    <li
+                      className=""
+                      role="presentation"
+                    >
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                      >
+                        <i
+                          className="fa fa-barcode"
+                        />
+                         Find 
+                        Samples
+                         by Barcode
+                      </a>
+                    </li>
+                    <li
+                      className=""
+                      role="presentation"
+                    >
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                      >
+                        <i
+                          className="fa fa-hashtag"
+                        />
+                         Find 
+                        Samples
+                         by ID
+                      </a>
+                    </li>
+                    <li
+                      className=""
+                      role="presentation"
+                    >
+                      <a
+                        href="#/search/samplesByFilter"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                      >
+                        <i
+                          className="fa fa-sitemap"
+                        />
+                         Sample Finder
+                      </a>
+                    </li>
+                    <li
+                      className=""
+                      role="presentation"
+                    >
+                      <a
+                        href="#"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                      >
+                        <i
+                          className="fa fa-search"
+                        />
+                         Search
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </nav>
   </div>
-</nav>
+</div>
 `;
 
 exports[`<NavigationBar/> with search box 1`] = `
-<nav
-  className="navbar navbar-container test-loc-nav-header"
+<div
+  className="sticky-on-top"
 >
   <div
-    className="container"
+    className="app-header-wrapper"
   >
-    <div
-      className="row"
+    <nav
+      className="navbar navbar-container test-loc-nav-header"
     >
       <div
-        className="navbar-left col-xs-8 col-md-7"
-      >
-        <span
-          className="navbar-item pull-left"
-        />
-      </div>
-      <div
-        className="navbar-right col-xs-4 col-md-5"
+        className="container"
       >
         <div
-          className="navbar-item pull-right"
+          className="row"
         >
           <div
-            className="hidden-md hidden-sm hidden-xs"
+            className="navbar-left col-xs-8 col-md-7"
           >
-            <form
-              className="navbar__search-form"
-              onSubmit={[Function]}
-            >
-              <div
-                className="form-group"
-              >
-                <i
-                  className="fa fa-search navbar__search-icon"
-                />
-                <span
-                  className="navbar__input-group "
-                >
-                  <input
-                    className="form-control navbar__search-input"
-                    onChange={[Function]}
-                    placeholder="Enter Search Terms"
-                    size={34}
-                    type="text"
-                    value=""
-                  />
-                </span>
-              </div>
-            </form>
+            <span
+              className="navbar-item pull-left"
+            />
           </div>
           <div
-            className="visible-md visible-sm visible-xs"
+            className="navbar-right col-xs-4 col-md-5"
           >
-            <i
-              className="fa fa-search navbar__xs-search-icon"
-              onClick={[Function]}
-            />
+            <div
+              className="navbar-item pull-right"
+            >
+              <div
+                className="hidden-md hidden-sm hidden-xs"
+              >
+                <form
+                  className="navbar__search-form"
+                  onSubmit={[Function]}
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <i
+                      className="fa fa-search navbar__search-icon"
+                    />
+                    <span
+                      className="navbar__input-group "
+                    >
+                      <input
+                        className="form-control navbar__search-input"
+                        onChange={[Function]}
+                        placeholder="Enter Search Terms"
+                        size={34}
+                        type="text"
+                        value=""
+                      />
+                    </span>
+                  </div>
+                </form>
+              </div>
+              <div
+                className="visible-md visible-sm visible-xs"
+              >
+                <i
+                  className="fa fa-search navbar__xs-search-icon"
+                  onClick={[Function]}
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </nav>
   </div>
-</nav>
+</div>
 `;
 
 exports[`<NavigationBar/> without search but with findByIds 1`] = `
-<nav
-  className="navbar navbar-container test-loc-nav-header"
+<div
+  className="sticky-on-top"
 >
   <div
-    className="container"
+    className="app-header-wrapper"
   >
-    <div
-      className="row"
+    <nav
+      className="navbar navbar-container test-loc-nav-header"
     >
       <div
-        className="navbar-left col-xs-8 col-md-7"
+        className="container"
       >
-        <span
-          className="navbar-item pull-left"
-        />
+        <div
+          className="row"
+        >
+          <div
+            className="navbar-left col-xs-8 col-md-7"
+          >
+            <span
+              className="navbar-item pull-left"
+            />
+          </div>
+          <div
+            className="navbar-right col-xs-4 col-md-5"
+          />
+        </div>
       </div>
-      <div
-        className="navbar-right col-xs-4 col-md-5"
-      />
-    </div>
+    </nav>
   </div>
-</nav>
+</div>
 `;

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, FC, memo, PureComponent, ReactNode, useMemo } from 'react';
 import classNames from 'classnames';
 import { fromJS, List, Set } from 'immutable';
-import { Filter, Query } from '@labkey/api';
+import { Query } from '@labkey/api';
 
 import {
     Alert,

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -846,22 +846,18 @@ export class QueryModel {
      * Returns the model attributes given a set of queryParams from the URL. Used for URL Binding.
      * @param queryParams: The query attribute from a ReactRouter Location object.
      */
-    attributesForURLQueryParams(queryParams): QueryModelURLState {
+    attributesForURLQueryParams(queryParams: Record<string, string>): QueryModelURLState {
         const prefix = this.urlPrefix;
         const viewName = queryParams[`${prefix}.view`] ?? this.viewName;
-        let filterArray = Filter.getFiltersFromParameters(queryParams, prefix) || this.filterArray;
-        const searchFilters = searchFiltersFromString(queryParams[`${prefix}.q`]);
-
-        if (searchFilters !== undefined) {
-            filterArray = filterArray.concat(searchFilters);
-        }
+        const searchFilters = searchFiltersFromString(queryParams[`${prefix}.q`]) ?? [];
+        const columnFilters = Filter.getFiltersFromParameters(queryParams, prefix) || [];
 
         return {
-            filterArray,
-            offset: offsetFromString(this.maxRows, queryParams[`${prefix}.p`]) ?? this.offset,
+            filterArray: columnFilters.concat(searchFilters),
+            offset: offsetFromString(this.maxRows, queryParams[`${prefix}.p`]) ?? DEFAULT_OFFSET,
             schemaQuery: SchemaQuery.create(this.schemaName, this.queryName, viewName),
-            sorts: querySortsFromString(queryParams[`${prefix}.sort`]) ?? this.sorts,
-            selectedReportId: queryParams[`${prefix}.reportId`] ?? this.selectedReportId,
+            sorts: querySortsFromString(queryParams[`${prefix}.sort`]) ?? [],
+            selectedReportId: queryParams[`${prefix}.reportId`] ?? undefined,
         };
     }
 

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -42,7 +42,7 @@ export interface GridMessage {
 
 export interface QueryConfig {
     /**
-     * An array of base [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/_filter_filter_.ifilter.html)
+     * An array of base [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html)
      * filters to be applied to the [[QueryModel]] data load. These base filters will be concatenated with URL filters,
      * the keyValue filter, and view filters when applicable.
      */
@@ -52,7 +52,7 @@ export interface QueryConfig {
      */
     bindURL?: boolean;
     /**
-     * One of the values of [Query.ContainerFilter](https://labkey.github.io/labkey-api-js/enums/_query_utils_.containerfilter.html)
+     * One of the values of [Query.ContainerFilter](https://labkey.github.io/labkey-api-js/enums/Query.ContainerFilter.html)
      * that sets the scope of this query. Defaults to ContainerFilter.current, and is interpreted relative to
      * config.containerPath.
      */
@@ -130,7 +130,7 @@ const DEFAULT_MAX_ROWS = 20;
 
 /**
  * This is the base model used to store all the data for a query. At a high level the QueryModel API is a wrapper around
- * the [selectRows](https://labkey.github.io/labkey-api-js/modules/_query_selectrows_.html#selectrows) API.
+ * the [selectRows](https://labkey.github.io/labkey-api-js/modules/Query.html#selectRows) API.
  * If you need to retrieve data from a LabKey table or query, so you can render it in a React
  * component, then the QueryModel API is most likely what you want.
  *
@@ -150,7 +150,7 @@ export class QueryModel {
     // Fields from QueryConfig
     // Some of the fields we have in common with QueryConfig are not optional because we give them default values.
     /**
-     * An array of base [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/_filter_filter_.ifilter.html)
+     * An array of base [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html)
      * filters to be applied to the QueryModel data load. These base filters will be concatenated with URL filters,
      * they keyValue filter, and view filters when applicable.
      */
@@ -160,7 +160,7 @@ export class QueryModel {
      */
     readonly bindURL: boolean;
     /**
-     * One of the values of [Query.ContainerFilter](https://labkey.github.io/labkey-api-js/enums/_query_utils_.containerfilter.html)
+     * One of the values of [Query.ContainerFilter](https://labkey.github.io/labkey-api-js/enums/Query.ContainerFilter.html)
      * that sets the scope of this query. Defaults to ContainerFilter.current, and is interpreted relative to
      * config.containerPath.
      */
@@ -234,7 +234,7 @@ export class QueryModel {
 
     // QueryModel only fields
     /**
-     * An array of [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/_filter_filter_.ifilter.html)
+     * An array of [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html)
      * filters to be applied to the QueryModel data load. These filters will be concatenated with base filters, URL filters,
      * they keyValue filter, and view filters when applicable.
      */
@@ -436,7 +436,7 @@ export class QueryModel {
     }
 
     /**
-     * An array of [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/_filter_filter_.ifilter.html) objects
+     * An array of [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html) objects
      * for the QueryModel. If a keyValue is provided, this will be a filter on the primary key column concatenated with
      * the detailFilters. Otherwise, this will be a concatenation of the baseFilters, filterArray, and [[QueryInfo]] view filters.
      */

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -784,7 +784,9 @@ export function withQueryModels<Props>(
                     if (!filterArraysEqual(model.filterArray, filters)) {
                         shouldLoad = true;
                         model.filterArray = filters;
-                        resetRowsState(model); // Changing filters affects row count so we need to reset rows state.
+                        // Changing filters affects row count so we need to reset the offset or pagination can get into
+                        // an impossible state (e.g. page 3 on a grid with one row of data).
+                        model.offset = 0;
                     }
                 }),
                 // When filters change we need to reload selections.

--- a/packages/components/src/test/jest.setup.ts
+++ b/packages/components/src/test/jest.setup.ts
@@ -19,3 +19,8 @@ import Adapter from 'enzyme-adapter-react-16';
 // Enzyme expects an adapter to be configured
 // http://airbnb.io/enzyme/docs/installation/react-16.html
 configure({ adapter: new Adapter() });
+
+// This silences errors related to our Page component using window.scrollTo. JSDom doesn't implement scrollTo, but that
+// is ok, we aren't testing that behavior.
+const noop = () => {};
+Object.defineProperty(window, 'scrollTo', { value: noop, writable: true });


### PR DESCRIPTION
#### Rationale
Right now due to an implementation detail of HeaderWrapper anytime the URL is changed the page scrolls to the top. This is especially egregious when changing filters/sorts for grids, or when using the new ELN Home page. [This PR fixes that issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44859), and also reduces the need for duplicate code in our apps by slightly refactoring NavigationBar.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1195
* https://github.com/LabKey/sampleManagement/pull/875
* https://github.com/LabKey/inventory/pull/394

#### Changes
* Fix Issue 44859
  * HeaderWrapper no longer scrolls to the top of the page during update
  * Page component now scrolls to top of the page on mount
* Remove circular dependency between Page and NotFound
* Refactor NavigationBar to render HeaderWrapper and sticky class
  * This eliminates duplicated code between our apps
* Fix issue with URL binding pagination offsets when filters change