### PR TITLE
Issue 45126: Job start and due dates are not saved after being updated

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.147.0",
+  "version": "2.147.1-workflowMinorFixes214.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.147.1-workflowMinorFixes214.0",
+  "version": "2.147.1-workflowMinorFixes214.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.147.1-workflowMinorFixes214.1",
+  "version": "2.147.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45126: Job start and due dates are not saved after being updated
+
 ### version 2.147.0
 *Released*: 28 March 2022
 * Item 10192: Support two filter clauses per field in the `FilterExpressionView` and `FilterCards`

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.147.1
+*Released*: 29 March 2022
 * Issue 45126: Job start and due dates are not saved after being updated
 
 ### version 2.147.0

--- a/packages/components/src/internal/components/DateInput.tsx
+++ b/packages/components/src/internal/components/DateInput.tsx
@@ -27,10 +27,15 @@ export class DateInput extends PureComponent<ReactDatePickerProps> {
         this.input.current?.setFocus();
     };
 
+    onSelect = (): void => {
+        // focus the input so an onBlur action gets triggered after selection has been made
+        this.input.current?.setFocus()
+    }
+
     render(): ReactNode {
         return (
             <span className="input-group date-input">
-                <DatePicker {...this.props} ref={this.input} />
+                <DatePicker {...this.props} ref={this.input} onSelect={this.onSelect} />
                 <span className="input-group-addon" onClick={this.onIconClick}>
                     <i className="fa fa-calendar" />
                 </span>

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -91,14 +91,6 @@ export const EditInlineField: FC<Props> = memo(props => {
         setState({ ignoreBlur: false });
     }, [allowBlank, getInputValue, isDate, saveEdit, state.ignoreBlur]);
 
-    // The onBlur callback doesn't have the desired effect for the date picker fields
-    // because after picking a date the input field is not focused, so there is no blur event.
-    useEffect(() => {
-        if (state.editing) {
-            onBlur();
-        }
-    }, [dateValue]);
-
     const onDateChange = useCallback((date: Date | [Date, Date]) => {
         if (date instanceof Array) throw new Error('Unsupported date type');
         setDateValue(date);

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -1,4 +1,15 @@
-import React, { FC, FormEvent, memo, ReactNode, useCallback, useMemo, useReducer, useRef, useState } from 'react';
+import React, {
+    FC,
+    FormEvent,
+    memo,
+    ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useReducer,
+    useRef,
+    useState
+} from 'react';
 import moment from 'moment';
 
 import { getDateFormat } from '../util/Date';
@@ -79,6 +90,14 @@ export const EditInlineField: FC<Props> = memo(props => {
         }
         setState({ ignoreBlur: false });
     }, [allowBlank, getInputValue, isDate, saveEdit, state.ignoreBlur]);
+
+    // The onBlur callback doesn't have the desired effect for the date picker fields
+    // because after picking a date the input field is not focused, so there is no blur event.
+    useEffect(() => {
+        if (state.editing) {
+            onBlur();
+        }
+    }, [dateValue]);
 
     const onDateChange = useCallback((date: Date | [Date, Date]) => {
         if (date instanceof Array) throw new Error('Unsupported date type');


### PR DESCRIPTION
#### Rationale
In `EditInlineField`, the `onBlur` callback is not being called after dates are chosen from the datepicker because the user doesn't actually focus in the input field when using the datepicker. The result is that updated dates aren't saved unless a user sort of accidentally focuses on the cell.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/897
* https://github.com/LabKey/biologics/pull/1215

#### Changes
* Add a `useEffect` to save the dates when they change in the state.
