### PR TITLE
Issues 45529 and 45290: Layout adjustments in navbar and for .container width

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.0",
+  "version": "2.177.1-adjustContainerWidth.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.3-adjustContainerWidth.2",
+  "version": "2.177.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.1-adjustContainerWidth.0",
+  "version": "2.177.1-adjustContainerWidth.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 45529: Adjust width of `.container` to use more of the screen
+* Issue 45290: Adjust width of items in NavBar for better display (with lots of notifications) in medium media
 
 ### version 2.177.0
 *Released*: 27 May 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.177.3
+*Released*: 31 May 2022
 * Issue 45529: Adjust width of `.container` to use more of the screen
 * Issue 45290: Adjust width of search box in NavBar for better display (with lots of notifications) in medium media
 * Issue 45290: Use relative positioning for search-icon

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Issue 45529: Adjust width of `.container` to use more of the screen
 * Issue 45290: Adjust width of items in NavBar for better display (with lots of notifications) in medium media
+* Issue 45290: Use relative positioning for search-icon
 
 ### version 2.177.0
 *Released*: 27 May 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45529: Adjust width of `.container` to use more of the screen
+
 ### version 2.177.0
 *Released*: 27 May 2022
 * Item 10374: Begin adding support for customizing views in our application

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -92,7 +92,7 @@ export const NavigationBar: FC<Props> = memo(props => {
                 <nav className="navbar navbar-container test-loc-nav-header">
                     <div className="container">
                         <div className="row">
-                            <div className="navbar-left col-xs-8 col-md-7">
+                            <div className="navbar-left col-xs-8 col-md-6">
                                 <span className="navbar-item pull-left">{brand}</span>
                                 {showFolderMenu && (
                                     <span className="navbar-item">
@@ -105,7 +105,7 @@ export const NavigationBar: FC<Props> = memo(props => {
                                     </span>
                                 )}
                             </div>
-                            <div className="navbar-right col-xs-4 col-md-5">
+                            <div className="navbar-right col-xs-4 col-md-6">
                                 {!!user && (
                                     <div className="navbar-item pull-right">
                                         <UserMenu

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -69,7 +69,7 @@ export const NavigationBar: FC<Props> = memo(props => {
         onFindByIds,
         onSignIn,
         onSignOut,
-        searchPlaceholder,
+        searchPlaceholder = 'Search for samples, assays, ...',
         showFolderMenu,
         showNavMenu,
         showNotifications,
@@ -92,7 +92,7 @@ export const NavigationBar: FC<Props> = memo(props => {
                 <nav className="navbar navbar-container test-loc-nav-header">
                     <div className="container">
                         <div className="row">
-                            <div className="navbar-left col-xs-8 col-md-6">
+                            <div className="navbar-left col-xs-8 col-md-7">
                                 <span className="navbar-item pull-left">{brand}</span>
                                 {showFolderMenu && (
                                     <span className="navbar-item">
@@ -105,7 +105,7 @@ export const NavigationBar: FC<Props> = memo(props => {
                                     </span>
                                 )}
                             </div>
-                            <div className="navbar-right col-xs-4 col-md-6">
+                            <div className="navbar-right col-xs-4 col-md-5">
                                 {!!user && (
                                     <div className="navbar-item pull-right">
                                         <UserMenu

--- a/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
@@ -17,14 +17,14 @@ exports[`<NavigationBar/> default props 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-6"
+            className="navbar-left col-xs-8 col-md-7"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-6"
+            className="navbar-right col-xs-4 col-md-5"
           />
         </div>
       </div>
@@ -50,14 +50,14 @@ exports[`<NavigationBar/> with findByIds 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-6"
+            className="navbar-left col-xs-8 col-md-7"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-6"
+            className="navbar-right col-xs-4 col-md-5"
           >
             <div
               className="navbar-item pull-right"
@@ -81,7 +81,7 @@ exports[`<NavigationBar/> with findByIds 1`] = `
                       <input
                         className="form-control navbar__search-input"
                         onChange={[Function]}
-                        placeholder="Enter Search Terms"
+                        placeholder="Search for samples, assays, ..."
                         size={34}
                         type="text"
                         value=""
@@ -306,14 +306,14 @@ exports[`<NavigationBar/> with search box 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-6"
+            className="navbar-left col-xs-8 col-md-7"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-6"
+            className="navbar-right col-xs-4 col-md-5"
           >
             <div
               className="navbar-item pull-right"
@@ -337,7 +337,7 @@ exports[`<NavigationBar/> with search box 1`] = `
                       <input
                         className="form-control navbar__search-input"
                         onChange={[Function]}
-                        placeholder="Enter Search Terms"
+                        placeholder="Search for samples, assays, ..."
                         size={34}
                         type="text"
                         value=""
@@ -380,14 +380,14 @@ exports[`<NavigationBar/> without search but with findByIds 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-6"
+            className="navbar-left col-xs-8 col-md-7"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-6"
+            className="navbar-right col-xs-4 col-md-5"
           />
         </div>
       </div>

--- a/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/NavigationBar.spec.tsx.snap
@@ -17,14 +17,14 @@ exports[`<NavigationBar/> default props 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-7"
+            className="navbar-left col-xs-8 col-md-6"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-5"
+            className="navbar-right col-xs-4 col-md-6"
           />
         </div>
       </div>
@@ -50,14 +50,14 @@ exports[`<NavigationBar/> with findByIds 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-7"
+            className="navbar-left col-xs-8 col-md-6"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-5"
+            className="navbar-right col-xs-4 col-md-6"
           >
             <div
               className="navbar-item pull-right"
@@ -306,14 +306,14 @@ exports[`<NavigationBar/> with search box 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-7"
+            className="navbar-left col-xs-8 col-md-6"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-5"
+            className="navbar-right col-xs-4 col-md-6"
           >
             <div
               className="navbar-item pull-right"
@@ -380,14 +380,14 @@ exports[`<NavigationBar/> without search but with findByIds 1`] = `
           className="row"
         >
           <div
-            className="navbar-left col-xs-8 col-md-7"
+            className="navbar-left col-xs-8 col-md-6"
           >
             <span
               className="navbar-item pull-left"
             />
           </div>
           <div
-            className="navbar-right col-xs-4 col-md-5"
+            className="navbar-right col-xs-4 col-md-6"
           />
         </div>
       </div>

--- a/packages/components/src/internal/components/search/SearchBox.tsx
+++ b/packages/components/src/internal/components/search/SearchBox.tsx
@@ -43,7 +43,7 @@ export const SearchBox: FC<Props> = memo(props => {
             evt.preventDefault();
             onSearch(searchValue);
 
-            // reset the input value after it is has submitted
+            // reset the input value after it has been submitted
             setSearchValue('');
         },
         [onSearch, searchValue]

--- a/packages/components/src/theme/app/bootstrapXL.scss
+++ b/packages/components/src/theme/app/bootstrapXL.scss
@@ -68,6 +68,10 @@
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
+  .container {
+    width: 95%;
+  }
+
   .visible-sm {
     display: block !important;
   }
@@ -102,6 +106,10 @@
 }
 
 @media (min-width: 992px) and (max-width: 1199px) {
+  .container {
+    width: 95%;
+  }
+
   .visible-md {
     display: block !important;
   }
@@ -136,6 +144,10 @@
 }
 
 @media (min-width: 1200px) {
+  .container {
+    width: 95%;
+  }
+
   .col-lg-3 {
     width: 25%;
   }
@@ -181,7 +193,7 @@
 
 @media (min-width: 1600px) {
   .container {
-    width: 1570px;
+    width: 95%
   }
 
   .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12 {

--- a/packages/components/src/theme/app/bootstrapXL.scss
+++ b/packages/components/src/theme/app/bootstrapXL.scss
@@ -445,7 +445,7 @@
 
 @media (min-width: 2048px) {
   .container {
-    width: 1570px;
+    width: 95%;
   }
 
   .col-xx-1, .col-xx-2, .col-xx-3, .col-xx-4, .col-xx-5, .col-xx-6, .col-xx-7, .col-xx-8, .col-xx-9, .col-xx-10, .col-xx-11, .col-xx-12 {

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -455,7 +455,7 @@ $nav-menu-btn-width: 85px;
   }
 
   .navbar__input-group {
-      width: 300px;
+      width: 245px;
   }
   .navbar__find-and-search-button {
       border-color: $white;

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -439,7 +439,9 @@ $nav-menu-btn-width: 85px;
   height: 34px;
 
   .navbar__search-icon {
-    position: absolute;
+    position: relative;
+    float: left;
+    left: 18px;
     top: 8px;
     margin-left: 5px;
     color: $gray-light;


### PR DESCRIPTION
#### Rationale
[Issue 45529](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45529) - Adjusted all `.container` sizes to be 95% of screen width.
[Issue 45290](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45290)

#### Related Pull Requests
https://github.com/LabKey/sampleManagement/pull/970
https://github.com/LabKey/biologics/pull/1339
https://github.com/LabKey/inventory/pull/441


#### Changes
* Adjust width of `.container` to use more of the screen
* Adjust width of items in NavBar for better display (with lots of notifications) in medium media
* Use relative positioning for search-icon to avoid problems in Safari
