### PR TITLE
44316: Add default selection to "Create related issue" dialog

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.150.1-fb-issue-44316.0",
+  "version": "2.153.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.150.0",
+  "version": "2.150.1-fb-issue-44316.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -10,6 +10,10 @@ Components, models, actions, and utility functions for LabKey applications and p
     * add "Remove all" option to the end of the filter pill display if > 1 present
     * hide omnibox when experimental feature is enabled
 
+### version TBD
+*Released*: TBD
+* Add a configuration option in the issue definition properties panel to select the default related issues folder.
+
 ### version 2.149.6
 *Released*: 4 April 2022
 * Remove QueryGridPanel and related components and action/util functions

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.153.1
+*Released*: 12 April 2022
+* Add a configuration option in the issue definition properties panel to select the default related issues folder.
+
 ### version 2.153.0
 *Released*: 12 April 2022
 * Add AncestorRenderer for display of ancestor lookup columns
@@ -39,10 +43,6 @@ Components, models, actions, and utility functions for LabKey applications and p
     * display the view, filter, and search grid action values in the grid info section (previously displayed in the OmniBox input)
     * add "Remove all" option to the end of the filter pill display if > 1 present
     * hide omnibox when experimental feature is enabled
-
-### version TBD
-*Released*: TBD
-* Add a configuration option in the issue definition properties panel to select the default related issues folder.
 
 ### version 2.149.6
 *Released*: 4 April 2022

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -72,7 +72,7 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
             const relatedFolders = await getRelatedFolders(this.props.model.issueDefName);
             this.setState({ coreGroups, relatedFolders });
         } catch (e) {
-            console.error('AssignmentOptions: failed to load initialize project groups', e);
+            console.error('AssignmentOptions: failed to load initialize project groups and related folders.', e);
         }
 
         await this.loadUsersForGroup(this.props.model.assignedToGroup);

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -8,14 +8,15 @@ import { SectionHeading } from '../SectionHeading';
 import { DomainFieldLabel } from '../DomainFieldLabel';
 import { LoadingSpinner, Principal, SelectInput } from '../../../..';
 
-import { IssuesListDefModel } from './models';
+import { IssuesListDefModel, IssuesRelatedFolder } from './models';
 import {
     ISSUES_LIST_DEF_SORT_DIRECTION_TIP,
     ISSUES_LIST_DEF_SINGULAR_PLURAL_TIP,
     ISSUES_LIST_GROUP_ASSIGN_TIP,
     ISSUES_LIST_USER_ASSIGN_TIP,
+    ISSUES_LIST_RELATED_FOLDER_TIP,
 } from './constants';
-import { getProjectGroups, getUsersForGroup } from './actions';
+import { getProjectGroups, getRelatedFolders, getUsersForGroup } from './actions';
 
 interface IssuesListDefBasicPropertiesInputsProps {
     model: IssuesListDefModel;
@@ -31,6 +32,7 @@ interface AssignmentOptionsProps {
 interface AssignmentOptionsState {
     coreGroups?: List<Principal>;
     coreUsers?: List<Principal>;
+    relatedFolders?: List<IssuesRelatedFolder>;
 }
 
 // For AssignedToGroupInput & DefaultUserAssignmentInput components
@@ -40,6 +42,7 @@ interface AssignmentOptionsInputProps {
     coreGroups?: List<Principal>;
     coreUsers?: List<Principal>;
     onGroupChange?: (groupId: number) => any;
+    relatedFolders?: List<IssuesRelatedFolder>;
 }
 
 export class BasicPropertiesFields extends PureComponent<IssuesListDefBasicPropertiesInputsProps> {
@@ -60,12 +63,14 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
     state: Readonly<AssignmentOptionsState> = {
         coreGroups: undefined,
         coreUsers: undefined,
+        relatedFolders: undefined,
     };
 
     componentDidMount = async (): Promise<void> => {
         try {
             const coreGroups = await getProjectGroups();
-            this.setState({ coreGroups });
+            const relatedFolders = await getRelatedFolders(this.props.model.issueDefName);
+            this.setState({ coreGroups, relatedFolders });
         } catch (e) {
             console.error('AssignmentOptions: failed to load initialize project groups', e);
         }
@@ -84,7 +89,7 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
 
     render() {
         const { model, onSelect } = this.props;
-        const { coreUsers, coreGroups } = this.state;
+        const { coreUsers, coreGroups, relatedFolders } = this.state;
 
         return (
             <Col xs={12} md={6}>
@@ -96,6 +101,7 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
                     onGroupChange={this.loadUsersForGroup}
                 />
                 <DefaultUserAssignmentInput model={model} coreUsers={coreUsers} onSelect={onSelect} />
+                <DefaultRelatedFolderInput model={model} relatedFolders={relatedFolders} onSelect={onSelect} />
             </Col>
         );
     }
@@ -256,6 +262,44 @@ export class DefaultUserAssignmentInput extends PureComponent<AssignmentOptionsI
                             labelKey="displayName"
                             onChange={this.onChange}
                             value={model.assignedToUser}
+                        />
+                    )}
+                </Col>
+            </Row>
+        );
+    }
+}
+
+export class DefaultRelatedFolderInput extends PureComponent<AssignmentOptionsInputProps, any> {
+    onChange = (name: string, formValue: any, selected: IssuesRelatedFolder, ref: any): any => {
+        this.props.onSelect(name, selected ? selected.key : undefined);
+    };
+
+    render() {
+        const { model, relatedFolders } = this.props;
+
+        return (
+            <Row className="margin-top">
+                <Col xs={3} lg={4}>
+                    <DomainFieldLabel
+                        label="Default Related Issue Folder"
+                        helpTipBody={ISSUES_LIST_RELATED_FOLDER_TIP}
+                        required={false}
+                    />
+                </Col>
+                <Col xs={9} lg={8}>
+                    {!relatedFolders ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <SelectInput
+                            name="relatedFolderName"
+                            options={relatedFolders?.toArray()}
+                            placeholder="Unassigned"
+                            inputClass="col-xs-12"
+                            valueKey="key"
+                            labelKey="displayName"
+                            onChange={this.onChange}
+                            value={model.relatedFolderName}
                         />
                     )}
                 </Col>

--- a/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefDesignerPanels.spec.tsx.snap
@@ -456,6 +456,58 @@ Array [
                 </span>
               </div>
             </div>
+            <div
+              className="margin-top row"
+            >
+              <div
+                className="col-lg-4 col-xs-3"
+              >
+                Default Related Issue 
+                <span
+                  className="domain-no-wrap"
+                >
+                  Folder
+                  <span
+                    className="label-help-target"
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                      data-icon="question-circle"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                  </span>
+                  
+                </span>
+              </div>
+              <div
+                className="col-lg-8 col-xs-9"
+              >
+                <span
+                  className=""
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-spinner fa-pulse"
+                  />
+                   
+                  Loading...
+                </span>
+              </div>
+            </div>
           </div>
         </form>
       </div>

--- a/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefPropertiesPanel.spec.tsx.snap
@@ -430,6 +430,58 @@ exports[`IssuesListDefPropertiesPanel new Issue Def 1`] = `
             </span>
           </div>
         </div>
+        <div
+          className="margin-top row"
+        >
+          <div
+            className="col-lg-4 col-xs-3"
+          >
+            Default Related Issue 
+            <span
+              className="domain-no-wrap"
+            >
+              Folder
+              <span
+                className="label-help-target"
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
+                  data-icon="question-circle"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              
+            </span>
+          </div>
+          <div
+            className="col-lg-8 col-xs-9"
+          >
+            <span
+              className=""
+            >
+              <i
+                aria-hidden="true"
+                className="fa fa-spinner fa-pulse"
+              />
+               
+              Loading...
+            </span>
+          </div>
+        </div>
       </div>
     </form>
   </div>

--- a/packages/components/src/internal/components/domainproperties/issues/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/actions.ts
@@ -6,7 +6,7 @@ import { buildURL, Principal } from '../../../..';
 
 import { DuplicateFilesResponse } from '../../assay/actions';
 
-import { IssuesListDefModel, IssuesListDefOptionsConfig } from './models';
+import { IssuesListDefModel, IssuesListDefOptionsConfig, IssuesRelatedFolder } from './models';
 
 export function fetchIssuesListDefDesign(issueDefName?: string): Promise<IssuesListDefModel> {
     return new Promise((resolve, reject) => {
@@ -81,6 +81,28 @@ export function saveIssueListDefOptions(options: IssuesListDefOptionsConfig): Pr
             failure: Utils.getCallbackWrapper(response => {
                 console.error(response);
                 reject(response);
+            }),
+        });
+    });
+}
+
+export function getRelatedFolders(issueDefName?: string): Promise<List<IssuesRelatedFolder>> {
+    return new Promise((resolve, reject) => {
+        Ajax.request({
+            url: ActionURL.buildURL('issues', 'getRelatedFolder.api'),
+            method: 'GET',
+            params: { issueDefName },
+            scope: this,
+            success: Utils.getCallbackWrapper(res => {
+                let folders = List<IssuesRelatedFolder>();
+                res.containers.forEach(container => {
+                    const folder = IssuesRelatedFolder.create(container);
+                    folders = folders.push(folder);
+                });
+                resolve(folders);
+            }),
+            failure: Utils.getCallbackWrapper(error => {
+                reject(error);
             }),
         });
     });

--- a/packages/components/src/internal/components/domainproperties/issues/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/constants.ts
@@ -8,3 +8,5 @@ export const ISSUES_LIST_GROUP_ASSIGN_TIP =
     "Select a specific group from the dropdown, both site and project level groups are available. If left blank, the 'Assigned To' field will display all users who are a) assigned the role of Editor or higher in the folder, and b) are members of at least one project-level security group.";
 export const ISSUES_LIST_USER_ASSIGN_TIP =
     'In some workflows it is useful to have a default user to whom all issues are assigned, such as for initial triage and balancing assignments across a group. If left blank, no user will be assigned by default.';
+export const ISSUES_LIST_RELATED_FOLDER_TIP =
+    'A related issue can be created in any issue list that the user can insert into. This setting controls the default folder selection in the related issue dialog box.';

--- a/packages/components/src/internal/components/domainproperties/issues/models.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/models.ts
@@ -15,6 +15,8 @@
  */
 import { immerable } from 'immer';
 
+import { Record } from 'immutable';
+
 import { DomainDesign } from '../models';
 
 export interface IssuesListDefOptionsConfig {
@@ -25,6 +27,7 @@ export interface IssuesListDefOptionsConfig {
     commentSortDirection: string;
     assignedToGroup: number;
     assignedToUser: number;
+    relatedFolderName: string;
 }
 
 interface IssuesListDefModelConfig extends IssuesListDefOptionsConfig {
@@ -48,6 +51,7 @@ export class IssuesListDefModel implements IssuesListDefModelConfig {
     readonly assignedToGroup: number;
     readonly assignedToUser: number;
     readonly domainKindName: string;
+    readonly relatedFolderName: string;
 
     constructor(values?: Partial<IssuesListDefModelConfig>) {
         Object.assign(this, values);
@@ -84,6 +88,23 @@ export class IssuesListDefModel implements IssuesListDefModelConfig {
             commentSortDirection: this.commentSortDirection,
             assignedToGroup: this.assignedToGroup,
             assignedToUser: this.assignedToUser,
+            relatedFolderName: this.relatedFolderName,
         };
+    }
+}
+
+export class IssuesRelatedFolder extends Record({
+    issueDefName: undefined,
+    displayName: undefined,
+    containerPath: undefined,
+    key: undefined,
+}) {
+    declare issueDefName: string;
+    declare displayName: string;
+    declare containerPath: string;
+    declare key: string;
+
+    static create(raw: any): IssuesRelatedFolder {
+        return new IssuesRelatedFolder({ ...raw });
     }
 }


### PR DESCRIPTION
#### Rationale
We want to introduce a new dropdown in the issue definition properties panel to allow administrators to configure the default folder that is offered when a user creates a new related issue.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44316

#### Related Pull Requests
https://github.com/LabKey/platform/pull/3243

#### Changes
- update issue props to query for available containers and render in the admin panel