### PR TITLE
EntityInsertPanel updates for Biologics DataClasses

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.164.1",
+  "version": "2.164.1-fb-registry-grid-create.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.164.1-fb-registry-grid-create.1",
+  "version": "2.164.1-fb-registry-grid-create.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.164.1-fb-registry-grid-create.0",
+  "version": "2.164.1-fb-registry-grid-create.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.167.0-fb-registry-grid-create.0",
+  "version": "2.167.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.167.1
+*Released*: 9 May 2022
+* Updates to EntityInsertPanel to accommodate Registry Data Class editing
+  * Add props to allow wrapping component to control parents
+  * Add prop to hide parent controls
+  * Update 'Parents' suffix in grid and bulk fields to only apply to data types of same type
+
 ### version 2.167.0
 *Released*: 5 May 2022
 * SamplesAssayButton update to handle case where no assay designs are defined

--- a/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
@@ -95,7 +95,7 @@ export class EditableGridPanelDeprecated extends ReactN.Component<Props, State, 
     ): void => {
         const { onCellModify, onRowCountChange } = this.props;
         const editorModel = this.getEditorModel();
-        const newRowCount = editorModelChanges.rowCount - editorModel.rowCount;
+        const newRowCount = Math.abs(editorModelChanges.rowCount - editorModel.rowCount);
 
         updateEditorModel(editorModel, editorModelChanges);
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -141,12 +141,12 @@ interface OwnProps {
     creationTypeOptions?: SampleCreationTypeModel[];
     disableMerge?: boolean;
     entityDataType: EntityDataType;
-    errorNounPlural?: string;  // Used if you want a different noun in error messages than on the other components
+    errorNounPlural?: string; // Used if you want a different noun in error messages than on the other components
     fileSizeLimits?: Map<string, FileSizeLimitProps>;
     getFileTemplateUrl?: (queryInfo: QueryInfo, importAliases: Record<string, string>) => string;
     fileImportParameters?: Record<string, any>;
     filePreviewFormats?: string;
-    hideParentEntityButtons?: boolean;  // Used if you have an initial parent but don't want to enable ability to change it
+    hideParentEntityButtons?: boolean; // Used if you have an initial parent but don't want to enable ability to change it
     importHelpLinkNode: ReactNode;
     importOnly?: boolean;
     // loadNameExpressionOptions is a prop for testing purposes only, see default implementation below
@@ -165,7 +165,7 @@ interface OwnProps {
     parentDataTypes?: List<EntityDataType>;
     saveToPipeline?: boolean;
     selectedTarget?: string; // controlling target from a parent component
-    selectedParents?: Array<string>
+    selectedParents?: string[];
 }
 
 interface FromLocationProps {
@@ -250,7 +250,10 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     }
 
     componentDidUpdate(prevProps: Readonly<Props>): void {
-        if (prevProps.entityDataType !== this.props.entityDataType || prevProps.selectedParents !== this.props.selectedParents) {
+        if (
+            prevProps.entityDataType !== this.props.entityDataType ||
+            prevProps.selectedParents !== this.props.selectedParents
+        ) {
             this.init();
         }
     }
@@ -289,7 +292,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             target,
             isItemSamples,
             selectedTarget,
-            selectedParents
+            selectedParents,
         } = this.props;
 
         const { creationType } = this.state;
@@ -319,7 +322,9 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             insertModel &&
             insertModel.getTargetEntityTypeValue() === selected &&
             insertModel.selectionKey === selectionKey &&
-            (insertModel.originalParents === parents || insertModel.originalParents === selectedParents || !allowParents)
+            (insertModel.originalParents === parents ||
+                insertModel.originalParents === selectedParents ||
+                !allowParents)
         ) {
             return;
         }
@@ -1040,8 +1045,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     toggleInsertOptionChange = (): void => {
         const { onChangeInsertOption } = this.props;
 
-        if (onChangeInsertOption)
-            onChangeInsertOption(!this.state.isMerge);
+        if (onChangeInsertOption) onChangeInsertOption(!this.state.isMerge);
 
         this.setState(state => ({ isMerge: !state.isMerge }));
     };
@@ -1121,7 +1125,12 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             }
         } catch (error) {
             this.setState({
-                error: resolveErrorMessage(error, errorNounPlural ?? nounPlural, errorNounPlural ?? nounPlural, 'importing'),
+                error: resolveErrorMessage(
+                    error,
+                    errorNounPlural ?? nounPlural,
+                    errorNounPlural ?? nounPlural,
+                    'importing'
+                ),
                 isSubmitting: false,
             });
         }

--- a/packages/components/src/internal/components/entities/EntityParentTypeSelectors.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityParentTypeSelectors.spec.tsx
@@ -16,7 +16,7 @@ import {
 } from './EntityParentTypeSelectors';
 import { EntityDataType, EntityParentType, IParentOption } from './models';
 import { DataClassDataType, SampleTypeDataType } from './constants';
-import {SCHEMAS} from "../../schemas";
+import { SCHEMAS } from "../../schemas";
 
 const DATA_TYPES = List.of(SampleTypeDataType, {
     ...DataClassDataType,

--- a/packages/components/src/internal/components/entities/EntityParentTypeSelectors.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityParentTypeSelectors.spec.tsx
@@ -16,6 +16,7 @@ import {
 } from './EntityParentTypeSelectors';
 import { EntityDataType, EntityParentType, IParentOption } from './models';
 import { DataClassDataType, SampleTypeDataType } from './constants';
+import {SCHEMAS} from "../../schemas";
 
 const DATA_TYPES = List.of(SampleTypeDataType, {
     ...DataClassDataType,
@@ -197,7 +198,8 @@ describe('getUpdatedEntityParentType', () => {
             2,
             'DataClasses',
             'LSID',
-            undefined
+            undefined,
+            SCHEMAS.DATA_CLASSES.SCHEMA
         );
 
         expect(parentColumnName).toBe('MaterialInputs/Test2');
@@ -214,7 +216,8 @@ describe('getUpdatedEntityParentType', () => {
             2,
             'DataClasses',
             'LSID',
-            { schema: 'a', query: 'test1' }
+            { schema: 'a', query: 'test1' },
+            'a'
         );
 
         expect(parentColumnName).toBe(undefined);
@@ -231,7 +234,8 @@ describe('getUpdatedEntityParentType', () => {
             2,
             'DataClasses',
             'LSID',
-            { schema: 'a', query: 'test2' }
+            { schema: 'a', query: 'test2' },
+            'a'
         );
 
         expect(parentColumnName).toBe(undefined);

--- a/packages/components/src/internal/components/entities/EntityParentTypeSelectors.tsx
+++ b/packages/components/src/internal/components/entities/EntityParentTypeSelectors.tsx
@@ -34,7 +34,8 @@ export const getUpdatedEntityParentType = (
     index: number,
     queryName: string,
     uniqueFieldKey: string,
-    parent: IParentOption
+    parent: IParentOption,
+    targetSchema: string
 ): {
     updatedEntityParents: Map<string, List<EntityParentType>>;
     column: QueryColumn;
@@ -70,7 +71,7 @@ export const getUpdatedEntityParentType = (
             schema: parent.schema,
         });
         updatedEntityParents = entityParentsMap.mergeIn([queryName, existingParentKey], parentType);
-        column = parentType.generateColumn(uniqueFieldKey);
+        column = parentType.generateColumn(uniqueFieldKey, targetSchema);
     } else {
         const parentToResetKey = entityParents.findKey(parent => parent.get('index') === index);
         const existingParent = entityParents.get(parentToResetKey);
@@ -107,7 +108,8 @@ export const changeEntityParentType = (
             index,
             queryName,
             entityDataType.uniqueFieldKey,
-            parent
+            parent,
+            queryGridModel.schema
         );
 
         // no updated model if nothing has changed, so we can just stop

--- a/packages/components/src/internal/components/entities/models.spec.ts
+++ b/packages/components/src/internal/components/entities/models.spec.ts
@@ -27,31 +27,31 @@ import {
 
 describe('EntityParentType', () => {
     test('generateColumn captionSuffix', () => {
-        let col = EntityParentType.create({ query: 'dataclass' }).generateColumn('Display Column');
+        let col = EntityParentType.create({ schema: SCHEMAS.DATA_CLASSES.SCHEMA, query: 'dataclass' }).generateColumn('Display Column', SCHEMAS.DATA_CLASSES.SCHEMA);
         expect(col.caption).toBe('Dataclass Parents');
 
         col = EntityParentType.create({ schema: SCHEMAS.DATA_CLASSES.SCHEMA, query: 'dataclass' }).generateColumn(
-            'Display Column'
+            'Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA
         );
         expect(col.caption).toBe('Dataclass');
 
-        col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column');
+        col = EntityParentType.create({ schema: SCHEMAS.SAMPLE_SETS.SCHEMA, query: 'sampletype' }).generateColumn('Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA);
         expect(col.caption).toBe('Sampletype Parents');
 
         col = EntityParentType.create({ schema: SCHEMAS.SAMPLE_SETS.SCHEMA, query: 'sampletype' }).generateColumn(
-            'Display Column'
+            'Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA
         );
         expect(col.caption).toBe('Sampletype Parents');
     });
 
     test('generateColumn isAliquotParent', () => {
-        let col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column');
+        let col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA);
         expect(col.caption).not.toBe('AliquotedFrom');
         expect(col.description).not.toBe('The parent sample of the aliquot');
         expect(col.lookup.multiValued).toBe('junction');
         expect(col.required).toBe(false);
 
-        col = EntityParentType.create({ query: 'sampletype', isAliquotParent: true }).generateColumn('Display Column');
+        col = EntityParentType.create({ query: 'sampletype', isAliquotParent: true }).generateColumn('Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA);
         expect(col.caption).toBe('AliquotedFrom');
         expect(col.description).toBe('The parent sample of the aliquot');
         expect(col.lookup.multiValued).toBe(undefined);
@@ -59,25 +59,25 @@ describe('EntityParentType', () => {
     });
 
     test('generateColumn parentColName', () => {
-        let col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column');
+        let col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA);
         expect(col.name).toBe('MaterialInputs/Sampletype');
         expect(col.fieldKey).toBe('MaterialInputs/Sampletype');
         expect(col.fieldKeyArray[0]).toBe('MaterialInputs/Sampletype');
 
-        col = EntityParentType.create({ query: 'sampletype', isAliquotParent: true }).generateColumn('Display Column');
+        col = EntityParentType.create({ query: 'sampletype', isAliquotParent: true }).generateColumn('Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA);
         expect(col.name).toBe('AliquotedFrom');
         expect(col.fieldKey).toBe('AliquotedFrom');
         expect(col.fieldKeyArray[0]).toBe('AliquotedFrom');
     });
 
     test('generateColumn displayColumn', () => {
-        let col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column');
+        let col = EntityParentType.create({ query: 'sampletype' }).generateColumn('Display Column', SCHEMAS.DATA_CLASSES.SCHEMA);
         expect(col.lookup.displayColumn).toBe('Display Column');
 
         col = EntityParentType.create({
             schema: SCHEMAS.DATA_CLASSES.INGREDIENTS.schemaName,
             query: SCHEMAS.DATA_CLASSES.INGREDIENTS.queryName,
-        }).generateColumn('Display Column');
+        }).generateColumn('Display Column', SCHEMAS.DATA_CLASSES.SCHEMA);
         expect(col.lookup.displayColumn).toBe('scientificName');
     });
 

--- a/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
+++ b/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
@@ -926,7 +926,7 @@ export function getLineageEditorUpdateColumns(
         sampleParents.forEach(sampleParent => {
             const { schema, query } = sampleParent.type;
             const parentCol = EntityParentType.create({ index: parentColIndex, schema, query }).generateColumn(
-                sampleParent.type.entityDataType.uniqueFieldKey
+                sampleParent.type.entityDataType.uniqueFieldKey, displayQueryModel.schemaName
             );
 
             if (!parentColumns[parentCol.fieldKey]) {

--- a/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
+++ b/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
@@ -357,7 +357,10 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     initLineageEditableGrid = async (): Promise<void> => {
         const { determineLineage, parentDataTypes } = this.props;
         if (determineLineage) {
-            const { originalParents, parentTypeOptions } = await getOriginalParentsFromSampleLineage(this.props.sampleLineage, parentDataTypes.toArray());
+            const { originalParents, parentTypeOptions } = await getOriginalParentsFromSampleLineage(
+                this.props.sampleLineage,
+                parentDataTypes.toArray()
+            );
             this.setState(
                 () => ({ originalParents, parentTypeOptions }),
                 () => {
@@ -926,7 +929,8 @@ export function getLineageEditorUpdateColumns(
         sampleParents.forEach(sampleParent => {
             const { schema, query } = sampleParent.type;
             const parentCol = EntityParentType.create({ index: parentColIndex, schema, query }).generateColumn(
-                sampleParent.type.entityDataType.uniqueFieldKey, displayQueryModel.schemaName
+                sampleParent.type.entityDataType.uniqueFieldKey,
+                displayQueryModel.schemaName
             );
 
             if (!parentColumns[parentCol.fieldKey]) {


### PR DESCRIPTION
#### Rationale
Allow Biologics data classes to automatically set and control a parent type for each data class.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1283

#### Changes
* Add props to allow wrapping component to control parents
* Add prop to hide parent controls
* Update 'Parents' suffix in grid and bulk fields to only apply to data types of same type (dataclass or sample)
