### PR TITLE
Dev Build: exclude test files

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,9 @@
 # @labkey/build
 
+### version 6.1.1
+*Released:* 28 April 2022
+* Exclude test files from dev build
+
 ### version 6.1.0
 *Released*: 27 April 2002
 * Add shared package build (package.config.js)

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -152,6 +152,8 @@ const TS_CHECKER_DEV_CONFIG = {
     typescript: {
         ...TS_CHECKER_CONFIG.typescript,
         configOverwrite: {
+            include: ["src/client/**/*"],
+            exclude: ["node_modules", "**/*.spec.*", "src/test", "resources", "packages"],
             compilerOptions: {
                 "paths": {
                     "@labkey/components": [labkeyUIComponentsPath],


### PR DESCRIPTION
#### Rationale
Our dev/watch builds have their own configOverwrite, which resets the include/exclude directives to their default setting, this PR re-adds the include/exclude directives to the dev build so test files are ignored.

#### Related Pull Requests
* n/a

#### Changes
* Exclude test files from dev build
