### PR TITLE
45265: Handle "name" and "listId" for list ActionMappers

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.7-fb-fix-45265-deux.0",
+  "version": "2.138.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.138.7",
+  "version": "2.138.7-fb-fix-45265-deux.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.138.8
 *Released*: 26 April 2022
-* Issue 45265: adjust List ActionMappers
+* Issue 45265: Handle "name" and "listId" for list ActionMappers
 
 ### version 2.138.7
 *Released*: 24 March 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.138.8
+*Released*: 26 April 2022
+* Issue 45265: adjust List ActionMappers
+
 ### version 2.138.7
 *Released*: 24 March 2022
 * Issue 45093: Fix production navigation menu URl action for going from LKS to app

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -399,11 +399,11 @@ const LIST_MAPPERS = [
             const params = ActionURL.getParameters(row.get('url'));
             const urlParts = parsePathName(row.get('url'));
 
-            if (params && urlParts?.containerPath) {
+            if (params) {
                 if (params.name) {
                     const parts = ['q', 'lists', params.name];
                     return AppURL.create(...parts);
-                } else if (params.listId) {
+                } else if (params.listId && urlParts?.containerPath) {
                     const resolverPath = ListResolver.encodeResolverPath(urlParts.containerPath);
                     const parts = ['q', 'lists', resolverPath, params.listId];
                     return AppURL.create(...parts);

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -381,10 +381,15 @@ const LIST_MAPPERS = [
             const params = ActionURL.getParameters(row.get('url'));
             const urlParts = parsePathName(row.get('url'));
 
-            if (params && urlParts?.containerPath) {
-                const resolverPath = ListResolver.encodeResolverPath(urlParts.containerPath);
-                const parts = ['q', 'lists', resolverPath, params.listId, params.pk];
-                return AppURL.create(...parts);
+            if (params?.pk) {
+                if (params.name) {
+                    const parts = ['q', 'lists', params.name, params.pk];
+                    return AppURL.create(...parts);
+                } else if (params.listId && urlParts?.containerPath) {
+                    const resolverPath = ListResolver.encodeResolverPath(urlParts.containerPath);
+                    const parts = ['q', 'lists', resolverPath, params.listId, params.pk];
+                    return AppURL.create(...parts);
+                }
             }
         }
     }),
@@ -395,9 +400,14 @@ const LIST_MAPPERS = [
             const urlParts = parsePathName(row.get('url'));
 
             if (params && urlParts?.containerPath) {
-                const resolverPath = ListResolver.encodeResolverPath(urlParts.containerPath);
-                const parts = ['q', 'lists', resolverPath, params.listId];
-                return AppURL.create(...parts);
+                if (params.name) {
+                    const parts = ['q', 'lists', params.name];
+                    return AppURL.create(...parts);
+                } else if (params.listId) {
+                    const resolverPath = ListResolver.encodeResolverPath(urlParts.containerPath);
+                    const parts = ['q', 'lists', resolverPath, params.listId];
+                    return AppURL.create(...parts);
+                }
             }
         }
     }),


### PR DESCRIPTION
#### Rationale
This fixes an issue where list URLs are no longer being mapped appropriately on the client due to a [change in the URLs being generated](https://github.com/LabKey/platform/pull/3282) by the server.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/817
* https://github.com/LabKey/biologics/pull/1266
* https://github.com/LabKey/sampleManagement/pull/931
* https://github.com/LabKey/inventory/pull/423

#### Changes
* Add support for "name" parameter in addition to "listId" parameter in list `ActionMapper` instances.
