### PR TITLE
Fix linting commands

### DIFF
--- a/packages/components/lint.diff.mjs
+++ b/packages/components/lint.diff.mjs
@@ -1,5 +1,4 @@
-
-const execa = require('execa');
+import { execa } from 'execa';
 
 const fileExtensions = ['.tsx', '.ts'];  // linted file types
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,10 +19,10 @@
     "watch": "npm run watch:build",
     "lint": "eslint",
     "lint-fix": "eslint --fix",
-    "lint-precommit": "node lint.diff.js",
-    "lint-precommit-fix": "node lint.diff.js --fix",
-    "lint-branch": "node lint.diff.js --currentBranch",
-    "lint-branch-fix": "node lint.diff.js --currentBranch --fix"
+    "lint-precommit": "node lint.diff.mjs",
+    "lint-precommit-fix": "node lint.diff.mjs --fix",
+    "lint-branch": "node lint.diff.mjs --currentBranch",
+    "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Rationale
Fixes usage of `execa` package used for lint diffing. This was broken due to my package updates with https://github.com/LabKey/labkey-ui-components/pull/784.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/788
* https://github.com/LabKey/biologics/pull/1218
* https://github.com/LabKey/platform/pull/3186
* https://github.com/LabKey/moduleEditor/pull/54
* https://github.com/LabKey/provenance/pull/100

#### Changes
* Rename `lint.diff.js` to `lint.diff.mjs` and switch to using `import` of module dependencies.
