### PR TITLE
Fix issue 44707

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.1",
+  "version": "2.177.2-fb-issue-47707.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.177.2-fb-issue-47707.0",
+  "version": "2.177.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.177.2
+*Released*: 31 May 2022
+* Issue 44707
+  * Don't override background-color or text shadow in print styles
+
 ### version 2.177.1
 *Released*: 31 May 2022
 * Issue 45451: Grid drop down menu (page size, views) does not retract after selection

--- a/packages/components/src/theme/app/bootstrap.scss
+++ b/packages/components/src/theme/app/bootstrap.scss
@@ -7,7 +7,8 @@
 
 // Reset and dependencies
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/normalize";
-@import "~bootstrap-sass/assets/stylesheets/bootstrap/print";
+@import "print";
+//@import "~bootstrap-sass/assets/stylesheets/bootstrap/print";
 //@import "~bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
 
 // Core CSS

--- a/packages/components/src/theme/app/print.scss
+++ b/packages/components/src/theme/app/print.scss
@@ -14,10 +14,7 @@
     *,
     *:before,
     *:after {
-        text-shadow: none !important;
-        background: transparent !important;
         box-shadow: none !important;
-        print-color-adjust: exact;
     }
 
     a,

--- a/packages/components/src/theme/app/print.scss
+++ b/packages/components/src/theme/app/print.scss
@@ -1,0 +1,104 @@
+/*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
+
+// ==========================================================================
+// Print styles.
+// Inlined to avoid the additional HTTP request: h5bp.com/r
+// ==========================================================================
+
+// ==========================================================================
+// This file is a slightly modified version of the bootstrap print file
+// See Issue 44707
+// ==========================================================================
+
+@media print {
+    *,
+    *:before,
+    *:after {
+        text-shadow: none !important;
+        background: transparent !important;
+        box-shadow: none !important;
+        print-color-adjust: exact;
+    }
+
+    a,
+    a:visited {
+        text-decoration: underline;
+    }
+
+    a[href]:after {
+        content: " (" attr(href) ")";
+    }
+
+    abbr[title]:after {
+        content: " (" attr(title) ")";
+    }
+
+    // Don't show links that are fragment identifiers,
+    // or use the `javascript:` pseudo protocol
+    a[href^="#"]:after,
+    a[href^="javascript:"]:after {
+        content: "";
+    }
+
+    pre,
+    blockquote {
+        border: 1px solid #999;
+        page-break-inside: avoid;
+    }
+
+    thead {
+        display: table-header-group; // h5bp.com/t
+    }
+
+    tr,
+    img {
+        page-break-inside: avoid;
+    }
+
+    img {
+        max-width: 100% !important;
+    }
+
+    p,
+    h2,
+    h3 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    h2,
+    h3 {
+        page-break-after: avoid;
+    }
+
+    // Bootstrap specific changes start
+
+    // Bootstrap components
+    .navbar {
+        display: none;
+    }
+    .btn,
+    .dropup > .btn {
+        > .caret {
+            border-top-color: #000 !important;
+        }
+    }
+    .label {
+        border: 1px solid #000;
+    }
+
+    .table {
+        border-collapse: collapse !important;
+
+        td,
+        th {
+            background-color: #fff !important;
+        }
+    }
+    .table-bordered {
+        th,
+        td {
+            border: 1px solid #ddd !important;
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
Our component app styles don't override the default print style provided by bootstrap (unlike our theme styles), which results in colors being removed during print view. This causes issues for us during ELN PDF export.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/189
* https://github.com/LabKey/biologics/pull/1342
* https://github.com/LabKey/sampleManagement/pull/973

#### Changes
* Override default bootstrap print styles
