### PR TITLE
Issue 45222: Editable grid doesn't automatically expand width of dropdowns to show long values

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.171.0",
+  "version": "2.171.0-fb-editGridWidth45222.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.171.0-fb-editGridWidth45222.0",
+  "version": "2.171.0-fb-editGridWidth45222.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.12.0",
+    "@labkey/api": "1.12.1",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.171.0-fb-editGridWidth45222.1",
+  "version": "2.171.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD May 2022
+### version 2.171.1
+*Released*: 13 May 2022
 * Issue 45222: Editable grid doesn't automatically expand width of dropdowns to show long values
 
 ### version 2.171.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,12 +3,16 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.171.0
 *Released*: 12 May 2022
-Item 10353: Convert EditableGridPanelForUpdate to QueryModel-based EditableGridPanel
-- remove unused EditableGridLoader
-- update EditableGridPanelForUpdate to initialize the dataModel and editorModel
-- update EditableGridLoaderFromSelection.tsx and related components/models for QueryModel
-- update EditableGridPanel.tsx for tabbed panel with multiple models
-- update SampleEditableGrid actions from EntityParentTypeSelector to work with QueryModel
+* Issue 45222: Editable grid doesn't automatically expand width of dropdowns to show long values
+
+### version 2.171.0
+*Released*: 12 May 2022
+* Item 10353: Convert EditableGridPanelForUpdate to QueryModel-based EditableGridPanel
+  * remove unused EditableGridLoader
+  * update EditableGridPanelForUpdate to initialize the dataModel and editorModel
+  * update EditableGridLoaderFromSelection.tsx and related components/models for QueryModel
+  * update EditableGridPanel.tsx for tabbed panel with multiple models
+  * update SampleEditableGrid actions from EntityParentTypeSelector to work with QueryModel
 
 ### version 2.170.0
 *Released*: 12 May 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.171.0
-*Released*: 12 May 2022
+### version TBD
+*Released*: TBD May 2022
 * Issue 45222: Editable grid doesn't automatically expand width of dropdowns to show long values
 
 ### version 2.171.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -224,7 +224,6 @@ import {
 } from './internal/url/AppURLResolver';
 import { loadEditorModelData } from './internal/components/editable/utils';
 import { EditableGridPanel } from './internal/components/editable/EditableGridPanel';
-import { EditableGridPanelDeprecated } from './internal/components/editable/EditableGridPanelDeprecated';
 import { EditableGridPanelForUpdate } from './internal/components/editable/EditableGridPanelForUpdate';
 import { EditableGridLoaderFromSelection } from './internal/components/editable/EditableGridLoaderFromSelection';
 
@@ -873,7 +872,6 @@ export {
     MAX_EDITABLE_GRID_ROWS,
     EditableGridLoaderFromSelection,
     EditableGridPanel,
-    EditableGridPanelDeprecated,
     EditableGridPanelForUpdate,
     EditorModel,
     cancelEvent,

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -255,7 +255,6 @@ export class Cell extends React.PureComponent<Props> {
                 autoFocus: selected,
                 className: classNames('cellular-display', {
                     'cell-selected': selected,
-                    'size-limited': col.isLookup(),
                     'cell-selection': selection,
                     'cell-warning': message !== undefined,
                     'cell-read-only': this.isReadOnly(),

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -28,7 +28,6 @@ import {
     capitalizeFirstChar,
     DomainDetails,
     EditableColumnMetadata,
-    EditableGridPanelDeprecated,
     FileAttachmentForm,
     FileSizeLimitProps,
     FormStep,
@@ -108,6 +107,7 @@ import {
     EntityParentTypeSelectors,
 } from './EntityParentTypeSelectors';
 import { ENTITY_CREATION_METRIC } from './constants';
+import { EditableGridPanelDeprecated } from '../editable/EditableGridPanelDeprecated';
 
 const ALIQUOT_FIELD_COLS = ['aliquotedfrom', 'name', 'description', 'samplestate'];
 const ALIQUOT_NOUN_SINGULAR = 'Aliquot';

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -241,11 +241,6 @@ $table-cell-selection-bg-color: #EDF3FF;
       height: 30px;
       white-space: nowrap;
 
-      &.size-limited {
-        max-width: 200px;
-        text-overflow: ellipsis;
-      }
-
       &.cell-selection {
         border: $table-cell-border-width solid $table-cell-selection-bg-color;
         background-color: $table-cell-selection-bg-color;
@@ -263,6 +258,7 @@ $table-cell-selection-bg-color: #EDF3FF;
       outline: none;
       padding: 6px 2px;
       width: 100%;
+      min-width: 200px;
 
       &:focus {
         border: $table-cell-selected-border;
@@ -293,12 +289,10 @@ $table-cell-selection-bg-color: #EDF3FF;
     .cell-menu {
         position: relative;
         min-height: 30px;
-        width: 200px;
     }
 
     .cell-menu-value {
-        width: 170px;
-        text-overflow: ellipsis;
+        min-width: 200px;
     }
 
     .cell-menu-selector {
@@ -349,15 +343,11 @@ $table-cell-selection-bg-color: #EDF3FF;
   }
 }
 
-
-.select-input-cell {
-    width: 200px;
-}
-
 .select-input-cell .select-input__control {
     border-style: none;
     min-height: 30px;
-    width: 200px;
+    width: 100%;
+    min-width: 200px;
 }
 
 .select-input-cell-container {

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.12.0":
-  version "1.12.0"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.12.0.tgz#1179a3aeffd17d9d453214a305e79ef139c10808"
-  integrity sha1-EXmjrv/RfZ1FMhSjBeee8TnBCAg=
+"@labkey/api@1.12.1":
+  version "1.12.1"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.12.1.tgz#78dc000911278966e6e652218b71bb50218c5ab2"
+  integrity sha1-eNwACREniWbm5lIhi3G7UCGMWrI=
 
 "@labkey/build@6.1.0":
   version "6.1.0"


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45222

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/835
* https://github.com/LabKey/inventory/pull/433
* https://github.com/LabKey/biologics/pull/1305
* https://github.com/LabKey/sampleManagement/pull/955

#### Changes
* Update editable grid lookup cell width related styling
