### PR TITLE
Limit active users

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.172.0-fb-limit-active-users.1",
+  "version": "2.173.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.171.1",
+  "version": "2.171.1-fb-limit-active-users.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.171.1-fb-limit-active-users.0",
+  "version": "2.171.1-fb-limit-active-users.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.172.0-fb-limit-active-users.0",
+  "version": "2.172.0-fb-limit-active-users.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.171.1-fb-limit-active-users.1",
+  "version": "2.171.1-fb-limit-active-users.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.172.0",
+  "version": "2.172.0-fb-limit-active-users.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD May 2022
+* Item 10386: Active user limit app messaging
+  * Add API to get user limit settings
+  * Display user limit message on User Management page and disable create/reactivate accordingly
+  * Display user limit settings on Admin Settings page
+
 ### version 2.171.1
 *Released*: 13 May 2022
 * Issue 45222: Editable grid doesn't automatically expand width of dropdowns to show long values

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Item 10386: Active user limit app messaging
   * Add API to get user limit settings
   * Display user limit message on User Management page and disable create/reactivate accordingly
+  * Handle user creation with and without limit errors in User Management page alerts
   * Display user limit settings on Admin Settings page
 
 ### version 2.171.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD May 2022
+### version 2.173.0
+*Released*: 19 May 2022
 * Item 10386: Active user limit app messaging
   * Add API to get user limit settings
   * Display user limit message on User Management page and disable create/reactivate accordingly

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -297,6 +297,7 @@ import { GenerateEntityResponse, OperationConfirmationData } from './internal/co
 import { SearchResultCard } from './internal/components/search/SearchResultCard';
 import { SearchResultsPanel } from './internal/components/search/SearchResultsPanel';
 import { SampleFinderSection } from './internal/components/search/SampleFinderSection';
+import { ActiveUserLimit } from './internal/components/settings/ActiveUserLimit';
 import { NameIdSettings } from './internal/components/settings/NameIdSettings';
 import { loadNameExpressionOptions } from './internal/components/settings/actions';
 import { AdministrationSubNav } from './internal/components/administration/AdministrationSubNav';
@@ -1093,6 +1094,7 @@ export {
     searchUsingIndex,
     SampleFinderSection,
     // settings
+    ActiveUserLimit,
     NameIdSettings,
     loadNameExpressionOptions,
     // administration

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -448,7 +448,7 @@ import { ExpandableContainer } from './internal/components/ExpandableContainer';
 import { PermissionAssignments } from './internal/components/permissions/PermissionAssignments';
 import { withPermissionsPage } from './internal/components/permissions/withPermissionsPage';
 import { Principal, SecurityPolicy, SecurityRole } from './internal/components/permissions/models';
-import { fetchContainerSecurityPolicy } from './internal/components/permissions/actions';
+import { fetchContainerSecurityPolicy, getUserLimitSettings } from './internal/components/permissions/actions';
 import {
     extractEntityTypeOptionFromRow,
     getDataDeleteConfirmationData,
@@ -975,6 +975,7 @@ export {
     hasAnyPermissions,
     hasPermissions,
     fetchContainerSecurityPolicy,
+    getUserLimitSettings,
     PermissionAssignments,
     withPermissionsPage,
     SecurityPolicy,

--- a/packages/components/src/internal/components/administration/UserManagement.spec.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.spec.tsx
@@ -15,6 +15,7 @@ import { App, InjectedPermissionsPage } from '../../../index';
 import { TEST_FOLDER_CONTAINER, TEST_PROJECT, TEST_PROJECT_CONTAINER } from '../../../test/data/constants';
 
 import { getNewUserRoles, UserManagementPageImpl } from './UserManagement';
+import { ActiveUserLimitMessage } from '../settings/ActiveUserLimit';
 
 declare const LABKEY: LabKey;
 
@@ -41,6 +42,7 @@ describe('UserManagement', () => {
 
     function validate(wrapper: ReactWrapper, hasNewUserRoles = false, allowResetPassword = true): void {
         expect(wrapper.find(BasePermissionsCheckPage)).toHaveLength(1);
+        expect(wrapper.find(ActiveUserLimitMessage)).toHaveLength(1);
         expect(wrapper.find(UsersGridPanel)).toHaveLength(1);
         expect(wrapper.find(UsersGridPanel).prop('allowResetPassword')).toBe(allowResetPassword);
 
@@ -53,6 +55,7 @@ describe('UserManagement', () => {
             user: App.TEST_USER_APP_ADMIN,
         });
         validate(wrapper);
+        wrapper.unmount();
     });
 
     test('non-inherit security policy', () => {
@@ -61,6 +64,7 @@ describe('UserManagement', () => {
         });
         wrapper.find('UserManagement').setState({ policy: new SecurityPolicy({ resourceId: '1', containerId: '1' }) });
         validate(wrapper, true);
+        wrapper.unmount();
     });
 
     test('inherit security policy', () => {
@@ -69,6 +73,7 @@ describe('UserManagement', () => {
         });
         wrapper.find('UserManagement').setState({ policy: new SecurityPolicy({ resourceId: '1', containerId: '2' }) });
         validate(wrapper);
+        wrapper.unmount();
     });
 
     test('allowResetPassword false', () => {
@@ -77,6 +82,7 @@ describe('UserManagement', () => {
             moduleContext: { api: { AutoRedirectSSOAuthConfiguration: true } },
         });
         validate(wrapper, false, false);
+        wrapper.unmount();
     });
 });
 

--- a/packages/components/src/internal/components/administration/UserManagement.spec.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.spec.tsx
@@ -14,8 +14,9 @@ import { App, InjectedPermissionsPage } from '../../../index';
 
 import { TEST_FOLDER_CONTAINER, TEST_PROJECT, TEST_PROJECT_CONTAINER } from '../../../test/data/constants';
 
-import { getNewUserRoles, UserManagementPageImpl } from './UserManagement';
 import { ActiveUserLimitMessage } from '../settings/ActiveUserLimit';
+
+import { getNewUserRoles, UserManagementPageImpl } from './UserManagement';
 
 declare const LABKEY: LabKey;
 

--- a/packages/components/src/internal/components/administration/UserManagement.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.tsx
@@ -196,10 +196,10 @@ export class UserManagement extends PureComponent<UserManagementProps, State> {
             });
         }
 
-        if (response.errors?.length > 0) {
+        if (response.htmlErrors?.length > 0) {
             createNotification({
                 alertClass: 'danger',
-                message: response.errors.join(' '),
+                message: response.htmlErrors.join(' '),
             });
         }
 

--- a/packages/components/src/internal/components/administration/UserManagement.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.tsx
@@ -26,10 +26,12 @@ import { InjectedPermissionsPage, withPermissionsPage } from '../permissions/wit
 import { AppContext, useAppContext } from '../../AppContext';
 import { SecurityAPIWrapper } from '../security/APIWrapper';
 
+import { ActiveUserLimitMessage } from '../settings/ActiveUserLimit';
+
+import { UserLimitSettings } from '../permissions/actions';
+
 import { isLoginAutoRedirectEnabled, showPremiumFeatures } from './utils';
 import { getUserGridFilterURL, updateSecurityPolicy } from './actions';
-import { ActiveUserLimitMessage } from '../settings/ActiveUserLimit';
-import { UserLimitSettings } from '../permissions/actions';
 
 export function getNewUserRoles(
     user: User,

--- a/packages/components/src/internal/components/administration/UserManagement.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.tsx
@@ -24,11 +24,12 @@ import { useServerContext } from '../base/ServerContext';
 import { InjectedPermissionsPage, withPermissionsPage } from '../permissions/withPermissionsPage';
 
 import { AppContext, useAppContext } from '../../AppContext';
-import { SecurityAPIWrapper, UserLimitSettings } from '../security/APIWrapper';
+import { SecurityAPIWrapper } from '../security/APIWrapper';
 
 import { isLoginAutoRedirectEnabled, showPremiumFeatures } from './utils';
 import { getUserGridFilterURL, updateSecurityPolicy } from './actions';
 import { ActiveUserLimitMessage } from '../settings/ActiveUserLimit';
+import { UserLimitSettings } from '../permissions/actions';
 
 export function getNewUserRoles(
     user: User,
@@ -130,7 +131,7 @@ export class UserManagement extends PureComponent<UserManagementProps, State> {
         }
     };
 
-    onCreateComplete = (response: any, roleUniqueNames: string[]) => {
+    onCreateComplete = (response: any, roleUniqueNames: string[]): void => {
         const { container, project } = this.props;
         this.invalidateGlobal();
 
@@ -194,6 +195,15 @@ export class UserManagement extends PureComponent<UserManagementProps, State> {
                 },
             });
         }
+
+        if (response.errors?.length > 0) {
+            createNotification({
+                alertClass: 'danger',
+                message: response.errors.join(' '),
+            });
+        }
+
+        this.loadUserLimitSettings();
     };
 
     onUsersStateChangeComplete = (response: any) => {

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -1114,6 +1114,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
         "security": ServerSecurityAPIWrapper {
           "fetchContainers": [Function],
           "fetchPolicy": [Function],
+          "getUserLimitSettings": [Function],
         },
       }
     }

--- a/packages/components/src/internal/components/permissions/actions.ts
+++ b/packages/components/src/internal/components/permissions/actions.ts
@@ -4,7 +4,7 @@
  */
 import { List, Map, fromJS } from 'immutable';
 
-import { Filter, Security } from '@labkey/api';
+import { ActionURL, Ajax, Filter, Security, Utils } from '@labkey/api';
 
 import { ISelectRowsResult, selectRowsDeprecated } from '../../..';
 
@@ -121,6 +121,32 @@ export function fetchContainerSecurityPolicy(
                 console.error('Failed to fetch security policy', error);
                 reject(error);
             },
+        });
+    });
+}
+
+export type UserLimitSettings = {
+    activeUsers: number;
+    messageHtml: string;
+    remainingUsers: number;
+    success: boolean;
+    userLimitLevel: number;
+    userLimit: boolean;
+};
+
+export function getUserLimitSettings(): Promise<UserLimitSettings> {
+    return new Promise((resolve, reject) => {
+        Ajax.request({
+            url: ActionURL.buildURL('user', 'getuserLimitSettings.api'),
+            method: 'GET',
+            scope: this,
+            success: Utils.getCallbackWrapper(settings => {
+                resolve(settings as UserLimitSettings);
+            }),
+            failure: Utils.getCallbackWrapper(error => {
+                console.error(error);
+                reject(error);
+            }),
         });
     });
 }

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -1,48 +1,23 @@
-import {ActionURL, Ajax, Security, Utils} from '@labkey/api';
+import { Security } from '@labkey/api';
 import { Map } from 'immutable';
 
 import { Container } from '../base/models/Container';
-import { fetchContainerSecurityPolicy } from '../permissions/actions';
+import { fetchContainerSecurityPolicy, UserLimitSettings, getUserLimitSettings } from '../permissions/actions';
 import { Principal, SecurityPolicy } from '../permissions/models';
 
 export type FetchContainerOptions = Omit<Security.GetContainersOptions, 'success' | 'failure' | 'scope'>;
 
-export type UserLimitSettings = {
-    activeUsers: number;
-    messageHtml: string;
-    remainingUsers: number;
-    success: boolean;
-    userLimitLevel: number;
-    userLimit: boolean;
-};
-
 export interface SecurityAPIWrapper {
-    getUserLimitSettings: () => Promise<UserLimitSettings>;
     fetchContainers: (options: FetchContainerOptions) => Promise<Container[]>;
     fetchPolicy: (
         containerId: string,
         principalsById: Map<number, Principal>,
         inactiveUsersById?: Map<number, Principal>
     ) => Promise<SecurityPolicy>;
+    getUserLimitSettings: () => Promise<UserLimitSettings>;
 }
 
 export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
-    getUserLimitSettings = (): Promise<UserLimitSettings> => {
-        return new Promise((resolve, reject) => {
-            Ajax.request({
-                url: ActionURL.buildURL('user', 'getuserLimitSettings.api'),
-                method: 'GET',
-                scope: this,
-                success: Utils.getCallbackWrapper(settings => {
-                    resolve(settings as UserLimitSettings);
-                }),
-                failure: Utils.getCallbackWrapper(error => {
-                    console.error(error);
-                    reject(error);
-                }),
-            });
-        });
-    };
     fetchContainers = (options: FetchContainerOptions): Promise<Container[]> => {
         return new Promise((resolve, reject) => {
             Security.getContainers({
@@ -58,6 +33,7 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         });
     };
     fetchPolicy = fetchContainerSecurityPolicy;
+    getUserLimitSettings = getUserLimitSettings;
 }
 
 function recurseContainerHierarchy(data: Security.ContainerHierarchy, container: Container): Container[] {
@@ -75,9 +51,9 @@ export function getSecurityTestAPIWrapper(
     overrides: Partial<SecurityAPIWrapper> = {}
 ): SecurityAPIWrapper {
     return {
-        getUserLimitSettings: mockFn(),
         fetchContainers: mockFn(),
         fetchPolicy: mockFn(),
+        getUserLimitSettings: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.spec.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.spec.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { ReactWrapper } from 'enzyme';
+
+import { Alert } from '../base/Alert';
+import { UserLimitSettings } from '../permissions/actions';
+import { mountWithAppServerContext, waitForLifecycle } from '../../testHelpers';
+import { TEST_USER_APP_ADMIN, TEST_USER_FOLDER_ADMIN, TEST_USER_PROJECT_ADMIN } from '../../userFixtures';
+import { getTestAPIWrapper } from '../../APIWrapper';
+
+import {ActiveUserLimit, ActiveUserLimitMessage} from './ActiveUserLimit';
+import {getSecurityTestAPIWrapper} from "../security/APIWrapper";
+
+describe('ActiveUserLimitMessage', () => {
+    test('without message', () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimitMessage settings={{} as UserLimitSettings} />,
+            { api: getTestAPIWrapper(jest.fn) },
+            { user: TEST_USER_APP_ADMIN }
+        );
+        expect(wrapper.find(Alert)).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('with message', () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimitMessage settings={{ messageHtml: 'test' } as UserLimitSettings} />,
+            { api: getTestAPIWrapper(jest.fn) },
+            { user: TEST_USER_APP_ADMIN }
+        );
+        expect(wrapper.find(Alert)).toHaveLength(1);
+        expect(wrapper.find(Alert).text()).toBe('test');
+        wrapper.unmount();
+    });
+
+    test('with html message', () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimitMessage settings={{ messageHtml: '<b>test</b>' } as UserLimitSettings} />,
+            { api: getTestAPIWrapper(jest.fn) },
+            { user: TEST_USER_APP_ADMIN }
+        );
+        expect(wrapper.find(Alert)).toHaveLength(1);
+        expect(wrapper.find(Alert).text()).toBe('test');
+        wrapper.unmount();
+    });
+});
+
+describe('ActiveUserLimit', () => {
+    const USER_LIMIT_ENABLED = {
+        userLimit: true,
+        userLimitLevel: 10,
+        remainingUsers: 1,
+    } as UserLimitSettings;
+    const USER_LIMIT_DISABLED = {
+        userLimit: false,
+        userLimitLevel: 10,
+        remainingUsers: 1,
+    } as UserLimitSettings;
+
+    function validate(wrapper: ReactWrapper, rendered = true, hasError = false): void {
+        const count = rendered ? 1 : 0;
+        expect(wrapper.find('.active-user-limit-panel')).toHaveLength(count);
+        expect(wrapper.find(Alert)).toHaveLength(count);
+        expect(wrapper.find(ActiveUserLimitMessage)).toHaveLength(!hasError ? count : 0);
+        expect(wrapper.find('.active-user-limit-message')).toHaveLength(!hasError ? count : 0);
+    }
+
+    test('with user limit', async () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimit />,
+            {
+                api: getTestAPIWrapper(jest.fn, {
+                    security: getSecurityTestAPIWrapper(jest.fn, {
+                        getUserLimitSettings: jest.fn().mockResolvedValue(USER_LIMIT_ENABLED),
+                    }),
+                }),
+            },
+            { user: TEST_USER_PROJECT_ADMIN }
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper);
+        expect(wrapper.find(Alert).text()).toBe('');
+        expect(wrapper.find('.active-user-limit-message').text()).toBe(
+            'Active user limit is 10. You can add or reactivate 1 more user.'
+        );
+        wrapper.unmount();
+    });
+
+    test('error', async () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimit />,
+            {
+                api: getTestAPIWrapper(jest.fn, {
+                    security: getSecurityTestAPIWrapper(jest.fn, {
+                        getUserLimitSettings: jest.fn().mockRejectedValue('test'),
+                    }),
+                }),
+            },
+            { user: TEST_USER_PROJECT_ADMIN }
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper, true, true);
+        expect(wrapper.find(Alert).text()).toBe('Error: test');
+        wrapper.unmount();
+    });
+
+    test('without add user perm', async () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimit />,
+            {
+                api: getTestAPIWrapper(jest.fn, {
+                    security: getSecurityTestAPIWrapper(jest.fn, {
+                        getUserLimitSettings: jest.fn().mockResolvedValue(USER_LIMIT_ENABLED),
+                    }),
+                }),
+            },
+            { user: TEST_USER_FOLDER_ADMIN }
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper, false);
+        wrapper.unmount();
+    });
+
+    test('with user limit disabled', async () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimit />,
+            {
+                api: getTestAPIWrapper(jest.fn, {
+                    security: getSecurityTestAPIWrapper(jest.fn, {
+                        getUserLimitSettings: jest.fn().mockResolvedValue(USER_LIMIT_DISABLED),
+                    }),
+                }),
+            },
+            { user: TEST_USER_PROJECT_ADMIN }
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper, false);
+        wrapper.unmount();
+    });
+
+    test('without user limit settings', async () => {
+        const wrapper = mountWithAppServerContext(
+            <ActiveUserLimit />,
+            {
+                api: getTestAPIWrapper(jest.fn, {
+                    security: getSecurityTestAPIWrapper(jest.fn, {
+                        getUserLimitSettings: jest.fn().mockResolvedValue(undefined),
+                    }),
+                }),
+            },
+            { user: TEST_USER_PROJECT_ADMIN }
+        );
+        await waitForLifecycle(wrapper);
+        validate(wrapper, false);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.spec.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.spec.tsx
@@ -7,7 +7,7 @@ import { mountWithAppServerContext, waitForLifecycle } from '../../testHelpers';
 import { TEST_USER_APP_ADMIN, TEST_USER_FOLDER_ADMIN, TEST_USER_PROJECT_ADMIN } from '../../userFixtures';
 import { getTestAPIWrapper } from '../../APIWrapper';
 
-import {ActiveUserLimit, ActiveUserLimitMessage} from './ActiveUserLimit';
+import { ActiveUserLimit, ActiveUserLimitMessage } from './ActiveUserLimit';
 import {getSecurityTestAPIWrapper} from "../security/APIWrapper";
 
 describe('ActiveUserLimitMessage', () => {

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
@@ -2,9 +2,9 @@ import React, { FC, memo, useEffect, useState } from 'react';
 
 import { resolveErrorMessage } from '../../util/messaging';
 import { AppContext, useAppContext } from '../../AppContext';
-import { UserLimitSettings } from '../security/APIWrapper';
 import { Alert } from '../base/Alert';
 import { useServerContext } from '../base/ServerContext';
+import { UserLimitSettings } from '../permissions/actions';
 
 const TITLE = 'Active User Limit';
 

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo, useEffect, useState } from 'react';
+import { Utils } from '@labkey/api';
 
 import { resolveErrorMessage } from '../../util/messaging';
 import { AppContext, useAppContext } from '../../AppContext';
@@ -6,7 +7,7 @@ import { Alert } from '../base/Alert';
 import { useServerContext } from '../base/ServerContext';
 import { UserLimitSettings } from '../permissions/actions';
 
-const TITLE = 'Active User Limit';
+const TITLE = 'Active Users';
 
 interface Props {
     titleCls?: string;
@@ -45,9 +46,10 @@ export const ActiveUserLimit: FC<Props> = memo(props => {
                 {settings && (
                     <>
                         <ActiveUserLimitMessage settings={settings} />
-                        <div>Current user count: {settings.activeUsers}</div>
-                        <div>User limit: {settings.userLimitLevel}</div>
-                        <div>Number of users that can be added or reactivated: {settings.remainingUsers}</div>
+                        <div>
+                            Active user limit is {settings.userLimitLevel}. You can add or reactivate{' '}
+                            {Utils.pluralBasic(settings.remainingUsers, 'more user')}.
+                        </div>
                         <br />
                         <div>Contact your LabKey Account Manager to upgrade the number of allowed users.</div>
                     </>

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
@@ -35,7 +35,7 @@ export const ActiveUserLimit: FC<Props> = memo(props => {
     }, [api, user]);
 
     if (!user.hasAddUsersPermission()) return null;
-    if (!error && (!settings || !settings.userLimit)) return null;
+    if (!error && !settings?.userLimit) return null;
 
     return (
         <div className="active-user-limit-panel panel panel-default">

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
@@ -46,7 +46,7 @@ export const ActiveUserLimit: FC<Props> = memo(props => {
                 {settings && (
                     <>
                         <ActiveUserLimitMessage settings={settings} />
-                        <div>
+                        <div className="active-user-limit-message">
                             Active user limit is {settings.userLimitLevel}. You can add or reactivate{' '}
                             {Utils.pluralBasic(settings.remainingUsers, 'more user')}.
                         </div>

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
@@ -1,0 +1,74 @@
+import React, { FC, memo, useEffect, useState } from 'react';
+
+import { resolveErrorMessage } from '../../util/messaging';
+import { AppContext, useAppContext } from '../../AppContext';
+import { UserLimitSettings } from '../security/APIWrapper';
+import { Alert } from '../base/Alert';
+import { useServerContext } from '../base/ServerContext';
+
+const TITLE = 'Active User Limit';
+
+interface Props {
+    titleCls?: string;
+}
+
+export const ActiveUserLimit: FC<Props> = memo(props => {
+    const { titleCls } = props;
+    const [error, setError] = useState<string>();
+    const [settings, setSettings] = useState<UserLimitSettings>();
+    const { user } = useServerContext();
+    const { api } = useAppContext<AppContext>();
+
+    useEffect(() => {
+        if (!user.hasAddUsersPermission()) return;
+
+        setError(undefined);
+        (async () => {
+            try {
+                const limitSettings = await api.security.getUserLimitSettings();
+                setSettings(limitSettings);
+            } catch (e) {
+                setError(`Error: ${resolveErrorMessage(e)}`);
+            }
+        })();
+    }, [api, user]);
+
+    if (!user.hasAddUsersPermission()) return null;
+    if (!error && (!settings || !settings.userLimit)) return null;
+
+    return (
+        <div className="active-user-limit-panel panel panel-default">
+            {!titleCls && <div className="panel-heading">{TITLE}</div>}
+            <div className="panel-body">
+                {titleCls && <h4 className={titleCls}>{TITLE}</h4>}
+                <Alert>{error}</Alert>
+                {settings && (
+                    <>
+                        <ActiveUserLimitMessage settings={settings} />
+                        <div>Current user count: {settings.activeUsers}</div>
+                        <div>User limit: {settings.userLimitLevel}</div>
+                        <div>Number of users that can be added or reactivated: {settings.remainingUsers}</div>
+                        <br />
+                        <div>Contact your LabKey Account Manager to upgrade the number of allowed users.</div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+});
+
+interface ActiveUserLimitMessageProps {
+    settings: UserLimitSettings;
+}
+
+export const ActiveUserLimitMessage: FC<ActiveUserLimitMessageProps> = memo(({ settings }) => {
+    return (
+        <>
+            {settings?.messageHtml && (
+                <Alert bsStyle="warning">
+                    <div dangerouslySetInnerHTML={{ __html: settings.messageHtml }} />
+                </Alert>
+            )}
+        </>
+    );
+});

--- a/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
@@ -18,8 +18,9 @@ import { mount } from 'enzyme';
 
 import { SECURITY_ROLE_AUTHOR, SECURITY_ROLE_EDITOR, SECURITY_ROLE_READER } from '../../../test/data/constants';
 
+import { UserLimitSettings } from '../permissions/actions';
+
 import { CreateUsersModal } from './CreateUsersModal';
-import {UserLimitSettings} from "../permissions/actions";
 
 const ROLE_OPTIONS = [
     { id: SECURITY_ROLE_READER, label: 'Reader (default)' },

--- a/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
@@ -19,6 +19,7 @@ import { mount } from 'enzyme';
 import { SECURITY_ROLE_AUTHOR, SECURITY_ROLE_EDITOR, SECURITY_ROLE_READER } from '../../../test/data/constants';
 
 import { CreateUsersModal } from './CreateUsersModal';
+import {UserLimitSettings} from "../permissions/actions";
 
 const ROLE_OPTIONS = [
     { id: SECURITY_ROLE_READER, label: 'Reader (default)' },
@@ -32,6 +33,7 @@ describe('<CreateUsersModal/>', () => {
 
         const wrapper = mount(component);
         expect(wrapper.find('Alert')).toHaveLength(0);
+        expect(wrapper.find('.create-users-limit-message')).toHaveLength(0);
         expect(wrapper.find('textarea')).toHaveLength(2);
         expect(wrapper.find('textarea#create-users-email-input').props().value).toBe('');
         expect(wrapper.find('textarea#create-users-optionalMessage-input').props().value).toBe('');
@@ -52,6 +54,7 @@ describe('<CreateUsersModal/>', () => {
 
         const wrapper = mount(component);
         expect(wrapper.find('Alert')).toHaveLength(0);
+        expect(wrapper.find('.create-users-limit-message')).toHaveLength(0);
         expect(wrapper.find('textarea')).toHaveLength(2);
         expect(wrapper.find('textarea#create-users-email-input').props().value).toBe('');
         expect(wrapper.find('textarea#create-users-optionalMessage-input').props().value).toBe('');
@@ -82,6 +85,7 @@ describe('<CreateUsersModal/>', () => {
         });
 
         expect(wrapper.find('Alert')).toHaveLength(2);
+        expect(wrapper.find('.create-users-limit-message')).toHaveLength(0);
         expect(wrapper.find('textarea')).toHaveLength(2);
         expect(wrapper.find('textarea#create-users-email-input').props().value).toBe('TestEmailText');
         expect(wrapper.find('textarea#create-users-optionalMessage-input').props().value).toBe('TestOptionalMessage');
@@ -93,6 +97,21 @@ describe('<CreateUsersModal/>', () => {
         expect(wrapper.find('.btn')).toHaveLength(2);
         expect(wrapper.find('.btn-success')).toHaveLength(1);
         expect(wrapper.find('.btn-success').props().disabled).toBe(true);
+        wrapper.unmount();
+    });
+
+    test('with userLimitSettings', () => {
+        const component = (
+            <CreateUsersModal
+                show={true}
+                userLimitSettings={{ userLimit: true, remainingUsers: 2 } as UserLimitSettings}
+                onCancel={jest.fn()}
+                onComplete={jest.fn()}
+            />
+        );
+
+        const wrapper = mount(component);
+        expect(wrapper.find('.create-users-limit-message').text()).toBe('Number of users that can be added: 2');
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -3,7 +3,7 @@ import { Checkbox, FormControl, Modal } from 'react-bootstrap';
 import { Security } from '@labkey/api';
 
 import { WizardNavButtons, Alert, SelectInput } from '../../..';
-import { UserLimitSettings } from '../security/APIWrapper';
+import { UserLimitSettings } from '../permissions/actions';
 
 interface Props {
     onCancel: () => void;

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -113,7 +113,9 @@ export class CreateUsersModal extends React.Component<Props, State> {
                     onChange={this.handleEmail}
                 />
                 {userLimitSettings?.userLimit && (
-                    <div>Number of users that can be added: {userLimitSettings.remainingUsers}</div>
+                    <div className="create-users-limit-message">
+                        Number of users that can be added: {userLimitSettings.remainingUsers}
+                    </div>
                 )}
                 {this.hasRoleOptions() && (
                     <>

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Checkbox, FormControl, Modal } from 'react-bootstrap';
 import { Security } from '@labkey/api';
 
 import { WizardNavButtons, Alert, SelectInput } from '../../..';
+import { UserLimitSettings } from '../security/APIWrapper';
 
 interface Props {
     onCancel: () => void;
     onComplete: (response: any, roles: string[]) => void;
     show: boolean;
+    userLimitSettings?: UserLimitSettings;
 
     // optional array of role options, objects with id and label values (i.e. [{id: "org.labkey.api.security.roles.ReaderRole", label: "Reader (default)"}])
     // note that the createNewUser action will not use this value but it will be passed back to the onComplete
@@ -39,17 +41,17 @@ export class CreateUsersModal extends React.Component<Props, State> {
         this.state = DEFAULT_STATE;
     }
 
-    handleEmail = (evt: any) => {
+    handleEmail = (evt: any): void => {
         const emailText = evt.target.value;
         this.setState(() => ({ emailText }));
     };
 
-    handleOptionalMessage = (evt: any) => {
+    handleOptionalMessage = (evt: any): void => {
         const optionalMessage = evt.target.value;
         this.setState(() => ({ optionalMessage }));
     };
 
-    handleSendEmail = (evt: any) => {
+    handleSendEmail = (evt: any): void => {
         const sendEmail = evt.target.checked;
         this.setState(state => ({
             sendEmail,
@@ -58,12 +60,12 @@ export class CreateUsersModal extends React.Component<Props, State> {
         }));
     };
 
-    handleRoles = (name, formValue, selectedOptions: Array<{ id: string; label: string }>) => {
+    handleRoles = (name, formValue, selectedOptions: Array<{ id: string; label: string }>): void => {
         const roles = selectedOptions ? selectedOptions.map(option => option.id) : undefined;
         this.setState({ roles });
     };
 
-    createUsers = () => {
+    createUsers = (): void => {
         const { emailText, sendEmail, optionalMessage } = this.state;
         this.setState(() => ({ isSubmitting: true, error: undefined }));
 
@@ -93,7 +95,8 @@ export class CreateUsersModal extends React.Component<Props, State> {
         return this.hasRoleOptions() ? this.state.roles || [this.props.roleOptions[0].id] : undefined;
     }
 
-    renderForm() {
+    renderForm(): ReactNode {
+        const { userLimitSettings } = this.props;
         const { emailText, sendEmail, optionalMessage } = this.state;
 
         return (
@@ -109,6 +112,9 @@ export class CreateUsersModal extends React.Component<Props, State> {
                     value={emailText || ''}
                     onChange={this.handleEmail}
                 />
+                {userLimitSettings?.userLimit && (
+                    <div>Number of users that can be added: {userLimitSettings.remainingUsers}</div>
+                )}
                 {this.hasRoleOptions() && (
                     <>
                         <div className="create-users-label-top create-users-label-bottom">Roles:</div>
@@ -150,7 +156,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
         );
     }
 
-    renderButtons() {
+    renderButtons(): ReactNode {
         return (
             <WizardNavButtons
                 containerClassName=""
@@ -164,7 +170,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
         );
     }
 
-    render() {
+    render(): ReactNode {
         const { show, onCancel } = this.props;
         const { error } = this.state;
 

--- a/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { getRolesByUniqueName, processGetRolesResponse } from '../permissions/actions';
+import { getRolesByUniqueName, processGetRolesResponse, UserLimitSettings } from '../permissions/actions';
 import { initQueryGridState } from '../../global';
 import policyJSON from '../../../test/data/security-getPolicy.json';
 import rolesJSON from '../../../test/data/security-getRoles.json';
@@ -28,6 +28,7 @@ import { SCHEMAS } from '../../schemas';
 import { QueryInfo } from '../../../public/QueryInfo';
 
 import { UsersGridPanelImpl } from './UsersGridPanel';
+import {DisableableButton} from "../buttons/DisableableButton";
 
 const POLICY = SecurityPolicy.create(policyJSON);
 const ROLES = processGetRolesResponse(rolesJSON.roles);
@@ -80,7 +81,8 @@ describe('<UsersGridPanel/>', () => {
         expect(wrapper.find('GridPanel')).toHaveLength(1);
         expect(wrapper.find('UserDetailsPanel')).toHaveLength(1);
         expect(wrapper.find('.panel-heading').first().text()).toBe('Active Users');
-        expect(wrapper.find('.btn-success')).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton).prop('disabledMsg')).toBe(undefined);
         expect(wrapper.find('#users-manage-btn-managebtn').hostNodes()).toHaveLength(1);
         wrapper.find('#users-manage-btn-managebtn').hostNodes().simulate('click');
         expect(wrapper.find('a').filterWhere(a => a.text() === 'Deactivate Users')).toHaveLength(1);
@@ -99,7 +101,7 @@ describe('<UsersGridPanel/>', () => {
         expect(wrapper.find('GridPanel')).toHaveLength(1);
         expect(wrapper.find('UserDetailsPanel')).toHaveLength(1);
         expect(wrapper.find('.panel-heading').first().text()).toBe('Active Users');
-        expect(wrapper.find('.btn-success')).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button
         expect(wrapper.find('#users-manage-btn-managebtn').hostNodes()).toHaveLength(1);
         wrapper.find('#users-manage-btn-managebtn').hostNodes().simulate('click');
         expect(wrapper.find('a').filterWhere(a => a.text() === 'Deactivate Users')).toHaveLength(0);
@@ -118,7 +120,7 @@ describe('<UsersGridPanel/>', () => {
         expect(wrapper.find('GridPanel')).toHaveLength(1);
         expect(wrapper.find('UserDetailsPanel')).toHaveLength(1);
         expect(wrapper.find('.panel-heading').first().text()).toBe('Active Users');
-        expect(wrapper.find('.btn-success')).toHaveLength(0); // create button
+        expect(wrapper.find(DisableableButton)).toHaveLength(0); // create button
         expect(wrapper.find('#users-manage-btn-managebtn').hostNodes()).toHaveLength(1);
         wrapper.find('#users-manage-btn-managebtn').hostNodes().simulate('click');
         expect(wrapper.find('a').filterWhere(a => a.text() === 'Deactivate Users')).toHaveLength(0);
@@ -139,7 +141,7 @@ describe('<UsersGridPanel/>', () => {
         expect(wrapper.find('GridPanel')).toHaveLength(1);
         expect(wrapper.find('UserDetailsPanel')).toHaveLength(1);
         expect(wrapper.find('.panel-heading').first().text()).toBe('Inactive Users');
-        expect(wrapper.find('.btn-success')).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button
         expect(wrapper.find('#users-manage-btn-managebtn').hostNodes()).toHaveLength(1);
         wrapper.find('#users-manage-btn-managebtn').hostNodes().simulate('click');
         expect(wrapper.find('a').filterWhere(a => a.text() === 'Deactivate Users')).toHaveLength(0);
@@ -160,7 +162,7 @@ describe('<UsersGridPanel/>', () => {
         expect(wrapper.find('GridPanel')).toHaveLength(1);
         expect(wrapper.find('UserDetailsPanel')).toHaveLength(1);
         expect(wrapper.find('.panel-heading').first().text()).toBe('All Users');
-        expect(wrapper.find('.btn-success')).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button
         expect(wrapper.find('#users-manage-btn-managebtn').hostNodes()).toHaveLength(1);
         wrapper.find('#users-manage-btn-managebtn').hostNodes().simulate('click');
         expect(wrapper.find('a').filterWhere(a => a.text() === 'Deactivate Users')).toHaveLength(0);
@@ -169,6 +171,55 @@ describe('<UsersGridPanel/>', () => {
         expect(wrapper.find('a').filterWhere(a => a.text() === 'View Inactive Users')).toHaveLength(1);
         expect(wrapper.find('a').filterWhere(a => a.text() === 'View Active Users')).toHaveLength(1);
         expect(wrapper.find('a').filterWhere(a => a.text() === 'View All Users')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('active user limit reached', () => {
+        const component = (
+            <UsersGridPanelImpl
+                {...DEFAULT_PROPS}
+                userLimitSettings={{ userLimit: true, remainingUsers: 0 } as UserLimitSettings}
+            />
+        );
+        const wrapper = mount(component);
+        wrapper.setState({ usersView: 'inactive' });
+        expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton).prop('disabledMsg')).toBe('User limit has been reached');
+        wrapper.find('#users-manage-btn-managebtn').hostNodes().simulate('click');
+        const reactivateMenuItem = wrapper.find('#reactivate-users-menu-item');
+        expect(reactivateMenuItem.prop('maxSelection')).toBe(0);
+        expect(reactivateMenuItem.prop('maxSelectionDisabledMsg')).toBe('User limit has been reached');
+        wrapper.unmount();
+    });
+
+    test('active user limit not reached', () => {
+        const component = (
+            <UsersGridPanelImpl
+                {...DEFAULT_PROPS}
+                userLimitSettings={{ userLimit: true, remainingUsers: 2 } as UserLimitSettings}
+            />
+        );
+        const wrapper = mount(component);
+        wrapper.setState({ usersView: 'inactive' });
+        expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton).prop('disabledMsg')).toBe(undefined);
+        wrapper.find('#users-manage-btn-managebtn').hostNodes().simulate('click');
+        const reactivateMenuItem = wrapper.find('#reactivate-users-menu-item');
+        expect(reactivateMenuItem.prop('maxSelection')).toBe(2);
+        expect(reactivateMenuItem.prop('maxSelectionDisabledMsg')).toBe(undefined);
+        wrapper.unmount();
+    });
+
+    test('active user limit disabled', () => {
+        const component = (
+            <UsersGridPanelImpl
+                {...DEFAULT_PROPS}
+                userLimitSettings={{ userLimit: false, remainingUsers: 0 } as UserLimitSettings}
+            />
+        );
+        const wrapper = mount(component);
+        expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button
+        expect(wrapper.find(DisableableButton).prop('disabledMsg')).toBe(undefined);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
@@ -27,8 +27,9 @@ import { makeTestActions, makeTestQueryModel } from '../../../public/QueryModel/
 import { SCHEMAS } from '../../schemas';
 import { QueryInfo } from '../../../public/QueryInfo';
 
+import { DisableableButton } from '../buttons/DisableableButton';
+
 import { UsersGridPanelImpl } from './UsersGridPanel';
-import {DisableableButton} from "../buttons/DisableableButton";
 
 const POLICY = SecurityPolicy.create(policyJSON);
 const ROLES = processGetRolesResponse(rolesJSON.roles);

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -31,11 +31,12 @@ import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 
+import { UserLimitSettings } from '../permissions/actions';
+
 import { UserDeleteConfirmModal } from './UserDeleteConfirmModal';
 import { UserActivateChangeConfirmModal } from './UserActivateChangeConfirmModal';
 import { UserDetailsPanel } from './UserDetailsPanel';
 import { CreateUsersModal } from './CreateUsersModal';
-import { UserLimitSettings } from '../permissions/actions';
 
 const OMITTED_COLUMNS = [
     'phone',

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -35,7 +35,7 @@ import { UserDeleteConfirmModal } from './UserDeleteConfirmModal';
 import { UserActivateChangeConfirmModal } from './UserActivateChangeConfirmModal';
 import { UserDetailsPanel } from './UserDetailsPanel';
 import { CreateUsersModal } from './CreateUsersModal';
-import { UserLimitSettings } from '../security/APIWrapper';
+import { UserLimitSettings } from '../permissions/actions';
 
 const OMITTED_COLUMNS = [
     'phone',


### PR DESCRIPTION
#### Rationale
We want the option for LabKey Server deployments to limit the number of active users. See the spec for details: https://docs.google.com/document/d/15TenwfucW9XNO8OhHB6ibEIIyxPycbB9SqcXtoimcgE/edit#

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/838
* https://github.com/LabKey/platform/pull/3334
* https://github.com/LabKey/biologics/pull/1318
* https://github.com/LabKey/sampleManagement/pull/959

#### Changes
* Add API to get user limit settings
* Display user limit message on User Management page and disable create/reactivate accordingly
* Handle user creation with and without limit errors in User Management page alerts
* Display user limit settings on Admin Settings page
