### PR TITLE
Bump build dep to 6.1.0

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "6.5.2"
   },
   "devDependencies": {
-    "@labkey/build": "6.1.0-fb-package-build.11",
+    "@labkey/build": "6.1.0",
     "@labkey/eslint-config-react": "0.0.11",
     "@types/enzyme": "3.10.11",
     "@types/history": "4.7.9",

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1516,10 +1516,10 @@
   resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz#fa7d4bf1f2f57692513f4b1cd2aca3c4dd85e860"
   integrity sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA=
 
-"@labkey/build@6.1.0-fb-package-build.11":
-  version "6.1.0-fb-package-build.11"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.1.0-fb-package-build.11.tgz#471572dbb731c48d8baaa7b8980a5de278f7ed18"
-  integrity sha1-RxVy27cxxI2Lqqe4mApd4nj37Rg=
+"@labkey/build@6.1.0":
+  version "6.1.0"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.1.0.tgz#cd811d580733e19be88fe0c68b98d7b38fd1ca8b"
+  integrity sha1-zYEdWAcz4Zvoj+DGi5jXs4/Ryos=
   dependencies:
     "@babel/core" "7.17.8"
     "@babel/plugin-proposal-class-properties" "7.16.7"


### PR DESCRIPTION
#### Rationale
The build version is pinned to a pre-release version

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/815

#### Changes
* Components: Bump build to 6.1.0