### PR TITLE
Item 10251: Misc grid filtering related issues for 22.5 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.152.0",
+  "version": "2.152.0-fb-smGridFilterIssues.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.152.0-fb-smGridFilterIssues.0",
+  "version": "2.152.0-fb-smGridFilterIssues.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.150.0",
+  "version": "2.150.0-fb-smGridFilterIssues.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.152.0-fb-smGridFilterIssues.2",
+  "version": "2.152.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.152.0-fb-smGridFilterIssues.1",
+  "version": "2.152.0-fb-smGridFilterIssues.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.150.0-fb-smGridFilterIssues.0",
+  "version": "2.150.0-fb-smGridFilterIssues.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD April 2022
+### version 2.152.1
+*Released*: 11 April 2022
 * Issue 45139: grid header menu is clipped by the bounding container instead of overflowing it
 * Issue 45135: grid filter modal Choose Values should include model/context filters (baseFilters or queryInfo filters)
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD April 2022
+* Issue 45139: grid header menu is clipped by the bounding container instead of overflowing it
+* Issue 45135: grid filter modal Choose Values should include model/context filters (baseFilters or queryInfo filters)
+
 ### version 2.150.0
 *Released*: 7 April 2022
 * Item 10223: GridPanel updates for search input and filter display in grid header

--- a/packages/components/src/internal/components/search/FilterExpressionView.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.tsx
@@ -319,6 +319,7 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                             onFieldFilterTypeChange(fieldname, filterUrlSuffix, 1)
                         }
                         options={unusedFilterOptions(1)}
+                        menuPosition="fixed"
                     />
                     {renderFilterTypeInputs(1)}
                 </>

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -38,7 +38,7 @@ interface Props {
     metricFeatureArea?: string;
     onFilterUpdate: (field: QueryColumn, newFilters: Filter.IFilter[], index: number) => void;
     queryInfo: QueryInfo;
-    getSelectDistinctOptions?: (column: string, allFilters?: boolean) => Query.SelectDistinctOptions;
+    selectDistinctOptions?: Query.SelectDistinctOptions;
     skipDefaultViewCheck?: boolean;
     validFilterField?: (field: QueryColumn, queryInfo: QueryInfo, exprColumnsWithSubSelect?: string[]) => boolean;
     viewName?: string;
@@ -59,7 +59,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
         onFilterUpdate,
         metricFeatureArea,
         fullWidth,
-        getSelectDistinctOptions,
+        selectDistinctOptions,
         filterTypesToExclude,
     } = props;
     const [queryFields, setQueryFields] = useState<List<QueryColumn>>(undefined);
@@ -164,7 +164,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
         if (!filters || !queryName || !activeField) return null;
 
         // Issue 45135: include any model filters (baseFilters or queryInfo filters)
-        const valueFilters = getSelectDistinctOptions?.(undefined, false).filterArray ?? [];
+        const valueFilters = selectDistinctOptions ? [...selectDistinctOptions.filterArray] : [];
 
         // use active filters to filter distinct values, but exclude filters on current field
         filters?.[queryName]?.forEach(field => {
@@ -172,7 +172,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
         });
 
         return valueFilters;
-    }, [filters, queryName, activeField, activeFieldKey, getSelectDistinctOptions]);
+    }, [filters, queryName, activeField, activeFieldKey, selectDistinctOptions]);
 
     const onFieldClick = useCallback((queryColumn: QueryColumn) => {
         setActiveField(queryColumn);
@@ -260,7 +260,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                             </div>
                                             <FilterFacetedSelector
                                                 selectDistinctOptions={{
-                                                    ...getSelectDistinctOptions?.(undefined),
+                                                    ...selectDistinctOptions,
                                                     column: activeFieldKey,
                                                     schemaName: queryInfo.schemaName,
                                                     queryName,

--- a/packages/components/src/public/QueryModel/GridFilterModal.tsx
+++ b/packages/components/src/public/QueryModel/GridFilterModal.tsx
@@ -19,12 +19,12 @@ interface Props {
     model: QueryModel;
     onApply: (filters: Filter.IFilter[]) => void;
     onCancel: () => void;
-    selectDistinctOptions?: Query.SelectDistinctOptions;
+    getSelectDistinctOptions?: (column: string, allFilters?: boolean) => Query.SelectDistinctOptions;
     skipDefaultViewCheck?: boolean; // for jest tests only due to lack of views from QueryInfo.fromJSON. check all fields, instead of only columns from default view
 }
 
 export const GridFilterModal: FC<Props> = memo(props => {
-    const { api, onCancel, initFilters, model, onApply, fieldKey, selectDistinctOptions, skipDefaultViewCheck } = props;
+    const { api, onCancel, initFilters, model, onApply, fieldKey, getSelectDistinctOptions, skipDefaultViewCheck } = props;
     const { queryInfo } = model;
     const [filterError, setFilterError] = useState<string>(undefined);
     const [filters, setFilters] = useState<FieldFilter[]>(
@@ -98,7 +98,7 @@ export const GridFilterModal: FC<Props> = memo(props => {
                     fullWidth
                     onFilterUpdate={onFilterUpdate}
                     queryInfo={queryInfo}
-                    selectDistinctOptions={selectDistinctOptions}
+                    getSelectDistinctOptions={getSelectDistinctOptions}
                     skipDefaultViewCheck={skipDefaultViewCheck}
                     validFilterField={isValidFilterField}
                     viewName={model.viewName}

--- a/packages/components/src/public/QueryModel/GridFilterModal.tsx
+++ b/packages/components/src/public/QueryModel/GridFilterModal.tsx
@@ -19,12 +19,12 @@ interface Props {
     model: QueryModel;
     onApply: (filters: Filter.IFilter[]) => void;
     onCancel: () => void;
-    getSelectDistinctOptions?: (column: string, allFilters?: boolean) => Query.SelectDistinctOptions;
+    selectDistinctOptions?: Query.SelectDistinctOptions;
     skipDefaultViewCheck?: boolean; // for jest tests only due to lack of views from QueryInfo.fromJSON. check all fields, instead of only columns from default view
 }
 
 export const GridFilterModal: FC<Props> = memo(props => {
-    const { api, onCancel, initFilters, model, onApply, fieldKey, getSelectDistinctOptions, skipDefaultViewCheck } = props;
+    const { api, onCancel, initFilters, model, onApply, fieldKey, selectDistinctOptions, skipDefaultViewCheck } = props;
     const { queryInfo } = model;
     const [filterError, setFilterError] = useState<string>(undefined);
     const [filters, setFilters] = useState<FieldFilter[]>(
@@ -98,7 +98,7 @@ export const GridFilterModal: FC<Props> = memo(props => {
                     fullWidth
                     onFilterUpdate={onFilterUpdate}
                     queryInfo={queryInfo}
-                    getSelectDistinctOptions={getSelectDistinctOptions}
+                    selectDistinctOptions={selectDistinctOptions}
                     skipDefaultViewCheck={skipDefaultViewCheck}
                     validFilterField={isValidFilterField}
                     viewName={model.viewName}

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -357,7 +357,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     };
 
     // Needed by OmniBox and GridFilterModal.
-    getSelectDistinctOptions = (column: string): Query.SelectDistinctOptions => {
+    getSelectDistinctOptions = (column: string, allFilters = true): Query.SelectDistinctOptions => {
         const { model } = this.props;
         return {
             column,
@@ -366,7 +366,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             schemaName: model.schemaName,
             queryName: model.queryName,
             viewName: model.viewName,
-            filterArray: model.filters,
+            filterArray: allFilters ? model.filters : model.modelFilters,
             parameters: model.queryParameters,
         };
     };
@@ -840,7 +840,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 {showFilterModalFieldKey && (
                     <GridFilterModal
                         fieldKey={showFilterModalFieldKey}
-                        selectDistinctOptions={this.getSelectDistinctOptions(undefined)}
+                        getSelectDistinctOptions={this.getSelectDistinctOptions}
                         initFilters={model.filterArray} // using filterArray to indicate user-defined filters only
                         model={model}
                         onApply={this.handleApplyFilters}

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -840,7 +840,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 {showFilterModalFieldKey && (
                     <GridFilterModal
                         fieldKey={showFilterModalFieldKey}
-                        getSelectDistinctOptions={this.getSelectDistinctOptions}
+                        selectDistinctOptions={this.getSelectDistinctOptions(undefined, false)}
                         initFilters={model.filterArray} // using filterArray to indicate user-defined filters only
                         model={model}
                         onApply={this.handleApplyFilters}

--- a/packages/components/src/public/QueryModel/QueryModel.spec.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.spec.ts
@@ -1,4 +1,5 @@
-import { GRID_CHECKBOX_OPTIONS, LoadingState, QueryInfo, QuerySort, SchemaQuery } from '../..';
+import { Filter } from '@labkey/api';
+import { GRID_CHECKBOX_OPTIONS, LoadingState, makeTestQueryModel, QueryInfo, QuerySort, SchemaQuery } from '../..';
 import { initUnitTests, makeQueryInfo } from '../../internal/testHelpers';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 
@@ -216,5 +217,27 @@ describe('QueryModel', () => {
         expect(model.getSelectedIdsAsInts()[0]).toBe(1);
         expect(model.getSelectedIdsAsInts()[1]).toBe(3);
         expect(model.getSelectedIdsAsInts()[2]).toBe(2);
+    });
+
+    test('filters', () => {
+        const model = makeTestQueryModel(SCHEMA_QUERY, new QueryInfo()).mutate({
+            baseFilters: [
+                Filter.create('a', null, Filter.Types.ISBLANK),
+                Filter.create('replaced', null, Filter.Types.ISBLANK),
+            ],
+            filterArray: [Filter.create('b', null, Filter.Types.ISBLANK)],
+        });
+
+        expect(model.filters).toHaveLength(3);
+        expect(model.filters[0].getColumnName()).toBe('a');
+        expect(model.filters[1].getColumnName()).toBe('replaced');
+        expect(model.filters[2].getColumnName()).toBe('b');
+
+        expect(model.modelFilters).toHaveLength(2);
+        expect(model.modelFilters[0].getColumnName()).toBe('a');
+        expect(model.modelFilters[1].getColumnName()).toBe('replaced');
+
+        expect(model.detailFilters).toHaveLength(1);
+        expect(model.detailFilters[0].getColumnName()).toBe('replaced');
     });
 });

--- a/packages/components/src/public/QueryModel/QueryModel.spec.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.spec.ts
@@ -1,4 +1,5 @@
 import { Filter } from '@labkey/api';
+
 import { GRID_CHECKBOX_OPTIONS, LoadingState, makeTestQueryModel, QueryInfo, QuerySort, SchemaQuery } from '../..';
 import { initUnitTests, makeQueryInfo } from '../../internal/testHelpers';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -435,13 +435,8 @@ export class QueryModel {
         return this.baseFilters.filter(filter => filter.getColumnName().toLowerCase() === 'replaced');
     }
 
-    /**
-     * An array of [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html) objects
-     * for the QueryModel. If a keyValue is provided, this will be a filter on the primary key column concatenated with
-     * the detailFilters. Otherwise, this will be a concatenation of the baseFilters, filterArray, and [[QueryInfo]] view filters.
-     */
-    get filters(): Filter.IFilter[] {
-        const { baseFilters, filterArray, queryInfo, keyValue, viewName } = this;
+    get modelFilters(): Filter.IFilter[] {
+        const { baseFilters, queryInfo, keyValue, viewName } = this;
 
         if (!queryInfo) {
             // Throw an error because this method is only used when making an API request, and if we don't have a
@@ -464,7 +459,20 @@ export class QueryModel {
             return [...pkFilter, ...this.detailFilters];
         }
 
-        return [...baseFilters, ...filterArray, ...queryInfo.getFilters(viewName).toArray()];
+        return [...baseFilters, ...queryInfo.getFilters(viewName).toArray()];
+    }
+
+    /**
+     * An array of [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html) objects
+     * for the QueryModel. If a keyValue is provided, this will be a filter on the primary key column concatenated with
+     * the detailFilters. Otherwise, this will be a concatenation of the baseFilters, filterArray, and [[QueryInfo]] view filters.
+     */
+    get filters(): Filter.IFilter[] {
+        const modelFilters = this.modelFilters;
+
+        if (this.keyValue !== undefined) return modelFilters;
+
+        return [...modelFilters, ...this.filterArray];
     }
 
     /**

--- a/packages/components/src/theme/filter.scss
+++ b/packages/components/src/theme/filter.scss
@@ -122,6 +122,12 @@
 
 .filter-expression__input-select {
     width: 75%;
+
+    // Issue 45139
+    .select-input__menu-portal {
+        top: auto;
+        left: auto;
+    }
 }
 
 .filter-cards__card {

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -152,3 +152,11 @@
         cursor: pointer;
     }
 }
+
+// Issue 45139: grid header menu is clipped by the bounding container instead of overflowing it
+.grid-panel .grid-header-cell .dropdown-menu {
+    position: fixed;
+    top: auto;
+    left: auto;
+    right: auto;
+}


### PR DESCRIPTION
#### Rationale
Issue [45135](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45135): App grid filter modal handling of distinct values query for Choose Values tab needs updates

Issue [45139](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45139): A drop down menu can be truncated by its container
NOTE: this one has two parts. One for the grid menu display on column header click and a second for the filter modal when you are selecting the 2nd filter type to apply for a given field.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/800
* https://github.com/LabKey/biologics/pull/1238
* https://github.com/LabKey/inventory/pull/416
* https://github.com/LabKey/sampleManagement/pull/914
* https://github.com/LabKey/testAutomation/pull/1071

#### Changes
* FilterExpressionView update to set SelectInput menuPosition to fixed and top/left to auto (via SCSS)
* QueryFilterPanel update to get the model baseFilters and queryInfo filters to apply to the Choose Values query for the GridPanel case 
* HeaderCellDropdown update to use a fixed position menu and adjust the top/left values on open based on the given header column position
