### PR TITLE
Entity grid button/menu update to handle case where no assay designs and/or sample types are defined

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.164.1-fb-appMoreEmptyCases.0",
+  "version": "2.164.1-fb-appMoreEmptyCases.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.166.0",
+  "version": "2.166.0-fb-appMoreEmptyCases.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.165.0",
+  "version": "2.165.0-fb-appMoreEmptyCases.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.166.0-fb-appMoreEmptyCases.0",
+  "version": "2.167.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.164.1",
+  "version": "2.164.1-fb-appMoreEmptyCases.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.164.1-fb-appMoreEmptyCases.1",
+  "version": "2.164.1-fb-appMoreEmptyCases.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD May 2022
+### version 2.167.0
+*Released*: 5 May 2022
 * SamplesAssayButton update to handle case where no assay designs are defined
 * Issue 45328: Add the 'More' grid menu (Assays, Picklists, Jobs, Storage) to the sample aliquots grid
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD May 2022
+* SamplesAssayButton update to handle case where no assay designs are defined
+
 ### version 2.164.1
 *Released*: 2 May 2022
 * Replace usages of `parsePathName` with `ActionURL.getPathFromLocation()` from `@labkey/api`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD May 2022
 * SamplesAssayButton update to handle case where no assay designs are defined
+* Issue 45328: Add the 'More' grid menu (Assays, Picklists, Jobs, Storage) to the sample aliquots grid
 
 ### version 2.164.1
 *Released*: 2 May 2022

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.spec.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.spec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { ReactWrapper } from 'enzyme';
+import { PermissionTypes } from '@labkey/api';
 
 import { PicklistButton } from '../picklist/PicklistButton';
-import { TEST_USER_READER } from '../../userFixtures';
+import { TEST_USER_FOLDER_ADMIN, TEST_USER_READER } from '../../userFixtures';
 
 import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 import { SchemaQuery } from '../../../public/SchemaQuery';
@@ -16,22 +17,32 @@ describe('ResponsiveMenuButtonGroup', () => {
     const model = makeTestQueryModel(SchemaQuery.create('s', 'q'));
     const DEFAULT_PROPS = {
         items: [
-            <PicklistButton model={model} user={TEST_USER_READER} />,
-            <PicklistButton model={model} user={TEST_USER_READER} />,
+            { button: <PicklistButton model={model} user={TEST_USER_READER} />, perm: PermissionTypes.ManagePicklists },
+            { button: <PicklistButton model={model} user={TEST_USER_READER} />, perm: PermissionTypes.ManagePicklists },
         ],
     };
 
-    function validate(wrapper: ReactWrapper): void {
-        expect(wrapper.find(DropdownButton)).toHaveLength(1);
-        expect(wrapper.find(MenuItem)).toHaveLength(1); // divider
-        expect(wrapper.find(PicklistButton).first().prop('asSubMenu')).toBe(true);
+    function validate(wrapper: ReactWrapper, rendered = true): void {
+        expect(wrapper.find(DropdownButton)).toHaveLength(rendered ? 1 : 0);
+        expect(wrapper.find(MenuItem)).toHaveLength(rendered ? 3 : 0); // with divider
+        if (rendered) expect(wrapper.find(PicklistButton).first().prop('asSubMenu')).toBe(true);
     }
 
-    test('default props', () => {
-        const wrapper = mountWithServerContext(<ResponsiveMenuButtonGroup {...DEFAULT_PROPS} />, {
-            user: TEST_USER_READER,
-        });
+    test('admin', () => {
+        const wrapper = mountWithServerContext(
+            <ResponsiveMenuButtonGroup {...DEFAULT_PROPS} user={TEST_USER_FOLDER_ADMIN} />,
+            { user: TEST_USER_FOLDER_ADMIN }
+        );
         validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('reader', () => {
+        const wrapper = mountWithServerContext(
+            <ResponsiveMenuButtonGroup {...DEFAULT_PROPS} user={TEST_USER_READER} />,
+            { user: TEST_USER_READER }
+        );
+        validate(wrapper, false);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, FC, memo, useMemo, useState, useEffect } from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
-import {hasPermissions, User} from '../base/models/User';
+
+import { hasPermissions, User } from '../base/models/User';
 
 interface ResponsiveMenuItem {
     button: ReactElement;

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -1,12 +1,19 @@
 import React, { ReactElement, FC, memo, useMemo, useState, useEffect } from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
+import {hasPermissions, User} from '../base/models/User';
+
+interface ResponsiveMenuItem {
+    button: ReactElement;
+    perm: string;
+}
 
 interface Props {
-    items: ReactElement[];
+    items: ResponsiveMenuItem[];
+    user: User;
 }
 
 export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
-    const { items } = props;
+    const { items, user } = props;
     const [width, setWidth] = useState<number>(window.innerWidth);
     useEffect(() => {
         function handleResize() {
@@ -19,16 +26,20 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
     // bootstrap v3 doesn't support hidden-xl/visible-xl, so use the width=1600 check as a proxy
     const asSubMenu = useMemo(() => width < 1600, [width]);
 
+    const buttons = items.filter(item => hasPermissions(user, [item.perm], false)).map(item => item.button);
+
+    if (buttons.length === 0) return null;
+
     return (
         <>
-            {!asSubMenu && items}
+            {!asSubMenu && buttons}
             {asSubMenu && (
                 <DropdownButton id="responsive-menu-button-group" title="More" className="responsive-menu">
-                    {items.map((item, index) => {
+                    {buttons.map((item, index) => {
                         return (
                             <>
                                 {React.cloneElement(item, { asSubMenu: true })}
-                                {index < items.length - 1 && <MenuItem divider />}
+                                {index < buttons.length - 1 && <MenuItem divider />}
                             </>
                         );
                     })}

--- a/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.spec.tsx
@@ -16,8 +16,9 @@ import {
 import { mountWithServerContext } from '../../testHelpers';
 import { makeTestActions, makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 
-import { SampleAliquotsGridPanelImpl } from './SampleAliquotsGridPanel';
 import { TEST_USER_READER, TEST_USER_STORAGE_EDITOR } from '../../userFixtures';
+
+import { SampleAliquotsGridPanelImpl } from './SampleAliquotsGridPanel';
 
 describe('SampleAliquotsGridPanel', () => {
     const SCHEMA_QUERY = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'SampleTypeName');

--- a/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.spec.tsx
@@ -17,7 +17,7 @@ import { mountWithServerContext } from '../../testHelpers';
 import { makeTestActions, makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 
 import { SampleAliquotsGridPanelImpl } from './SampleAliquotsGridPanel';
-import { TEST_USER_STORAGE_EDITOR } from '../../userFixtures';
+import { TEST_USER_READER, TEST_USER_STORAGE_EDITOR } from '../../userFixtures';
 
 describe('SampleAliquotsGridPanel', () => {
     const SCHEMA_QUERY = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'SampleTypeName');
@@ -34,7 +34,7 @@ describe('SampleAliquotsGridPanel', () => {
         user: App.TEST_USER_READER,
     };
 
-    test('check buttons', () => {
+    test('check buttons with permissions', () => {
         const DummyButton1 = () => <div className="storage-button-test"> foo </div>;
         const DummyButton2 = () => <div className="jobs-button-test"> bar </div>;
 
@@ -51,6 +51,24 @@ describe('SampleAliquotsGridPanel', () => {
         expect(wrapper.find(ResponsiveMenuButtonGroup)).toHaveLength(1);
         const items = wrapper.find(ResponsiveMenuButtonGroup).prop('items');
         expect(items.length).toBe(4);
+        wrapper.unmount();
+    });
+
+    test('check buttons without permissions', () => {
+        const DummyButton1 = () => <div className="storage-button-test"> foo </div>;
+        const DummyButton2 = () => <div className="jobs-button-test"> bar </div>;
+
+        const wrapper = mountWithServerContext(
+            <SampleAliquotsGridPanelImpl
+                {...DEFAULT_PROPS}
+                user={TEST_USER_READER}
+                lineageUpdateAllowed
+                storageButton={DummyButton1}
+                jobsButton={DummyButton2}
+            />,
+            { user: TEST_USER_READER }
+        );
+        expect(wrapper.find(ResponsiveMenuButtonGroup)).toHaveLength(0);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.spec.tsx
@@ -7,6 +7,7 @@ import {
     LoadingState,
     ManageDropdownButton,
     QueryInfo,
+    ResponsiveMenuButtonGroup,
     SampleAliquotsGridPanel,
     SchemaQuery,
     SCHEMAS,
@@ -16,6 +17,7 @@ import { mountWithServerContext } from '../../testHelpers';
 import { makeTestActions, makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 
 import { SampleAliquotsGridPanelImpl } from './SampleAliquotsGridPanel';
+import { TEST_USER_STORAGE_EDITOR } from '../../userFixtures';
 
 describe('SampleAliquotsGridPanel', () => {
     const SCHEMA_QUERY = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'SampleTypeName');
@@ -32,14 +34,23 @@ describe('SampleAliquotsGridPanel', () => {
         user: App.TEST_USER_READER,
     };
 
-    test('with storageButton node', () => {
-        const DummyButton = () => <div className="dummyButton"> foo </div>;
+    test('check buttons', () => {
+        const DummyButton1 = () => <div className="storage-button-test"> foo </div>;
+        const DummyButton2 = () => <div className="jobs-button-test"> bar </div>;
 
         const wrapper = mountWithServerContext(
-            <SampleAliquotsGridPanelImpl storageButton={DummyButton} {...DEFAULT_PROPS} lineageUpdateAllowed={true} />,
-            DEFAULT_CONTEXT
+            <SampleAliquotsGridPanelImpl
+                {...DEFAULT_PROPS}
+                user={TEST_USER_STORAGE_EDITOR}
+                lineageUpdateAllowed
+                storageButton={DummyButton1}
+                jobsButton={DummyButton2}
+            />,
+            { user: TEST_USER_STORAGE_EDITOR }
         );
-        expect(wrapper.find(DummyButton).exists()).toEqual(true);
+        expect(wrapper.find(ResponsiveMenuButtonGroup)).toHaveLength(1);
+        const items = wrapper.find(ResponsiveMenuButtonGroup).prop('items');
+        expect(items.length).toBe(4);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
@@ -1,20 +1,24 @@
-import React, { FC, PureComponent } from 'react';
+import React, {FC, PureComponent} from 'react';
 
-import { PermissionTypes } from '@labkey/api';
+import {PermissionTypes} from '@labkey/api';
 
-import { List } from 'immutable';
+import {List} from 'immutable';
 
 import {
     DisableableButton,
     EntityDeleteModal,
     getStateModelId,
     GridPanel,
+    PicklistButton,
     QueryModel,
     RequiresPermission,
+    ResponsiveMenuButtonGroup,
+    SamplesAssayButton,
     SampleTypeDataType,
     SchemaQuery,
     SCHEMAS,
     User,
+    hasPermissions,
 } from '../../..';
 
 // These need to be direct imports from files to avoid circular dependencies in index.ts
@@ -26,41 +30,76 @@ import {
 
 import { getOmittedSampleTypeColumns } from './utils';
 import { getSampleAliquotsQueryConfig } from './actions';
-import { SampleStorageButton } from './models';
+import { JobsButton, SampleStorageButton } from './models';
 
 interface AliquotGridButtonsProps {
     afterAction: () => void;
     onDelete: () => void;
-    StorageButtonsComponent?: SampleStorageButton;
+    StorageButtonComponent?: SampleStorageButton;
+    JobsButtonComponent?: JobsButton;
     user: User;
     lineageUpdateAllowed: boolean;
+    assayProviderType?: string;
 }
 
 const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> = props => {
-    const { afterAction, lineageUpdateAllowed, model, onDelete, StorageButtonsComponent, user } = props;
+    const {
+        afterAction,
+        lineageUpdateAllowed,
+        model,
+        onDelete,
+        StorageButtonComponent,
+        JobsButtonComponent,
+        user,
+        assayProviderType,
+    } = props;
+    const metricFeatureArea = 'sampleAliquots';
+    const showStorageButton = hasPermissions(user, [PermissionTypes.EditStorageData], false);
+
+    const moreItems = [];
+    moreItems.push(<SamplesAssayButton model={model} providerType={assayProviderType} />);
+    moreItems.push(<PicklistButton model={model} user={user} metricFeatureArea={metricFeatureArea} />);
+    if (JobsButtonComponent) {
+        moreItems.push(<JobsButtonComponent model={model} user={user} metricFeatureArea={metricFeatureArea} />);
+    }
+    if (StorageButtonComponent && showStorageButton) {
+        moreItems.push(
+            <StorageButtonComponent
+                afterStorageUpdate={afterAction}
+                queryModel={model}
+                user={user}
+                nounPlural="aliquots"
+                metricFeatureArea={metricFeatureArea}
+            />
+        );
+    }
 
     return (
         <div className="responsive-btn-group">
-            <RequiresPermission perms={PermissionTypes.Delete}>
+            <RequiresPermission
+                permissionCheck="any"
+                perms={[
+                    PermissionTypes.Insert,
+                    PermissionTypes.Update,
+                    PermissionTypes.Delete,
+                    PermissionTypes.ManagePicklists,
+                    PermissionTypes.ManageSampleWorkflows,
+                    PermissionTypes.EditStorageData,
+                ]}
+            >
                 {lineageUpdateAllowed && (
-                    <DisableableButton
-                        bsStyle="default"
-                        onClick={onDelete}
-                        disabledMsg={!model.hasSelections ? 'Select one or more aliquots.' : undefined}
-                    >
-                        <span className="fa fa-trash" />
-                        <span>&nbsp;Delete</span>
-                    </DisableableButton>
+                    <RequiresPermission perms={PermissionTypes.Delete}>
+                        <DisableableButton
+                            bsStyle="default"
+                            onClick={onDelete}
+                            disabledMsg={!model.hasSelections ? 'Select one or more aliquots.' : undefined}
+                        >
+                            <span className="fa fa-trash" />
+                            <span>&nbsp;Delete</span>
+                        </DisableableButton>
+                    </RequiresPermission>
                 )}
-                {StorageButtonsComponent && (
-                    <StorageButtonsComponent
-                        className="responsive-menu"
-                        afterStorageUpdate={afterAction}
-                        queryModel={model}
-                        user={user}
-                        nounPlural="aliquots"
-                    />
-                )}
+                <ResponsiveMenuButtonGroup items={moreItems} />
             </RequiresPermission>
         </div>
     );
@@ -69,8 +108,10 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
 interface Props {
     onSampleChangeInvalidate: (schemaQuery: SchemaQuery) => void;
     storageButton?: SampleStorageButton;
+    jobsButton?: JobsButton;
     user: User;
     lineageUpdateAllowed: boolean;
+    assayProviderType?: string;
 }
 
 interface State {
@@ -110,7 +151,7 @@ export class SampleAliquotsGridPanelImpl extends PureComponent<Props & InjectedQ
     }
 
     render() {
-        const { actions, storageButton, user, lineageUpdateAllowed } = this.props;
+        const { actions, storageButton, jobsButton, ...buttonProps } = this.props;
         const queryModel = this.getQueryModel();
 
         return (
@@ -119,11 +160,11 @@ export class SampleAliquotsGridPanelImpl extends PureComponent<Props & InjectedQ
                     actions={actions}
                     ButtonsComponent={AliquotGridButtons}
                     buttonsComponentProps={{
+                        ...buttonProps,
                         afterAction: this.afterAction,
                         onDelete: this.onDelete,
-                        StorageButtonsComponent: storageButton,
-                        user,
-                        lineageUpdateAllowed,
+                        StorageButtonComponent: storageButton,
+                        JobsButtonComponent: jobsButton,
                     }}
                     model={queryModel}
                     showViewMenu={false}

--- a/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
@@ -1,8 +1,6 @@
-import React, {FC, PureComponent} from 'react';
-
-import {PermissionTypes} from '@labkey/api';
-
-import {List} from 'immutable';
+import React, { FC, PureComponent } from 'react';
+import { List } from 'immutable';
+import { PermissionTypes } from '@labkey/api';
 
 import {
     DisableableButton,
@@ -18,7 +16,6 @@ import {
     SchemaQuery,
     SCHEMAS,
     User,
-    hasPermissions,
 } from '../../..';
 
 // These need to be direct imports from files to avoid circular dependencies in index.ts
@@ -54,39 +51,50 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
         assayProviderType,
     } = props;
     const metricFeatureArea = 'sampleAliquots';
-    const showStorageButton = hasPermissions(user, [PermissionTypes.EditStorageData], false);
 
     const moreItems = [];
-    moreItems.push(<SamplesAssayButton model={model} providerType={assayProviderType} />);
-    moreItems.push(<PicklistButton model={model} user={user} metricFeatureArea={metricFeatureArea} />);
+    moreItems.push({
+        button: <SamplesAssayButton model={model} providerType={assayProviderType} />,
+        perm: PermissionTypes.Insert,
+    });
+    moreItems.push({
+        button: <PicklistButton model={model} user={user} metricFeatureArea={metricFeatureArea} />,
+        perm: PermissionTypes.ManagePicklists,
+    });
     if (JobsButtonComponent) {
-        moreItems.push(<JobsButtonComponent model={model} user={user} metricFeatureArea={metricFeatureArea} />);
+        moreItems.push({
+            button: <JobsButtonComponent model={model} user={user} metricFeatureArea={metricFeatureArea} />,
+            perm: PermissionTypes.ManageSampleWorkflows,
+        });
     }
-    if (StorageButtonComponent && showStorageButton) {
-        moreItems.push(
-            <StorageButtonComponent
-                afterStorageUpdate={afterAction}
-                queryModel={model}
-                user={user}
-                nounPlural="aliquots"
-                metricFeatureArea={metricFeatureArea}
-            />
-        );
+    if (StorageButtonComponent) {
+        moreItems.push({
+            button: (
+                <StorageButtonComponent
+                    afterStorageUpdate={afterAction}
+                    queryModel={model}
+                    user={user}
+                    nounPlural="aliquots"
+                    metricFeatureArea={metricFeatureArea}
+                />
+            ),
+            perm: PermissionTypes.EditStorageData
+        });
     }
 
     return (
-        <div className="responsive-btn-group">
-            <RequiresPermission
-                permissionCheck="any"
-                perms={[
-                    PermissionTypes.Insert,
-                    PermissionTypes.Update,
-                    PermissionTypes.Delete,
-                    PermissionTypes.ManagePicklists,
-                    PermissionTypes.ManageSampleWorkflows,
-                    PermissionTypes.EditStorageData,
-                ]}
-            >
+        <RequiresPermission
+            permissionCheck="any"
+            perms={[
+                PermissionTypes.Insert,
+                PermissionTypes.Update,
+                PermissionTypes.Delete,
+                PermissionTypes.ManagePicklists,
+                PermissionTypes.ManageSampleWorkflows,
+                PermissionTypes.EditStorageData,
+            ]}
+        >
+            <div className="responsive-btn-group">
                 {lineageUpdateAllowed && (
                     <RequiresPermission perms={PermissionTypes.Delete}>
                         <DisableableButton
@@ -99,9 +107,9 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
                         </DisableableButton>
                     </RequiresPermission>
                 )}
-                <ResponsiveMenuButtonGroup items={moreItems} />
-            </RequiresPermission>
-        </div>
+                <ResponsiveMenuButtonGroup user={user} items={moreItems} />
+            </div>
+        </RequiresPermission>
     );
 };
 

--- a/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
@@ -78,7 +78,7 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
                     metricFeatureArea={metricFeatureArea}
                 />
             ),
-            perm: PermissionTypes.EditStorageData
+            perm: PermissionTypes.EditStorageData,
         });
     }
 

--- a/packages/components/src/internal/components/samples/SamplesAssayButton.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesAssayButton.spec.tsx
@@ -12,8 +12,9 @@ import { AssayImportSubMenuItem } from '../assay/AssayImportSubMenuItem';
 
 import { GENERAL_ASSAY_PROVIDER_NAME } from '../assay/actions';
 
-import { SamplesAssayButtonImpl } from './SamplesAssayButton';
 import { TEST_ASSAY_STATE_MODEL } from '../../../test/data/constants';
+
+import { SamplesAssayButtonImpl } from './SamplesAssayButton';
 
 describe('SamplesAssayButton', () => {
     const DEFAULT_PROPS = {

--- a/packages/components/src/internal/components/samples/SamplesAssayButton.spec.tsx
+++ b/packages/components/src/internal/components/samples/SamplesAssayButton.spec.tsx
@@ -12,10 +12,15 @@ import { AssayImportSubMenuItem } from '../assay/AssayImportSubMenuItem';
 
 import { GENERAL_ASSAY_PROVIDER_NAME } from '../assay/actions';
 
-import { SamplesAssayButton } from './SamplesAssayButton';
+import { SamplesAssayButtonImpl } from './SamplesAssayButton';
+import { TEST_ASSAY_STATE_MODEL } from '../../../test/data/constants';
 
 describe('SamplesAssayButton', () => {
     const DEFAULT_PROPS = {
+        assayModel: TEST_ASSAY_STATE_MODEL,
+        reloadAssays: jest.fn,
+        assayDefinition: undefined,
+        assayProtocol: undefined,
         model: makeTestQueryModel(
             SCHEMAS.SAMPLE_SETS.SAMPLES,
             QueryInfo.create({ importUrl: 'testimporturl', insertUrl: 'testinserturl' })
@@ -28,7 +33,9 @@ describe('SamplesAssayButton', () => {
     }
 
     test('default props', () => {
-        const wrapper = mountWithServerContext(<SamplesAssayButton {...DEFAULT_PROPS} />, { user: TEST_USER_EDITOR });
+        const wrapper = mountWithServerContext(<SamplesAssayButtonImpl {...DEFAULT_PROPS} />, {
+            user: TEST_USER_EDITOR,
+        });
         validate(wrapper);
         expect(wrapper.find(AssayImportSubMenuItem).prop('providerType')).toBe(undefined);
         wrapper.unmount();
@@ -36,7 +43,7 @@ describe('SamplesAssayButton', () => {
 
     test('providerType', () => {
         const wrapper = mountWithServerContext(
-            <SamplesAssayButton {...DEFAULT_PROPS} providerType={GENERAL_ASSAY_PROVIDER_NAME} />,
+            <SamplesAssayButtonImpl {...DEFAULT_PROPS} providerType={GENERAL_ASSAY_PROVIDER_NAME} />,
             { user: TEST_USER_EDITOR }
         );
         validate(wrapper);
@@ -49,7 +56,7 @@ describe('SamplesAssayButton', () => {
             SchemaQuery.create('schema', 'query'),
             QueryInfo.create({ importUrl: 'testimporturl', insertUrl: 'testinserturl' })
         ).mutate({ selections: new Set(['1']) });
-        const wrapper = mountWithServerContext(<SamplesAssayButton {...DEFAULT_PROPS} model={model} />, {
+        const wrapper = mountWithServerContext(<SamplesAssayButtonImpl {...DEFAULT_PROPS} model={model} />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper, false);
@@ -57,13 +64,15 @@ describe('SamplesAssayButton', () => {
     });
 
     test('reader', () => {
-        const wrapper = mountWithServerContext(<SamplesAssayButton {...DEFAULT_PROPS} />, { user: TEST_USER_READER });
+        const wrapper = mountWithServerContext(<SamplesAssayButtonImpl {...DEFAULT_PROPS} />, {
+            user: TEST_USER_READER,
+        });
         validate(wrapper, false);
         wrapper.unmount();
     });
 
     test('asSubMenu', () => {
-        const wrapper = mountWithServerContext(<SamplesAssayButton {...DEFAULT_PROPS} asSubMenu />, {
+        const wrapper = mountWithServerContext(<SamplesAssayButtonImpl {...DEFAULT_PROPS} asSubMenu />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper, true, true);

--- a/packages/components/src/internal/components/samples/SamplesAssayButton.tsx
+++ b/packages/components/src/internal/components/samples/SamplesAssayButton.tsx
@@ -1,11 +1,13 @@
 import React, { FC, memo } from 'react';
+import { MenuItem } from 'react-bootstrap';
 import { PermissionTypes } from '@labkey/api';
 
-import { RequiresPermission, ResponsiveMenuButton } from '../../..';
+import { RequiresPermission, ResponsiveMenuButton, isLoading } from '../../..';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
 import { AssayImportSubMenuItem } from '../assay/AssayImportSubMenuItem';
+import { InjectedAssayModel, withAssayModels } from '../assay/withAssayModels';
 
 import { isSamplesSchema } from './utils';
 
@@ -15,12 +17,12 @@ interface Props {
     asSubMenu?: boolean;
 }
 
-export const SamplesAssayButton: FC<Props> = memo(props => {
-    const { model, providerType, asSubMenu } = props;
+export const SamplesAssayButtonImpl: FC<Props & InjectedAssayModel> = memo(props => {
+    const { model, providerType, asSubMenu, assayModel } = props;
 
     if (!isSamplesSchema(model?.schemaQuery)) return null;
 
-    const items = (
+    let items = (
         <AssayImportSubMenuItem
             queryModel={model?.hasSelections ? model : undefined}
             providerType={providerType}
@@ -29,9 +31,15 @@ export const SamplesAssayButton: FC<Props> = memo(props => {
         />
     );
 
+    if (!isLoading(assayModel?.definitionsLoadingState) && assayModel.definitions.length === 0) {
+        items = <MenuItem disabled>No assays defined</MenuItem>;
+    }
+
     return (
         <RequiresPermission permissionCheck="any" perms={PermissionTypes.Insert}>
             <ResponsiveMenuButton id="samples-assay-menu" items={items} text="Assay" asSubMenu={asSubMenu} />
         </RequiresPermission>
     );
 });
+
+export const SamplesAssayButton = withAssayModels<Props>(SamplesAssayButtonImpl);

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -119,16 +119,24 @@ export interface SampleStatus {
     description?: string;
 }
 
-export interface SampleStorageButtonsComponentProps {
+interface SampleStorageButtonComponentProps {
     user: User;
     afterStorageUpdate?: () => void;
-    queryModel?: QueryModel;
+    queryModel: QueryModel;
     isPicklist?: boolean;
     nounPlural?: string;
-    className?: string;
+    metricFeatureArea?: string;
 }
 
-export type SampleStorageButton = ComponentType<SampleStorageButtonsComponentProps>;
+export type SampleStorageButton = ComponentType<SampleStorageButtonComponentProps>;
+
+interface JobsButtonsComponentProps {
+    user: User;
+    model: QueryModel;
+    metricFeatureArea?: string;
+}
+
+export type JobsButton = ComponentType<JobsButtonsComponentProps>;
 
 export class SampleState {
     [immerable] = true;


### PR DESCRIPTION
#### Rationale
After we made the changes for the entity grid actions/buttons, it was seen that we didn't handle the empty state for all of the buttons (i.e. assays and create samples button would show an empty dropdown if no assay/sampletypes were defined. This PR fixes that up along with addressing a related issue for adding some More options/menus to the sample aliquot grid:
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45328

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/828
* https://github.com/LabKey/sampleManagement/pull/941
* https://github.com/LabKey/biologics/pull/1279

#### Changes
* SamplesAssayButton update to handle case where no assay designs are defined
* Issue 45328: Add the 'More' grid menu (Assays, Picklists, Jobs, Storage) to the sample aliquots grid
