### PR TITLE
Issue 45366: Export of Sample Finder results produces empty files

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.162.1-fb-issue45366.2",
+  "version": "2.162.1-fb-issue45366.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.162.1-fb-issue45366.1",
+  "version": "2.162.1-fb-issue45366.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.162.0",
+  "version": "2.162.1-fb-issue45366.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.162.1-fb-issue45366.3",
+  "version": "2.162.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.162.1
+*Released*: 29 April 2022
+* Issue 45366: Export of Sample Finder results produces empty files
+  * Escape quote characters in export form
+
 ### version 2.162.0
 *Released*: 29 April 2022
 * Issue 45304: Add inherit permissions control to permissions page

--- a/packages/components/src/internal/actions.spec.ts
+++ b/packages/components/src/internal/actions.spec.ts
@@ -38,7 +38,7 @@ import {
     genCellKey,
     parseCellKey,
     getExportParams,
-    quoteEncodedValue
+    quoteEncodedValue,
 } from './actions';
 import { CellMessage, ValueDescriptor } from './models';
 import { resetQueryGridState, updateQueryGridModel } from './global';
@@ -504,14 +504,20 @@ describe('quoteEncodedValue', () => {
 
     test('without double quote', () => {
         expect(quoteEncodedValue(["hello' world"])).toEqual(["hello' world"]);
-        expect(quoteEncodedValue(["hello' world", "a second value"])).toEqual(["hello' world", "a second value"]);
+        expect(quoteEncodedValue(["hello' world", 'a second value'])).toEqual(["hello' world", 'a second value']);
         expect(quoteEncodedValue("hello' world")).toEqual("hello' world");
     });
 
     test('with double quote(s)', () => {
-        expect(quoteEncodedValue(["hello\" world"])).toEqual(["hello&quot; world"]);
-        expect(quoteEncodedValue(["hello \"world\"", "a second value"])).toEqual(["hello &quot;world&quot;", "a second value"]);
-        expect(quoteEncodedValue(["hello' world", "a second \"value\""])).toEqual(["hello' world", "a second &quot;value&quot;"]);
-        expect(quoteEncodedValue("hello \"world\"")).toEqual("hello &quot;world&quot;");
+        expect(quoteEncodedValue(['hello" world'])).toEqual(['hello&quot; world']);
+        expect(quoteEncodedValue(['hello "world"', 'a second value'])).toEqual([
+            'hello &quot;world&quot;',
+            'a second value',
+        ]);
+        expect(quoteEncodedValue(["hello' world", 'a second "value"'])).toEqual([
+            "hello' world",
+            'a second &quot;value&quot;',
+        ]);
+        expect(quoteEncodedValue('hello "world"')).toEqual('hello &quot;world&quot;');
     });
 });

--- a/packages/components/src/internal/actions.spec.ts
+++ b/packages/components/src/internal/actions.spec.ts
@@ -31,7 +31,15 @@ import {
 
 import sampleSet2QueryInfo from '../test/data/sampleSet2-getQueryDetails.json';
 
-import { addColumns, changeColumn, removeColumn, genCellKey, parseCellKey, getExportParams } from './actions';
+import {
+    addColumns,
+    changeColumn,
+    removeColumn,
+    genCellKey,
+    parseCellKey,
+    getExportParams,
+    quoteEncodedValue
+} from './actions';
 import { CellMessage, ValueDescriptor } from './models';
 import { resetQueryGridState, updateQueryGridModel } from './global';
 // FIXME, when the editableGridWithData file is read in, the objects are automatically
@@ -485,5 +493,25 @@ describe('getExportParams', () => {
             includeColumn: ['extra1', 'extra2'],
             excludeColumn: ['Field3', 'extra2'],
         });
+    });
+});
+
+describe('quoteEncodedValue', () => {
+    test('non string type', () => {
+        expect(quoteEncodedValue(1)).toEqual(1);
+        expect(quoteEncodedValue(false)).toEqual(false);
+    });
+
+    test('without double quote', () => {
+        expect(quoteEncodedValue(["hello' world"])).toEqual(["hello' world"]);
+        expect(quoteEncodedValue(["hello' world", "ignore rest"])).toEqual(["hello' world", "ignore rest"]);
+        expect(quoteEncodedValue(["hello' world", "ignore \"rest\""])).toEqual(["hello' world", "ignore \"rest\""]);
+        expect(quoteEncodedValue("hello' world")).toEqual("hello' world");
+    });
+
+    test('with double quote(s)', () => {
+        expect(quoteEncodedValue(["hello\" world"])).toEqual("hello&quot; world");
+        expect(quoteEncodedValue(["hello \"world\"", "ignore rest"])).toEqual("hello &quot;world&quot;");
+        expect(quoteEncodedValue("hello \"world\"")).toEqual("hello &quot;world&quot;");
     });
 });

--- a/packages/components/src/internal/actions.spec.ts
+++ b/packages/components/src/internal/actions.spec.ts
@@ -504,14 +504,14 @@ describe('quoteEncodedValue', () => {
 
     test('without double quote', () => {
         expect(quoteEncodedValue(["hello' world"])).toEqual(["hello' world"]);
-        expect(quoteEncodedValue(["hello' world", "ignore rest"])).toEqual(["hello' world", "ignore rest"]);
-        expect(quoteEncodedValue(["hello' world", "ignore \"rest\""])).toEqual(["hello' world", "ignore \"rest\""]);
+        expect(quoteEncodedValue(["hello' world", "a second value"])).toEqual(["hello' world", "a second value"]);
         expect(quoteEncodedValue("hello' world")).toEqual("hello' world");
     });
 
     test('with double quote(s)', () => {
-        expect(quoteEncodedValue(["hello\" world"])).toEqual("hello&quot; world");
-        expect(quoteEncodedValue(["hello \"world\"", "ignore rest"])).toEqual("hello &quot;world&quot;");
+        expect(quoteEncodedValue(["hello\" world"])).toEqual(["hello&quot; world"]);
+        expect(quoteEncodedValue(["hello \"world\"", "a second value"])).toEqual(["hello &quot;world&quot;", "a second value"]);
+        expect(quoteEncodedValue(["hello' world", "a second \"value\""])).toEqual(["hello' world", "a second &quot;value&quot;"]);
         expect(quoteEncodedValue("hello \"world\"")).toEqual("hello &quot;world&quot;");
     });
 });

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -523,7 +523,9 @@ export function getExportParams(
         if (options.filters) {
             options.filters.forEach(f => {
                 if (f) {
-                    params[f.getURLParameterName()] = [f.getURLParameterValue()];
+                    if (!params[f.getURLParameterName()])
+                        params[f.getURLParameterName()] = [];
+                    params[f.getURLParameterName()].push(f.getURLParameterValue());
                 }
             });
         }
@@ -565,7 +567,15 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
     // POST a form
     const form = $(`<form method="POST" action="${url}">`);
     $.each(params, function (k, v) {
-        form.append($(`<input type="hidden" name="${k.toString()}" value="${quoteEncodedValue(v)}">`));
+        const safeValue = quoteEncodedValue(v);
+        if (safeValue instanceof Array) {
+            safeValue.forEach(val => {
+                form.append($(`<input type="hidden" name="${k.toString()}" value="${val}">`));
+            })
+        }
+        else
+            form.append($(`<input type="hidden" name="${k.toString()}" value="${safeValue}">`));
+
     });
     $('body').append(form);
     form.trigger('submit');

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -578,12 +578,24 @@ const QUOTE_ENTITY = '&quot;';
 export function quoteEncodedValue(rawValue: any) {
     let safeValue = rawValue;
 
-    const flattenedValue = rawValue instanceof Array ? rawValue[0] : rawValue;
-    if (typeof flattenedValue === 'string' && flattenedValue.indexOf('"') > -1) {
-        safeValue = flattenedValue.replace(QUOTE_REGEX, QUOTE_ENTITY);
+    if (rawValue instanceof Array) {
+        safeValue = [];
+        rawValue.forEach(rawVal => {
+            safeValue.push(_quoteEncodedValue(rawVal));
+        });
     }
+    else
+        safeValue = _quoteEncodedValue(rawValue);
 
     return safeValue;
+}
+
+function _quoteEncodedValue(rawValue: any) {
+    let safeValue = rawValue;
+    if (typeof rawValue === 'string' && rawValue.indexOf('"') > -1) {
+        safeValue = rawValue.replace(QUOTE_REGEX, QUOTE_ENTITY);
+    }
+    return safeValue
 }
 
 // Complex comparator to determine if the location matches the models location-sensitive properties

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -575,7 +575,7 @@ const QUOTE_REGEX = new RegExp('"', 'g');
 const QUOTE_ENTITY = '&quot;';
 
 // Issue 45366: form value containing unescaped quotes gets truncated
-function quoteEncodedValue(rawValue: any) {
+export function quoteEncodedValue(rawValue: any) {
     let safeValue = rawValue;
 
     const flattenedValue = rawValue instanceof Array ? rawValue[0] : rawValue;

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -571,15 +571,15 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
     form.trigger('submit');
 }
 
-const QUOTE_REGEX = new RegExp("\"", 'g');
-const QUOTE_ENTITY = "&quot;";
+const QUOTE_REGEX = new RegExp('"', 'g');
+const QUOTE_ENTITY = '&quot;';
 
 // Issue 45366: form value containing unescaped quotes gets truncated
 function quoteEncodedValue(rawValue: any) {
     let safeValue = rawValue;
 
-    let flattenedValue = rawValue instanceof Array ? rawValue[0] : rawValue;
-    if (typeof flattenedValue == 'string' && flattenedValue.indexOf('"') > -1) {
+    const flattenedValue = rawValue instanceof Array ? rawValue[0] : rawValue;
+    if (typeof flattenedValue === 'string' && flattenedValue.indexOf('"') > -1) {
         safeValue = flattenedValue.replace(QUOTE_REGEX, QUOTE_ENTITY);
     }
 

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -583,9 +583,7 @@ export function quoteEncodedValue(rawValue: any) {
         rawValue.forEach(rawVal => {
             safeValue.push(_quoteEncodedValue(rawVal));
         });
-    }
-    else
-        safeValue = _quoteEncodedValue(rawValue);
+    } else safeValue = _quoteEncodedValue(rawValue);
 
     return safeValue;
 }
@@ -595,7 +593,7 @@ function _quoteEncodedValue(rawValue: any) {
     if (typeof rawValue === 'string' && rawValue.indexOf('"') > -1) {
         safeValue = rawValue.replace(QUOTE_REGEX, QUOTE_ENTITY);
     }
-    return safeValue
+    return safeValue;
 }
 
 // Complex comparator to determine if the location matches the models location-sensitive properties

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -523,8 +523,7 @@ export function getExportParams(
         if (options.filters) {
             options.filters.forEach(f => {
                 if (f) {
-                    if (!params[f.getURLParameterName()])
-                        params[f.getURLParameterName()] = [];
+                    if (!params[f.getURLParameterName()]) params[f.getURLParameterName()] = [];
                     params[f.getURLParameterName()].push(f.getURLParameterValue());
                 }
             });
@@ -571,11 +570,8 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
         if (safeValue instanceof Array) {
             safeValue.forEach(val => {
                 form.append($(`<input type="hidden" name="${k.toString()}" value="${val}">`));
-            })
-        }
-        else
-            form.append($(`<input type="hidden" name="${k.toString()}" value="${safeValue}">`));
-
+            });
+        } else form.append($(`<input type="hidden" name="${k.toString()}" value="${safeValue}">`));
     });
     $('body').append(form);
     form.trigger('submit');

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -565,10 +565,25 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
     // POST a form
     const form = $(`<form method="POST" action="${url}">`);
     $.each(params, function (k, v) {
-        form.append($(`<input type="hidden" name="${k.toString()}" value="${v}">`));
+        form.append($(`<input type="hidden" name="${k.toString()}" value="${quoteEncodedValue(v)}">`));
     });
     $('body').append(form);
     form.trigger('submit');
+}
+
+const QUOTE_REGEX = new RegExp("\"", 'g');
+const QUOTE_ENTITY = "&quot;";
+
+// Issue 45366: form value containing unescaped quotes gets truncated
+function quoteEncodedValue(rawValue: any) {
+    let safeValue = rawValue;
+
+    let flattenedValue = rawValue instanceof Array ? rawValue[0] : rawValue;
+    if (typeof flattenedValue == 'string' && flattenedValue.indexOf('"') > -1) {
+        safeValue = flattenedValue.replace(QUOTE_REGEX, QUOTE_ENTITY);
+    }
+
+    return safeValue;
 }
 
 // Complex comparator to determine if the location matches the models location-sensitive properties


### PR DESCRIPTION
#### Rationale
Html form values doesn't allow unescaped quotes. An html form is built to use for download post action. Sample Finder query form contains subselect sqls, which contains double quote characters. Those subselect form values needs to be escaped when building the download form. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/825
* https://github.com/LabKey/sampleManagement/pull/937
* https://github.com/LabKey/biologics/pull/1274

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
