### PR TITLE
Issue 45270: Allow all admins to see the Settings page

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.1-settingsForAllAdmins.1",
+  "version": "2.177.1-settingsForAllAdmins.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.12.1",
+    "@labkey/api": "1.12.2-settingsForAllAdmins.0",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.4-settingsForAllAdmins.3",
+  "version": "2.178.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.12.2-settingsForAllAdmins.0",
+    "@labkey/api": "1.13.0",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.0",
+  "version": "2.177.1-settingsForAllAdmin.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.1-settingsForAllAdmin.0",
+  "version": "2.177.1-settingsForAllAdmins.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.4-settingsForAllAdmins.2",
+  "version": "2.177.4-settingsForAllAdmins.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+* Issue 45270: Show settings page to all admins
+
 ### version 2.177.0
 *Released*: 27 May 2022
 * Item 10374: Begin adding support for customizing views in our application

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
+### version 2.178.0
+*Released*: 31 May 2022
 * Issue 45270: Show settings page to all admins
 
 ### version 2.177.3

--- a/packages/components/src/internal/components/administration/AdministrationSubNav.spec.tsx
+++ b/packages/components/src/internal/components/administration/AdministrationSubNav.spec.tsx
@@ -9,8 +9,8 @@ describe('AdministrationSubNav', () => {
         expect(getAdministrationSubNavTabs(App.TEST_USER_AUTHOR).size).toBe(0);
         expect(getAdministrationSubNavTabs(App.TEST_USER_EDITOR).size).toBe(0);
         expect(getAdministrationSubNavTabs(App.TEST_USER_ASSAY_DESIGNER).size).toBe(0);
-        expect(getAdministrationSubNavTabs(App.TEST_USER_FOLDER_ADMIN).size).toBe(2);
-        expect(getAdministrationSubNavTabs(App.TEST_USER_PROJECT_ADMIN).size).toBe(2);
+        expect(getAdministrationSubNavTabs(App.TEST_USER_FOLDER_ADMIN).size).toBe(3);
+        expect(getAdministrationSubNavTabs(App.TEST_USER_PROJECT_ADMIN).size).toBe(3);
         expect(getAdministrationSubNavTabs(App.TEST_USER_APP_ADMIN).size).toBe(3);
     });
 });

--- a/packages/components/src/internal/components/administration/AdministrationSubNav.tsx
+++ b/packages/components/src/internal/components/administration/AdministrationSubNav.tsx
@@ -18,9 +18,6 @@ export const getAdministrationSubNavTabs = (user: User): List<ITab> => {
     if (user.isAdmin) {
         tabs = tabs.push('Users');
         tabs = tabs.push('Permissions');
-    }
-    // Settings tab to be implemented in story 2 of In-App Admin
-    if (user.isAppAdmin()) {
         tabs = tabs.push('Settings');
     }
 

--- a/packages/components/src/internal/components/administration/BasePermissions.tsx
+++ b/packages/components/src/internal/components/administration/BasePermissions.tsx
@@ -67,17 +67,20 @@ export const BasePermissionsImpl: FC<BasePermissionsImplProps> = memo(props => {
     const loadPolicy = useCallback(async () => {
         setError(undefined);
         setIsDirty(false);
-        setLoadingState(LoadingState.LOADING);
+        if (user.isAppAdmin()) {
+            setLoadingState(LoadingState.LOADING);
 
-        try {
-            const policy_ = await api.security.fetchPolicy(containerId, principalsById, inactiveUsersById);
-            setPolicy(policy_);
-        } catch (e) {
-            setError(resolveErrorMessage(e) ?? 'Failed to load security policy');
+            try {
+                const policy_ = await api.security.fetchPolicy(containerId, principalsById, inactiveUsersById);
+                setPolicy(policy_);
+            }
+            catch (e) {
+                setError(resolveErrorMessage(e) ?? 'Failed to load security policy');
+            }
         }
 
         setLoadingState(LoadingState.LOADED);
-    }, [api.security, containerId, inactiveUsersById, principalsById, setIsDirty]);
+    }, [api.security, containerId, inactiveUsersById, principalsById, setIsDirty, user]);
 
     useEffect(() => {
         loadPolicy();
@@ -130,7 +133,7 @@ export const BasePermissionsImpl: FC<BasePermissionsImplProps> = memo(props => {
         >
             {!loaded && <LoadingSpinner />}
             {!!error && <Alert>{error}</Alert>}
-            {loaded && !error && (
+            {loaded && !error && user.isAppAdmin() && (
                 <PermissionAssignments
                     {...props}
                     {...rolesProps}

--- a/packages/components/src/internal/components/administration/BasePermissions.tsx
+++ b/packages/components/src/internal/components/administration/BasePermissions.tsx
@@ -26,6 +26,7 @@ import { PermissionAssignments } from '../permissions/PermissionAssignments';
 import { AppContext, useAppContext } from '../../AppContext';
 
 import { getUpdatedPolicyRoles, getUpdatedPolicyRolesByUniqueName } from './actions';
+import { getServerContext } from '@labkey/api';
 
 interface OwnProps {
     containerId: string;
@@ -63,11 +64,14 @@ export const BasePermissionsImpl: FC<BasePermissionsImplProps> = memo(props => {
     const { api } = useAppContext<AppContext>();
     const { user } = useServerContext();
     const loaded = !isLoading(loadingState);
+    const isRoot = getServerContext().project.rootId === containerId;
+    const showAssignments = (!isRoot && user.isAdmin) || user.isRootAdmin;
 
     const loadPolicy = useCallback(async () => {
         setError(undefined);
         setIsDirty(false);
-        if (user.isAppAdmin()) {
+
+        if (showAssignments) {
             setLoadingState(LoadingState.LOADING);
 
             try {
@@ -133,7 +137,7 @@ export const BasePermissionsImpl: FC<BasePermissionsImplProps> = memo(props => {
         >
             {!loaded && <LoadingSpinner />}
             {!!error && <Alert>{error}</Alert>}
-            {loaded && !error && user.isAppAdmin() && (
+            {loaded && !error && showAssignments && (
                 <PermissionAssignments
                     {...props}
                     {...rolesProps}

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.12.1":
-  version "1.12.1"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.12.1.tgz#78dc000911278966e6e652218b71bb50218c5ab2"
-  integrity sha1-eNwACREniWbm5lIhi3G7UCGMWrI=
+"@labkey/api@1.12.2-settingsForAllAdmins.0":
+  version "1.12.2-settingsForAllAdmins.0"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.12.2-settingsForAllAdmins.0.tgz#85de831fe6021c3a548cd1ac78750c83b06d1cda"
+  integrity sha1-hd6DH+YCHDpUjNGseHUMg7BtHNo=
 
 "@labkey/build@6.1.3":
   version "6.1.3"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.12.2-settingsForAllAdmins.0":
-  version "1.12.2-settingsForAllAdmins.0"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.12.2-settingsForAllAdmins.0.tgz#85de831fe6021c3a548cd1ac78750c83b06d1cda"
-  integrity sha1-hd6DH+YCHDpUjNGseHUMg7BtHNo=
+"@labkey/api@1.13.0":
+  version "1.13.0"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.13.0.tgz#8cce97cf5e85be67a7adf801877f4449048a2f84"
+  integrity sha1-jM6Xz16FvmenrfgBh39ESQSKL4Q=
 
 "@labkey/build@6.1.3":
   version "6.1.3"


### PR DESCRIPTION
#### Rationale
We currently allow only the AppAdmins to see the Settings page, despite the fact that some of the sections on this page don't require AppAdmin permission.  There also does not seem to be a reason to prevent project and folder admins from updating most of these settings. 

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/971
* https://github.com/LabKey/biologics/pull/1340

#### Changes
* Show Settings tab for all admins
