### PR TITLE
 Issue 44841: Support commas in names of samples and data class objects (and types)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.170.0-commaNames.4",
+  "version": "2.170.0-commaNames.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.170.0-commaNames.1",
+  "version": "2.170.0-commaNames.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.168.0",
+  "version": "2.169.0-commaNames.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.170.0-commaNames.7",
+  "version": "2.170.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.169.0-commaNames.0",
+  "version": "2.169.0-commaNames.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.170.0-commaNames.5",
+  "version": "2.170.0-commaNames.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.170.0-commaNames.6",
+  "version": "2.170.0-commaNames.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.170.0-commaNames.3",
+  "version": "2.170.0-commaNames.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add support for names containing commas
+  * Update QuerySelect initialization to escape values that contain delimiters
+  * Update SingleParenEntityPanel to encode parent names containing delimiters
+  *
+
 ### version 2.168.0
 *Released*: 9 May 2022
 * Add SubNavWithContext, SubNavContextProvider, useSubNavContext

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.170.0
+*Released*: 12 May 2022
 * Add support for names containing commas
   * Update QuerySelect initialization to escape values that contain delimiters
   * Update SingleParenEntityPanel to encode parent names containing delimiters

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,7 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Add support for names containing commas
   * Update QuerySelect initialization to escape values that contain delimiters
   * Update SingleParenEntityPanel to encode parent names containing delimiters
-  *
+  * Update parsing of values pasted into editable grid and processing of values to be saved from the editable grid
 
 ### version 2.168.0
 *Released*: 9 May 2022

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -64,6 +64,8 @@ import {
     isIntegerInRange,
     isNonNegativeFloat,
     isNonNegativeInteger,
+    parseCsvString,
+    quoteValueWithDelimiters,
     toggleDevTools,
     valueIsEmpty,
 } from './internal/util/utils';
@@ -1299,6 +1301,8 @@ export {
     applyDevTools,
     devToolsActive,
     toggleDevTools,
+    parseCsvString,
+    quoteValueWithDelimiters,
     // buttons and menus
     MultiMenuButton,
     SubMenu,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -191,7 +191,7 @@ import {
     InsertRowsResponse,
     invalidateQueryDetailsCache,
     invalidateQueryDetailsCacheKey,
-    searchRows,
+
     selectRowsDeprecated,
     updateRows,
 } from './internal/query/api';
@@ -867,7 +867,6 @@ export {
     insertRows,
     selectRows,
     selectRowsDeprecated,
-    searchRows,
     updateRows,
     deleteRows,
     importData,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2036,7 +2036,7 @@ function getPasteValuesByColumn(paste: IPasteModel): List<List<string>> {
     data.forEach(row => {
         row.forEach((value, index) => {
             // if values contain commas, users will need to paste the values enclosed in quotes
-            // but we don't want to retain hese quotes for purposes of selecting values in the grid
+            // but we don't want to retain these quotes for purposes of selecting values in the grid
             parseCsvString(value, ',', true).forEach(v => {
                 if (v.trim().length > 0) valuesByColumn.get(index).push(v.trim());
             });

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -67,7 +67,7 @@ import {
 import { EditableColumnMetadata } from './components/editable/EditableGrid';
 import { getSortFromUrl } from './url/ActionURL';
 
-import { intersect } from './util/utils';
+import { intersect, parseCsvString } from './util/utils';
 import { resolveErrorMessage } from './util/messaging';
 import { hasModule } from './app/utils';
 
@@ -2035,7 +2035,9 @@ function getPasteValuesByColumn(paste: IPasteModel): List<List<string>> {
     }
     data.forEach(row => {
         row.forEach((value, index) => {
-            value.split(',').forEach(v => {
+            // if values contain commas, users will need to paste the values enclosed in quotes
+            // but we don't want to retain hese quotes for purposes of selecting values in the grid
+            parseCsvString(value, ',', true).forEach(v => {
                 if (v.trim().length > 0) valuesByColumn.get(index).push(v.trim());
             });
         });
@@ -2239,8 +2241,9 @@ function parsePasteCellLookup(column: QueryColumn, descriptors: ValueDescriptor[
     let message: CellMessage;
     const unmatched: string[] = [];
 
-    const values = value
-        .split(',')
+    // parse pasted strings to split properly around quoted values.
+    // Remove the quotes for storing the actual values in the grid.
+    const values = parseCsvString(value, ',', true)
         .map(v => {
             const vt = v.trim();
             if (vt.length > 0) {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -508,7 +508,6 @@ export function getExportParams(
             if (advancedOptions && advancedOptions['excludeColumn']) {
                 const toExclude = advancedOptions['excludeColumn'];
                 const columns = [];
-                // FIXME comma-split case to consider
                 columnsString.split(',').forEach(col => {
                     if (toExclude.indexOf(col) == -1 && toExclude.indexOf(col.toLowerCase()) == -1) {
                         columns.push(col);

--- a/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
@@ -95,7 +95,7 @@ export class EditableGridPanelDeprecated extends ReactN.Component<Props, State, 
     ): void => {
         const { onCellModify, onRowCountChange } = this.props;
         const editorModel = this.getEditorModel();
-        const newRowCount = Math.abs(editorModelChanges.rowCount - editorModel.rowCount);
+        const newRowCount = Math.abs(editorModelChanges?.rowCount - editorModel.rowCount);
 
         updateEditorModel(editorModel, editorModelChanges);
 
@@ -109,7 +109,7 @@ export class EditableGridPanelDeprecated extends ReactN.Component<Props, State, 
             onRowCountChange?.();
         }
 
-        if (newRowCount > 0 || editorModelChanges.cellValues !== undefined) {
+        if (newRowCount > 0 || editorModelChanges?.cellValues !== undefined) {
             onCellModify?.();
         }
     };

--- a/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelDeprecated.tsx
@@ -95,7 +95,7 @@ export class EditableGridPanelDeprecated extends ReactN.Component<Props, State, 
     ): void => {
         const { onCellModify, onRowCountChange } = this.props;
         const editorModel = this.getEditorModel();
-        const newRowCount = Math.abs(editorModelChanges?.rowCount - editorModel.rowCount);
+        const newRowCount = Math.abs((editorModelChanges?.rowCount ?? 0) - editorModel.rowCount);
 
         updateEditorModel(editorModel, editorModelChanges);
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -1204,7 +1204,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         inferred.fields.forEach(field => {
             const lcName = field.name.toLowerCase();
 
-            if (!field.isExpInput() && allowedFields.indexOf(lcName) < 0) {
+            if (!field.isExpInput(false) && allowedFields.indexOf(lcName) < 0) {
                 const aliasField = domainDesign.fields.find(
                     domainField => domainField.importAliases?.toLowerCase().indexOf(lcName) >= 0
                 );

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -30,6 +30,7 @@ import { getFilterForSampleOperation } from '../samples/utils';
 
 import { IEntityTypeOption } from './models';
 import { isSampleEntity } from './utils';
+import { encodeStringWithDelimiters } from '../../util/utils';
 
 interface OwnProps {
     chosenType: IEntityTypeOption;
@@ -81,10 +82,6 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
         onChangeParentType?.(fieldName, chosenType, selectedOption, index);
     };
 
-    removeParent = (): void => {
-        this.props.onRemoveParentType?.(this.props.index);
-    };
-
     onChangeParentValue = (name: string, chosenValue: string | any[]): void => {
         this.props.onValueChange(chosenValue);
         this.props.onChangeParentValue?.(name, chosenValue, this.props.index);
@@ -111,7 +108,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
         let value = chosenValue ?? undefined;
         if (!value && model?.hasData && parentLSIDs?.length > 0) {
             value = Object.values(model.rows)
-                .map(row => caseInsensitive(row, 'Name').value)
+                .map(row => encodeStringWithDelimiters(caseInsensitive(row, 'Name').value, DELIMITER))
                 .join(DELIMITER);
         }
         let queryFilters = List<Filter.IFilter>();

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -30,7 +30,7 @@ import { getFilterForSampleOperation } from '../samples/utils';
 
 import { IEntityTypeOption } from './models';
 import { isSampleEntity } from './utils';
-import { encodeStringWithDelimiters } from '../../util/utils';
+import { quoteValueWithDelimiters } from '../../util/utils';
 
 interface OwnProps {
     chosenType: IEntityTypeOption;
@@ -108,7 +108,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
         let value = chosenValue ?? undefined;
         if (!value && model?.hasData && parentLSIDs?.length > 0) {
             value = Object.values(model.rows)
-                .map(row => encodeStringWithDelimiters(caseInsensitive(row, 'Name').value, DELIMITER))
+                .map(row => quoteValueWithDelimiters(caseInsensitive(row, 'Name').value, DELIMITER))
                 .join(DELIMITER);
         }
         let queryFilters = List<Filter.IFilter>();

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -1,6 +1,14 @@
 import { List, Map, Set } from 'immutable';
 
-import { caseInsensitive, EditableColumnMetadata, naturalSort, QueryInfo, SchemaQuery, SCHEMAS } from '../../..';
+import {
+    caseInsensitive,
+    EditableColumnMetadata,
+    naturalSort,
+    parseCsvString,
+    QueryInfo,
+    SchemaQuery,
+    SCHEMAS
+} from '../../..';
 import { DELIMITER } from '../forms/input/SelectInput';
 
 import { getCurrentProductName } from '../../app/utils';
@@ -22,8 +30,8 @@ export function parentValuesDiffer(
         if (current.type && original.type.rowId !== current.type.rowId) {
             return true;
         }
-        const originalValues = original.value ? original.value.split(DELIMITER).sort(naturalSort).join(DELIMITER) : '';
-        const currentValues = current.value ? current.value.split(DELIMITER).sort(naturalSort).join(DELIMITER) : '';
+        const originalValues = original.value ? parseCsvString(original.value, DELIMITER).sort(naturalSort).join(DELIMITER) : '';
+        const currentValues = current.value ? parseCsvString(current.value, DELIMITER).sort(naturalSort).join(DELIMITER) : '';
         if (originalValues !== currentValues) {
             return true;
         }
@@ -186,7 +194,7 @@ export function getUpdatedLineageRowsForBulkEdit(
                         .sort(naturalSort)
                         .join(',');
                 }
-                const selValue = selected.value ? selected.value.split(',').sort(naturalSort).join(',') : null;
+                const selValue = selected.value ? parseCsvString(selected.value,',', false).sort(naturalSort).join(',') : null;
                 if (originalValue !== selValue) {
                     updatedValues[selected.type.entityDataType.insertColumnNamePrefix + selected.type.label] = selValue;
                     haveUpdate = true;

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -34,7 +34,7 @@ import {
 import { similaritySortFactory } from '../../util/similaritySortFactory';
 
 import { QuerySelectModel, QuerySelectModelProps } from './model';
-import { encodeResultsForCsv, searchRows } from '../../query/api';
+import { quoteValueColumnWithDelimiters, searchRows } from '../../query/api';
 import { parseCsvString } from '../../util/utils';
 
 const emptyMap = Map<string, any>();
@@ -121,7 +121,7 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                             queryName,
                             filterArray: [filter],
                         }).then(data => {
-                            const selectedItems = fromJS(encodeResultsForCsv(data, props.valueColumn, props.delimiter).models[data.key]);
+                            const selectedItems = fromJS(quoteValueColumnWithDelimiters(data, props.valueColumn, props.delimiter).models[data.key]);
 
                             model = model.merge({
                                 rawSelectedValue: props.value,

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -26,7 +26,6 @@ import {
     QueryModel,
     QuerySelectOwnProps,
     resolveDetailFieldValue,
-    searchRows,
     SelectInputOption,
     selectRowsDeprecated,
     updateRows,
@@ -35,6 +34,8 @@ import {
 import { similaritySortFactory } from '../../util/similaritySortFactory';
 
 import { QuerySelectModel, QuerySelectModelProps } from './model';
+import { encodeResultsForCsv, searchRows } from '../../query/api';
+import { parseCsvString } from '../../util/utils';
 
 const emptyMap = Map<string, any>();
 
@@ -102,7 +103,7 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                                 // This requires updating the filter and the string
                                 filter = Filter.create(
                                     valueColumn,
-                                    props.value.split(props.delimiter),
+                                    parseCsvString(props.value, props.delimiter, true),
                                     Filter.Types.IN
                                 );
                             }
@@ -120,7 +121,7 @@ export function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel
                             queryName,
                             filterArray: [filter],
                         }).then(data => {
-                            const selectedItems = fromJS(data.models[data.key]);
+                            const selectedItems = fromJS(encodeResultsForCsv(data, props.valueColumn, props.delimiter).models[data.key]);
 
                             model = model.merge({
                                 rawSelectedValue: props.value,
@@ -221,21 +222,17 @@ export function fetchSearchResults(model: QuerySelectModel, input: any): Promise
     }
 
     // 35112: Explicitly request exact matches -- can be disabled via QuerySelectModel.addExactFilter = false
-    return searchRows(
-        {
-            containerFilter: model.containerFilter,
-            containerPath: model.containerPath,
-            schemaName: schemaQuery.getSchema(),
-            queryName: schemaQuery.getQuery(),
-            columns: getQueryColumnNames(model),
-            filterArray: allFilters,
-            sort: displayColumn,
-            maxRows,
-            includeTotalCount: 'f',
-        },
-        filterVal,
-        addExactFilter ? displayColumn : undefined
-    );
+    return searchRows({
+        containerFilter: model.containerFilter,
+        containerPath: model.containerPath,
+        schemaName: schemaQuery.getSchema(),
+        queryName: schemaQuery.getQuery(),
+        columns: getQueryColumnNames(model),
+        filterArray: allFilters,
+        sort: displayColumn,
+        maxRows,
+        includeTotalCount: 'f',
+    }, filterVal, model.valueColumn, model.delimiter, addExactFilter ? displayColumn : undefined);
 }
 
 export function saveSearchResults(
@@ -298,7 +295,7 @@ function getSelectedOptions(model: QuerySelectModel, value: any): Map<string, an
 
     // multi-value case
     if (model.multiple === true) {
-        const values = value.toString().split(model.delimiter);
+        const values = parseCsvString(value.toString(), model.delimiter);
         return sources
             .filter(result => {
                 const resultValue = result.getIn(keyPath);

--- a/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
+++ b/packages/components/src/internal/components/samples/SamplesEditableGrid.tsx
@@ -32,6 +32,7 @@ import {
     QueryGridModel,
     QueryInfo,
     QueryModel,
+    quoteValueWithDelimiters,
     resolveErrorMessage,
     SampleStateType,
     SampleTypeDataType,
@@ -854,9 +855,11 @@ export function getUpdatedLineageRows(
                 let originalVal = originalModel.data.get('' + rowId).get(key);
                 if (List.isList(originalVal)) {
                     originalVal = originalVal
-                        ?.map(parentRow => parentRow.displayValue)
+                        ?.map(parentRow => quoteValueWithDelimiters(parentRow.displayValue, ','))
                         .sort(naturalSort)
                         .join(', ');
+                } else {
+                    originalVal = quoteValueWithDelimiters(originalVal, ',');
                 }
 
                 if (originalVal !== updatedVal) {

--- a/packages/components/src/internal/global.ts
+++ b/packages/components/src/internal/global.ts
@@ -273,6 +273,9 @@ export function getEditorModel(modelId: string): EditorModel {
  * @param failIfNotFound Boolean indicating if an error should be thrown if the model is not found in global state
  */
 export function updateEditorModel(model: EditorModel, updates: any, failIfNotFound = true): EditorModel {
+    if (!model)
+        return model;
+
     if (failIfNotFound && !getGlobalState('editors').has(model.id)) {
         throw new Error('Unable to find EditorModel for modelId: ' + model.id);
     }

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -35,7 +35,7 @@ import { DefaultGridLoader } from './components/GridLoader';
 import { GRID_EDIT_INDEX } from './constants';
 import { IQueryGridModel } from './QueryGridModel';
 import { getColDateFormat, getJsonDateTimeFormatString, parseDate } from './util/Date';
-import { encodeStringWithDelimiters } from './util/utils';
+import { quoteValueWithDelimiters } from './util/utils';
 
 export function getStateModelId(gridId: string, schemaQuery: SchemaQuery, keyValue?: any): string {
     const parts = [gridId, resolveSchemaQuery(schemaQuery)];
@@ -443,7 +443,7 @@ export class EditorModel
                             col.name,
                             values.reduce((str, vd) => {
                                 if (vd.display !== undefined && vd.display !== null) {
-                                    str += sep + encodeStringWithDelimiters(vd.display, ',');
+                                    str += sep + quoteValueWithDelimiters(vd.display, ',');
                                     sep = ', ';
                                 }
                                 return str;
@@ -460,7 +460,7 @@ export class EditorModel
                             }, [])
                         );
                     } else if (col.lookup.displayColumn == col.lookup.keyColumn) {
-                        row = row.set(col.name, values.size === 1 ? encodeStringWithDelimiters(values.first().display, ',') : undefined);
+                        row = row.set(col.name, values.size === 1 ? quoteValueWithDelimiters(values.first().display, ',') : undefined);
                     } else {
                         row = row.set(col.name, values.size === 1 ? values.first()?.raw : undefined);
                     }

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -35,6 +35,7 @@ import { DefaultGridLoader } from './components/GridLoader';
 import { GRID_EDIT_INDEX } from './constants';
 import { IQueryGridModel } from './QueryGridModel';
 import { getColDateFormat, getJsonDateTimeFormatString, parseDate } from './util/Date';
+import { encodeStringWithDelimiters } from './util/utils';
 
 export function getStateModelId(gridId: string, schemaQuery: SchemaQuery, keyValue?: any): string {
     const parts = [gridId, resolveSchemaQuery(schemaQuery)];
@@ -442,7 +443,7 @@ export class EditorModel
                             col.name,
                             values.reduce((str, vd) => {
                                 if (vd.display !== undefined && vd.display !== null) {
-                                    str += sep + vd.display;
+                                    str += sep + encodeStringWithDelimiters(vd.display, ',');
                                     sep = ', ';
                                 }
                                 return str;
@@ -459,7 +460,7 @@ export class EditorModel
                             }, [])
                         );
                     } else if (col.lookup.displayColumn == col.lookup.keyColumn) {
-                        row = row.set(col.name, values.size === 1 ? values.first().display : undefined);
+                        row = row.set(col.name, values.size === 1 ? encodeStringWithDelimiters(values.first().display, ',') : undefined);
                     } else {
                         row = row.set(col.name, values.size === 1 ? values.first()?.raw : undefined);
                     }

--- a/packages/components/src/internal/query/api.spec.ts
+++ b/packages/components/src/internal/query/api.spec.ts
@@ -1,7 +1,7 @@
-import { encodeResultsForCsv } from "./api";
+import { quoteValueColumnWithDelimiters } from "./api";
 import { List } from 'immutable';
 
-describe('encodeResultsForCsv', () => {
+describe('quoteValueColumnWithDelimiters', () => {
     const results = {
         key: 'test',
         models: {
@@ -17,7 +17,7 @@ describe('encodeResultsForCsv', () => {
         totalRows: 4,
     };
     test('encode', () => {
-        expect(encodeResultsForCsv(results, 'Name', ',')).toStrictEqual(
+        expect(quoteValueColumnWithDelimiters(results, 'Name', ',')).toStrictEqual(
         {
             key: 'test',
             models: {

--- a/packages/components/src/internal/query/api.spec.ts
+++ b/packages/components/src/internal/query/api.spec.ts
@@ -1,0 +1,44 @@
+import { encodeResultsForCsv } from "./api";
+import { List } from 'immutable';
+
+describe('encodeResultsForCsv', () => {
+    const results = {
+        key: 'test',
+        models: {
+            test: {
+                1: { Name: { value: 'one', url: "http://one/test"}},
+                2: { Name: { value: 'with, comma', url: "http://with, comma/test"}},
+                4: { Name: { value: 'with "quotes", and comma'}},
+                3: { NoName: { value: 'nonesuch', url: "http://with, comma/test"}}
+            }
+        },
+        orderedModels: List([1, 2, 3, 4]),
+        queries: {},
+        totalRows: 4,
+    };
+    test('encode', () => {
+        expect(encodeResultsForCsv(results, 'Name', ',')).toStrictEqual(
+        {
+            key: 'test',
+            models: {
+                test: {
+                    1: { Name: { value: 'one', url: "http://one/test", displayValue: 'one'}},
+                    2: { Name: { value: '"with, comma"', url: 'http://with, comma/test', displayValue: 'with, comma'}},
+                    4: { Name: { value: '"with ""quotes"", and comma"', url: undefined, displayValue:  'with "quotes", and comma'}},
+                    3: { NoName: { value: 'nonesuch', url: "http://with, comma/test" }}
+                }
+            },
+            orderedModels: List([1, 2, 3, 4]),
+                queries: {},
+            totalRows: 4,
+        });
+    });
+
+    test('with delimiter', () => {
+
+    });
+
+    test('missing field', () => {
+
+    });
+});

--- a/packages/components/src/internal/query/api.spec.ts
+++ b/packages/components/src/internal/query/api.spec.ts
@@ -9,12 +9,13 @@ describe('quoteValueColumnWithDelimiters', () => {
                 1: { Name: { value: 'one', url: "http://one/test"}},
                 2: { Name: { value: 'with, comma', url: "http://with, comma/test"}},
                 4: { Name: { value: 'with "quotes", and comma'}},
-                3: { NoName: { value: 'nonesuch', url: "http://with, comma/test"}}
+                3: { NoName: { value: 'nonesuch', url: "http://with, comma/test"}},
+                5: { Name: { value: ', comma first', displayValue: ',', url: "http://with, comma/test"}}
             }
         },
-        orderedModels: List([1, 2, 3, 4]),
+        orderedModels: List([1, 2, 3, 4, 5]),
         queries: {},
-        totalRows: 4,
+        totalRows: 5,
     };
     test('encode', () => {
         expect(quoteValueColumnWithDelimiters(results, 'Name', ',')).toStrictEqual(
@@ -25,20 +26,13 @@ describe('quoteValueColumnWithDelimiters', () => {
                     1: { Name: { value: 'one', url: "http://one/test", displayValue: 'one'}},
                     2: { Name: { value: '"with, comma"', url: 'http://with, comma/test', displayValue: 'with, comma'}},
                     4: { Name: { value: '"with ""quotes"", and comma"', url: undefined, displayValue:  'with "quotes", and comma'}},
-                    3: { NoName: { value: 'nonesuch', url: "http://with, comma/test" }}
+                    3: { NoName: { value: 'nonesuch', url: "http://with, comma/test" }},
+                    5: { Name: { value: '", comma first"', displayValue: ',', url: "http://with, comma/test"}}
                 }
             },
-            orderedModels: List([1, 2, 3, 4]),
+            orderedModels: List([1, 2, 3, 4, 5]),
                 queries: {},
-            totalRows: 4,
+            totalRows: 5,
         });
-    });
-
-    test('with delimiter', () => {
-
-    });
-
-    test('missing field', () => {
-
     });
 });

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -567,7 +567,7 @@ export function handleSelectRowsResponse(json): any {
 }
 
 // exported for jest testing
-export function encodeResultsForCsv(selectRowsResult: ISelectRowsResult, valueColumn: string, delimiter: string): ISelectRowsResult {
+export function quoteValueColumnWithDelimiters(selectRowsResult: ISelectRowsResult, valueColumn: string, delimiter: string): ISelectRowsResult {
     const rowMap = selectRowsResult.models[selectRowsResult.key];
     Object.keys(rowMap).forEach(key => {
         if (rowMap[key][valueColumn]) {
@@ -651,7 +651,7 @@ export function searchRows(selectRowsConfig, token: any, valueColumn: string, de
                     finalResults = queryResults;
                 }
 
-                resolve(encodeResultsForCsv(finalResults, valueColumn, delimiter));
+                resolve(quoteValueColumnWithDelimiters(finalResults, valueColumn, delimiter));
             })
             .catch(reason => {
                 reject(reason);

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -575,7 +575,7 @@ export function quoteValueColumnWithDelimiters(selectRowsResult: ISelectRowsResu
                 {
                     [valueColumn]: {
                         value: quoteValueWithDelimiters(rowMap[key][valueColumn].value, delimiter),
-                        displayValue: rowMap[key][valueColumn].value,
+                        displayValue: rowMap[key][valueColumn].displayValue ?? rowMap[key][valueColumn].value,
                         url: rowMap[key][valueColumn].url
                     }
                 }

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -31,7 +31,7 @@ import {
     URLResolver,
     ViewInfo,
 } from '../..';
-import { encodeStringWithDelimiters } from '../util/utils';
+import { quoteValueWithDelimiters } from '../util/utils';
 
 let queryDetailsCache: Record<string, Promise<QueryInfo>> = {};
 
@@ -574,7 +574,7 @@ export function encodeResultsForCsv(selectRowsResult: ISelectRowsResult, valueCo
             Object.assign(rowMap[key],
                 {
                     [valueColumn]: {
-                        value: encodeStringWithDelimiters(rowMap[key][valueColumn].value, delimiter),
+                        value: quoteValueWithDelimiters(rowMap[key][valueColumn].value, delimiter),
                         displayValue: rowMap[key][valueColumn].value,
                         url: rowMap[key][valueColumn].url
                     }

--- a/packages/components/src/internal/util/utils.spec.ts
+++ b/packages/components/src/internal/util/utils.spec.ts
@@ -22,6 +22,7 @@ import { BOOLEAN_TYPE, DATE_TYPE, INTEGER_TYPE, TEXT_TYPE } from '../components/
 import {
     camelCaseToTitleCase,
     caseInsensitive,
+    encodeStringWithDelimiters,
     findMissingValues,
     formatBytes,
     getCommonDataValues,
@@ -36,9 +37,10 @@ import {
     isIntegerInRange,
     isNonNegativeFloat,
     isNonNegativeInteger,
+    parseCsvString,
     parseScientificInt,
     toLowerSafe,
-    unorderedEqual,
+    unorderedEqual
 } from './utils';
 
 const emptyList = List<string>();
@@ -1426,3 +1428,85 @@ describe('findMissingValues', () => {
         expect(findMissingValues([3], ['a', 'b', 'c', 'd', 'e', 'f'])).toStrictEqual(['a', 'b', 'd', 'e', 'f']);
     });
 });
+
+describe('parseCsvString', () => {
+    test('no value', () => {
+        expect(parseCsvString(null, ',')).toBeUndefined();
+        expect(parseCsvString(undefined, ';')).toBeUndefined();
+        expect(parseCsvString('', undefined)).toBeUndefined();
+        expect(parseCsvString(null, undefined)).toBeUndefined();
+    });
+
+    test('no quotes', () => {
+        expect(parseCsvString('', '\t')).toStrictEqual([]);
+        expect(parseCsvString('abcd', ' ')).toStrictEqual(['abcd']);
+        expect(parseCsvString('a,b,c', ',')).toStrictEqual(['a', 'b', 'c']);
+        expect(parseCsvString(',b,c,', ',')).toStrictEqual(['', 'b', 'c']);
+        expect(parseCsvString('a,,c', ',')).toStrictEqual(['a', '', 'c']);
+        expect(parseCsvString('a\tb\tc', '\t')).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    test("quote as delimiter", () => {
+        expect(() => parseCsvString('a"b"c"', '"')).toThrow('Unsupported delimiter: "');
+    })
+
+    test("quoted values", () => {
+        expect(parseCsvString('a,"b","c,d"', ',')).toStrictEqual(['a', '"b"', '"c,d"']);
+        expect(parseCsvString(',"b","c,d"', ',')).toStrictEqual(['', '"b"', '"c,d"']);
+        expect(parseCsvString('a,"b","c', ',')).toStrictEqual(['a', '"b"', '"c']);
+        expect(parseCsvString('a,"b",c"', ',')).toStrictEqual(['a', '"b"', 'c"']);
+        expect(parseCsvString('"b"', ',')).toStrictEqual(['"b"']);
+    });
+
+    test("double quotes", () => {
+        expect(parseCsvString('a,"b\"\"b2","c,d"', ',')).toStrictEqual(['a', '"b\"\"b2"', '"c,d"']);
+        expect(parseCsvString('"b\"\"b2\"\"b3\"\""', ',')).toStrictEqual(['"b\"\"b2\"\"b3\"\""']);
+    });
+
+    test("remove quotes", () => {
+        expect(parseCsvString('a,"b","c,d"', ',', true)).toStrictEqual(['a', 'b', 'c,d']);
+        expect(parseCsvString(',"b","c,d"', ',', true)).toStrictEqual(['', 'b', 'c,d']);
+        expect(parseCsvString('a,"b","c', ',', true)).toStrictEqual(['a', 'b', 'c']);
+        expect(parseCsvString('a,"b",c"', ',', true)).toStrictEqual(['a', 'b', 'c"']);
+        expect(parseCsvString('"b"', ',', true)).toStrictEqual(['b']);
+        expect(parseCsvString('a,"b\"\"b2","c,d"',',', true)).toStrictEqual(['a', 'b"b2', 'c,d']);
+        expect(parseCsvString('"b\"\"b2\"\"b3\"\""',',', true)).toStrictEqual(['b"b2"b3"']);
+    });
+});
+
+describe('encodeStringForCsv', () => {
+    test('no value', () => {
+        expect(encodeStringWithDelimiters(undefined, ",")).toBeUndefined();
+        expect(encodeStringWithDelimiters(null, ';')).toBeNull();
+        expect(encodeStringWithDelimiters('', ' ')).toBe('');
+    });
+
+    test("non-string value", () => {
+        expect(encodeStringWithDelimiters(4, ',')).toBe(4);
+        expect(encodeStringWithDelimiters(4, undefined)).toBe(4);
+        expect(encodeStringWithDelimiters({value: "4,5"}, undefined)).toStrictEqual({value: "4,5"});
+        expect(encodeStringWithDelimiters([4, 5, 6], ',')).toStrictEqual([4, 5, 6]);
+    })
+
+    test('invalid delimiter', () => {
+        expect(() => encodeStringWithDelimiters("value", undefined)).toThrow("Delimiter is required.")
+        expect(() => encodeStringWithDelimiters("value", null)).toThrow("Delimiter is required.")
+        expect(() => encodeStringWithDelimiters("value", '')).toThrow("Delimiter is required.")
+    });
+
+    test('without delimiter in value', () => {
+        expect(encodeStringWithDelimiters('abc d', ',')).toBe('abc d');
+        expect(encodeStringWithDelimiters('a', ';')).toBe('a');
+    });
+
+    test('with delimiter', () => {
+        expect(encodeStringWithDelimiters('abc,d', ',')).toBe('"abc,d"');
+        expect(encodeStringWithDelimiters('ab "cd,e"', ',')).toBe('"ab ""cd,e"""');
+    });
+
+    test("round trip", () => {
+        const initialString = 'ab "cd,e"';
+        expect(parseCsvString(encodeStringWithDelimiters(initialString, ','), ',', true)).toStrictEqual([initialString]);
+    })
+})
+

--- a/packages/components/src/internal/util/utils.spec.ts
+++ b/packages/components/src/internal/util/utils.spec.ts
@@ -22,7 +22,7 @@ import { BOOLEAN_TYPE, DATE_TYPE, INTEGER_TYPE, TEXT_TYPE } from '../components/
 import {
     camelCaseToTitleCase,
     caseInsensitive,
-    encodeStringWithDelimiters,
+    quoteValueWithDelimiters,
     findMissingValues,
     formatBytes,
     getCommonDataValues,
@@ -1474,39 +1474,39 @@ describe('parseCsvString', () => {
     });
 });
 
-describe('encodeStringForCsv', () => {
+describe('quoteValueWithDelimiters', () => {
     test('no value', () => {
-        expect(encodeStringWithDelimiters(undefined, ",")).toBeUndefined();
-        expect(encodeStringWithDelimiters(null, ';')).toBeNull();
-        expect(encodeStringWithDelimiters('', ' ')).toBe('');
+        expect(quoteValueWithDelimiters(undefined, ",")).toBeUndefined();
+        expect(quoteValueWithDelimiters(null, ';')).toBeNull();
+        expect(quoteValueWithDelimiters('', ' ')).toBe('');
     });
 
     test("non-string value", () => {
-        expect(encodeStringWithDelimiters(4, ',')).toBe(4);
-        expect(encodeStringWithDelimiters(4, undefined)).toBe(4);
-        expect(encodeStringWithDelimiters({value: "4,5"}, undefined)).toStrictEqual({value: "4,5"});
-        expect(encodeStringWithDelimiters([4, 5, 6], ',')).toStrictEqual([4, 5, 6]);
+        expect(quoteValueWithDelimiters(4, ',')).toBe(4);
+        expect(quoteValueWithDelimiters(4, undefined)).toBe(4);
+        expect(quoteValueWithDelimiters({value: "4,5"}, undefined)).toStrictEqual({value: "4,5"});
+        expect(quoteValueWithDelimiters([4, 5, 6], ',')).toStrictEqual([4, 5, 6]);
     })
 
     test('invalid delimiter', () => {
-        expect(() => encodeStringWithDelimiters("value", undefined)).toThrow("Delimiter is required.")
-        expect(() => encodeStringWithDelimiters("value", null)).toThrow("Delimiter is required.")
-        expect(() => encodeStringWithDelimiters("value", '')).toThrow("Delimiter is required.")
+        expect(() => quoteValueWithDelimiters("value", undefined)).toThrow("Delimiter is required.")
+        expect(() => quoteValueWithDelimiters("value", null)).toThrow("Delimiter is required.")
+        expect(() => quoteValueWithDelimiters("value", '')).toThrow("Delimiter is required.")
     });
 
     test('without delimiter in value', () => {
-        expect(encodeStringWithDelimiters('abc d', ',')).toBe('abc d');
-        expect(encodeStringWithDelimiters('a', ';')).toBe('a');
+        expect(quoteValueWithDelimiters('abc d', ',')).toBe('abc d');
+        expect(quoteValueWithDelimiters('a', ';')).toBe('a');
     });
 
     test('with delimiter', () => {
-        expect(encodeStringWithDelimiters('abc,d', ',')).toBe('"abc,d"');
-        expect(encodeStringWithDelimiters('ab "cd,e"', ',')).toBe('"ab ""cd,e"""');
+        expect(quoteValueWithDelimiters('abc,d', ',')).toBe('"abc,d"');
+        expect(quoteValueWithDelimiters('ab "cd,e"', ',')).toBe('"ab ""cd,e"""');
     });
 
     test("round trip", () => {
         const initialString = 'ab "cd,e"';
-        expect(parseCsvString(encodeStringWithDelimiters(initialString, ','), ',', true)).toStrictEqual([initialString]);
+        expect(parseCsvString(quoteValueWithDelimiters(initialString, ','), ',', true)).toStrictEqual([initialString]);
     })
 })
 

--- a/packages/components/src/internal/util/utils.spec.ts
+++ b/packages/components/src/internal/util/utils.spec.ts
@@ -1502,6 +1502,7 @@ describe('quoteValueWithDelimiters', () => {
     test('with delimiter', () => {
         expect(quoteValueWithDelimiters('abc,d', ',')).toBe('"abc,d"');
         expect(quoteValueWithDelimiters('ab "cd,e"', ',')).toBe('"ab ""cd,e"""');
+        expect(quoteValueWithDelimiters('ab, "cd,e"', ',')).toBe('"ab, ""cd,e"""');
     });
 
     test("round trip", () => {

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -716,3 +716,70 @@ export const handleFileInputChange = (
         }
     };
 };
+
+
+export function parseCsvString(value: string, delimiter: string, removeQuotes?: boolean) : string[]
+{
+    if (delimiter === '"')
+        throw "Unsupported delimiter: " + delimiter;
+
+    if (!delimiter)
+        return undefined;
+
+    if (value == null)
+        return undefined;
+
+    let start = 0;
+    let parsedValues = [];
+    while (start < value.length) {
+        let end;
+        let ch = value[start];
+        if (ch === delimiter) { // empty string case
+            end = start;
+            parsedValues.push("");
+        } else if (ch === '"') { // starting a quoted value
+            end = start;
+            while (true) { // find the end of the quoted value
+                end = value.indexOf('"', end+1);
+                if (end === -1) { // no ending quote
+                    end = value.length;
+                    break;
+                }
+                if (end === value.length -1 || value[end + 1] !== '"') { // end quote at end of string or without double quote
+                    break;
+                }
+                end++; // skip double ""
+            }
+            let parsedValue = removeQuotes ?  value.substring(start+1, end) : value.substring(start, end+1) ; // start is at the quote
+            if (removeQuotes && parsedValue.indexOf('""') !== -1) {
+                parsedValue = parsedValue.replace(/""/g, '"');
+            }
+            parsedValues.push(parsedValue);
+            end++; // get past the last "
+        }
+        else {
+            end = value.indexOf(delimiter, start);
+            if (end === -1)
+                end = value.length;
+            parsedValues.push(value.substring(start, end))
+
+        }
+        start = end + delimiter.length;
+    }
+    return parsedValues;
+}
+
+export function encodeStringWithDelimiters(value: any, delimiter: string) {
+    if (!value || !Utils.isString(value)) {
+        return value;
+    }
+    if (!delimiter) {
+        throw "Delimiter is required.";
+    }
+    if (value.indexOf(delimiter) === -1)
+        return value; // nothing to do for a string that doesn't contain the delimiter
+    if (value.indexOf('"') !== -1) {
+        value = value.replace(/"/g, '""');
+    }
+    return '"' + value + '"';
+}

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -769,7 +769,7 @@ export function parseCsvString(value: string, delimiter: string, removeQuotes?: 
     return parsedValues;
 }
 
-export function encodeStringWithDelimiters(value: any, delimiter: string) {
+export function quoteValueWithDelimiters(value: any, delimiter: string) {
     if (!value || !Utils.isString(value)) {
         return value;
     }

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -241,15 +241,15 @@ export class QueryColumn extends Record({
         return this.fieldKeyArray.join('/');
     }
 
-    isExpInput(): boolean {
-        return this.isDataInput() || this.isMaterialInput();
+    isExpInput(checkLookup: boolean = true): boolean {
+        return this.isDataInput(checkLookup) || this.isMaterialInput(checkLookup);
     }
 
-    isDataInput(): boolean {
+    isDataInput(checkLookup: boolean = true): boolean {
         return (
             this.name &&
             this.name.toLowerCase().indexOf(QueryColumn.DATA_INPUTS.toLowerCase()) !== -1 &&
-            this.isLookup()
+            (!checkLookup && this.isLookup())
         );
     }
 
@@ -291,11 +291,11 @@ export class QueryColumn extends Record({
         return SCHEMAS.EXP_TABLES.MATERIALS.isEqual(lookupSQ) || lookupSQ.hasSchema(SCHEMAS.SAMPLE_SETS.SCHEMA);
     }
 
-    isMaterialInput(): boolean {
+    isMaterialInput(checkLookup: boolean = true): boolean {
         return (
             this.name &&
             this.name.toLowerCase().indexOf(QueryColumn.MATERIAL_INPUTS.toLowerCase()) !== -1 &&
-            this.isLookup()
+            (!checkLookup || this.isLookup())
         );
     }
 

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -249,7 +249,7 @@ export class QueryColumn extends Record({
         return (
             this.name &&
             this.name.toLowerCase().indexOf(QueryColumn.DATA_INPUTS.toLowerCase()) !== -1 &&
-            (!checkLookup && this.isLookup())
+            (!checkLookup || this.isLookup())
         );
     }
 


### PR DESCRIPTION
#### Rationale
Having commas in names of samples is, in some cases (such as pooled samples), a very natural thing to do. Because we also use the comma as a separate between multiple Ids in various places, we effectively don't support the use of commas in names. This work adds the ability for users to provide names of samples and data class objects with commas in them by quoting the values (as we do when importing other data on the server side).

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1299
* https://github.com/LabKey/platform/pull/3348
* https://github.com/LabKey/sampleManagement/pull/954
* https://github.com/LabKey/inventory/pull/432
* https://github.com/LabKey/labbook/pull/172

#### Changes
* Update QuerySelect initialization to escape values that contain delimiters
* Update SingleParenEntityPanel to encode parent names containing delimiters
* Update parsing of values pasted into editable grid and processing of values to be saved from the 
