### PR TITLE
Item 10203: Support sample type and data class renaming

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.156.0-fb-sampleTypeRename.1",
+  "version": "2.156.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.155.1",
+  "version": "2.156.0-fb-sampleTypeRename.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.154.1",
+  "version": "2.155.0-fb-sampleTypeRename.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.154.2",
+  "version": "2.155.0-fb-sampleTypeRename.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.XX
-*Released*: XX April 2022
+### version 2.156.0
+*Released*: 20 April 2022
 * Item 10203: Support sample type and data class renaming
 
 ### version 2.155.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.XX
+*Released*: XX April 2022
+* Item 10203: Support sample type and data class renaming
+
 ### version 2.154.1
 *Released*: 13 April 2022
 * Issue 45021: Sample Finder: Filtering on a field whose name contains special characters does not work

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -88,11 +88,11 @@ class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDomainDesi
             if (response.prefix) {
                 this.setState(
                     produce((draft: Draft<State>) => {
-                        draft.model.nameExpression = response.prefix + (draft.model.nameExpression ? draft.model.nameExpression : '');
+                        draft.model.nameExpression =
+                            response.prefix + (draft.model.nameExpression ? draft.model.nameExpression : '');
                     })
                 );
             }
-
         }
     };
 

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -124,13 +124,18 @@ class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDomainDesi
     saveDomain = async (hasConfirmedNameExpression?: boolean): Promise<void> => {
         const { api, beforeFinish, onComplete, setSubmitting, validateNameExpressions } = this.props;
         const { model } = this.state;
+        const { name, domain } = model;
 
         beforeFinish?.(model);
+
+        const domainDesign = domain.merge({
+            name, // This will be the Data Class Name
+        }) as DomainDesign;
 
         if (validateNameExpressions && !hasConfirmedNameExpression) {
             try {
                 const response = await api.domain.validateDomainNameExpressions(
-                    model.domain,
+                    domainDesign,
                     Domain.KINDS.DATA_CLASS,
                     model.options,
                     true
@@ -157,7 +162,7 @@ class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDomainDesi
         }
 
         try {
-            const savedDomain = await saveDomain(model.domain, Domain.KINDS.DATA_CLASS, model.options, model.name);
+            const savedDomain = await saveDomain(domainDesign, Domain.KINDS.DATA_CLASS, model.options, model.name);
 
             setSubmitting(false, () => {
                 this.saveModel({ domain: savedDomain, exception: undefined }, () => {

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
@@ -166,6 +166,7 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
                     previewName={previewName}
                     onNameFieldHover={onNameFieldHover}
                     nameExpressionGenIdProps={nameExpressionGenIdProps}
+                    nameReadOnly={model.isBuiltIn}
                 />
                 {!appPropertiesOnly && (
                     <Row>

--- a/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
@@ -43,6 +43,7 @@ export class DataClassModel implements DataClassModelConfig {
     readonly nameExpression: string;
     readonly rowId: number;
     readonly sampleSet: number;
+    readonly isBuiltIn?: boolean;
 
     constructor(values?: Partial<DataClassModelConfig>) {
         Object.assign(this, values);

--- a/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
@@ -79,7 +79,7 @@ export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, a
                             placeholder={`Enter a name for this ${noun.toLowerCase()}`}
                             onChange={onFormChange}
                             value={getEntityNameValue(formValues, data)}
-                            disabled={isExistingEntity(formValues, data) || nameReadOnly}
+                            disabled={nameReadOnly}
                         />
                     </Col>
                 </Row>

--- a/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
@@ -202,7 +202,6 @@ exports[`<EntityDetailsForm/> initial data 1`] = `
     >
       <input
         className="form-control"
-        disabled={true}
         id="entity-name"
         onChange={[MockFunction]}
         placeholder="Enter a name for this entity"
@@ -773,7 +772,6 @@ exports[`<EntityDetailsForm/> with previewName 1`] = `
               <FormControl
                 bsClass="form-control"
                 componentClass="input"
-                disabled={true}
                 id="entity-name"
                 onChange={[MockFunction]}
                 placeholder="Enter a name for this entity"
@@ -782,7 +780,6 @@ exports[`<EntityDetailsForm/> with previewName 1`] = `
               >
                 <input
                   className="form-control"
-                  disabled={true}
                   id="entity-name"
                   onChange={[MockFunction]}
                   placeholder="Enter a name for this entity"

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
@@ -95,9 +95,9 @@ describe('<SampleTypePropertiesPanel/>', () => {
 
         const wrapper = mount(component);
 
-        // Name input should be visible but disabled
+        // Name input should not be disabled
         expect(wrapper.find('input#' + ENTITY_FORM_IDS.NAME)).toHaveLength(1);
-        expect(wrapper.find('input#' + ENTITY_FORM_IDS.NAME).prop('disabled')).toBeTruthy();
+        expect(wrapper.find('input#' + ENTITY_FORM_IDS.NAME).prop('disabled')).toBeFalsy();
 
         // Check initial input values
         expect(wrapper.find('input#' + ENTITY_FORM_IDS.NAME_EXPRESSION).props().value).toBe(nameExpVal);
@@ -111,6 +111,28 @@ describe('<SampleTypePropertiesPanel/>', () => {
         expect(wrapper.text()).not.toContain('Linked Dataset Category');
 
         expect(wrapper.find(DomainFieldLabel)).toHaveLength(3);
+
+        wrapper.unmount();
+    });
+
+    test('Load SampleTypeModel with readonly name', () => {
+        const data = DomainDetails.create(
+            fromJS({
+                options: Map<string, any>({
+                    rowId: 1
+                }),
+                domainKindName: 'SampleType',
+                domainDesign: sampleTypeModel.get('domain'),
+                nameReadOnly: true
+            })
+        );
+
+        const component = <SampleTypePropertiesPanel {...BASE_PROPS} model={SampleTypeModel.create(data)} />;
+
+        const wrapper = mount(component);
+
+        expect(wrapper.find('input#' + ENTITY_FORM_IDS.NAME)).toHaveLength(1);
+        expect(wrapper.find('input#' + ENTITY_FORM_IDS.NAME).prop('disabled')).toBeTruthy();
 
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
@@ -25,10 +25,11 @@ import { sleep } from '../../../testHelpers';
 
 import { DomainFieldLabel } from '../DomainFieldLabel';
 
+import { initUnitTestMocks } from '../../../testHelperMocks';
+
 import { SampleTypePropertiesPanel } from './SampleTypePropertiesPanel';
 import { SampleTypeModel } from './models';
 import { UniqueIdBanner } from './UniqueIdBanner';
-import { initUnitTestMocks } from '../../../testHelperMocks';
 
 beforeAll(() => {
     initUnitTestMocks();
@@ -119,11 +120,11 @@ describe('<SampleTypePropertiesPanel/>', () => {
         const data = DomainDetails.create(
             fromJS({
                 options: Map<string, any>({
-                    rowId: 1
+                    rowId: 1,
                 }),
                 domainKindName: 'SampleType',
                 domainDesign: sampleTypeModel.get('domain'),
-                nameReadOnly: true
+                nameReadOnly: true,
             })
         );
 

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -2532,7 +2532,6 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                                 <FormControl
                                   bsClass="form-control"
                                   componentClass="input"
-                                  disabled={true}
                                   id="entity-name"
                                   onChange={[Function]}
                                   placeholder="Enter a name for this sample type"
@@ -2541,7 +2540,6 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                                 >
                                   <input
                                     className="form-control"
-                                    disabled={true}
                                     id="entity-name"
                                     onChange={[Function]}
                                     placeholder="Enter a name for this sample type"


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/808
* https://github.com/LabKey/platform/pull/3256
* https://github.com/LabKey/commonAssays/pull/458
* https://github.com/LabKey/sampleManagement/pull/922
* https://github.com/LabKey/biologics/pull/1255
* https://github.com/LabKey/testAutomation/pull/1089

#### Changes
* Enable name field on designer update
