### PR TITLE
Issue 45093: Fix production navigation menu URl action for going from LKS to app

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.6-fb-productMenu45093.0",
+  "version": "2.138.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.6",
+  "version": "2.138.6-fb-productMenu45093.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.138.TBD
-*Released*: TBD March 2022
+### version 2.138.7
+*Released*: 24 March 2022
 * Issue 45093: Fix production navigation menu URl action for going from LKS to app
   * Revert change from PR747 to createProductURL() so that we go back to always using app action
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.138.TBD
+*Released*: TBD March 2022
+* Issue 45093: Fix production navigation menu URl action for going from LKS to app
+
 ### version 2.138.6
 *Released*: 10 March 2022
 * Sample Finder Optimizations

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.138.TBD
 *Released*: TBD March 2022
 * Issue 45093: Fix production navigation menu URl action for going from LKS to app
+  * Revert change from PR747 to createProductURL() so that we go back to always using app action
 
 ### version 2.138.6
 *Released*: 10 March 2022

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -35,9 +35,8 @@ export function createProductUrl(
 ): string | AppURL {
     if (urlProductId && (!currentProductId || urlProductId.toLowerCase() !== currentProductId.toLowerCase())) {
         const href = appUrl instanceof AppURL ? appUrl.toHref() : appUrl;
-        const action = ActionURL.getAction() || 'app';
         return (
-            buildURL(urlProductId.toLowerCase(), action + '.view', undefined, {
+            buildURL(urlProductId.toLowerCase(), 'app.view', undefined, {
                 returnUrl: false,
                 container: containerPath, // if undefined, buildURL will use current container from server context
             }) + href


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45093

With a PR from Feb 2022, I made a small change to the URL builder in AppURL.ts (createProductUrl) to try and better account for the HMR mode: https://github.com/LabKey/labkey-ui-components/pull/747/files#diff-8d074006d4fd625a8c8814b797fd36473401359fccda16729d1ccd1fb10aeb51R40

This inadvertently broke the product navigation menu for going from LKS to the apps. This PR reverts that change to AppURL.ts

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/774
* https://github.com/LabKey/sampleManagement/pull/888
* https://github.com/LabKey/biologics/pull/1206
* https://github.com/LabKey/inventory/pull/403
* https://github.com/LabKey/platform/pull/3164

#### Changes
* revert change to AppURL.ts createProductUrl() so that we go back to always using the app action
