### PR TITLE
Populate application user permissions from page context

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.168.0-fb-app-user-perms.0",
+  "version": "2.169.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.168.0",
+  "version": "2.168.0-fb-app-user-perms.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.169.0
+*Released*: 10 May 2022
+* Initialize application user's `permissionsList` directly from page context via `getServerContext().container.effectivePermissions`.
+* Remove `getUserPermissions` and associated redux functionality.
+* Remove `requestPermissions` bit from application model.
+
 ### version 2.168.0
 *Released*: 9 May 2022
 * Add SubNavWithContext, SubNavContextProvider, useSubNavContext

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -637,7 +637,6 @@ import {
 } from './internal/app/utils';
 import {
     doResetQueryGridState,
-    getUserPermissions,
     menuInit,
     menuInvalidate,
     menuReload,
@@ -697,8 +696,6 @@ import {
     UPDATE_USER,
     UPDATE_USER_DISPLAY_NAME,
     USER_KEY,
-    USER_PERMISSIONS_REQUEST,
-    USER_PERMISSIONS_SUCCESS,
     WORKFLOW_HOME_HREF,
     WORKFLOW_KEY,
 } from './internal/app/constants';
@@ -742,7 +739,6 @@ const App = {
     getDateFormat: getAppDateFormat,
     getDateTimeFormat: getAppDateTimeFormat,
     useMenuSectionConfigs,
-    getUserPermissions,
     doResetQueryGridState,
     menuInit,
     menuInvalidate,
@@ -767,8 +763,6 @@ const App = {
     SECURITY_SERVER_UNAVAILABLE,
     SECURITY_SESSION_TIMEOUT,
     SET_RELOAD_REQUIRED,
-    USER_PERMISSIONS_SUCCESS,
-    USER_PERMISSIONS_REQUEST,
     UPDATE_USER,
     UPDATE_USER_DISPLAY_NAME,
     BIOLOGICS: BIOLOGICS_APP_PROPERTIES,

--- a/packages/components/src/internal/app/actions.ts
+++ b/packages/components/src/internal/app/actions.ts
@@ -3,7 +3,6 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { List } from 'immutable';
-import { Security } from '@labkey/api';
 
 import { User } from '../components/base/models/User';
 import { ServerActivity } from '../components/notifications/model';
@@ -17,8 +16,6 @@ import {
     SET_RELOAD_REQUIRED,
     UPDATE_USER,
     UPDATE_USER_DISPLAY_NAME,
-    USER_PERMISSIONS_REQUEST,
-    USER_PERMISSIONS_SUCCESS,
     SERVER_NOTIFICATIONS_LOADING_START,
     SERVER_NOTIFICATIONS_LOADING_END,
     SERVER_NOTIFICATIONS_LOADING_ERROR,
@@ -26,36 +23,6 @@ import {
     RESET_QUERY_GRID_STATE,
 } from './constants';
 import { getAppProductIds } from './utils';
-
-function fetchUserPermissions() {
-    return new Promise((resolve, reject) => {
-        Security.getUserPermissions({
-            success: data => {
-                resolve(data);
-            },
-            failure: error => {
-                reject(error);
-            },
-        });
-    });
-}
-
-export function getUserPermissions() {
-    return dispatch => {
-        dispatch({ type: USER_PERMISSIONS_REQUEST });
-
-        return fetchUserPermissions()
-            .then(response => {
-                dispatch({
-                    type: USER_PERMISSIONS_SUCCESS,
-                    response,
-                });
-            })
-            .catch(error => {
-                console.error(error);
-            });
-    };
-}
 
 export const updateUser = (userProps: Partial<User>) => ({ type: UPDATE_USER, userProps });
 

--- a/packages/components/src/internal/app/models.ts
+++ b/packages/components/src/internal/app/models.ts
@@ -10,7 +10,7 @@ import { User } from '../components/base/models/User';
 
 const user = new User({
     ...getServerContext().user,
-    permissionsList: List(getServerContext().container.effectivePermissions ?? []),
+    permissionsList: List(getServerContext().container?.effectivePermissions ?? []),
 });
 
 export enum LogoutReason {

--- a/packages/components/src/internal/app/models.ts
+++ b/packages/components/src/internal/app/models.ts
@@ -2,13 +2,16 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { Record } from 'immutable';
+import { List, Record } from 'immutable';
 import { ActionURL, getServerContext } from '@labkey/api';
 
 import { Container } from '../components/base/models/Container';
 import { User } from '../components/base/models/User';
 
-const user = new User(getServerContext().user);
+const user = new User({
+    ...getServerContext().user,
+    permissionsList: List(getServerContext().container.effectivePermissions ?? []),
+});
 
 export enum LogoutReason {
     SERVER_LOGOUT,
@@ -22,7 +25,6 @@ export class AppModel extends Record({
     initialUserId: user.id,
     logoutReason: undefined,
     reloadRequired: false,
-    requestPermissions: true,
     user,
     needsInvalidateQueryGrid: false,
 }) {
@@ -31,7 +33,6 @@ export class AppModel extends Record({
     declare initialUserId: number;
     declare logoutReason: LogoutReason;
     declare reloadRequired: boolean;
-    declare requestPermissions: boolean;
     declare user: User;
     declare needsInvalidateQueryGrid: boolean; // separate query grid invalidate from menu reload, allow grid to invalidate on route change, to avoid invalid query grid state
 

--- a/packages/components/src/internal/app/reducers.ts
+++ b/packages/components/src/internal/app/reducers.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { fromJS, Map } from 'immutable';
+import { Map } from 'immutable';
 import { handleActions } from 'redux-actions';
 
 import { ServerNotificationModel, ProductMenuModel } from '../..';
@@ -17,8 +17,6 @@ import {
     SET_RELOAD_REQUIRED,
     UPDATE_USER,
     UPDATE_USER_DISPLAY_NAME,
-    USER_PERMISSIONS_REQUEST,
-    USER_PERMISSIONS_SUCCESS,
     ADD_TABLE_ROUTE,
     MENU_INVALIDATE,
     MENU_LOADING_START,
@@ -48,17 +46,6 @@ export const AppReducers = handleActions<AppReducerState, any>(
         [UPDATE_USER_DISPLAY_NAME]: (state: AppReducerState, action: any) => {
             return state.merge({
                 user: state.user.set('displayName', action.displayName),
-            });
-        },
-
-        [USER_PERMISSIONS_REQUEST]: (state: AppReducerState) => state.set('requestPermissions', false),
-
-        [USER_PERMISSIONS_SUCCESS]: (state: AppReducerState, action: any) => {
-            const { response } = action;
-            const { container } = response;
-
-            return state.merge({
-                user: state.user.set('permissionsList', fromJS(container.effectivePermissions)),
             });
         },
 


### PR DESCRIPTION
#### Rationale
With https://github.com/LabKey/platform/pull/3323 I've made it so LKS will inject user permissions for the current container onto the page immediately. This change respects that in our applications by immediately loading from page context the permissions. Subsequently, there is no longer a need for fetching user permissions upon application startup so I've removed this functionality in redux.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3323
* https://github.com/LabKey/labkey-ui-components/pull/831
* https://github.com/LabKey/biologics/pull/1286
* https://github.com/LabKey/sampleManagement/pull/946
* https://github.com/LabKey/inventory/pull/429

#### Changes
* Initialize application user's `permissionsList` directly from page context via `getServerContext().container.effectivePermissions`.
* Remove `getUserPermissions` and associated redux functionality.
* Remove `requestPermissions` bit from application model.
