### PR TITLE
Fix issue with QueryModel initialization when bindURL is true

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.145.1-fb-fix-url-binding-initialization.0",
+  "version": "2.145.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.145.0",
+  "version": "2.145.1-fb-fix-url-binding-initialization.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.145.1
+*Released*: ?? March 2022
+* Fix issue where models with bindURl set to true could not have default sorts/filters/etc.
+
 ### version 2.145.0
 *Released*: 22 March 2022
 * Fix Issue 44859

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.145.1
-*Released*: ?? March 2022
+*Released*: 24 March 2022
 * Fix issue where models with bindURl set to true could not have default sorts/filters/etc.
 
 ### version 2.145.0

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -144,7 +144,7 @@ export function withQueryModels<Props>(
             let model = new QueryModel({ id, ...queryConfigs[id] });
 
             if (model.bindURL && location) {
-                model = model.mutate(model.attributesForURLQueryParams(location.query));
+                model = model.mutate(model.attributesForURLQueryParams(location.query, true));
             }
 
             models[id] = model;


### PR DESCRIPTION
#### Rationale
My recent PR broke the edge case where a model has `bindURL` set to true *and* we set a default sort. This PR updates the `QueryModel.attributesForURLQueryParams` method to optionally use the values on the model as the default values.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/394

#### Changes
* Fix issue where models with bindURl set to true could not have default sorts/filters/etc.
