### PR TITLE
Improve SelectRows endpoint wrapper

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.150.0",
+  "version": "2.150.0-fb-select-rows-deux.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.150.0-fb-select-rows-deux.0",
+  "version": "2.151.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,19 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.151.0
+*Released*: 8 April 2022
+* Improve SelectRows endpoint wrapper
+    * Options/arguments are now fully typed.
+    * Continues to retrieve the associated `QueryInfo` from `query-getQueryDetails.api`. Rejection/errors are now handled solely by `getQueryDetails()`.
+    * Continues to resolve application URLs via `URLResolver.resolveSelectRows()`.
+    * No longer wraps `Query.executeSql`.
+    * Requires a `schemaQuery: SchemaQuery` argument instead of separate `schemaName` and `queryName` arguments.
+    * Remove `caller` argument as paradigm is not necessary to support.
+    * The `containerFilter` argument defaults to value returned from `getContainerFilter()` (unchanged from `selectRowsDeprecated`).
+    * The `method` argument defaults to `POST` (unchanged from `selectRowsDeprecated`).
+    * The `columns` argument defaults to `'*'` (unchanged from `selectRowsDeprecated`).
+
 ### version 2.150.0
 *Released*: 7 April 2022
 * Item 10223: GridPanel updates for search input and filter display in grid header

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -195,6 +195,7 @@ import {
     selectRowsDeprecated,
     updateRows,
 } from './internal/query/api';
+import { selectRows } from './internal/query/selectRows';
 import { flattenBrowseDataTreeResponse, loadReports } from './internal/query/reports';
 import {
     DataViewInfoTypes,
@@ -855,6 +856,7 @@ export {
     InsertFormats,
     InsertOptions,
     insertRows,
+    selectRows,
     selectRowsDeprecated,
     searchRows,
     updateRows,
@@ -1503,6 +1505,7 @@ export type { AppRouteResolver } from './internal/url/AppURLResolver';
 export type { WithFormStepsProps } from './internal/components/forms/FormStep';
 export type { BulkAddData, EditableColumnMetadata } from './internal/components/editable/EditableGrid';
 export type { IImportData, ISelectRowsResult } from './internal/query/api';
+export type { SelectRowsOptions, SelectRowsResponse } from './internal/query/selectRows';
 export type { Location } from './internal/util/URL';
 export type {
     RoutingTableState,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -192,7 +192,7 @@ import {
     invalidateQueryDetailsCache,
     invalidateQueryDetailsCacheKey,
     searchRows,
-    selectRows,
+    selectRowsDeprecated,
     updateRows,
 } from './internal/query/api';
 import { flattenBrowseDataTreeResponse, loadReports } from './internal/query/reports';
@@ -855,7 +855,7 @@ export {
     InsertFormats,
     InsertOptions,
     insertRows,
-    selectRows,
+    selectRowsDeprecated,
     searchRows,
     updateRows,
     deleteRows,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -32,7 +32,7 @@ import {
     SchemaQuery,
 } from '..';
 
-import { getQueryDetails, selectRows } from './query/api';
+import { getQueryDetails, selectRowsDeprecated } from './query/api';
 import { isEqual } from './query/filter';
 import { buildQueryString, getLocation, Location } from './util/URL';
 import {
@@ -1095,7 +1095,7 @@ export function getSelectedData(
     filterArray.push(Filter.create(keyColumn, selections, Filter.Types.IN));
 
     return new Promise((resolve, reject) =>
-        selectRows({
+        selectRowsDeprecated({
             schemaName,
             queryName,
             filterArray,
@@ -1324,7 +1324,7 @@ const findLookupValues = async (
         selectRowsOptions.filterArray = [Filter.create(keyColumn, lookupKeyValues, Filter.Types.IN)];
     }
 
-    const result = await selectRows(selectRowsOptions);
+    const result = await selectRowsDeprecated(selectRowsOptions);
 
     const { key, models } = result;
 

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2380,25 +2380,25 @@ export function createQueryConfigFilteredBySample(
 export function incrementClientSideMetricCount(featureArea: string, metricName: string): void {
     if (!featureArea || !metricName || getServerContext().user.isGuest) {
         return;
-    } else {
-        Ajax.request({
-            url: buildURL('core', 'incrementClientSideMetricCount.api'),
-            method: 'POST',
-            jsonData: {
-                featureArea,
-                metricName,
-            },
-            success: Utils.getCallbackWrapper(response => {
-                // success, no-op
-            }),
-            failure: Utils.getCallbackWrapper(
-                response => {
-                    // log the error but don't prevent from proceeding
-                    console.error(response);
-                },
-                this,
-                true
-            ),
-        });
     }
+
+    Ajax.request({
+        url: buildURL('core', 'incrementClientSideMetricCount.api'),
+        method: 'POST',
+        jsonData: {
+            featureArea,
+            metricName,
+        },
+        success: Utils.getCallbackWrapper(response => {
+            // success, no-op
+        }),
+        failure: Utils.getCallbackWrapper(
+            response => {
+                // log the error but don't prevent from proceeding
+                console.error(response);
+            },
+            this,
+            true
+        ),
+    });
 }

--- a/packages/components/src/internal/components/GridLoader.tsx
+++ b/packages/components/src/internal/components/GridLoader.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { fromJS, List } from 'immutable';
 
-import { selectRows, IGridLoader, IGridResponse, QueryGridModel } from '../..';
+import { selectRowsDeprecated, IGridLoader, IGridResponse, QueryGridModel } from '../..';
 import { getSelected } from '../actions';
 
 import { IGridSelectionResponse } from '../QueryGridModel';
@@ -24,7 +24,7 @@ import { IGridSelectionResponse } from '../QueryGridModel';
 class GridLoader implements IGridLoader {
     fetch(model: QueryGridModel): Promise<IGridResponse> {
         return new Promise((resolve, reject) => {
-            return selectRows({
+            return selectRowsDeprecated({
                 containerPath: model.containerPath,
                 containerFilter: model.containerFilter,
                 schemaName: model.schema,

--- a/packages/components/src/internal/components/PreviewGrid.tsx
+++ b/packages/components/src/internal/components/PreviewGrid.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactNode } from 'react';
 import { fromJS, List } from 'immutable';
 import { Alert } from 'react-bootstrap';
 
-import { resolveErrorMessage, SchemaQuery, getQueryDetails, QueryInfo, selectRows, LoadingSpinner, Grid } from '../..';
+import { resolveErrorMessage, SchemaQuery, getQueryDetails, QueryInfo, selectRowsDeprecated, LoadingSpinner, Grid } from '../..';
 
 interface PreviewGridProps {
     schemaQuery: SchemaQuery;
@@ -96,7 +96,7 @@ export class PreviewGrid extends PureComponent<PreviewGridProps, PreviewGridStat
                     .map(c => c.fieldKey)
                     .join(',');
 
-                selectRows({
+                selectRowsDeprecated({
                     schemaName,
                     queryName,
                     viewName,

--- a/packages/components/src/internal/components/PreviewGrid.tsx
+++ b/packages/components/src/internal/components/PreviewGrid.tsx
@@ -2,7 +2,15 @@ import React, { PureComponent, ReactNode } from 'react';
 import { fromJS, List } from 'immutable';
 import { Alert } from 'react-bootstrap';
 
-import { resolveErrorMessage, SchemaQuery, getQueryDetails, QueryInfo, selectRowsDeprecated, LoadingSpinner, Grid } from '../..';
+import {
+    resolveErrorMessage,
+    SchemaQuery,
+    getQueryDetails,
+    QueryInfo,
+    selectRowsDeprecated,
+    LoadingSpinner,
+    Grid,
+} from '../..';
 
 interface PreviewGridProps {
     schemaQuery: SchemaQuery;

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -25,11 +25,13 @@ import { getDateFormat, isSampleFinderEnabled } from '../../app/utils';
 
 import { ASSAYS_KEY, SAMPLES_KEY } from '../../app/constants';
 
+import { SAMPLE_FILTER_METRIC_AREA } from '../search/utils';
+
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
 import { processChartData } from './utils';
 import { BaseBarChart } from './BaseBarChart';
 import { ChartConfig, ChartData, ChartSelector } from './types';
-import { SAMPLE_FILTER_METRIC_AREA } from '../search/utils';
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 function fetchItemCount(schemaQuery: SchemaQuery, filters?: Filter.IFilter[]): Promise<number> {
     return new Promise(resolve => {
@@ -265,7 +267,7 @@ interface SampleButtonProps {
 }
 
 // export for jest testing
-export const SampleButtons: FC<SampleButtonProps> = memo((props) => {
+export const SampleButtons: FC<SampleButtonProps> = memo(props => {
     const { api } = props;
 
     const onSampleFinder = useCallback(() => {

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -16,7 +16,7 @@ import {
     SampleTypeEmptyAlert,
     SchemaQuery,
     Section,
-    selectRows,
+    selectRowsDeprecated,
     Tip,
     User,
 } from '../../..';
@@ -93,7 +93,7 @@ export class BarChartViewer extends PureComponent<Props, State> {
                 const itemCount = await fetchItemCount(itemCountSQ, itemCountFilters);
 
                 const { queryName, schemaName, sort } = this.getSelectedChartGroup();
-                const response = await selectRows({ schemaName, queryName, sort });
+                const response = await selectRowsDeprecated({ schemaName, queryName, sort });
 
                 this.setState(state => ({
                     itemCounts: { ...state.itemCounts, [currentGroup]: itemCount },

--- a/packages/components/src/internal/components/domainproperties/dataset/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/actions.ts
@@ -18,7 +18,7 @@ import { ActionURL, Ajax, Domain, getServerContext, Utils } from '@labkey/api';
 
 import { fromJS, List } from 'immutable';
 
-import { DomainDesign, DomainField, SelectInputOption, selectRows } from '../../../..';
+import { DomainDesign, DomainField, SelectInputOption, selectRowsDeprecated } from '../../../..';
 
 import { DatasetModel } from './models';
 import {
@@ -35,7 +35,7 @@ import {
 
 export function fetchCategories(): Promise<List<SelectInputOption>> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             saveInSession: true,
             schemaName: 'study',
             sql: 'SELECT DISTINCT CategoryId.Label, CategoryId.RowId FROM DataSets',
@@ -93,7 +93,7 @@ export function getAdditionalKeyFields(domain: DomainDesign): List<SelectInputOp
 
 export function fetchCohorts(): Promise<List<SelectInputOption>> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: 'study',
             queryName: 'Cohort',
         })

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -1100,6 +1100,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
           "getQueryDetails": [Function],
           "incrementClientSideMetricCount": [Function],
           "selectDistinctRows": [Function],
+          "selectRows": [Function],
         },
         "samples": SamplesServerAPIWrapper {
           "getFieldLookupFromSelection": [Function],

--- a/packages/components/src/internal/components/editable/EditableGridLoader.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridLoader.tsx
@@ -16,13 +16,13 @@
 import React from 'react';
 import { fromJS, List } from 'immutable';
 
-import { IGridLoader, IGridResponse, selectRows, QueryGridModel } from '../../..';
+import { IGridLoader, IGridResponse, selectRowsDeprecated, QueryGridModel } from '../../..';
 import { EditorModel } from '../../models';
 
 export class EditableGridLoader implements IGridLoader {
     fetch(gridModel: QueryGridModel): Promise<IGridResponse> {
         return new Promise((resolve, reject) => {
-            return selectRows({
+            return selectRowsDeprecated({
                 schemaName: gridModel.schema,
                 queryName: gridModel.query,
                 filterArray: gridModel.getFilters().toJS(),

--- a/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/internal/components/entities/ParentEntityEditPanel.tsx
@@ -19,7 +19,7 @@ import {
     QueryInfo,
     resolveErrorMessage,
     SchemaQuery,
-    selectRows,
+    selectRowsDeprecated,
     updateRows,
 } from '../../..';
 import { DetailPanelHeader } from '../forms/detail/DetailPanelHeader';
@@ -99,7 +99,7 @@ export class ParentEntityEditPanel extends Component<Props, State> {
 
         if (childLSID) {
             try {
-                const { key, models, queries } = await selectRows({
+                const { key, models, queries } = await selectRowsDeprecated({
                     columns: ParentEntityRequiredColumns.toArray(),
                     containerPath: childContainerPath,
                     filterArray: [Filter.create('LSID', childLSID)],

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -15,7 +15,7 @@ import {
     SampleCreationType,
     SampleOperation,
     SchemaQuery,
-    selectRows,
+    selectRowsDeprecated,
     SHARED_CONTAINER_PATH,
 } from '../../..';
 
@@ -119,7 +119,7 @@ function getSelectedParents(
         if (isSampleParent) {
             columns += ',SampleSet';
         }
-        return selectRows({
+        return selectRowsDeprecated({
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             columns,
@@ -149,7 +149,7 @@ function getSelectedSampleParentsFromItems(itemIds: any[], isAliquotParent?: boo
                 if (opFilter) {
                     filterArray.push(opFilter);
                 }
-                return selectRows({
+                return selectRowsDeprecated({
                     schemaName: 'exp',
                     queryName: 'materials',
                     columns: 'LSID,Name,RowId,SampleSet',
@@ -425,7 +425,7 @@ export function getEntityTypeOptions(
     const { typeListingSchemaQuery, filterArray, instanceSchemaName } = entityDataType;
 
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             containerPath,
             schemaName: typeListingSchemaQuery.schemaName,
             queryName: typeListingSchemaQuery.queryName,

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -28,7 +28,7 @@ import {
     QuerySelectOwnProps,
     searchRows,
     SelectInputOption,
-    selectRows,
+    selectRowsDeprecated,
     updateRows,
 } from '../../..';
 
@@ -115,7 +115,7 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                             filter = Filter.create(valueColumn, props.value);
                         }
 
-                        selectRows({
+                        selectRowsDeprecated({
                             columns: getQueryColumnNames(model),
                             containerFilter,
                             containerPath,

--- a/packages/components/src/internal/components/forms/input/AssayTaskInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AssayTaskInput.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Filter } from '@labkey/api';
 
-import { Alert, LoadingSpinner, SelectInput, selectRows } from '../../../..';
+import { Alert, LoadingSpinner, SelectInput, selectRowsDeprecated } from '../../../..';
 
 interface InputOption {
     label: string;
@@ -9,7 +9,7 @@ interface InputOption {
 }
 
 async function loadInputOptions(assayId: number): Promise<InputOption[]> {
-    const { key, models } = await selectRows({
+    const { key, models } = await selectRowsDeprecated({
         schemaName: 'samplemanagement',
         queryName: 'Tasks',
         columns: 'RowId,Name,AssayTypes,Run/Name',

--- a/packages/components/src/internal/components/forms/input/LookupSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/LookupSelectInput.tsx
@@ -19,7 +19,7 @@ import { Filter, Query } from '@labkey/api';
 
 import {
     ISelectRowsResult,
-    selectRows,
+    selectRowsDeprecated,
     LoadingSpinner,
     QueryColumn,
     QueryLookup,
@@ -135,7 +135,7 @@ export class LookupSelectInput extends React.PureComponent<OwnProps, StateProps>
         this.setState(() => ({ isLoading: true }));
 
         const { schemaName, queryName } = queryColumn.lookup;
-        selectRows({ containerFilter, containerPath, schemaName, queryName, filterArray, sort })
+        selectRowsDeprecated({ containerFilter, containerPath, schemaName, queryName, filterArray, sort })
             .then(response => {
                 this.setState(() => ({
                     isLoading: false,

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -16,7 +16,7 @@ import {
     naturalSort,
     SchemaQuery,
     SCHEMAS,
-    selectRows,
+    selectRowsDeprecated,
 } from '../../..';
 
 import {
@@ -106,7 +106,7 @@ function fetchNodeMetadata(lineage: LineageResult): Array<Promise<ISelectRowsRes
             const node = nodes.first();
             const { fieldKey } = node.pkFilters[0];
 
-            return selectRows({
+            return selectRowsDeprecated({
                 containerPath: node.container,
                 schemaName: schemaQuery.schemaName,
                 queryName: schemaQuery.queryName,
@@ -258,7 +258,7 @@ export function loadLineageResult(
 }
 
 export function loadSampleStats(lineageResult: LineageResult): Promise<any> {
-    return selectRows({
+    return selectRowsDeprecated({
         schemaName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.schemaName,
         queryName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.queryName,
         containerFilter: Query.containerFilter.currentPlusProjectAndShared,

--- a/packages/components/src/internal/components/notifications/actions.ts
+++ b/packages/components/src/internal/components/notifications/actions.ts
@@ -15,7 +15,7 @@
  */
 import { ActionURL, Ajax, Filter, getServerContext, Utils } from '@labkey/api';
 
-import { App, buildURL, resolveErrorMessage, selectRows } from '../../..';
+import { App, buildURL, resolveErrorMessage, selectRowsDeprecated } from '../../..';
 
 import { NotificationItemModel, NotificationItemProps, ServerActivity, ServerActivityData } from './model';
 import { addNotification } from './global';
@@ -85,7 +85,7 @@ export function getServerNotifications(typeLabels?: string[], maxRows?: number):
 export function getRunningPipelineJobStatuses(filters?: Filter.IFilter[]): Promise<ServerActivity> {
     const statusFilter = Filter.create('Status', ['RUNNING', 'WAITING', 'SPLITWAITING'], Filter.Types.IN);
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: 'pipeline',
             queryName: 'job',
             filterArray: [statusFilter].concat(filters ?? []),

--- a/packages/components/src/internal/components/permissions/actions.ts
+++ b/packages/components/src/internal/components/permissions/actions.ts
@@ -6,7 +6,7 @@ import { List, Map, fromJS } from 'immutable';
 
 import { Filter, Security } from '@labkey/api';
 
-import { ISelectRowsResult, selectRows } from '../../..';
+import { ISelectRowsResult, selectRowsDeprecated } from '../../..';
 
 import { Principal, SecurityPolicy, SecurityRole } from './models';
 
@@ -41,7 +41,7 @@ function processPrincipalsResponse(data: ISelectRowsResult, resolve) {
 
 export function getPrincipals(): Promise<List<Principal>> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             saveInSession: true, // needed so that we can call getQueryDetails
             schemaName: 'core',
             // issue 17704, add displayName for users
@@ -59,7 +59,7 @@ export function getPrincipals(): Promise<List<Principal>> {
 
 export function getInactiveUsers(): Promise<List<Principal>> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: 'core',
             queryName: 'Users',
             columns: 'UserId,Email,DisplayName',

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -2,7 +2,7 @@ import { Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
 
 import { List } from 'immutable';
 
-import { deleteRows, insertRows, InsertRowsResponse, selectRows } from '../../query/api';
+import { deleteRows, insertRows, InsertRowsResponse, selectRowsDeprecated } from '../../query/api';
 import { resolveKey, SchemaQuery } from '../../../public/SchemaQuery';
 import { getSelected, getSelectedData, setSnapshotSelections } from '../../actions';
 import { PICKLIST, PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
@@ -22,7 +22,7 @@ import { Picklist, PICKLIST_KEY_COLUMN, PICKLIST_SAMPLE_ID_COLUMN } from './mode
 export function getPicklistsForInsert(): Promise<Picklist[]> {
     return new Promise((resolve, reject) => {
         const { queryName, schemaName } = SCHEMAS.LIST_METADATA_TABLES.PICKLISTS;
-        selectRows({
+        selectRowsDeprecated({
             containerFilter: isSubfolderDataEnabled() ? Query.ContainerFilter.current : undefined,
             schemaName,
             queryName,
@@ -147,7 +147,7 @@ export interface SampleTypeCount {
 export function getPicklistCountsBySampleType(listName: string): Promise<SampleTypeCount[]> {
     return new Promise(async (resolve, reject) => {
         try {
-            const { key, models, orderedModels } = await selectRows({
+            const { key, models, orderedModels } = await selectRowsDeprecated({
                 schemaName: SCHEMAS.PICKLIST_TABLES.SCHEMA,
                 queryName: listName,
                 sql: [
@@ -180,7 +180,7 @@ export function getPicklistCountsBySampleType(listName: string): Promise<SampleT
 export function getPicklistSamples(listName: string): Promise<Set<string>> {
     return new Promise((resolve, reject) => {
         const schemaName = SCHEMAS.PICKLIST_TABLES.SCHEMA;
-        selectRows({
+        selectRowsDeprecated({
             schemaName,
             queryName: listName,
         })
@@ -387,7 +387,7 @@ export const removeSamplesFromPicklist = async (picklist: Picklist, selectionMod
 
     // if the model is for the sample type, query to get the relevant list keys to delete.
     if (selectionModel.schemaName === SCHEMAS.SAMPLE_SETS.SCHEMA) {
-        const listResponse = await selectRows({
+        const listResponse = await selectRowsDeprecated({
             schemaName: SCHEMAS.PICKLIST_TABLES.SCHEMA,
             queryName: picklist.name,
             filterArray: [Filter.create('SampleID', [...selectionModel.selections], Filter.Types.IN)],
@@ -428,7 +428,7 @@ export function getPicklistUrl(listId: number, picklistProductId?: string, curre
 }
 
 export const getPicklistFromId = async (listId: number, loadSampleTypes = true): Promise<Picklist> => {
-    const listData = await selectRows({
+    const listData = await selectRowsDeprecated({
         containerFilter: getPicklistListingContainerFilter(),
         schemaName: SCHEMAS.LIST_METADATA_TABLES.PICKLISTS.schemaName,
         queryName: SCHEMAS.LIST_METADATA_TABLES.PICKLISTS.queryName,
@@ -440,7 +440,7 @@ export const getPicklistFromId = async (listId: number, loadSampleTypes = true):
     let picklist = Picklist.create(listRow);
 
     if (loadSampleTypes) {
-        const listSampleTypeData = await selectRows({
+        const listSampleTypeData = await selectRowsDeprecated({
             schemaName: SCHEMAS.PICKLIST_TABLES.SCHEMA,
             sql: `SELECT DISTINCT SampleID.SampleSet FROM "${picklist.name}" WHERE SampleID.SampleSet IS NOT NULL`,
         });

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -13,7 +13,7 @@ import { AddEntityButton } from '../buttons/AddEntityButton';
 import { DomainFieldLabel } from '../domainproperties/DomainFieldLabel';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SelectInput } from '../forms/input/SelectInput';
-import { selectRows, updateRows, insertRows, deleteRows } from '../../query/api';
+import { selectRowsDeprecated, updateRows, insertRows, deleteRows } from '../../query/api';
 import { caseInsensitive } from '../../util/utils';
 import { SCHEMAS } from '../../schemas';
 import { resolveErrorMessage } from '../../util/messaging';
@@ -48,7 +48,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
     const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>();
 
     useEffect(() => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: STATE_TYPE_SQ.schemaName,
             queryName: STATE_TYPE_SQ.queryName,
             columns: 'RowId,Value',

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -42,7 +42,7 @@ import {
     SampleTypeDataType,
     SchemaQuery,
     SCHEMAS,
-    selectRows,
+    selectRowsDeprecated,
     SHARED_CONTAINER_PATH,
     UNIQUE_ID_FIND_FIELD,
     updateRows,
@@ -70,7 +70,7 @@ export function initSampleSetSelects(
 
     // Get Sample Types
     promises.push(
-        selectRows({
+        selectRowsDeprecated({
             containerPath,
             schemaName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.schemaName,
             queryName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.queryName,
@@ -82,7 +82,7 @@ export function initSampleSetSelects(
     // Get Data Classes
     if (includeDataClasses) {
         promises.push(
-            selectRows({
+            selectRowsDeprecated({
                 containerPath,
                 schemaName: SCHEMAS.EXP_TABLES.DATA_CLASSES.schemaName,
                 queryName: SCHEMAS.EXP_TABLES.DATA_CLASSES.queryName,
@@ -155,7 +155,7 @@ export function fetchSamples(
     displayValueKey: string,
     valueKey: string
 ): Promise<OrderedMap<any, any>> {
-    return selectRows({
+    return selectRowsDeprecated({
         schemaName: schemaQuery.schemaName,
         queryName: schemaQuery.queryName,
         columns: ['RowId', displayValueKey, valueKey],
@@ -268,7 +268,7 @@ function getFilteredSampleSelection(
     }
 
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             queryName: sampleType,
             columns: 'RowId',
@@ -299,7 +299,7 @@ export function getSampleSelectionStorageData(selection: List<any>): Promise<Rec
     }
 
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: 'inventory',
             queryName: 'ItemSamples',
             columns: 'RowId, SampleId, StoredAmount',
@@ -328,7 +328,7 @@ export function getSampleSelectionStorageData(selection: List<any>): Promise<Rec
 
 export function getSampleStorageId(sampleRowId: number): Promise<number> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: 'inventory',
             queryName: 'ItemSamples',
             columns: 'RowId, SampleId',
@@ -357,7 +357,7 @@ export function getSampleSelectionLineageData(
     }
 
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             queryName: sampleType,
             columns: columns ?? List.of('RowId', 'Name', 'LSID').concat(ParentEntityLineageColumns).toArray(),
@@ -454,7 +454,7 @@ function getParentRowIdAndDataType(
     containerPath?: string
 ): Promise<Record<string, ParentIdData>> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             containerPath,
             schemaName: parentDataType.listingSchemaQuery.schemaName,
             queryName: parentDataType.listingSchemaQuery.queryName,
@@ -843,7 +843,7 @@ export function getSampleStatuses(): Promise<SampleState[]> {
 
 export function getSampleTypeRowId(name: string): Promise<number> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.schemaName,
             queryName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.queryName,
             columns: 'RowId,Name',
@@ -863,7 +863,7 @@ export function getSampleTypeRowId(name: string): Promise<number> {
 
 export function getSampleTypes(): Promise<Array<{ id: number; label: string }>> {
     return new Promise((resolve, reject) => {
-        selectRows({
+        selectRowsDeprecated({
             schemaName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.schemaName,
             queryName: SCHEMAS.EXP_TABLES.SAMPLE_SETS.queryName,
             sort: 'Name',

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -8,6 +8,7 @@ import { getEntityTypeOptions } from '../components/entities/actions';
 import { incrementClientSideMetricCount } from '../actions';
 
 import { getQueryDetails, GetQueryDetailsOptions, SelectDistinctResponse, selectDistinctRows } from './api';
+import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows';
 
 export interface QueryAPIWrapper {
     getEntityTypeOptions: (
@@ -16,6 +17,7 @@ export interface QueryAPIWrapper {
     ) => Promise<Map<string, List<IEntityTypeOption>>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
+    selectRows: (options: SelectRowsOptions) => Promise<SelectRowsResponse>;
     selectDistinctRows: (selectDistinctOptions: Query.SelectDistinctOptions) => Promise<SelectDistinctResponse>;
 }
 
@@ -23,6 +25,7 @@ export class QueryServerAPIWrapper implements QueryAPIWrapper {
     getEntityTypeOptions = getEntityTypeOptions;
     getQueryDetails = getQueryDetails;
     incrementClientSideMetricCount = incrementClientSideMetricCount;
+    selectRows = selectRows;
     selectDistinctRows = selectDistinctRows;
 }
 
@@ -37,6 +40,7 @@ export function getQueryTestAPIWrapper(
         getEntityTypeOptions: mockFn(),
         getQueryDetails: mockFn(),
         incrementClientSideMetricCount: mockFn(),
+        selectRows: mockFn(),
         selectDistinctRows: mockFn(),
         ...overrides,
     };

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -352,9 +352,12 @@ export interface ISelectRowsResult {
     caller?: any;
 }
 
-// Fetches an API response and normalizes the result JSON according to schema.
-// This makes every API response have the same shape, regardless of how nested it was.
-export function selectRows(userConfig, caller?): Promise<ISelectRowsResult> {
+/**
+ * @deprecated
+ * Fetches an API response and normalizes the result JSON according to schema.
+ * This makes every API response have the same shape, regardless of how nested it was.
+ */
+export function selectRowsDeprecated(userConfig, caller?): Promise<ISelectRowsResult> {
     return new Promise((resolve, reject) => {
         let schemaQuery, key;
         if (userConfig.queryName) {
@@ -579,7 +582,7 @@ export function searchRows(selectRowsConfig, token: any, exactColumn?: string): 
         }
 
         const selects = [
-            selectRows(
+            selectRowsDeprecated(
                 Object.assign({}, selectRowsConfig, {
                     filterArray: qFilters,
                 })
@@ -588,7 +591,7 @@ export function searchRows(selectRowsConfig, token: any, exactColumn?: string): 
 
         if (exactFilters) {
             selects.push(
-                selectRows(
+                selectRowsDeprecated(
                     Object.assign({}, selectRowsConfig, {
                         filterArray: exactFilters,
                     })

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -353,7 +353,7 @@ export interface ISelectRowsResult {
 }
 
 /**
- * @deprecated
+ * @deprecated use selectRows() instead.
  * Fetches an API response and normalizes the result JSON according to schema.
  * This makes every API response have the same shape, regardless of how nested it was.
  */

--- a/packages/components/src/internal/query/selectRows.ts
+++ b/packages/components/src/internal/query/selectRows.ts
@@ -1,6 +1,7 @@
 import { Query } from '@labkey/api';
 
 import { QueryInfo, SchemaQuery, URLResolver } from '../..';
+
 import { getContainerFilter, getQueryDetails } from './api';
 
 export interface SelectRowsOptions

--- a/packages/components/src/internal/query/selectRows.ts
+++ b/packages/components/src/internal/query/selectRows.ts
@@ -1,0 +1,69 @@
+import { Query } from '@labkey/api';
+
+import { QueryInfo, SchemaQuery, URLResolver } from '../..';
+import { getContainerFilter, getQueryDetails } from './api';
+
+export interface SelectRowsOptions
+    extends Omit<Query.SelectRowsOptions, 'queryName' | 'requiredVersion' | 'schemaName' | 'scope'> {
+    schemaQuery: SchemaQuery;
+}
+
+export interface RowResult {
+    displayValue?: any;
+    url?: string;
+    value: any;
+}
+
+export interface SelectRowsResponse {
+    messages: Array<Record<string, string>>;
+    queryInfo: QueryInfo;
+    rows: Array<Record<string, RowResult>>;
+    rowCount: number;
+    schemaQuery: SchemaQuery;
+}
+
+export async function selectRows(options: SelectRowsOptions): Promise<SelectRowsResponse> {
+    const {
+        containerFilter = getContainerFilter(options.containerPath),
+        columns = '*',
+        method = 'POST',
+        schemaQuery,
+        ...selectRowsOptions
+    } = options;
+    const { queryName, schemaName } = schemaQuery;
+
+    const [queryInfo, resolved] = await Promise.all([
+        getQueryDetails({ containerPath: options.containerPath, queryName, schemaName }),
+        new Promise<any>((resolve, reject) => {
+            Query.selectRows({
+                ...selectRowsOptions,
+                columns,
+                containerFilter,
+                method,
+                queryName,
+                requiredVersion: 17.1,
+                schemaName,
+                success: json => {
+                    resolve(new URLResolver().resolveSelectRows(json));
+                },
+                failure: (data, request) => {
+                    console.error('There was a problem retrieving the data', data);
+                    reject({
+                        exceptionClass: data.exceptionClass,
+                        message: data.exception,
+                        schemaQuery,
+                        status: request.status,
+                    });
+                },
+            });
+        }),
+    ]);
+
+    return {
+        messages: resolved.messages,
+        queryInfo,
+        rows: resolved.rows,
+        rowCount: resolved.rowCount,
+        schemaQuery,
+    };
+}

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -16,7 +16,7 @@
 import { List, Map } from 'immutable';
 import { Filter } from '@labkey/api';
 
-import { AssayProtocolModel, caseInsensitive, fetchProtocol, getQueryDetails, SCHEMAS, selectRows } from '../..';
+import { AssayProtocolModel, caseInsensitive, fetchProtocol, getQueryDetails, SCHEMAS, selectRowsDeprecated } from '../..';
 
 import { SAMPLE_MANAGEMENT } from '../schemas';
 
@@ -100,7 +100,7 @@ export class AssayRunResolver implements AppRouteResolver {
             return Promise.resolve(spliceURL(parts, newParts, 0, assayRunIdIndex));
         } else {
             return new Promise(resolve => {
-                return selectRows({
+                return selectRowsDeprecated({
                     schemaName: SCHEMAS.EXP_TABLES.ASSAY_RUNS.schemaName,
                     queryName: SCHEMAS.EXP_TABLES.ASSAY_RUNS.queryName,
                     columns: 'RowId,Protocol/RowId',
@@ -181,7 +181,7 @@ export class ListResolver implements AppRouteResolver {
 
         // fetch it
         try {
-            const result = await selectRows({
+            const result = await selectRowsDeprecated({
                 schemaName: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER.schemaName,
                 queryName: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER.queryName,
                 columns: 'ListId,Name,Container/Path',
@@ -246,7 +246,7 @@ export class SamplesResolver implements AppRouteResolver {
         } else {
             // fetch it
             return new Promise(resolve => {
-                return selectRows({
+                return selectRowsDeprecated({
                     schemaName: SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
                     queryName: SCHEMAS.EXP_TABLES.MATERIALS.queryName,
                     columns: 'RowId,SampleSet',
@@ -341,7 +341,7 @@ export class ExperimentRunResolver implements AppRouteResolver {
             return AppURL.create('workflow', rowId);
         }
         try {
-            const result = await selectRows({
+            const result = await selectRowsDeprecated({
                 schemaName: SAMPLE_MANAGEMENT.JOBS.schemaName,
                 queryName: SAMPLE_MANAGEMENT.JOBS.queryName,
                 filterArray: [Filter.create('RowId', rowId)],

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -16,7 +16,7 @@
 import { List, Map } from 'immutable';
 import { Filter } from '@labkey/api';
 
-import { AssayProtocolModel, caseInsensitive, fetchProtocol, getQueryDetails, SCHEMAS, selectRowsDeprecated } from '../..';
+import { AssayProtocolModel, caseInsensitive, fetchProtocol, getQueryDetails, SCHEMAS, selectRows } from '../..';
 
 import { SAMPLE_MANAGEMENT } from '../schemas';
 
@@ -88,47 +88,44 @@ export class AssayRunResolver implements AppRouteResolver {
         return /\/rd\/assayrun\/(\d+$|\d+\/)/.test(route);
     }
 
-    fetch(parts: any[]): Promise<AppURL | boolean> {
+    async fetch(parts: any[]): Promise<AppURL | boolean> {
         // ["rd", "assayrun", "543", ...]
         const assayRunIdIndex = 2;
         const assayRunId: number = parseInt(parts[assayRunIdIndex], 10);
 
         if (isNaN(assayRunId)) {
-            return Promise.resolve(true);
+            // skip it
+            return true;
         } else if (this.datas.has(assayRunId)) {
+            // resolve it
             const newParts = ['assays', this.datas.get(assayRunId), 'runs'];
-            return Promise.resolve(spliceURL(parts, newParts, 0, assayRunIdIndex));
-        } else {
-            return new Promise(resolve => {
-                return selectRowsDeprecated({
-                    schemaName: SCHEMAS.EXP_TABLES.ASSAY_RUNS.schemaName,
-                    queryName: SCHEMAS.EXP_TABLES.ASSAY_RUNS.queryName,
-                    columns: 'RowId,Protocol/RowId',
-                    filterArray: [Filter.create('RowId', assayRunId)],
-                })
-                    .then(result => {
-                        const entries = result.orderedModels[result.key];
-
-                        if (entries.size === 1) {
-                            const data = result.models[result.key][entries.first()];
-                            const assayProtocolId = data['Protocol/RowId']['value'];
-
-                            // cache
-                            this.datas.set(assayRunId, assayProtocolId);
-
-                            const newParts = ['assays', assayProtocolId, 'runs'];
-                            return resolve(spliceURL(parts, newParts, 0, assayRunIdIndex));
-                        }
-
-                        // skip it
-                        resolve(true);
-                    })
-                    .catch(() => {
-                        // skip it
-                        resolve(true);
-                    });
-            });
+            return spliceURL(parts, newParts, 0, assayRunIdIndex);
         }
+
+        // fetch it
+        try {
+            const result = await selectRows({
+                columns: 'RowId,Protocol/RowId',
+                filterArray: [Filter.create('RowId', assayRunId)],
+                schemaQuery: SCHEMAS.EXP_TABLES.ASSAY_RUNS,
+            });
+
+            if (result.rows.length === 1) {
+                const assayProtocolId = caseInsensitive(result.rows[0], 'Protocol/RowId').value;
+
+                // cache
+                this.datas.set(assayRunId, assayProtocolId);
+
+                // resolve it
+                const newParts = ['assays', assayProtocolId, 'runs'];
+                return spliceURL(parts, newParts, 0, assayRunIdIndex);
+            }
+        } catch (e) {
+            // skip it
+        }
+
+        // skip it
+        return true;
     }
 }
 
@@ -181,16 +178,15 @@ export class ListResolver implements AppRouteResolver {
 
         // fetch it
         try {
-            const result = await selectRowsDeprecated({
-                schemaName: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER.schemaName,
-                queryName: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER.queryName,
+            const result = await selectRows({
+                schemaQuery: SCHEMAS.LIST_METADATA_TABLES.LIST_MANAGER,
                 columns: 'ListId,Name,Container/Path',
             });
 
             this.fetched = true;
 
             // fulfill local cache
-            this.lists = Object.values(result.models[result.key])
+            this.lists = result.rows
                 .reduce<Map<string, string>>((map, list) => {
                     const _containerPath = caseInsensitive(list, 'Container/Path').value.toLowerCase();
                     const _listId = caseInsensitive(list, 'ListId').value;
@@ -231,81 +227,63 @@ export class SamplesResolver implements AppRouteResolver {
         return /\/rd\/samples\/(\d+$|\d+\/)/.test(route);
     }
 
-    fetch(parts: any[]): Promise<AppURL | boolean> {
+    async fetch(parts: any[]): Promise<AppURL | boolean> {
         // ["rd", "samples", "118", ...]
         const sampleRowIdIndex = 2;
         const sampleRowId: number = parseInt(parts[sampleRowIdIndex], 10);
 
         if (isNaN(sampleRowId)) {
             // skip it
-            return Promise.resolve(true);
+            return true;
         } else if (this.samples.has(sampleRowId)) {
             // resolve it
             const newParts = this.samples.get(sampleRowId).toArray();
-            return Promise.resolve(spliceURL(parts, newParts, 0, 2));
-        } else {
-            // fetch it
-            return new Promise(resolve => {
-                return selectRowsDeprecated({
-                    schemaName: SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
-                    queryName: SCHEMAS.EXP_TABLES.MATERIALS.queryName,
-                    columns: 'RowId,SampleSet',
-                    filterArray: [Filter.create('RowId', sampleRowId)],
-                })
-                    .then(result => {
-                        const samples = result.models[result.key];
-
-                        if (samples && samples[sampleRowId]) {
-                            const sample = samples[sampleRowId],
-                                sampleSetName = sample['SampleSet'].displayValue.toLowerCase();
-
-                            return getQueryDetails({
-                                schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
-                                queryName: sampleSetName,
-                            })
-                                .then(info => {
-                                    if (info) {
-                                        if (info.isMedia) {
-                                            // for supporting MIXTURE_BATCHES => mixturebatches
-                                            this.samples = this.samples.set(
-                                                sampleRowId,
-                                                List([
-                                                    'media',
-                                                    info.name.toLowerCase() ===
-                                                    SCHEMAS.SAMPLE_SETS.MIXTURE_BATCHES.queryName.toLowerCase()
-                                                        ? 'mixturebatches'
-                                                        : info.name,
-                                                ])
-                                            );
-                                        } else {
-                                            this.samples = this.samples.set(
-                                                sampleRowId,
-                                                List([
-                                                    SCHEMAS.SAMPLE_SETS.SCHEMA.toLowerCase(),
-                                                    encodeURIComponent(sampleSetName),
-                                                ])
-                                            );
-                                        }
-                                    }
-
-                                    if (this.samples.has(sampleRowId)) {
-                                        const newParts = this.samples.get(sampleRowId).toArray();
-                                        return resolve(spliceURL(parts, newParts, 0, 2));
-                                    }
-                                })
-                                .catch(() => {
-                                    resolve(true);
-                                });
-                        }
-
-                        // skip it
-                        return resolve(true);
-                    })
-                    .catch(() => {
-                        return resolve(true);
-                    });
-            });
+            return spliceURL(parts, newParts, 0, 2);
         }
+
+        // fetch it
+        try {
+            const result = await selectRows({
+                schemaQuery: SCHEMAS.EXP_TABLES.MATERIALS,
+                columns: 'RowId,SampleSet',
+                filterArray: [Filter.create('RowId', sampleRowId)],
+            });
+
+            if (result.rows.length === 1) {
+                const sampleTypeName = caseInsensitive(result.rows[0], 'SampleSet').displayValue.toLowerCase();
+
+                const info = await getQueryDetails({
+                    schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
+                    queryName: sampleTypeName,
+                });
+
+                // fulfill cache
+                let value: List<string>;
+                if (info?.isMedia) {
+                    // for supporting MIXTURE_BATCHES => mixturebatches
+                    const mediaTypeName =
+                        info.name.toLowerCase() === SCHEMAS.SAMPLE_SETS.MIXTURE_BATCHES.queryName.toLowerCase()
+                            ? 'mixturebatches'
+                            : info.name;
+                    value = List(['media', encodeURIComponent(mediaTypeName)]);
+                } else {
+                    value = List([SCHEMAS.SAMPLE_SETS.SCHEMA.toLowerCase(), encodeURIComponent(sampleTypeName)]);
+                }
+
+                this.samples = this.samples.set(sampleRowId, value);
+
+                if (this.samples.has(sampleRowId)) {
+                    // resolve it
+                    const newParts = this.samples.get(sampleRowId).toArray();
+                    return spliceURL(parts, newParts, 0, 2);
+                }
+            }
+        } catch (e) {
+            // skip it
+        }
+
+        // skip it
+        return true;
     }
 }
 
@@ -338,25 +316,26 @@ export class ExperimentRunResolver implements AppRouteResolver {
             return true;
         }
         if (this.jobs.has(rowId)) {
+            // resolve it
             return AppURL.create('workflow', rowId);
         }
         try {
-            const result = await selectRowsDeprecated({
-                schemaName: SAMPLE_MANAGEMENT.JOBS.schemaName,
-                queryName: SAMPLE_MANAGEMENT.JOBS.queryName,
+            const result = await selectRows({
+                schemaQuery: SAMPLE_MANAGEMENT.JOBS,
                 filterArray: [Filter.create('RowId', rowId)],
                 columns: 'RowId',
             });
 
-            if (Object.keys(result.models[result.key]).length) {
+            if (result.rows.length > 0) {
+                // resolve it
                 this.jobs.add(rowId);
                 return AppURL.create('workflow', rowId);
             }
-            // skip it
         } catch (e) {
             // skip it
         }
 
+        // skip it
         return true;
     }
 

--- a/packages/components/src/public/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/public/QueryModel/QueryModelLoader.ts
@@ -9,7 +9,7 @@ import {
     naturalSortByProperty,
     QueryInfo,
     replaceSelected,
-    selectRows,
+    selectRowsDeprecated,
     setSelected,
 } from '../..';
 import { bindColumnRenderers } from '../../internal/renderers';
@@ -92,7 +92,7 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
         return queryInfo.merge({ columns: bindColumnRenderers(queryInfo.columns) }) as QueryInfo;
     },
     async loadRows(model) {
-        const result = await selectRows({
+        const result = await selectRowsDeprecated({
             schemaName: model.schemaName,
             queryName: model.queryName,
             viewName: model.viewName,


### PR DESCRIPTION
#### Rationale
The `selectRows` endpoint wrapper function in `@labkey/components` was originally intended for use in a Redux-based data store. The data structure was normalized using [normalizr](https://github.com/paularmstrong/normalizr) and then subsequently persisted to the Redux store to be utilized by the application. As we've evolved our front-end applications over the past several years the structure and utility of this wrapper has become burdensome to use as it introduces unnecessary complexity and obfuscation over a typical LKS `query-selectRows.api` response.

With this PR I'm deprecating the current implementation of the `selectRows` and renaming it `selectRowsDeprecated`. The implementation of `selectRows` is replaced with, what I consider to be, a more straight-forward implementation of the wrapper. This new implementation does the following:

- Options/arguments are now fully typed.
- Continues to retrieve the associated `QueryInfo` from `query-getQueryDetails.api`. Rejection/errors are now handled solely by `getQueryDetails()`.
- Continues to resolve application URLs via `URLResolver.resolveSelectRows()`.
- No longer wraps `Query.executeSql`. `executeSql` could be separated out from `selectRowsDeprecated` in future work.
- Requires a `schemaQuery: SchemaQuery` argument instead of separate `schemaName` and `queryName` arguments.
- Remove `caller` argument as paradigm is not necessary to support.
- The `containerFilter` argument defaults to value returned from `getContainerFilter()` (unchanged from `selectRowsDeprecated`).
- The `method` argument defaults to `POST` (unchanged from `selectRowsDeprecated`).
- The `columns` argument defaults to `'*'` (unchanged from `selectRowsDeprecated`).

New response shape:
- `messages`: Type is now `Array<Record<string, string>>`.
- `queryInfo`: Unchanged.
- `rows`: Replaces `response.models` and `response.orderedModels`. Type is `Array<Record<string, RowResult>>`. Rows are returned in order received from server endpoint.
- `rowCount`: Replaces `totalCount`. Name matches same property returned by server endpoint.
- `schemaQuery`: The `schemaQuery` provided by the caller.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/796
* https://github.com/LabKey/biologics/pull/1240
* https://github.com/LabKey/inventory/pull/417
* https://github.com/LabKey/sampleManagement/pull/915

#### Changes
* Introduce new implementation for `selectRows` and deprecate original implementation by renaming to `selectRowsDeprecated`.
* Replace all usages of `selectRows` with `selectRowsDeprecated`.
* Refactor usages of `selectRows` in `AppURLResolver` to use new implementation. Gives new implementation at least one usages.