### PR TITLE
Issue 45451: Grid drop down menu (page size, views) does not retract after selection

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.0",
+  "version": "2.177.0-fb-gridMenus45451.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.0-fb-gridMenus45451.0",
+  "version": "2.177.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.177.1
+*Released*: 31 May 2022
 * Issue 45451: Grid drop down menu (page size, views) does not retract after selection
 
 ### version 2.177.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45451: Issue 45451: Grid drop down menu (page size, views) does not retract after selection
+
 ### version 2.177.0
 *Released*: 27 May 2022
 * Item 10374: Begin adding support for customizing views in our application

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* Issue 45451: Issue 45451: Grid drop down menu (page size, views) does not retract after selection
+* Issue 45451: Grid drop down menu (page size, views) does not retract after selection
 
 ### version 2.177.0
 *Released*: 27 May 2022

--- a/packages/components/src/internal/components/pagination/PageMenu.tsx
+++ b/packages/components/src/internal/components/pagination/PageMenu.tsx
@@ -58,17 +58,14 @@ export class PageMenu extends PureComponent<Props> {
                     <MenuItem header className="submenu-footer">
                         {disabled ? '...' : `${pageCount} Total Pages`}
                     </MenuItem>
-                    {showPageSizeMenu && (
-                        <>
-                            <MenuItem divider />
-                            <MenuItem header>Page Size</MenuItem>
-                            {pageSizes?.map(size => (
-                                <MenuItem key={size} active={size === pageSize} onClick={() => this.setPageSize(size)}>
-                                    {size}
-                                </MenuItem>
-                            ))}
-                        </>
-                    )}
+                    {showPageSizeMenu && <MenuItem divider />}
+                    {showPageSizeMenu && <MenuItem header>Page Size</MenuItem>}
+                    {showPageSizeMenu &&
+                        pageSizes?.map(size => (
+                            <MenuItem key={size} active={size === pageSize} onClick={() => this.setPageSize(size)}>
+                                {size}
+                            </MenuItem>
+                        ))}
                 </DropdownButton>
             </Tip>
         );

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -55,20 +55,12 @@ export class ViewMenu extends PureComponent<ViewMenuProps> {
                     }
                 >
                     {defaultView && viewMapper(defaultView)}
-                    {privateViews.length > 0 && (
-                        <>
-                            <MenuItem divider />
-                            <MenuItem header>My Saved Views</MenuItem>
-                            {privateViews.map(viewMapper)}
-                        </>
-                    )}
-                    {publicViews.length > 0 && (
-                        <>
-                            <MenuItem divider />
-                            <MenuItem header>All Saved Views</MenuItem>
-                            {publicViews.map(viewMapper)}
-                        </>
-                    )}
+                    {privateViews.length > 0 && <MenuItem divider />}
+                    {privateViews.length > 0 && <MenuItem header>My Saved Views</MenuItem>}
+                    {privateViews.length > 0 && privateViews.map(viewMapper)}
+                    {publicViews.length > 0 && <MenuItem divider />}
+                    {publicViews.length > 0 && <MenuItem header>All Saved Views</MenuItem>}
+                    {publicViews.length > 0 && publicViews.map(viewMapper)}
                 </DropdownButton>
             </div>
         );

--- a/packages/components/src/public/QueryModel/__snapshots__/ViewMenu.spec.tsx.snap
+++ b/packages/components/src/public/QueryModel/__snapshots__/ViewMenu.spec.tsx.snap
@@ -100,10 +100,12 @@ exports[`ViewMenu Render 3`] = `
       </li>
       <li
         className="divider"
+        onKeyDown={[Function]}
         role="separator"
       />
       <li
         className="dropdown-header"
+        onKeyDown={[Function]}
         role="heading"
       >
         All Saved Views
@@ -196,10 +198,12 @@ exports[`ViewMenu Render 4`] = `
       </li>
       <li
         className="divider"
+        onKeyDown={[Function]}
         role="separator"
       />
       <li
         className="dropdown-header"
+        onKeyDown={[Function]}
         role="heading"
       >
         My Saved Views
@@ -278,10 +282,12 @@ exports[`ViewMenu Render 5`] = `
       </li>
       <li
         className="divider"
+        onKeyDown={[Function]}
         role="separator"
       />
       <li
         className="dropdown-header"
+        onKeyDown={[Function]}
         role="heading"
       >
         My Saved Views


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45451

When using a react-bootstrap DropdownButton, the MenuItem must be a direct descendant of the DropdownButton in order for it to trigger the onSelect event needed to close the button's menu.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/846
* https://github.com/LabKey/biologics/pull/1338
* https://github.com/LabKey/sampleManagement/pull/969

#### Changes
* remove react fragment between the `DropdownButton` and the `MenuItem`s
