### PR TITLE
Issue 45149: "Assay Results" tabbed grid can remove tabs if you filter a grid to zero rows

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.149.0",
+  "version": "2.149.0-fb-assayTabbedGrid45149.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45149: "Assay Results" tabbed grid can remove tabs if you filter a grid to zero rows
+
 ### version 2.149.0
 *Released*: 30 March 2022
 * Item 10191: Add grid column header filter and sort behavior

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.spec.tsx
@@ -251,15 +251,17 @@ describe('SampleAssayDetailBodyImpl', () => {
             <SampleAssayDetailBodyImpl
                 {...IMPL_PROPS}
                 queryModels={{
-                    id1: modelLoadedNoRows.mutate({ id: 'id1' }),
-                    id2: modelLoadedWithRow.mutate({ id: 'id2' }),
+                    'assay-detail:id1': modelLoadedNoRows.mutate({ id: 'assay-detail:id1' }),
+                    'unfiltered-assay-detail:id1': modelLoadedNoRows.mutate({ id: 'unfiltered-assay-detail:id1' }),
+                    'assay-detail:id2': modelLoadedWithRow.mutate({ id: 'assay-detail:id2' }),
+                    'unfiltered-assay-detail:id2': modelLoadedWithRow.mutate({ id: 'unfiltered-assay-detail:id2' }),
                 }}
             />
         );
         validate(wrapper, false, undefined, true);
         const modelKeys = Object.keys(wrapper.find(TabbedGridPanel).prop('queryModels'));
-        expect(modelKeys.indexOf('id1')).toBe(-1);
-        expect(modelKeys.indexOf('id2')).toBe(0);
+        expect(modelKeys.indexOf('assay-detail:id1')).toBe(-1);
+        expect(modelKeys.indexOf('assay-detail:id2')).toBe(0);
         wrapper.unmount();
     });
 
@@ -268,14 +270,17 @@ describe('SampleAssayDetailBodyImpl', () => {
             <SampleAssayDetailBodyImpl
                 {...IMPL_PROPS}
                 queryModels={{
-                    id1: modelLoadedNoRows.mutate({ id: 'id1', title: 'C' }),
-                    id2: modelLoadedWithRow.mutate({ id: 'id2', title: 'B' }),
-                    id3: modelLoadedWithRow.mutate({ id: 'id3', title: 'A' }),
+                    'assay-detail:id1': modelLoadedNoRows.mutate({ id: 'assay-detail:id1', title: 'C' }),
+                    'unfiltered-assay-detail:id1': modelLoadedNoRows.mutate({ id: 'unfiltered-assay-detail:id1', title: 'C' }),
+                    'assay-detail:id2': modelLoadedWithRow.mutate({ id: 'assay-detail:id2', title: 'B' }),
+                    'unfiltered-assay-detail:id2': modelLoadedWithRow.mutate({ id: 'unfiltered-assay-detail:id2', title: 'B' }),
+                    'assay-detail:id3': modelLoadedWithRow.mutate({ id: 'assay-detail:id3', title: 'A' }),
+                    'unfiltered-assay-detail:id3': modelLoadedWithRow.mutate({ id: 'unfiltered-assay-detail:id3', title: 'A' }),
                 }}
             />
         );
         validate(wrapper, false, undefined, true);
-        expect(wrapper.find(TabbedGridPanel).prop('tabOrder')).toStrictEqual(['id3', 'id2']);
+        expect(wrapper.find(TabbedGridPanel).prop('tabOrder')).toStrictEqual(['assay-detail:id3', 'assay-detail:id2']);
         wrapper.unmount();
     });
 });
@@ -343,9 +348,11 @@ describe('SampleAssayDetailImpl', () => {
         await waitForLifecycle(wrapper);
         const configs = wrapper.find(SampleAssayDetailBody).prop('queryConfigs');
         const configKeys = Object.keys(configs);
-        expect(configKeys.length).toBe(1);
+        expect(configKeys.length).toBe(2);
         expect(configs[configKeys[0]].baseFilters[0].getColumnName()).toBe('filterKey');
         expect(configs[configKeys[0]].baseFilters[0].getValue()).toStrictEqual([1]); // RowId value of sample row
+        expect(configs[configKeys[1]].baseFilters[0].getColumnName()).toBe('filterKey');
+        expect(configs[configKeys[1]].baseFilters[0].getValue()).toStrictEqual([1]); // RowId value of sample row
         wrapper.unmount();
     });
 
@@ -371,9 +378,11 @@ describe('SampleAssayDetailImpl', () => {
         await waitForLifecycle(wrapper);
         const configs = wrapper.find(SampleAssayDetailBody).prop('queryConfigs');
         const configKeys = Object.keys(configs);
-        expect(configKeys.length).toBe(1);
+        expect(configKeys.length).toBe(2);
         expect(configs[configKeys[0]].baseFilters[0].getColumnName()).toBe('filterKey');
         expect(configs[configKeys[0]].baseFilters[0].getValue()).toStrictEqual(['Name1']); // Name value of sample row
+        expect(configs[configKeys[1]].baseFilters[0].getColumnName()).toBe('filterKey');
+        expect(configs[configKeys[1]].baseFilters[0].getValue()).toStrictEqual(['Name1']); // Name value of sample row
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
+++ b/packages/components/src/internal/components/samples/SampleAssayDetail.tsx
@@ -197,25 +197,15 @@ export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & Injected
 
     const { queryModelsWithData, tabOrder } = useMemo(() => {
         const models: Record<string, QueryModel> = {};
-        let targetQueryModels = Object.values(queryModels);
-        const isFilteredView =
-            showAliquotViewSelector &&
-            activeSampleAliquotType !== null &&
-            activeSampleAliquotType !== ALIQUOT_FILTER_MODE.all;
-        if (isFilteredView) {
-            targetQueryModels = [];
-            Object.values(queryModels).forEach(model => {
-                if (model.id?.indexOf(UNFILTERED_GRID_ID_PREFIX) === 0) targetQueryModels.push(model);
-            });
-        }
+        const targetQueryModels = [];
+        Object.values(queryModels).forEach(model => {
+            if (model.id?.indexOf(UNFILTERED_GRID_ID_PREFIX) === 0) targetQueryModels.push(model);
+        });
 
         targetQueryModels.forEach(model => {
-            let targetModel = model;
-            if (isFilteredView) {
-                targetModel = Object.values(queryModels).find(
-                    m => m.id === model.id.substring(UNFILTERED_PREFIX.length)
-                );
-            }
+            const targetModel = Object.values(queryModels).find(
+                m => m.id === model.id.substring(UNFILTERED_PREFIX.length)
+            );
             if (model.hasRows) {
                 models[targetModel.id] = targetModel;
             }
@@ -447,26 +437,22 @@ export const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
         }, {});
 
         // keep tab when "all" view has data, but filtered view is blank
-        const includeUnfilteredConfigs =
-            showAliquotViewSelector && activeSampleAliquotType && activeSampleAliquotType !== ALIQUOT_FILTER_MODE.all;
-        if (includeUnfilteredConfigs) {
-            const _unfilteredConfigs = getSampleAssayQueryConfigs(
-                assayModel,
-                allSampleIds,
-                queryGridSuffix,
-                UNFILTERED_GRID_ID_PREFIX,
-                false,
-                sampleSchemaQuery
-            );
+        const _unfilteredConfigs = getSampleAssayQueryConfigs(
+            assayModel,
+            allSampleIds,
+            queryGridSuffix,
+            UNFILTERED_GRID_ID_PREFIX,
+            false,
+            sampleSchemaQuery
+        );
 
-            const unfilteredConfigs = _unfilteredConfigs.reduce((_configs, config) => {
-                const modelId = config.id;
-                _configs[modelId] = config;
-                return _configs;
-            }, {});
+        const unfilteredConfigs = _unfilteredConfigs.reduce((_configs, config) => {
+            const modelId = config.id;
+            _configs[modelId] = config;
+            return _configs;
+        }, {});
 
-            configs = { ...configs, ...unfilteredConfigs };
-        }
+        configs = { ...configs, ...unfilteredConfigs };
 
         // add in the config objects for those module-defined sample assay result views (e.g. TargetedMS module),
         // note that the moduleName from the config must be active/enabled in the container
@@ -489,17 +475,15 @@ export const SampleAssayDetailImpl: FC<Props & InjectedAssayModel> = props => {
                     baseFilters: [Filter.create(config.filterKey, sampleFilterValues, Filter.Types.IN)],
                 };
 
-                if (includeUnfilteredConfigs) {
-                    modelId = `${UNFILTERED_GRID_ID_PREFIX}:${config.title}:${sampleId}`;
-                    sampleFilterValues = allSampleRows.map(
-                        row => caseInsensitive(row, config.sampleRowKey ?? 'RowId')?.value
-                    );
-                    configs[modelId] = {
-                        ...baseConfig,
-                        id: modelId,
-                        baseFilters: [Filter.create(config.filterKey, sampleFilterValues, Filter.Types.IN)],
-                    };
-                }
+                modelId = `${UNFILTERED_GRID_ID_PREFIX}:${config.title}:${sampleId}`;
+                sampleFilterValues = allSampleRows.map(
+                    row => caseInsensitive(row, config.sampleRowKey ?? 'RowId')?.value
+                );
+                configs[modelId] = {
+                    ...baseConfig,
+                    id: modelId,
+                    baseFilters: [Filter.create(config.filterKey, sampleFilterValues, Filter.Types.IN)],
+                };
             }
         });
 


### PR DESCRIPTION
#### Rationale
See issue for details: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45149

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/790
* https://github.com/LabKey/sampleManagement/pull/902
* https://github.com/LabKey/biologics/pull/1223

#### Changes
* SampleAssayDetail component update to alway include the unfiltered query configs for the assays with data in the withQueryModels, instead of just including them when the sample/aliquot view selector is not "all"
