### PR TITLE
Remove --runInBand

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,7 +14,7 @@
     "cleanAll": "nps cleanAll",
     "prepublishOnly": "yarn install && cross-env WEBPACK_STATS=errors-only yarn build",
     "test": "cross-env NODE_ENV=test jest --maxWorkers=6 --silent",
-    "test-ci": "cross-env NODE_ENV=test jest --ci --runInBand --silent",
+    "test-ci": "cross-env NODE_ENV=test jest --ci --silent",
     "watch:build": "watch 'yarn build' ./src",
     "watch": "npm run watch:build",
     "lint": "eslint",


### PR DESCRIPTION
#### Rationale
Back in https://github.com/LabKey/labkey-ui-components/pull/629 I attempted squash a bunch of intermittent failures we were seeing in the JS tests. One thing that happened consistently was [what I describe here](https://github.com/LabKey/labkey-ui-components/pull/629#issuecomment-920274331). The only recourse I could find that brought us stability was to trade-off a bit of time in TC runs and use the `--runInBand` flag.

Since then, we've upgraded to Node 16 (from 14 at the time) and things appear to be a lot more stable with regard to that test case race condition failure.

<img width="1632" alt="image" src="https://user-images.githubusercontent.com/3926239/161159340-49e6dcdf-9ea4-4527-999b-42c3e225e431.png">

I'd be good with removing this flag and getting back a few minutes for our runs (averaging ~5 minutes faster at this time).

#### Changes
* Remove `--runInBand` from `test-ci`.
