### PR TITLE
Use ActionURL.getPathFromLocation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.164.0",
+  "version": "2.164.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.10.0-fb-url-path-location.2",
+    "@labkey/api": "1.11.0",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.10.0",
+    "@labkey/api": "1.10.0-fb-url-path-location.2",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.164.1
+*Released*: 2 May 2022
+* Replace usages of `parsePathName` with `ActionURL.getPathFromLocation()` from `@labkey/api`.
+
 ### version 2.164.0
 *Released*: 2 May 2022
 * Issue 45374: LKSM issues when site "default display format for numbers" is set

--- a/packages/components/src/internal/components/administration/UserManagement.spec.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.spec.tsx
@@ -8,12 +8,11 @@ import { initNotificationsState } from '../notifications/global';
 import { BasePermissionsCheckPage } from '../permissions/BasePermissionsCheckPage';
 import { UsersGridPanel } from '../user/UsersGridPanel';
 import { SecurityPolicy } from '../permissions/models';
-import { Container } from '../base/models/Container';
 
 import { App } from '../../../index';
 
 import { getSecurityTestAPIWrapper } from '../security/APIWrapper';
-import { TEST_PROJECT_CONTAINER } from '../../../test/data/constants';
+import { TEST_FOLDER_CONTAINER, TEST_PROJECT, TEST_PROJECT_CONTAINER } from '../../../test/data/constants';
 
 import { getNewUserRoles, UserManagement, UserManagementProps } from './UserManagement';
 
@@ -83,9 +82,6 @@ describe('UserManagement', () => {
 });
 
 describe('getNewUsersRoles', () => {
-    const CONTAINER = new Container({ parentId: 'projectid' });
-    const PROJECT_CONTAINER = new Container({ parentId: 'rootid' });
-    const PROJECT = { rootId: 'rootid' };
     // Copied from freezermanager/src/constants.ts
     const STORAGE_ROLES = [
         ['org.labkey.api.inventory.security.StorageDesignerRole', 'Storage Designer'],
@@ -93,14 +89,14 @@ describe('getNewUsersRoles', () => {
     ];
 
     test('non premium, non project, app admin', () => {
-        const roles = getNewUserRoles(App.TEST_USER_APP_ADMIN, CONTAINER, PROJECT, STORAGE_ROLES);
+        const roles = getNewUserRoles(App.TEST_USER_APP_ADMIN, TEST_FOLDER_CONTAINER, TEST_PROJECT, STORAGE_ROLES);
         expect(roles.length).toBe(5);
         expect(roles.find(role => role.id === PermissionRoles.ApplicationAdmin)).toBeDefined();
     });
 
     test('premium, non project, app admin', () => {
         LABKEY.moduleContext = { api: { moduleNames: ['premium'] } };
-        const roles = getNewUserRoles(App.TEST_USER_APP_ADMIN, CONTAINER, PROJECT, STORAGE_ROLES);
+        const roles = getNewUserRoles(App.TEST_USER_APP_ADMIN, TEST_FOLDER_CONTAINER, TEST_PROJECT, STORAGE_ROLES);
         expect(roles.length).toBe(6);
         expect(roles.find(role => role.id === PermissionRoles.FolderAdmin)).toBeDefined();
         expect(roles.find(role => role.id === PermissionRoles.ApplicationAdmin)).toBeDefined();
@@ -108,7 +104,7 @@ describe('getNewUsersRoles', () => {
 
     test('premium, project, app admin', () => {
         LABKEY.moduleContext = { api: { moduleNames: ['premium'] } };
-        const roles = getNewUserRoles(App.TEST_USER_APP_ADMIN, PROJECT_CONTAINER, PROJECT, STORAGE_ROLES);
+        const roles = getNewUserRoles(App.TEST_USER_APP_ADMIN, TEST_PROJECT_CONTAINER, TEST_PROJECT, STORAGE_ROLES);
         expect(roles.length).toBe(7);
         expect(roles.find(role => role.id === PermissionRoles.FolderAdmin)).toBeDefined();
         expect(roles.find(role => role.id === PermissionRoles.ProjectAdmin)).toBeDefined();
@@ -116,14 +112,14 @@ describe('getNewUsersRoles', () => {
     });
 
     test('non premium, non project, non app admin', () => {
-        const roles = getNewUserRoles(App.TEST_USER_PROJECT_ADMIN, CONTAINER, PROJECT, STORAGE_ROLES);
+        const roles = getNewUserRoles(App.TEST_USER_PROJECT_ADMIN, TEST_FOLDER_CONTAINER, TEST_PROJECT, STORAGE_ROLES);
         expect(roles.length).toBe(4);
         expect(roles.find(role => role.id === PermissionRoles.ApplicationAdmin)).toBeUndefined();
     });
 
     test('premium, non project, non app admin', () => {
         LABKEY.moduleContext = { api: { moduleNames: ['premium'] } };
-        const roles = getNewUserRoles(App.TEST_USER_PROJECT_ADMIN, CONTAINER, PROJECT, STORAGE_ROLES);
+        const roles = getNewUserRoles(App.TEST_USER_PROJECT_ADMIN, TEST_FOLDER_CONTAINER, TEST_PROJECT, STORAGE_ROLES);
         expect(roles.length).toBe(5);
         expect(roles.find(role => role.id === PermissionRoles.FolderAdmin)).toBeDefined();
         expect(roles.find(role => role.id === PermissionRoles.ApplicationAdmin)).toBeUndefined();
@@ -131,7 +127,7 @@ describe('getNewUsersRoles', () => {
 
     test('premium, project, non app admin', () => {
         LABKEY.moduleContext = { api: { moduleNames: ['premium'] } };
-        const roles = getNewUserRoles(App.TEST_USER_PROJECT_ADMIN, PROJECT_CONTAINER, PROJECT, STORAGE_ROLES);
+        const roles = getNewUserRoles(App.TEST_USER_PROJECT_ADMIN, TEST_PROJECT_CONTAINER, TEST_PROJECT, STORAGE_ROLES);
         expect(roles.length).toBe(6);
         expect(roles.find(role => role.id === PermissionRoles.FolderAdmin)).toBeDefined();
         expect(roles.find(role => role.id === PermissionRoles.ProjectAdmin)).toBeDefined();

--- a/packages/components/src/internal/components/administration/UserManagement.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.tsx
@@ -5,7 +5,7 @@
 import React, { FC, PureComponent, ReactNode } from 'react';
 import { List } from 'immutable';
 import { MenuItem } from 'react-bootstrap';
-import { PermissionRoles, Utils } from '@labkey/api';
+import { PermissionRoles, Project, Utils } from '@labkey/api';
 
 import { User } from '../base/models/User';
 import { Container } from '../base/models/Container';
@@ -32,7 +32,7 @@ import { getUserGridFilterURL, updateSecurityPolicy } from './actions';
 export function getNewUserRoles(
     user: User,
     container: Partial<Container>,
-    project: any,
+    project: Project,
     extraRoles?: string[][]
 ): Array<Record<string, any>> {
     const roles = [
@@ -70,7 +70,7 @@ interface OwnProps {
     api: SecurityAPIWrapper;
     container: Container;
     extraRoles?: string[][];
-    project: any; // Project from @labkey/api
+    project: Project;
     user: User;
 }
 

--- a/packages/components/src/internal/url/URLResolver.spec.ts
+++ b/packages/components/src/internal/url/URLResolver.spec.ts
@@ -6,8 +6,9 @@ import { LineageResult } from '../components/lineage/models';
 
 import { registerDefaultURLMappers } from '../testHelpers';
 
-import { parsePathName, URLResolver } from './URLResolver';
-import {initUnitTestMocks} from "../../test/testHelperMocks";
+import { initUnitTestMocks } from '../../test/testHelperMocks';
+
+import { URLResolver } from './URLResolver';
 
 beforeAll(() => {
     initUnitTestMocks();
@@ -30,23 +31,23 @@ describe('resolveSearchUsingIndex', () => {
 describe('resolveLineage', () => {
     const resolver = new URLResolver();
 
-    let node = {
-            lsid: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
-            children: [
-                {
-                    lsid: 'urn:lsid:labkey.com:Run.Folder-252:a6e5fa05-28cd-1038-ad87-68bd1b9ac33e',
-                    role: 'no role',
-                },
-            ],
-            name: 'D-32',
-            cpasType: 'urn:lsid:labkey.com:DataClass.Folder-252:Source+1',
-            queryName: 'Source 1',
-            type: 'Data',
-            schemaName: 'exp.data',
-            url: '/labkey/testContainer/experiment-showData.view?rowId=6648',
-            parents: [],
-            rowId: 6648,
-    }
+    const node = {
+        lsid: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
+        children: [
+            {
+                lsid: 'urn:lsid:labkey.com:Run.Folder-252:a6e5fa05-28cd-1038-ad87-68bd1b9ac33e',
+                role: 'no role',
+            },
+        ],
+        name: 'D-32',
+        cpasType: 'urn:lsid:labkey.com:DataClass.Folder-252:Source+1',
+        queryName: 'Source 1',
+        type: 'Data',
+        schemaName: 'exp.data',
+        url: '/labkey/testContainer/experiment-showData.view?rowId=6648',
+        parents: [],
+        rowId: 6648,
+    };
 
     test('name with spaces', () => {
         const lineageResult = LineageResult.create({
@@ -64,12 +65,12 @@ describe('resolveLineage', () => {
     });
 
     test('url to different container', () => {
-        let url = '/labkey/otherContainer/experiment-showData.view?rowId=6648'
+        const url = '/labkey/otherContainer/experiment-showData.view?rowId=6648';
         node['url'] = url;
         const lineageResult = LineageResult.create({
             seed: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
             nodes: {
-                'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4': node
+                'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4': node,
             },
         });
         const resolvedLinks = resolver.resolveLineageItem(
@@ -96,43 +97,5 @@ describe('resolveLineage', () => {
 
         expect(resolvedLinks.list).toEqual(undefined);
         expect(resolvedLinks.overview).toEqual('/labkey/testContainer/experiment-showRunGraph.view?rowId=794');
-    });
-});
-
-describe('parsePathName', () => {
-    test('old style', () => {
-        const url = '/labkey/controller/my%20folder/my%20path/action.view?extra=123';
-        expect(parsePathName(url)).toEqual({
-            controller: 'controller',
-            action: 'action',
-            containerPath: '/my folder/my path',
-        });
-    });
-
-    test('new style', () => {
-        const url = '/labkey/my%20folder/my%20path/controller-action.view?extra=123';
-        expect(parsePathName(url)).toEqual({
-            controller: 'controller',
-            action: 'action',
-            containerPath: '/my folder/my path',
-        });
-    });
-
-    test('controller with dash', () => {
-        const url = '/labkey/my%20folder/my%20path/pipeline-status-details.view?rowId=123';
-        expect(parsePathName(url)).toEqual({
-            controller: 'pipeline-status',
-            action: 'details',
-            containerPath: '/my folder/my path',
-        });
-    });
-
-    test('controller with dash - old style', () => {
-        const url = '/labkey/pipeline-status/my%20folder/my%20path/details.view?rowId=123';
-        expect(parsePathName(url)).toEqual({
-            controller: 'pipeline-status',
-            action: 'details',
-            containerPath: '/my folder/my path',
-        });
     });
 });

--- a/packages/components/src/test/data/constants.ts
+++ b/packages/components/src/test/data/constants.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { List } from 'immutable';
-import { Filter, PermissionRoles } from '@labkey/api';
+import { Filter, PermissionRoles, Project } from '@labkey/api';
 
 import {
     AssayDefinitionModel,
@@ -399,7 +399,7 @@ export const TEST_PROJECT_CONTAINER = new Container({
     type: 'project',
 });
 
-export const TEST_PROJECT = {
+export const TEST_PROJECT: Project = {
     id: TEST_PROJECT_CONTAINER.id,
     name: TEST_PROJECT_CONTAINER.name,
     path: TEST_PROJECT_CONTAINER.path,

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.10.0":
-  version "1.10.0"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz#fa7d4bf1f2f57692513f4b1cd2aca3c4dd85e860"
-  integrity sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA=
+"@labkey/api@1.10.0-fb-url-path-location.2":
+  version "1.10.0-fb-url-path-location.2"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0-fb-url-path-location.2.tgz#b229f79584484ea63ef7fe262668bd5e123346ff"
+  integrity sha1-sin3lYRITqY+9/4mJmi9XhIzRv8=
 
 "@labkey/build@6.1.0":
   version "6.1.0"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.10.0-fb-url-path-location.2":
-  version "1.10.0-fb-url-path-location.2"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0-fb-url-path-location.2.tgz#b229f79584484ea63ef7fe262668bd5e123346ff"
-  integrity sha1-sin3lYRITqY+9/4mJmi9XhIzRv8=
+"@labkey/api@1.11.0":
+  version "1.11.0"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.11.0.tgz#d2513f39916c0ae273bda58d74af6bc8f3da1460"
+  integrity sha1-0lE/OZFsCuJzvaWNdK9ryPPaFGA=
 
 "@labkey/build@6.1.0":
   version "6.1.0"


### PR DESCRIPTION
#### Rationale
Replace usages of `parsePathName` with `ActionURL.getPathFromLocation()` from `@labkey/api`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/126
* https://github.com/LabKey/labkey-ui-components/pull/824

#### Changes
* Replace usages of `parsePathName` with `ActionURL.getPathFromLocation()` from `@labkey/api`.
* Updated typings for `Project` as exported by `@labkey/api`.
