### PR TITLE
EntityInsertPanel refactor to use QueryModel based EditableGridPanel

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.1",
+  "version": "2.177.1-fb-entityInsertPanelQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.4",
+  "version": "2.179.4-fb-entityInsertPanelQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.3",
+  "version": "2.179.3-fb-entityInsertPanelQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.0-fb-entityInsertPanelQueryModel.0",
+  "version": "2.177.0-fb-entityInsertPanelQueryModel.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.4-fb-entityInsertPanelQueryModel.0",
+  "version": "2.179.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.0",
+  "version": "2.177.0-fb-entityInsertPanelQueryModel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* EntityInsertPanel refactor to use QueryModel based EditableGridPanel
+
 ### version 2.177.0
 *Released*: 27 May 2022
 * Item 10374: Begin adding support for customizing views in our application

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.179.5
+*Released*: 10 June May 2022
 * EntityInsertPanel refactor to use QueryModel based EditableGridPanel
 
 ### version 2.179.4

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -157,22 +157,18 @@ import { EditorModel, getStateModelId, getStateQueryGridModel } from './internal
 import {
     clearSelected,
     createQueryConfigFilteredBySample,
-    createQueryGridModelFilteredBySample,
     getSelected,
     getSelectedData,
     getSelection,
     getSnapshotSelections,
     gridIdInvalidate,
-    gridInit,
     gridInvalidate,
-    gridShowError,
     incrementClientSideMetricCount,
     queryGridInvalidate,
     replaceSelected,
     schemaGridInvalidate,
     setSelected,
     setSnapshotSelections,
-    unselectAll,
 } from './internal/actions';
 import { cancelEvent } from './internal/events';
 import {
@@ -863,12 +859,9 @@ export {
     getSelectedData,
     getSelection,
     getQueryModelExportParams,
-    gridInit,
-    gridShowError,
     replaceSelected,
     setSelected,
     setSnapshotSelections,
-    unselectAll,
     // query related items
     InsertRowsResponse,
     InsertFormats,
@@ -1048,7 +1041,6 @@ export {
     fetchSamples,
     getSampleSet,
     getSampleTypeDetails,
-    createQueryGridModelFilteredBySample,
     createQueryConfigFilteredBySample,
     getFieldLookupFromSelection,
     getSelectedItemSamples,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -470,9 +470,9 @@ function bindSearch(searchTerm: string): List<Filter.IFilter> {
 export interface ExportOptions {
     columns?: string;
     filters?: List<Filter.IFilter>;
-    sorts?: string;
-    showRows?: 'ALL' | 'SELECTED' | 'UNSELECTED';
     selectionKey?: string;
+    showRows?: 'ALL' | 'SELECTED' | 'UNSELECTED';
+    sorts?: string;
 }
 
 export function getExportParams(
@@ -1423,7 +1423,7 @@ async function prepareInsertRowDataFromBulkForm(
     insertColumns: List<QueryColumn>,
     rowData: List<any>,
     colMin = 0
-): Promise<{ values: List<List<ValueDescriptor>>; messages: List<CellMessage> }> {
+): Promise<{ messages: List<CellMessage>; values: List<List<ValueDescriptor>> }> {
     let values = List<List<ValueDescriptor>>();
     let messages = List<CellMessage>();
 
@@ -1613,13 +1613,13 @@ type IParsePastePayload = {
 };
 
 type IPasteModel = {
-    message?: string;
     coordinates: {
         colMax: number;
         colMin: number;
         rowMax: number;
         rowMin: number;
     };
+    message?: string;
     payload: IParsePastePayload;
     rowsToAdd: number;
     success: boolean;
@@ -1810,8 +1810,8 @@ interface GridData {
 }
 
 export interface EditorModelUpdates {
-    editorModelChanges?: Partial<EditorModelProps>;
     data?: Map<any, Map<string, any>>;
+    editorModelChanges?: Partial<EditorModelProps>;
     queryInfo?: QueryInfo;
 }
 
@@ -2264,7 +2264,7 @@ export async function updateGridFromBulkForm(
 async function prepareUpdateRowDataFromBulkForm(
     queryInfo: QueryInfo,
     rowData: OrderedMap<string, any>
-): Promise<{ values: OrderedMap<number, List<ValueDescriptor>>; messages: OrderedMap<number, CellMessage> }> {
+): Promise<{ messages: OrderedMap<number, CellMessage>; values: OrderedMap<number, List<ValueDescriptor>> }> {
     const columns = queryInfo.getInsertColumns();
     let values = OrderedMap<number, List<ValueDescriptor>>();
     let messages = OrderedMap<number, CellMessage>();

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -886,13 +886,13 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     };
 
     getInsertColumns = (): List<QueryColumn> => {
-        const { dataModel } = this.state;
-        let columns: List<QueryColumn> = dataModel.queryInfo
+        const { queryInfo } = this.state.dataModel;
+        let columns: List<QueryColumn> = queryInfo
             .getInsertColumns()
             .filter(col => col.derivationDataScope !== DERIVATION_DATA_SCOPE_CHILD_ONLY)
             .toList();
         // we add the UniqueId columns, which will be displayed as read-only fields
-        columns = columns.concat(dataModel.queryInfo.getUniqueIdColumns()).toList();
+        columns = columns.concat(queryInfo.getUniqueIdColumns()).toList();
         return columns;
     };
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -84,6 +84,8 @@ import { SampleStatusLegend } from '../samples/SampleStatusLegend';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
+import { applyEditableGridChangesToModels } from '../editable/utils';
+
 import {
     EntityDataType,
     EntityIdCreationModel,
@@ -104,7 +106,6 @@ import {
     EditorModelUpdatesWithParents,
 } from './EntityParentTypeSelectors';
 import { ENTITY_CREATION_METRIC } from './constants';
-import { applyEditableGridChangesToModels } from '../editable/utils';
 
 const ENTITY_GRID_ID = 'entity-insert-grid-data';
 const ALIQUOT_FIELD_COLS = ['aliquotedfrom', 'name', 'description', 'samplestate'];
@@ -158,21 +159,21 @@ const initEditableGridModel = async (
 
 interface OwnProps {
     acceptedFormats?: string;
+    afterEntityCreation?: (entityTypeName, filter, entityCount, actionStr, transactionAuditId?, response?) => void;
+    allowedNonDomainFields?: string[];
     api?: ComponentsAPIWrapper;
     asyncSize?: number; // the file size cutoff to enable async import. If undefined, async is not supported
     auditBehavior?: AuditBehaviorTypes;
-    afterEntityCreation?: (entityTypeName, filter, entityCount, actionStr, transactionAuditId?, response?) => void;
-    allowedNonDomainFields?: string[];
     canEditEntityTypeDetails?: boolean;
     combineParentTypes?: boolean; // Puts all parent types in one parent button. Name on the button will be the first parent type listed
     creationTypeOptions?: SampleCreationTypeModel[];
     disableMerge?: boolean;
     entityDataType: EntityDataType;
     errorNounPlural?: string; // Used if you want a different noun in error messages than on the other components
-    fileSizeLimits?: Map<string, FileSizeLimitProps>;
-    getFileTemplateUrl?: (queryInfo: QueryInfo, importAliases: Record<string, string>) => string;
     fileImportParameters?: Record<string, any>;
     filePreviewFormats?: string;
+    fileSizeLimits?: Map<string, FileSizeLimitProps>;
+    getFileTemplateUrl?: (queryInfo: QueryInfo, importAliases: Record<string, string>) => string;
     hideParentEntityButtons?: boolean; // Used if you have an initial parent but don't want to enable ability to change it
     importHelpLinkNode: ReactNode;
     importOnly?: boolean;
@@ -191,39 +192,39 @@ interface OwnProps {
     onTargetChange?: (target: string) => void;
     parentDataTypes?: List<EntityDataType>;
     saveToPipeline?: boolean;
-    selectedTarget?: string; // controlling target from a parent component
     selectedParents?: string[];
+    selectedTarget?: string; // controlling target from a parent component
 }
 
 interface FromLocationProps {
     creationType?: SampleCreationType;
+    isItemSamples?: boolean;
     numPerParent?: number;
     parents?: string[];
     selectionKey?: string;
     tab?: number;
     target?: any;
     user?: User;
-    isItemSamples?: boolean;
 }
 
 type Props = FromLocationProps & OwnProps & WithFormStepsProps;
 
 interface StateProps {
+    allowUserSpecifiedNames: boolean;
+    creationType: SampleCreationType;
+    dataModel: QueryModel;
+    editorModel: EditorModel;
     error: ReactNode;
+    fieldsWarningMsg: ReactNode;
     file: File;
+    importAliases: Record<string, string>;
     insertModel: EntityIdCreationModel;
     isMerge: boolean;
     isSubmitting: boolean;
-    originalQueryInfo: QueryInfo;
-    importAliases: Record<string, string>;
-    useAsync: boolean;
-    fieldsWarningMsg: ReactNode;
-    creationType: SampleCreationType;
-    allowUserSpecifiedNames: boolean;
     previewName: string;
     previewAliquotName: string;
-    dataModel: QueryModel;
-    editorModel: EditorModel;
+    originalQueryInfo: QueryInfo;
+    useAsync: boolean;
 }
 
 enum EntityInsertPanelTabs {

--- a/packages/components/src/internal/components/entities/EntityParentTypeSelectors.tsx
+++ b/packages/components/src/internal/components/entities/EntityParentTypeSelectors.tsx
@@ -10,10 +10,12 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { addColumns, changeColumn, removeColumn, EditorModelUpdates } from '../../actions';
 
+import { QueryModel } from '../../../public/QueryModel/QueryModel';
+
+import { EditorModel } from '../../models';
+
 import { EntityDataType, EntityParentType, getParentEntities, getParentOptions, IParentOption } from './models';
 import { getEntityDescription } from './utils';
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
-import { EditorModel } from '../../models';
 
 // exported for jest testing
 export const getAddEntityButtonTitle = (
@@ -39,10 +41,10 @@ export const getUpdatedEntityParentType = (
     parent: IParentOption,
     targetSchema: string
 ): {
-    updatedEntityParents: Map<string, List<EntityParentType>>;
     column: QueryColumn;
     existingParent: EntityParentType;
     parentColumnName: string;
+    updatedEntityParents: Map<string, List<EntityParentType>>;
 } => {
     let column;
     let parentColumnName;
@@ -205,9 +207,9 @@ export const addEntityParentType = (
 
 interface AddEntityButtonProps {
     entityDataType: EntityDataType;
-    parentOptions: List<IParentOption>;
     entityParents: List<EntityParentType>;
     onAdd: (queryName: string) => void;
+    parentOptions: List<IParentOption>;
 }
 
 // exported for jest testing
@@ -240,13 +242,13 @@ export const EntityParentTypeAddEntityButton: FC<AddEntityButtonProps> = memo(pr
 EntityParentTypeAddEntityButton.displayName = 'EntityParentTypeAddEntityButton';
 
 interface Props {
-    parentDataTypes: List<EntityDataType>;
-    parentOptionsMap: Map<string, List<IParentOption>>;
-    entityParentsMap: Map<string, List<EntityParentType>>;
     combineParentTypes: boolean;
+    entityParentsMap: Map<string, List<EntityParentType>>;
     onAdd: (queryName: string) => void;
     onChange: (index: number, queryName: string, fieldName: string, formValue: any, parent: IParentOption) => void;
     onRemove: (index: number, queryName: string) => void;
+    parentDataTypes: List<EntityDataType>;
+    parentOptionsMap: Map<string, List<IParentOption>>;
 }
 
 export const EntityParentTypeSelectors: FC<Props> = memo(props => {

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -5,7 +5,6 @@ import {
     buildURL,
     caseInsensitive,
     getFilterForSampleOperation,
-    getQueryGridModel,
     getSelected,
     importData,
     InsertOptions,
@@ -218,31 +217,19 @@ async function initParents(
 
     if (selectionKey) {
         const { schemaQuery } = SchemaQuery.parseSelectionKey(selectionKey);
-        const queryGridModel = getQueryGridModel(selectionKey);
+        const selectionResponse = await getSelected(selectionKey);
 
-        if (queryGridModel?.selectedLoaded) {
-            const filterArray = [Filter.create('RowId', queryGridModel.selectedIds.toArray(), Filter.Types.IN)];
-            const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
-            if (opFilter) {
-                filterArray.push(opFilter);
-            }
-
-            return getSelectedParents(schemaQuery, filterArray, isAliquotParent);
-        } else {
-            const selectionResponse = await getSelected(selectionKey);
-
-            if (isItemSamples) {
-                return getSelectedSampleParentsFromItems(selectionResponse.selected, isAliquotParent);
-            }
-
-            const filterArray = [Filter.create('RowId', selectionResponse.selected, Filter.Types.IN)];
-            const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
-            if (opFilter) {
-                filterArray.push(opFilter);
-            }
-
-            return getSelectedParents(schemaQuery, filterArray, isAliquotParent);
+        if (isItemSamples) {
+            return getSelectedSampleParentsFromItems(selectionResponse.selected, isAliquotParent);
         }
+
+        const filterArray = [Filter.create('RowId', selectionResponse.selected, Filter.Types.IN)];
+        const opFilter = getFilterForSampleOperation(SampleOperation.EditLineage);
+        if (opFilter) {
+            filterArray.push(opFilter);
+        }
+
+        return getSelectedParents(schemaQuery, filterArray, isAliquotParent);
     } else if (initialParents?.length > 0) {
         const [parent] = initialParents;
         const [schema, query, value] = parent.toLowerCase().split(':');

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -169,9 +169,9 @@ export class EntityParentType extends Record({
 
 // represents a chosen entity type (e.g., Sample Set 1)
 export interface IEntityTypeOption extends SelectInputOption {
+    entityDataType: EntityDataType;
     lsid: string;
     rowId: number;
-    entityDataType: EntityDataType;
 }
 
 export class EntityTypeOption implements IEntityTypeOption {
@@ -193,10 +193,10 @@ export class EntityTypeOption implements IEntityTypeOption {
 
 // represents an entity type (e.g., Sample Type 1) and the values chosen of that type (e.g., S-1, S-2)
 export interface EntityChoice {
-    type: IEntityTypeOption;
-    ids: string[]; // LSIDs or RowIds
-    value: string; // String with comma-separated values (e.g., "S-1,S-2") for use with QuerySelect multi-select)
     gridValues?: DisplayObject[]; // array of RowId/DisplayValue DisplayObjects for use with EditableGrid
+    ids: string[]; // LSIDs or RowIds
+    type: IEntityTypeOption;
+    value: string; // String with comma-separated values (e.g., "S-1,S-2") for use with QuerySelect multi-select)
 }
 
 export interface MaterialOutput {
@@ -217,8 +217,8 @@ export class GenerateEntityResponse extends Record({
     success: false,
 }) {
     declare data: {
-        materialOutputs: MaterialOutput[];
         [key: string]: any;
+        materialOutputs: MaterialOutput[];
     };
     declare message: string;
     declare success: boolean;
@@ -403,7 +403,11 @@ export class EntityIdCreationModel extends Record({
         return entityTypeName ? SchemaQuery.create(this.entityDataType.instanceSchemaName, entityTypeName) : undefined;
     }
 
-    postEntityGrid(dataModel: QueryModel, editorModel: EditorModel, extraColumnsToInclude?: QueryColumn[]): Promise<InsertRowsResponse> {
+    postEntityGrid(
+        dataModel: QueryModel,
+        editorModel: EditorModel,
+        extraColumnsToInclude?: QueryColumn[]
+    ): Promise<InsertRowsResponse> {
         const rows = editorModel
             .getRawDataFromGridData(fromJS(dataModel.rows), fromJS(dataModel.orderedRows), dataModel.queryInfo, false)
             .valueSeq()
@@ -569,7 +573,7 @@ export class OperationConfirmationData {
 
     readonly allowed: any[];
     readonly notAllowed: any[];
-    readonly idMap: { key: number; isAllowed: boolean };
+    readonly idMap: { isAllowed: boolean; key: number };
 
     constructor(values?: Partial<OperationConfirmationData>) {
         Object.assign(this, values);

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 import { AuditBehaviorTypes, Filter, Query, Utils } from '@labkey/api';
-import { List, Map, OrderedMap, Record } from 'immutable';
+import { fromJS, List, Map, OrderedMap, Record } from 'immutable';
 
 import { immerable } from 'immer';
 
-import { getEditorModel } from '../../global';
-import { gridShowError } from '../../actions';
 import {
     capitalizeFirstChar,
     caseInsensitive,
+    EditorModel,
     generateId,
     insertRows,
     InsertRowsResponse,
     QueryColumn,
-    QueryGridModel,
     QueryInfo,
+    QueryModel,
     SampleCreationType,
     SchemaQuery,
     SCHEMAS,
@@ -404,17 +403,9 @@ export class EntityIdCreationModel extends Record({
         return entityTypeName ? SchemaQuery.create(this.entityDataType.instanceSchemaName, entityTypeName) : undefined;
     }
 
-    postEntityGrid(queryGridModel: QueryGridModel, extraColumnsToInclude?: QueryColumn[]): Promise<InsertRowsResponse> {
-        const editorModel = getEditorModel(queryGridModel.getId());
-        if (!editorModel) {
-            gridShowError(queryGridModel, {
-                message: 'Grid does not expose an editor. Ensure the grid is properly initialized for editing.',
-            });
-            return;
-        }
-
+    postEntityGrid(dataModel: QueryModel, editorModel: EditorModel, extraColumnsToInclude?: QueryColumn[]): Promise<InsertRowsResponse> {
         const rows = editorModel
-            .getRawData(queryGridModel, false)
+            .getRawDataFromGridData(fromJS(dataModel.rows), fromJS(dataModel.orderedRows), dataModel.queryInfo, false)
             .valueSeq()
             .reduce((rows, row) => {
                 let map = row.toMap();

--- a/packages/components/src/internal/models.spec.ts
+++ b/packages/components/src/internal/models.spec.ts
@@ -16,7 +16,7 @@
 import { fromJS, List, Map, Set } from 'immutable';
 
 import sampleSet2QueryInfo from '../test/data/sampleSet2-getQueryDetails.json';
-import { QueryInfo, QueryGridModel, SchemaQuery, QueryColumn } from '..';
+import { QueryInfo, SchemaQuery, QueryColumn, makeTestQueryModel } from '..';
 
 import { CellMessage, EditorModel, getPkData, ValueDescriptor } from './models';
 import { resetQueryGridState } from './global';
@@ -99,17 +99,11 @@ describe('EditorModel', () => {
                 selectionCells: [],
             };
             const editorModel = new EditorModel(emptyEditorGridData);
-            const emptyQueryGridModel = new QueryGridModel({
-                schema: schemaQ.schemaName,
-                query: schemaQ.queryName,
-                id: 'insert-samples|samples/sample set 2',
-                queryInfo: QueryInfo.fromJSON(sampleSet2QueryInfo),
-                editable: true,
-            });
-            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(emptyQueryGridModel, 'Name');
+            const emptyDataModel = makeTestQueryModel(schemaQ, QueryInfo.fromJSON(sampleSet2QueryInfo), {}, [], 0);
+            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(emptyDataModel, 'Name');
             expect(uniqueKeyViolations.isEmpty()).toBe(true);
             expect(missingRequired.isEmpty()).toBe(true);
-            const errors = editorModel.getValidationErrors(emptyQueryGridModel, 'Name');
+            const errors = editorModel.getValidationErrors(emptyDataModel, 'Name');
             expect(errors).toHaveLength(0);
         });
 
@@ -168,26 +162,22 @@ describe('EditorModel', () => {
                 selectionCells: [],
             };
             const editorModel = new EditorModel(editableGridData);
-            const queryGridModel = new QueryGridModel({
-                schema: schemaQ.schemaName,
-                query: schemaQ.queryName,
-                id: 'insert-samples|samples/sample set 2',
-                queryInfo: QueryInfo.fromJSON(sampleSet2QueryInfo),
-                editable: true,
-                data: Map<any, Map<string, any>>({
-                    '1': Map<string, any>({
+            const dataModel = makeTestQueryModel(
+                schemaQ,
+                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                {
+                    '1': {
                         RequiredData: 'Grid Requirement 1',
-                    }),
-                    '2': Map<string, any>({
+                    },
+                    '2': {
                         Description: 'grid S-2 Description',
-                    }),
-                }),
-                dataIds: List<any>(['1']),
-            });
-            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(queryGridModel, 'Name');
+                    },
+                },
+                ['1']);
+            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(dataModel, 'Name');
             expect(uniqueKeyViolations.isEmpty()).toBe(true);
             expect(missingRequired.isEmpty()).toBe(true);
-            const errors = editorModel.getValidationErrors(queryGridModel, 'Name');
+            const errors = editorModel.getValidationErrors(dataModel, 'Name');
             expect(errors).toHaveLength(0);
         });
 
@@ -246,26 +236,23 @@ describe('EditorModel', () => {
                 selectionCells: [],
             };
             const editorModel = new EditorModel(editableGridData);
-            const queryGridModel = new QueryGridModel({
-                schema: schemaQ.schemaName,
-                query: schemaQ.queryName,
-                id: 'insert-samples|samples/sample set 2',
-                queryInfo: QueryInfo.fromJSON(sampleSet2QueryInfo),
-                editable: true,
-                data: Map<any, Map<string, any>>({
-                    '1': Map<string, any>({
+            const dataModel = makeTestQueryModel(
+                schemaQ,
+                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                {
+                    '1': {
                         Description: 'grid S-1 Description',
-                    }),
-                    '2': Map<string, any>({
+                    },
+                    '2': {
                         Description: 'grid S-2 Description',
-                    }),
-                    '3': Map<string, any>({
+                    },
+                    '3': {
                         Description: 'grid S-3 Description',
-                    }),
-                }),
-                dataIds: List<any>(['1', '2', '3']),
-            });
-            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(queryGridModel, 'Name');
+                    },
+                },
+                ['1', '2', '3']
+            );
+            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(dataModel, 'Name');
             expect(uniqueKeyViolations.isEmpty()).toBe(true);
             expect(missingRequired.size).toBe(2);
             expect(missingRequired.has('Name')).toBe(true);
@@ -274,7 +261,7 @@ describe('EditorModel', () => {
             expect(missingRequired.get('Name').contains(3)).toBe(true);
             expect(missingRequired.get('Required Data').contains(2)).toBe(true); // Check whitespace trimmed
             expect(missingRequired.get('Required Data').contains(3)).toBe(false); // Check integer
-            const errors = editorModel.getValidationErrors(queryGridModel, 'Name');
+            const errors = editorModel.getValidationErrors(dataModel, 'Name');
             expect(errors).toHaveLength(1);
         });
 
@@ -381,22 +368,19 @@ describe('EditorModel', () => {
                 selectionCells: [],
             };
             const editorModel = new EditorModel(editableGridData);
-            const queryGridModel = new QueryGridModel({
-                schema: schemaQ.schemaName,
-                query: schemaQ.queryName,
-                id: 'insert-samples|samples/sample set 2',
-                queryInfo: QueryInfo.fromJSON(sampleSet2QueryInfo),
-                editable: true,
-                data: Map<any, Map<string, any>>({
-                    '1': Map<string, any>(),
-                    '2': Map<string, any>(),
-                    '3': Map<string, any>(),
-                    '4': Map<string, any>(),
-                    '5': Map<string, any>(),
-                }),
-                dataIds: List<any>(['1', '2', '3', '4', '5']),
-            });
-            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(queryGridModel, 'Name');
+            const dataModel = makeTestQueryModel(
+                schemaQ,
+                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                {
+                    '1': {},
+                    '2': {},
+                    '3': {},
+                    '4': {},
+                    '5': {},
+                },
+                ['1', '2', '3', '4', '5']
+            );
+            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(dataModel, 'Name');
             expect(missingRequired.isEmpty()).toBe(true);
             expect(uniqueKeyViolations.size).toBe(1);
             expect(uniqueKeyViolations.has('Name')).toBe(true);
@@ -405,19 +389,19 @@ describe('EditorModel', () => {
             expect(uniqueKeyViolations.get('Name').get('s-2')).toEqual(List<number>([1, 2]));
             expect(uniqueKeyViolations.get('Name').has('s-4')).toBe(true);
             expect(uniqueKeyViolations.get('Name').get('s-4')).toEqual(List<number>([4, 5]));
-            const errors = editorModel.getValidationErrors(queryGridModel, 'Name');
+            const errors = editorModel.getValidationErrors(dataModel, 'Name');
             expect(errors).toHaveLength(2);
             expect(errors[0].indexOf('Duplicate')).toBeGreaterThanOrEqual(0);
             expect(errors[1].indexOf('Duplicate')).toBeGreaterThanOrEqual(0);
 
-            const ciUniqueKeyViolations = editorModel.validateData(queryGridModel, 'Description').uniqueKeyViolations;
+            const ciUniqueKeyViolations = editorModel.validateData(dataModel, 'Description').uniqueKeyViolations;
             // Check whitespace trimmed when detecting duplicates
             expect(ciUniqueKeyViolations.get('Description').has('spacedupe')).toBe(true);
             expect(ciUniqueKeyViolations.get('Description').get('spacedupe')).toEqual(List<number>([2, 3]));
             // check case insensitivity when detecting duplicates
             expect(ciUniqueKeyViolations.get('Description').has('caseinsensitive')).toBe(true);
             expect(ciUniqueKeyViolations.get('Description').get('caseinsensitive')).toEqual(List<number>([4, 5]));
-            const ciErrors = editorModel.getValidationErrors(queryGridModel, 'Description');
+            const ciErrors = editorModel.getValidationErrors(dataModel, 'Description');
             expect(ciErrors[0].indexOf('Duplicate')).toBeGreaterThanOrEqual(0);
             expect(ciErrors[1].indexOf('Duplicate')).toBeGreaterThanOrEqual(0);
         });
@@ -491,22 +475,19 @@ describe('EditorModel', () => {
                 selectionCells: [],
             };
             const editorModel = new EditorModel(editableGridData);
-            const queryGridModel = new QueryGridModel({
-                schema: schemaQ.schemaName,
-                query: schemaQ.queryName,
-                id: 'insert-samples|samples/sample set 2',
-                queryInfo: QueryInfo.fromJSON(sampleSet2QueryInfo),
-                editable: true,
-                data: Map<any, Map<string, any>>({
-                    '1': Map<string, any>(),
-                    '2': Map<string, any>(),
-                    '3': Map<string, any>(),
-                    '4': Map<string, any>(),
-                    '5': Map<string, any>(),
-                }),
-                dataIds: List<any>(['1', '2', '3', '4', '5']),
-            });
-            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(queryGridModel, 'Name');
+            const dataModel = makeTestQueryModel(
+                schemaQ,
+                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                {
+                    '1': {},
+                    '2': {},
+                    '3': {},
+                    '4': {},
+                    '5': {},
+                },
+                ['1', '2', '3', '4', '5']
+            );
+            const { uniqueKeyViolations, missingRequired } = editorModel.validateData(dataModel, 'Name');
             expect(missingRequired.size).toBe(2);
             expect(missingRequired.has('Name')).toBe(true);
             expect(missingRequired.get('Name').size).toBe(1);
@@ -522,7 +503,7 @@ describe('EditorModel', () => {
             expect(uniqueKeyViolations.get('Name').get('s-2')).toEqual(List<number>([1, 2]));
             expect(uniqueKeyViolations.get('Name').has('s-4')).toBe(true);
             expect(uniqueKeyViolations.get('Name').get('s-4')).toEqual(List<number>([4, 5]));
-            const errors = editorModel.getValidationErrors(queryGridModel, 'Name');
+            const errors = editorModel.getValidationErrors(dataModel, 'Name');
             expect(errors).toHaveLength(3);
         });
 

--- a/packages/components/src/internal/models.spec.ts
+++ b/packages/components/src/internal/models.spec.ts
@@ -173,7 +173,8 @@ describe('EditorModel', () => {
                         Description: 'grid S-2 Description',
                     },
                 },
-                ['1']);
+                ['1']
+            );
             const { uniqueKeyViolations, missingRequired } = editorModel.validateData(dataModel, 'Name');
             expect(uniqueKeyViolations.isEmpty()).toBe(true);
             expect(missingRequired.isEmpty()).toBe(true);

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -149,10 +149,10 @@ export interface IDataViewInfo {
 }
 
 export interface DataViewClientMetadata extends IDataViewInfo {
+    error?: any;
+    isLoaded?: boolean;
     // The attributes here are all specific to the DataViewInfo class and are not useful as part of IDataViewInfo
     isLoading?: boolean;
-    isLoaded?: boolean;
-    error?: any;
 }
 
 const DataViewInfoDefaultValues = {
@@ -297,10 +297,10 @@ export interface EditorModelProps {
     cellMessages: CellMessages;
     cellValues: CellValues;
     colCount: number;
-    id: string;
     focusColIdx: number;
     focusRowIdx: number;
     focusValue: List<ValueDescriptor>;
+    id: string;
     rowCount: number;
     selectedColIdx: number;
     selectedRowIdx: number;
@@ -505,8 +505,8 @@ export class EditorModel
         queryModel: QueryModel,
         uniqueFieldKey?: string
     ): {
-        uniqueKeyViolations: Map<string, Map<string, List<number>>>; // map from the column captions (joined by ,) to a map from values that are duplicates to row numbers.
         missingRequired: Map<string, List<number>>; // map from column caption to row numbers with missing values
+        uniqueKeyViolations: Map<string, Map<string, List<number>>>; // map from the column captions (joined by ,) to a map from values that are duplicates to row numbers.
     } {
         const data = fromJS(queryModel.rows);
         const columns = queryModel.queryInfo.getInsertColumns();

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -208,6 +208,7 @@ $table-cell-selection-bg-color: #EDF3FF;
 
   & > tbody > tr.grid-empty > td {
       height: 30px;
+      padding: 0 4px;
   }
 
   & > tbody > tr > td {


### PR DESCRIPTION
#### Rationale
This is the final component usages of the QueryGridModel to be refactored. This PR updates the EntityInsertPanel component to store the dataModel (QueryModel) and editorModel (EditorModel) in state within the component instead of using the global state and QueryGridModel implementation.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/849
* https://github.com/LabKey/inventory/pull/443
* https://github.com/LabKey/biologics/pull/1341
* https://github.com/LabKey/sampleManagement/pull/972
