### PR TITLE
45148: Handle data indices for single/multi-part fieldKeys

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.149.4",
+  "version": "2.149.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.149.5
+*Released*: 31 March 2022
+* 45148: Handle data indices for single/multi-part fieldKeys
+* Add defensive check for presence of product
+
 ### version 2.149.4
 *Released*: 31 March 2022
 * Fix issue with Between filter type second input

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -39,7 +39,7 @@ function processColumns(columns: List<any>): List<GridColumn> {
                 align: c.align,
                 cell: c.cell,
                 format: c.jsonType === 'float' || c.jsonType === 'int' ? c.format : undefined,
-                index: c.index || c.fieldKeyArray.join('/'),
+                index: c.index,
                 raw: c,
                 tableCell: c.tableCell,
                 title: c.title || c.caption,

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -7,7 +7,7 @@ import {
     QueryModel,
     resolveErrorMessage,
     SchemaQuery,
-    URLResolver
+    URLResolver,
 } from '../../..';
 import { RELEVANT_SEARCH_RESULT_TYPES } from '../../constants';
 
@@ -22,7 +22,10 @@ export function searchUsingIndex(
     getCardDataFn?: GetCardDataFn,
     filterCategories?: string[]
 ): Promise<Record<string, any>> {
-    incrementClientSideMetricCount(getPrimaryAppProperties().productId + 'Search', 'count');
+    const appProps = getPrimaryAppProperties();
+    if (appProps?.productId) {
+        incrementClientSideMetricCount(appProps.productId + 'Search', 'count');
+    }
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL('search', 'json.api'),

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -11,9 +11,10 @@ import {
 } from '../../..';
 import { RELEVANT_SEARCH_RESULT_TYPES } from '../../constants';
 
+import { getPrimaryAppProperties } from '../../app/utils';
+
 import { SearchIdData, SearchResultCardData } from './models';
 import { SAMPLE_FINDER_VIEW_NAME } from './utils';
-import { getPrimaryAppProperties } from '../../app/utils';
 
 type GetCardDataFn = (data: Map<any, any>, category?: string) => SearchResultCardData;
 

--- a/packages/components/src/public/QueryColumn.spec.ts
+++ b/packages/components/src/public/QueryColumn.spec.ts
@@ -1,8 +1,10 @@
+import { FieldKey } from '@labkey/api';
+
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../internal/components/domainproperties/constants';
 
 import { insertColumnFilter, QueryColumn } from './QueryColumn';
 
-describe('QueryColumn: Sample Lookup', () => {
+describe('QueryColumn', () => {
     // prepare stuff we need
     const validColumn = QueryColumn.create({
         align: 'left',
@@ -134,6 +136,27 @@ describe('QueryColumn: Sample Lookup', () => {
         type: 'Text (String)',
         userEditable: true,
         removeFromViews: false,
+    });
+
+    test('index', () => {
+        const singlePartFieldKey = new FieldKey(null, 'This<Arro|?#$!Thing');
+
+        const singlePartFieldKeyColumn = QueryColumn.create({
+            fieldKey: singlePartFieldKey.toString(),
+            fieldKeyArray: singlePartFieldKey.getParts(),
+        });
+
+        expect(singlePartFieldKeyColumn.index).toEqual(singlePartFieldKey.name);
+
+        const parentFieldKey = new FieldKey(null, 'runApplicationOutput');
+        const multiPartFieldKey = new FieldKey(parentFieldKey, 'urn:recipe.labkey.org/#RecipeAmount');
+
+        const multiPartFieldKeyColumn = QueryColumn.create({
+            fieldKey: multiPartFieldKey.toString(),
+            fieldKeyArray: multiPartFieldKey.getParts(),
+        });
+
+        expect(multiPartFieldKeyColumn.index).toEqual(multiPartFieldKey.toString());
     });
 
     test('isSampleLookup', () => {


### PR DESCRIPTION
#### Rationale
This addresses [45148](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45148) by adjusting the underlying logic for computing data indices against select rows results. See comments on `QueryColumn.index()` for more detailed information.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1230
* https://github.com/LabKey/sampleManagement/pull/905
* https://github.com/LabKey/inventory/pull/413

#### Changes
* Add computed `index` property to `QueryColumn`. Determine data index based on `fieldKey` and `fieldKeyArray` configuration.
