### PR TITLE
QuerySelect: remove "componentId" prop

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.156.1",
+  "version": "2.156.1-fb-query-select-imp.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.156.1-fb-query-select-imp.0",
+  "version": "2.157.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.157.0
+*Released*: 21 April 2022
+* Factor out `componentId` prop on `QuerySelect`.
+
 ### version 2.156.1
 *Released*: 20 April 2022
 * Merge release22.4-SNAPSHOT to develop

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
@@ -175,7 +175,7 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
                         </Col>
                         <Col xs={10}>
                             <QuerySelect
-                                componentId={FORM_IDS.CATEGORY}
+                                key={FORM_IDS.CATEGORY}
                                 name={FORM_IDS.CATEGORY}
                                 schemaQuery={SCHEMAS.EXP_TABLES.DATA_CLASS_CATEGORY_TYPE}
                                 displayColumn="Value"
@@ -197,7 +197,7 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
                         </Col>
                         <Col xs={10}>
                             <QuerySelect
-                                componentId={FORM_IDS.SAMPLE_TYPE_ID}
+                                key={FORM_IDS.SAMPLE_TYPE_ID}
                                 name={FORM_IDS.SAMPLE_TYPE_ID}
                                 schemaQuery={SCHEMAS.EXP_TABLES.SAMPLE_SETS}
                                 onQSChange={this.onChange}

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -141,8 +141,8 @@ export class LookupCell extends PureComponent<LookupCellProps> {
                 disabled={this.props.disabled}
                 queryFilters={queryFilters}
                 multiple={isMultiple}
-                schemaQuery={SchemaQuery.create(lookup.schemaName, lookup.queryName)}
-                componentId={col.lookupKey}
+                schemaQuery={lookup.schemaQuery}
+                key={col.lookupKey}
                 maxRows={LOOKUP_DEFAULT_SIZE}
                 containerPath={lookup.containerPath}
                 containerClass="select-input-cell-container"

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -147,7 +147,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
                 {chosenType && (
                     <>
                         <QuerySelect
-                            componentId={'parentEntityValue_' + chosenType.label} // important that this key off of the schemaQuery or it won't update when the SelectInput changes
+                            key={'parentEntityValue_' + chosenType.label} // important that this key off of the schemaQuery or it won't update when the SelectInput changes
                             containerClass="row"
                             containerPath={containerPath}
                             inputClass="col-sm-6"

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -220,81 +220,69 @@ function resolveSampleParentTypes(response: any, isAliquotParent?: boolean): Lis
  * @param creationType
  * @param isItemSamples
  */
-function initParents(
+async function initParents(
     initialParents: string[],
     selectionKey: string,
     creationType?: SampleCreationType,
     isItemSamples?: boolean
 ): Promise<List<EntityParentType>> {
     const isAliquotParent = creationType === SampleCreationType.Aliquots;
-    return new Promise((resolve, reject) => {
-        if (selectionKey) {
-            const { schemaQuery } = SchemaQuery.parseSelectionKey(selectionKey);
-            const queryGridModel = getQueryGridModel(selectionKey);
 
-            if (queryGridModel && queryGridModel.selectedLoaded) {
-                const filterArray = [Filter.create('RowId', queryGridModel.selectedIds.toArray(), Filter.Types.IN)];
-                const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
-                if (opFilter) {
-                    filterArray.push(opFilter);
-                }
-                return getSelectedParents(schemaQuery, filterArray, isAliquotParent)
-                    .then(response => resolve(response))
-                    .catch(reason => reject(reason));
-            } else {
-                return getSelected(selectionKey)
-                    .then(selectionResponse => {
-                        if (isItemSamples) {
-                            return getSelectedSampleParentsFromItems(selectionResponse.selected, isAliquotParent)
-                                .then(response => resolve(response))
-                                .catch(reason => reject(reason));
-                        }
-                        const filterArray = [Filter.create('RowId', selectionResponse.selected, Filter.Types.IN)];
-                        const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
-                        if (opFilter) {
-                            filterArray.push(opFilter);
-                        }
-                        return getSelectedParents(schemaQuery, filterArray, isAliquotParent)
-                            .then(response => resolve(response))
-                            .catch(reason => reject(reason));
-                    })
-                    .catch(() => {
-                        console.warn('Unable to parse selectionKey', selectionKey);
-                        resolve(List<EntityParentType>());
-                    });
-            }
-        } else if (initialParents && initialParents.length > 0) {
-            const parent = initialParents[0];
-            const [schema, query, value] = parent.toLowerCase().split(':');
+    if (selectionKey) {
+        const { schemaQuery } = SchemaQuery.parseSelectionKey(selectionKey);
+        const queryGridModel = getQueryGridModel(selectionKey);
 
-            // if the parent key doesn't have a value, we don't need to make the request to getSelectedParents
-            if (value === undefined) {
-                resolve(
-                    List<EntityParentType>([
-                        EntityParentType.create({
-                            index: 1,
-                            schema,
-                            query,
-                            value: List<DisplayObject>(),
-                            isParentTypeOnly: true, // tell the UI to keep the parent type but not add any default rows to the editable grid
-                            isAliquotParent,
-                        }),
-                    ])
-                );
-            }
-
-            const filterArray = [Filter.create('RowId', value)];
+        if (queryGridModel?.selectedLoaded) {
+            const filterArray = [Filter.create('RowId', queryGridModel.selectedIds.toArray(), Filter.Types.IN)];
             const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
             if (opFilter) {
                 filterArray.push(opFilter);
             }
-            return getSelectedParents(SchemaQuery.create(schema, query), filterArray, isAliquotParent)
-                .then(response => resolve(response))
-                .catch(reason => reject(reason));
+
+            return getSelectedParents(schemaQuery, filterArray, isAliquotParent);
         } else {
-            resolve(List<EntityParentType>());
+            const selectionResponse = await getSelected(selectionKey);
+
+            if (isItemSamples) {
+                return getSelectedSampleParentsFromItems(selectionResponse.selected, isAliquotParent);
+            }
+
+            const filterArray = [Filter.create('RowId', selectionResponse.selected, Filter.Types.IN)];
+            const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
+            if (opFilter) {
+                filterArray.push(opFilter);
+            }
+
+            return getSelectedParents(schemaQuery, filterArray, isAliquotParent);
         }
-    });
+    } else if (initialParents?.length > 0) {
+        const [parent] = initialParents;
+        const [schema, query, value] = parent.toLowerCase().split(':');
+
+        // if the parent key doesn't have a value, we don't need to make the request to getSelectedParents
+        if (value === undefined) {
+            return List<EntityParentType>([
+                EntityParentType.create({
+                    index: 1,
+                    schema,
+                    query,
+                    value: List<DisplayObject>(),
+                    isParentTypeOnly: true, // tell the UI to keep the parent type but not add any default rows to the editable grid
+                    isAliquotParent,
+                }),
+            ]);
+        }
+
+        const filterArray = [Filter.create('RowId', value)];
+        const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
+        if (opFilter) {
+            filterArray.push(opFilter);
+        }
+
+        return getSelectedParents(SchemaQuery.create(schema, query), filterArray, isAliquotParent);
+    }
+
+    return List<EntityParentType>();
 }
 
 function resolveEntityParentTypeFromIds(
@@ -345,76 +333,59 @@ export function extractEntityTypeOptionFromRow(
 }
 
 // exported for jest testing
-export function getChosenParentData(
+export async function getChosenParentData(
     model: EntityIdCreationModel,
     parentEntityDataTypes: Map<string, EntityDataType>,
     allowParents: boolean,
     isItemSamples?: boolean
 ): Promise<Partial<EntityIdCreationModel>> {
-    return new Promise((resolve, reject) => {
-        const entityParents = EntityIdCreationModel.getEmptyEntityParents(
-            parentEntityDataTypes.reduce(
-                (names, entityDataType) => names.push(entityDataType.typeListingSchemaQuery.queryName),
-                List<string>()
-            )
-        );
+    const entityParents = EntityIdCreationModel.getEmptyEntityParents(
+        parentEntityDataTypes.reduce(
+            (names, entityDataType) => names.push(entityDataType.typeListingSchemaQuery.queryName),
+            List<string>()
+        )
+    );
 
-        if (allowParents) {
-            const parentSchemaNames = parentEntityDataTypes.keySeq();
-            initParents(model.originalParents, model.selectionKey, model.creationType, isItemSamples)
-                .then(chosenParents => {
-                    // if we have an initial parent, we want to start with a row in the grid (entityCount = 1) otherwise we start with none
-                    let totalParentValueCount = 0,
-                        isParentTypeOnly = false,
-                        parentEntityDataType;
-                    chosenParents.forEach(chosenParent => {
-                        if (chosenParent.value !== undefined && parentSchemaNames.contains(chosenParent.schema)) {
-                            totalParentValueCount += chosenParent.value.size;
-                            isParentTypeOnly = chosenParent.isParentTypeOnly;
-                            parentEntityDataType = parentEntityDataTypes.get(chosenParent.schema).typeListingSchemaQuery
-                                .queryName;
-                        }
-                    });
+    if (allowParents) {
+        const parentSchemaNames = parentEntityDataTypes.keySeq();
+        const { creationType, originalParents, selectionKey } = model;
 
-                    const numPerParent = model.numPerParent ?? 1;
-                    const validEntityCount = totalParentValueCount
-                        ? model.creationType === SampleCreationType.PooledSamples
-                            ? numPerParent
-                            : totalParentValueCount * numPerParent
-                        : 0;
+        const chosenParents = await initParents(originalParents, selectionKey, creationType, isItemSamples);
 
-                    if (
-                        validEntityCount >= 1 ||
-                        isParentTypeOnly ||
-                        model.creationType === SampleCreationType.Aliquots
-                    ) {
-                        resolve({
-                            entityCount: validEntityCount,
-                            entityParents: entityParents.set(parentEntityDataType, chosenParents),
-                        });
-                    } else {
-                        // if we did not find a valid parent, we clear out the parents and selection key from the model as they aren't relevant
-                        resolve({
-                            originalParents: undefined,
-                            selectionKey: undefined,
-                            entityParents,
-                            entityCount: 0,
-                        });
-                    }
-                })
-                .catch(reason => {
-                    console.error(reason);
-                    reject(reason);
-                });
-        } else {
-            resolve({
-                originalParents: undefined,
-                selectionKey: undefined,
-                entityParents,
-                entityCount: 0,
-            });
+        // if we have an initial parent, we want to start with a row in the grid (entityCount = 1) otherwise we start with none
+        let totalParentValueCount = 0,
+            isParentTypeOnly = false,
+            parentEntityDataType;
+        chosenParents.forEach(chosenParent => {
+            if (chosenParent.value !== undefined && parentSchemaNames.contains(chosenParent.schema)) {
+                totalParentValueCount += chosenParent.value.size;
+                isParentTypeOnly = chosenParent.isParentTypeOnly;
+                parentEntityDataType = parentEntityDataTypes.get(chosenParent.schema).typeListingSchemaQuery.queryName;
+            }
+        });
+
+        const numPerParent = model.numPerParent ?? 1;
+        const validEntityCount = totalParentValueCount
+            ? creationType === SampleCreationType.PooledSamples
+                ? numPerParent
+                : totalParentValueCount * numPerParent
+            : 0;
+
+        if (validEntityCount >= 1 || isParentTypeOnly || creationType === SampleCreationType.Aliquots) {
+            return {
+                entityCount: validEntityCount,
+                entityParents: entityParents.set(parentEntityDataType, chosenParents),
+            };
         }
-    });
+    }
+
+    // if we did not find a valid parent, we clear out the parents and selection key from the model as they aren't relevant
+    return {
+        originalParents: undefined,
+        selectionKey: undefined,
+        entityParents,
+        entityCount: 0,
+    };
 }
 
 export function getAllEntityTypeOptions(entityDataTypes: EntityDataType[]) : Promise<{ [p: string]: IEntityTypeOption[] }> {
@@ -497,10 +468,9 @@ export function getEntityTypeData(
             ...parentSchemaQueries.map(edt => getEntityTypeOptions(edt)).toArray(),
         ];
 
-        let partial: Partial<EntityIdCreationModel> = {};
         Promise.all(promises)
             .then(results => {
-                partial = { ...results[1] }; // incorporate the chosen parent data results including entityCount and entityParents
+                const partial = { ...results[1] }; // incorporate the chosen parent data results including entityCount and entityParents
                 let parentOptions = Map<string, List<IParentOption>>();
                 if (results.length > 2) {
                     results.slice(2).forEach(typeOptionsMap => {

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -15,7 +15,6 @@ import {
     SampleCreationType,
     SampleOperation,
     SchemaQuery,
-    selectRows,
     selectRowsDeprecated,
     SHARED_CONTAINER_PATH,
 } from '../../..';
@@ -42,9 +41,7 @@ export function getOperationConfirmationData(
     extraParams?: Record<string, any>
 ): Promise<OperationConfirmationData> {
     if (!selectionKey && !rowIds?.length) {
-        return new Promise(resolve => {
-            resolve(new OperationConfirmationData());
-        });
+        return Promise.resolve(new OperationConfirmationData());
     }
 
     return new Promise((resolve, reject) => {

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -248,7 +248,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                     <QuerySelect
                                         addLabelAsterisk={showAsteriskSymbol}
                                         allowDisable={allowFieldDisable}
-                                        componentId={id}
+                                        key={id}
                                         containerFilter={col.lookup.containerFilter ?? containerFilter}
                                         containerPath={col.lookup.containerPath}
                                         description={col.description}

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -123,7 +123,6 @@ type InheritedSelectInputProps = Omit<
 >;
 
 export interface QuerySelectOwnProps extends InheritedSelectInputProps {
-    componentId: string;
     containerFilter?: Query.ContainerFilter;
     /** The path to the LK container that the queries should be scoped to. */
     containerPath?: string;
@@ -164,32 +163,8 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
 
     constructor(props: QuerySelectOwnProps) {
         super(props);
-        this.state = this.getInitialState(props);
-    }
 
-    componentDidMount(): void {
-        this.initModel();
-    }
-
-    componentDidUpdate(prevProps: QuerySelectOwnProps): void {
-        if (prevProps.componentId !== this.props.componentId) {
-            this.initModel();
-        }
-    }
-
-    initModel = async (): Promise<void> => {
-        this.setState(this.getInitialState(this.props));
-
-        try {
-            const model = await initSelect(this.props);
-            this.setState({ model });
-        } catch (error) {
-            this.setState({ error: resolveErrorMessage(error) ?? 'Failed to initialize.' });
-        }
-    };
-
-    getInitialState = (props: QuerySelectOwnProps): State => {
-        return {
+        this.state = {
             // See note in onFocus() regarding support for "loadOnFocus"
             defaultOptions: props.preLoad !== false ? true : props.loadOnFocus ? [] : true,
             error: undefined,
@@ -197,6 +172,19 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
             loadOnFocusLock: false,
             model: undefined,
         };
+    }
+
+    componentDidMount(): void {
+        this.initModel();
+    }
+
+    initModel = async (): Promise<void> => {
+        try {
+            const model = await initSelect(this.props);
+            this.setState({ model });
+        } catch (error) {
+            this.setState({ error: resolveErrorMessage(error) ?? 'Failed to initialize.' });
+        }
     };
 
     componentWillUnmount(): void {
@@ -316,7 +304,7 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
                 labelClass,
                 menuPosition,
                 multiple,
-                name: this.props.name || this.props.componentId + '-error',
+                name: this.props.name,
                 onToggleDisable,
                 openMenuOnFocus,
                 placeholder: `Error: ${error}`,
@@ -328,7 +316,6 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
         } else if (model?.isInit) {
             const inputProps = Object.assign(
                 {
-                    id: model.id,
                     label: label !== undefined ? label : model.queryInfo.title,
                 },
                 this.props,
@@ -368,7 +355,7 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
                 labelClass,
                 menuPosition,
                 multiple,
-                name: this.props.name || this.props.componentId + '-loader',
+                name: this.props.name,
                 openMenuOnFocus,
                 onToggleDisable,
                 placeholder: 'Loading...',

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -73,7 +73,7 @@ function getQueryColumnNames(model: QuerySelectModel): string[] {
 
 export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel> {
     return new Promise((resolve, reject) => {
-        const { componentId, schemaQuery, containerFilter, containerPath } = props;
+        const { containerFilter, containerPath, schemaQuery } = props;
 
         if (schemaQuery) {
             const { queryName, schemaName } = schemaQuery;
@@ -86,7 +86,6 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                     let model = new QuerySelectModel({
                         ...props,
                         displayColumn,
-                        id: componentId,
                         isInit: true,
                         queryInfo,
                         valueColumn,
@@ -162,7 +161,6 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                 })
                 .catch(err => {
                     // TODO: Need better handling of errors
-                    console.warn(`QuerySelect failure -- componentId "${componentId}"`);
                     console.warn(err);
                     reject(err);
                 });

--- a/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailEditRenderer.tsx
@@ -109,7 +109,7 @@ export function resolveDetailEditRenderer(
 
                 return (
                     <QuerySelect
-                        componentId={col.fieldKey}
+                        key={col.fieldKey}
                         containerFilter={col.lookup.containerFilter ?? options?.containerFilter}
                         containerPath={col.lookup.containerPath ?? options?.containerPath}
                         description={col.description}

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -143,7 +143,7 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
             <QuerySelect
                 addLabelAsterisk={showAsteriskSymbol}
                 allowDisable={allowDisable}
-                componentId={col.fieldKey + key}
+                key={col.fieldKey + key}
                 containerFilter={col.lookup.containerFilter ?? containerFilter}
                 containerPath={col.lookup.containerPath ?? containerPath}
                 description={col.description}

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -27,7 +27,6 @@ export interface QuerySelectModelProps {
     containerPath?: string;
     displayColumn: string;
     delimiter: string;
-    id: string;
     isInit: boolean;
     maxRows: number;
     multiple: boolean;
@@ -49,7 +48,6 @@ export class QuerySelectModel
         containerPath: undefined,
         displayColumn: undefined,
         delimiter: DELIMITER,
-        id: undefined,
         isInit: false,
         maxRows: 20,
         multiple: false,
@@ -70,7 +68,6 @@ export class QuerySelectModel
     declare containerPath: string;
     declare displayColumn: string;
     declare delimiter: string;
-    declare id: string;
     declare isInit: boolean;
     declare maxRows: number;
     declare multiple: boolean;

--- a/packages/components/src/internal/components/samples/CreateSamplesSubMenuBase.tsx
+++ b/packages/components/src/internal/components/samples/CreateSamplesSubMenuBase.tsx
@@ -36,7 +36,7 @@ interface CreateSamplesSubMenuProps {
 
 export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(props => {
     const {
-        allowPooledSamples,
+        allowPooledSamples = true,
         menuCurrentChoice,
         menuText,
         parentType,
@@ -73,11 +73,11 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
     const useOnClick = parentKey !== undefined || (selectingSampleParents && selectedQuantity > 0);
 
     const selectionKey = useMemo(() => {
-        let selectionKey: string = null;
+        let selectionKey_: string = null;
         if ((parentModel?.allowSelection && parentModel.selectedIds.size > 0) || parentQueryModel?.hasSelections) {
-            selectionKey = parentModel?.getId() || parentQueryModel?.id;
+            selectionKey_ = parentModel?.getId() || parentQueryModel?.id;
         }
-        return selectionKey;
+        return selectionKey_;
     }, [parentModel, parentQueryModel]);
 
     const onSampleCreationMenuSelect = useCallback(
@@ -98,19 +98,19 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
                 return appURL;
             }
         },
-        [useOnClick, parentKey, selectionKey, setSampleCreationURL, setSelectedOption]
+        [sampleWizardURL, getProductSampleWizardURL, useOnClick, parentKey, selectionKey]
     );
 
     const onCancel = useCallback(() => {
         setSampleCreationURL(undefined);
         setSelectedOption(undefined);
-    }, [setSampleCreationURL, setSelectedOption]);
+    }, []);
 
     const onSampleCreationSubmit = useCallback(
         (creationType: SampleCreationType, numPerParent?: number) => {
-            if (sampleCreationURL instanceof AppURL)
+            if (sampleCreationURL instanceof AppURL) {
                 navigate(sampleCreationURL.addParams({ creationType, numPerParent }));
-            else {
+            } else {
                 window.location.href = sampleCreationURL + `&creationType=${creationType}&numPerParent=${numPerParent}`;
             }
         },
@@ -149,7 +149,3 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
         </>
     );
 });
-
-CreateSamplesSubMenuBase.defaultProps = {
-    allowPooledSamples: true,
-};

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.spec.tsx
@@ -80,7 +80,7 @@ describe('SamplesBulkUpdateForm', () => {
         determineSampleData: true,
 
         updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise.resolve(),
-        hasValidMaxSelection: () => true,
+        hasValidMaxSelection: true,
         onCancel: jest.fn,
         onBulkUpdateError: jest.fn,
         onBulkUpdateComplete: jest.fn,

--- a/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
@@ -86,20 +86,20 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
     } = props;
     const onLabelExport = { [EXPORT_TYPES.LABEL]: onPrintLabel };
 
-    const onTabSelect = useCallback((tab: string) => {
-        setActiveTabId(tab);
-    }, []);
     const tabs = useMemo(() => {
         return modelId ? [modelId] : Object.keys(queryModels);
     }, [modelId, queryModels]);
     const [activeTabId, setActiveTabId] = useState<string>(initialTabId ?? tabs[0]);
-
+    const onTabSelect = useCallback((tab: string) => {
+        setActiveTabId(tab);
+    }, []);
     const activeModel = useMemo(() => queryModels[activeTabId], [activeTabId, queryModels]);
-    const hasSelection = useMemo(() => activeModel.hasSelections, [activeModel.selections]);
+    const { hasSelections, selections } = activeModel;
+    const selection = useMemo(() => List(Array.from(selections ?? [])), [selections]);
     const hasValidMaxSelection = useMemo(() => {
-        const selSize = activeModel.selections?.size ?? 0;
+        const selSize = selections?.size ?? 0;
         return selSize > 0 && selSize <= MAX_EDITABLE_GRID_ROWS;
-    }, [activeModel.selections]);
+    }, [selections]);
 
     const [isEditing, setIsEditing] = useState<boolean>();
     const [showBulkUpdate, setShowBulkUpdate] = useState<boolean>();
@@ -111,13 +111,13 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             editableGridUpdateData: any,
             editableGridDataForSelection: Map<string, any>,
             editableGridDataIdsForSelection: List<any>
-        ): Promise<any> => {
+        ): Promise<Map<string, any>> => {
             setEditableGridData({
                 updateData: editableGridUpdateData,
                 dataForSelection: editableGridDataForSelection,
                 idsForSelection: editableGridDataIdsForSelection,
             });
-            return new Promise<any>(resolve => resolve(editableGridDataForSelection));
+            return Promise.resolve(editableGridDataForSelection);
         },
         []
     );
@@ -155,11 +155,11 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
     );
 
     const onShowBulkUpdate = useCallback(() => {
-        if (hasSelection) {
+        if (hasSelections) {
             dismissNotifications();
             setShowBulkUpdate(true);
         }
-    }, [hasSelection]);
+    }, [hasSelections]);
 
     const onBulkUpdateError = useCallback((message: string) => {
         withTimeout(() => {
@@ -174,17 +174,8 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             actions.loadModel(activeModel.id, true);
             afterSampleActionComplete?.();
         },
-        [actions, activeModel.id]
+        [actions, activeModel.id, afterSampleActionComplete]
     );
-
-    const toggleEditWithGridUpdate = useCallback(() => {
-        if (isEditing) {
-            resetState();
-        } else if (hasValidMaxSelection) {
-            dismissNotifications();
-            setIsEditing(true);
-        }
-    }, [isEditing, hasValidMaxSelection]);
 
     const resetState = useCallback(() => {
         setEditableGridData(undefined);
@@ -193,17 +184,26 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
         setShowBulkUpdate(false);
     }, []);
 
+    const toggleEditWithGridUpdate = useCallback(() => {
+        if (isEditing) {
+            resetState();
+        } else if (hasValidMaxSelection) {
+            dismissNotifications();
+            setIsEditing(true);
+        }
+    }, [isEditing, hasValidMaxSelection, resetState]);
+
     const onGridEditComplete = useCallback(() => {
         afterSampleActionComplete?.();
         resetState();
-    }, [resetState]);
+    }, [afterSampleActionComplete, resetState]);
 
     const _afterSampleActionComplete = useCallback(() => {
         dismissNotifications();
         actions.loadModel(activeModel.id, true);
         afterSampleActionComplete?.();
         resetState();
-    }, [actions, activeModel.id]);
+    }, [actions, activeModel.id, afterSampleActionComplete, resetState]);
 
     const afterSampleDelete = useCallback(
         (rowsToKeep: any[]) => {
@@ -217,20 +217,21 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
 
             _afterSampleActionComplete();
         },
-        [actions, activeModel]
+        [actions, activeModel, _afterSampleActionComplete]
     );
 
-    const onUpdateRows = useCallback((schemaQuery: SchemaQuery, rows: any[]): Promise<void> => {
-        if (rows.length === 0) {
-            return new Promise(resolve => {
+    const onUpdateRows = useCallback(
+        async (schemaQuery: SchemaQuery, rows: any[]): Promise<void> => {
+            if (rows.length === 0) {
                 dismissNotifications();
+
                 withTimeout(() => {
                     createNotification(NO_UPDATES_MESSAGE);
                 });
 
-                resolve();
-            });
-        } else {
+                return;
+            }
+
             return updateRows({
                 schemaQuery,
                 rows,
@@ -259,15 +260,16 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
                         ),
                     });
                 });
-        }
-    }, []);
+        },
+        [getSampleAuditBehaviorType]
+    );
 
     const _gridButtonProps = {
         ...gridButtonProps,
         afterSampleDelete,
         afterSampleActionComplete: _afterSampleActionComplete,
-        createBtnParentType: hasSelection ? undefined : createBtnParentType,
-        createBtnParentKey: hasSelection ? undefined : createBtnParentKey,
+        createBtnParentType: hasSelections ? undefined : createBtnParentType,
+        createBtnParentKey: hasSelections ? undefined : createBtnParentKey,
         excludedCreateMenuKeys,
         model: activeModel,
         showBulkUpdate: onShowBulkUpdate,
@@ -280,7 +282,7 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
         <>
             {isEditing || selectionData ? (
                 <SamplesEditableGrid
-                    {...samplesEditableGridProps}
+                    {...(samplesEditableGridProps as SamplesEditableGridProps)}
                     determineSampleData={user.canUpdate}
                     determineLineage={user.canUpdate}
                     determineStorage={App.userCanEditStorageData(user)}
@@ -290,10 +292,8 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
                     editableGridUpdateData={editableGridData?.updateData}
                     onGridEditCancel={resetState}
                     onGridEditComplete={onGridEditComplete}
-                    parentDataTypes={samplesEditableGridProps.parentDataTypes}
                     sampleSet={activeModel.schemaQuery.queryName}
-                    samplesGridRequiredColumns={samplesEditableGridProps.samplesGridRequiredColumns}
-                    selection={List(Array.from(activeModel.selections))}
+                    selection={selection}
                     selectionData={selectionData}
                     user={user}
                 />
@@ -318,11 +318,11 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             {showBulkUpdate && (
                 <SamplesBulkUpdateForm
                     determineSampleData
-                    selection={List(Array.from(activeModel.selections))}
+                    selection={selection}
                     sampleSet={activeModel.schemaQuery.queryName}
                     sampleSetLabel={activeModel.queryInfo.title}
                     queryModel={activeModel}
-                    hasValidMaxSelection={() => hasValidMaxSelection}
+                    hasValidMaxSelection={hasValidMaxSelection}
                     onCancel={resetState}
                     onBulkUpdateError={onBulkUpdateError}
                     onBulkUpdateComplete={onBulkUpdateComplete}


### PR DESCRIPTION
#### Rationale
This PR addresses a variety of issues:

1. The `componentId` prop has been factored out of the `QuerySelect` component in favor of using the normal React `key` prop paradigm. This was effectively redundant and confusing.
2. Entity related actions `getChosenParentData` and `initParents` have been refactored to `async` implementations to streamline the logic.
3. The `SamplesTabbedGridPanel` component needed updates for hook dependencies to function correctly.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/811
* https://github.com/LabKey/biologics/pull/1261
* https://github.com/LabKey/sampleManagement/pull/925
* https://github.com/LabKey/inventory/pull/421
* https://github.com/LabKey/platform/pull/3267

#### Changes
* Remove the `componentId` prop on `QuerySelect` in favor of React's `key` prop paradigm.
* Simplify logic for Entity related actions `getChosenParentData` and `initParents`.
* Update hook dependencies for `SamplesTabbedGridPanel`.
