### PR TITLE
Remove client-side user caching

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.154.2-fb-remove-user-caching.0",
+  "version": "2.154.2-fb-remove-user-caching.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.154.2",
+  "version": "2.154.2-fb-remove-user-caching.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.154.2-fb-remove-user-caching.1",
+  "version": "2.155.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.155.0
+*Released*: 18 April 2022
+* Remove "users" from `global` state cache and all associated methods.
+* Change `getUsersWithPermissions` to return an `User[]` instead of `List<User>`.
+* Change `UserSelectInput` default to `clearCacheOnChange=false` and implement `generateKey` to handle path/perm changes.
+* Refactor how `AuditDetails` fetches user permissions.
+* Remove `invalidateUsers` and its usages.
+
 ### version 2.154.2
 *Released*: 15 April 2022
 * Issue 45223: Wrap multiline text fields on line breaks

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -175,7 +175,6 @@ import {
     getEditorModel,
     getQueryGridModel,
     initQueryGridState,
-    invalidateUsers,
     removeQueryGridModel,
     updateEditorModel,
 } from './internal/global';
@@ -833,7 +832,6 @@ export {
     getQueryGridModel,
     getEditorModel,
     removeQueryGridModel,
-    invalidateUsers,
     clearSelected,
     gridInvalidate,
     gridIdInvalidate,

--- a/packages/components/src/internal/components/administration/BasePermissions.tsx
+++ b/packages/components/src/internal/components/administration/BasePermissions.tsx
@@ -11,7 +11,6 @@ import { InjectedRouteLeaveProps, withRouteLeave } from '../../util/RouteLeave';
 import { fetchContainerSecurityPolicy } from '../permissions/actions';
 import { dismissNotifications } from '../notifications/global';
 import { createNotification } from '../notifications/actions';
-import { invalidateUsers } from '../../global';
 import { CreatedModified } from '../base/CreatedModified';
 import { ManageDropdownButton } from '../buttons/ManageDropdownButton';
 import { ServerContextConsumer } from '../base/ServerContext';
@@ -78,7 +77,6 @@ class BasePermissionsImpl extends React.PureComponent<Props, State> {
         createNotification('Successfully updated roles and assignments.');
 
         this.loadSecurityPolicy();
-        invalidateUsers();
     };
 
     renderButtons = () => {

--- a/packages/components/src/internal/components/administration/UserManagement.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.tsx
@@ -15,7 +15,6 @@ import { fetchContainerSecurityPolicy } from '../permissions/actions';
 import { createNotification } from '../notifications/actions';
 import { queryGridInvalidate } from '../../actions';
 import { SCHEMAS } from '../../schemas';
-import { invalidateUsers } from '../../global';
 import { ManageDropdownButton } from '../buttons/ManageDropdownButton';
 import { AppURL } from '../../url/AppURL';
 import { BasePermissionsCheckPage } from '../permissions/BasePermissionsCheckPage';
@@ -240,7 +239,6 @@ export class UserManagement extends PureComponent<Props, State> {
 
     invalidateGlobal() {
         queryGridInvalidate(SCHEMAS.CORE_TABLES.USERS);
-        invalidateUsers();
     }
 
     renderButtons = () => {

--- a/packages/components/src/internal/components/forms/actions.spec.tsx
+++ b/packages/components/src/internal/components/forms/actions.spec.tsx
@@ -15,14 +15,13 @@
  */
 import { PermissionTypes } from '@labkey/api';
 import { mount } from 'enzyme';
-import { fromJS, List } from 'immutable';
+import { fromJS } from 'immutable';
 import React, { FC } from 'react';
 
 import { LoadingState } from '../../../public/LoadingState';
 import { TEST_USER_EDITOR, TEST_USER_READER } from '../../../test/data/users';
 import { waitForLifecycle } from '../../testHelpers';
 import { LoadingSpinner } from '../base/LoadingSpinner';
-import { User } from '../base/models/User';
 
 import { parseSelectedQuery, UsersLoader, useUsersWithPermissions } from './actions';
 
@@ -110,7 +109,7 @@ describe('useUsersWithPermissions', () => {
     test('state', async () => {
         const error = 'There was a problem retrieving users with the given permissions';
         const containerPath = '/';
-        const loader = jest.fn(async () => List<User>([TEST_USER_EDITOR, TEST_USER_READER]));
+        const loader = jest.fn().mockResolvedValue([TEST_USER_EDITOR, TEST_USER_READER]);
         const wrapper = mount(
             <TestComponent containerPath={containerPath} permissions={[PermissionTypes.Read]} loader={loader} />
         );
@@ -130,7 +129,7 @@ describe('useUsersWithPermissions', () => {
 
     test('reload permissions', async () => {
         const containerPath = '/';
-        const loader = jest.fn(async () => List<User>([TEST_USER_EDITOR, TEST_USER_READER]));
+        const loader = jest.fn().mockResolvedValue([TEST_USER_EDITOR, TEST_USER_READER]);
         const wrapper = mount(
             <TestComponent containerPath={containerPath} permissions={[PermissionTypes.Read]} loader={loader} />
         );

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -321,7 +321,6 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
     };
 
     loadOptions = async (input: string): Promise<SelectInputOption[]> => {
-        console.log(`loadOptions: "${input}"`);
         // We don't support the older callback-based variant
         const options = await this.props.loadOptions(input);
 

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -321,6 +321,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
     };
 
     loadOptions = async (input: string): Promise<SelectInputOption[]> => {
+        console.log(`loadOptions: "${input}"`);
         // We don't support the older callback-based variant
         const options = await this.props.loadOptions(input);
 

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -6,7 +6,7 @@ import React, { FC, useCallback } from 'react';
 
 import { getUsersWithPermissions } from '../actions';
 
-import { SelectInput, SelectInputProps } from './SelectInput';
+import { SelectInput, SelectInputOption, SelectInputProps } from './SelectInput';
 
 interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loadOptions'> {
     containerPath?: string;
@@ -17,11 +17,11 @@ interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loa
 }
 
 export const UserSelectInput: FC<UserSelectInputProps> = props => {
-    const { containerPath, notifyList, permissions, useEmail, ...selectInputProps } = props;
+    const { clearCacheOnChange = false, containerPath, notifyList, permissions, useEmail, ...selectInputProps } = props;
 
     const loadOptions = useCallback(
         async (input: string) => {
-            let options;
+            let options: SelectInputOption[];
             const sanitizedInput = input?.trim().toLowerCase();
 
             try {
@@ -37,8 +37,7 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
                     .map(v => ({
                         label: v.displayName,
                         value: notifyList ? v.displayName : useEmail ? v.email : v.userId,
-                    }))
-                    .toArray();
+                    }));
             } catch (error) {
                 console.error(error);
             }
@@ -48,7 +47,14 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
         [containerPath, notifyList, permissions, useEmail]
     );
 
-    return <SelectInput {...selectInputProps} delimiter={notifyList ? ';' : ','} loadOptions={loadOptions} />;
+    return (
+        <SelectInput
+            {...selectInputProps}
+            clearCacheOnChange={clearCacheOnChange}
+            delimiter={notifyList ? ';' : ','}
+            loadOptions={loadOptions}
+        />
+    );
 };
 
 UserSelectInput.defaultProps = {

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -6,8 +6,9 @@ import React, { FC, memo, useCallback, useMemo } from 'react';
 
 import { getUsersWithPermissions } from '../actions';
 
-import { SelectInput, SelectInputOption, SelectInputProps } from './SelectInput';
 import { naturalSort } from '../../../../public/sort';
+
+import { SelectInput, SelectInputOption, SelectInputProps } from './SelectInput';
 
 function generateKey(permissions?: string | string[], containerPath?: string): string {
     let key = 'allPermissions';

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -2,11 +2,27 @@
  * Copyright (c) 2017-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, useCallback } from 'react';
+import React, { FC, memo, useCallback, useMemo } from 'react';
 
 import { getUsersWithPermissions } from '../actions';
 
 import { SelectInput, SelectInputOption, SelectInputProps } from './SelectInput';
+import { naturalSort } from '../../../../public/sort';
+
+function generateKey(permissions?: string | string[], containerPath?: string): string {
+    let key = 'allPermissions';
+    if (permissions) {
+        if (Array.isArray(permissions)) {
+            key = permissions.sort(naturalSort).join(';');
+        } else {
+            key = permissions;
+        }
+    }
+    if (containerPath) {
+        key = [containerPath, key].join('|');
+    }
+    return key;
+}
 
 interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loadOptions'> {
     containerPath?: string;
@@ -16,8 +32,9 @@ interface UserSelectInputProps extends Omit<SelectInputProps, 'delimiter' | 'loa
     useEmail?: boolean;
 }
 
-export const UserSelectInput: FC<UserSelectInputProps> = props => {
+export const UserSelectInput: FC<UserSelectInputProps> = memo(props => {
     const { clearCacheOnChange = false, containerPath, notifyList, permissions, useEmail, ...selectInputProps } = props;
+    const key = useMemo(() => generateKey(permissions, containerPath), [containerPath, permissions]);
 
     const loadOptions = useCallback(
         async (input: string) => {
@@ -52,10 +69,11 @@ export const UserSelectInput: FC<UserSelectInputProps> = props => {
             {...selectInputProps}
             clearCacheOnChange={clearCacheOnChange}
             delimiter={notifyList ? ';' : ','}
+            key={key}
             loadOptions={loadOptions}
         />
     );
-};
+});
 
 UserSelectInput.defaultProps = {
     notifyList: false,

--- a/packages/components/src/internal/global.ts
+++ b/packages/components/src/internal/global.ts
@@ -15,9 +15,8 @@
  */
 import { getGlobal, setGlobal } from 'reactn';
 import { List, Map } from 'immutable';
-import { User } from '@labkey/api';
 
-import { naturalSort, NotificationItemModel, QueryColumn, QueryGridModel, resolveSchemaQuery, SchemaQuery } from '..';
+import { NotificationItemModel, QueryGridModel, resolveSchemaQuery, SchemaQuery } from '..';
 
 import { initBrowserHistoryState } from './util/global';
 import { EditorModel } from './models';
@@ -29,7 +28,6 @@ export type GlobalAppState = {
     QueryGrid_metadata: Map<string, any>;
     QueryGrid_models: Map<string, QueryGridModel>;
     QueryGrid_columnrenderers: Map<string, any>;
-    QueryGrid_users: Map<string, List<User>>;
 
     // src/util/global.ts
     BrowserHistory: any; // TODO what type to use here?
@@ -76,7 +74,6 @@ export function resetQueryGridState(): void {
         QueryGrid_metadata: Map<string, any>(),
         QueryGrid_models: Map<string, QueryGridModel>(),
         QueryGrid_columnrenderers: Map<string, any>(),
-        QueryGrid_users: Map<string, List<User>>(),
     });
 }
 
@@ -287,47 +284,4 @@ export function updateEditorModel(model: EditorModel, updates: any, failIfNotFou
     });
 
     return updatedModel;
-}
-
-function getUsersCacheKey(permissions?: string | string[], containerPath?: string): string {
-    let key = 'allPermissions';
-    if (permissions) {
-        if (Array.isArray(permissions)) {
-            key = permissions.sort(naturalSort).join(';');
-        } else {
-            key = permissions;
-        }
-    }
-    if (containerPath) {
-        key = [containerPath, key].join('|');
-    }
-    return key;
-}
-
-/**
- * Get the users list from the global QueryGrid state
- */
-export function getUsers(permissions?: string | string[], containerPath?: string): Promise<List<User>> {
-    return getGlobalState('users').get(getUsersCacheKey(permissions, containerPath));
-}
-
-/**
- * Sets the users list to be used for this application in the global QueryGrid state
- * @param users List of users
- * @param permissions the PermissionType or array of PermissionType values that can be used to identify a list of users.
- * @param containerPath the containerPath
- */
-export function setUsers(users: Promise<List<User>>, permissions?: string | string[], containerPath?: string): void {
-    setGlobal({
-        QueryGrid_users: getGlobalState('users').set(getUsersCacheKey(permissions, containerPath), users),
-    });
-}
-
-/**
- * Invalidate the global state users list
- */
-export function invalidateUsers(): void {
-    setGlobal({
-        QueryGrid_users: Map<string, Promise<List<User>>>(),
-    });
 }


### PR DESCRIPTION
#### Rationale
Removes users from the `global` state cache as it is unnecessary. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/809
* https://github.com/LabKey/biologics/pull/1256
* https://github.com/LabKey/inventory/pull/419
* https://github.com/LabKey/sampleManagement/pull/923

#### Changes
* Remove "users" from `global` state cache and all associated methods.
* Change `getUsersWithPermissions` to return an `User[]` instead of `List<User>`.
* Change `UserSelectInput` default to `clearCacheOnChange=false` and implement `generateKey` to handle path/perm changes.
* Refactor how `AuditDetails` fetches user permissions.
* Remove `invalidateUsers` and its usages.
