### PR TITLE
Item 10373: GridPanel updates to show sorts and filters saved with the view

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.178.0-fb-savedViewSortsFilters.0",
+  "version": "2.178.0-fb-savedViewSortsFilters.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.178.0-fb-savedViewSortsFilters.1",
+  "version": "2.178.0-fb-savedViewSortsFilters.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.5",
+  "version": "2.179.5-fb-savedViewSortsFilters.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.178.0",
+  "version": "2.178.0-fb-savedViewSortsFilters.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.5-fb-savedViewSortsFilters.1",
+  "version": "2.179.5-fb-savedViewSortsFilters.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.5-fb-savedViewSortsFilters.2",
+  "version": "2.179.5-fb-savedViewSortsFilters.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.5-fb-savedViewSortsFilters.3",
+  "version": "2.180.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.5-fb-savedViewSortsFilters.0",
+  "version": "2.179.5-fb-savedViewSortsFilters.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.1-fb-savedViewSortsFilters.0",
+  "version": "2.179.1-fb-savedViewSortsFilters.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.1",
+  "version": "2.179.1-fb-savedViewSortsFilters.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.178.0-fb-savedViewSortsFilters.2",
+  "version": "2.178.0-fb-savedViewSortsFilters.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.178.0-fb-savedViewSortsFilters.3",
+  "version": "2.178.0-fb-savedViewSortsFilters.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.180.0
+*Released*: 13 June May 2022
 * Item 10373: GridPanel updates to show sorts and filters saved with the view
   * Show saved view filters in the grid panel filter display section
   * Show saved view sorts in the grid column header icons

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Item 10373: GridPanel updates to show sorts and filters saved with the view
+  * Show saved view filters in the grid panel filter display section
+  * Show saved view sorts in the grid column header icons
+  * Allow for saved view sorts and filters to be updated/remove alongside the user-defined sorts/filters
+
 ### version 2.178.0
 *Released*: 31 May 2022
 * Issue 45270: Show settings page to all admins

--- a/packages/components/src/internal/ViewInfo.spec.ts
+++ b/packages/components/src/internal/ViewInfo.spec.ts
@@ -1,4 +1,5 @@
 import { List } from 'immutable';
+
 import { ViewInfo } from './ViewInfo';
 
 describe('ViewInfo', () => {

--- a/packages/components/src/internal/ViewInfo.spec.ts
+++ b/packages/components/src/internal/ViewInfo.spec.ts
@@ -1,0 +1,48 @@
+import { List } from 'immutable';
+import { ViewInfo } from './ViewInfo';
+
+describe('ViewInfo', () => {
+    test('create', () => {
+        let view = ViewInfo.create({ name: 'test', label: 'Testing' });
+        expect(view.name).toBe('test');
+        expect(view.label).toBe('Testing');
+
+        view = ViewInfo.create({ name: 'test', label: 'Testing', default: true });
+        expect(view.name).toBe(ViewInfo.DEFAULT_NAME);
+        expect(view.label).toBe('Default');
+
+        view = ViewInfo.create({ default: true });
+        expect(view.name).toBe(ViewInfo.DEFAULT_NAME);
+        expect(view.label).toBe('Default');
+    });
+
+    test('serialize', () => {
+        let view = ViewInfo.create({ name: 'test' });
+        expect(ViewInfo.serialize(view).name).toBe('test');
+        view = ViewInfo.create({ name: ViewInfo.DEFAULT_NAME });
+        expect(ViewInfo.serialize(view).name).toBe('');
+
+        const filterObj = { fieldKey: 'test', value: 'val', op: 'contains' };
+        view = ViewInfo.create({ filter: [filterObj] });
+        expect(ViewInfo.serialize(view).filters).toBe(undefined);
+        expect(ViewInfo.serialize(view).filter).toStrictEqual(List([filterObj]));
+
+        const sortObj = { fieldKey: 'test', dir: '+' };
+        view = ViewInfo.create({ sort: [sortObj] });
+        expect(ViewInfo.serialize(view).sorts).toBe(undefined);
+        expect(ViewInfo.serialize(view).sort).toStrictEqual(List([sortObj]));
+    });
+
+    test('isVisible', () => {
+        let view = ViewInfo.create({ default: false, hidden: false, name: 'test' });
+        expect(view.isVisible).toBeTruthy();
+        view = ViewInfo.create({ default: true, hidden: false, name: 'test' });
+        expect(view.isVisible).toBeFalsy();
+        view = ViewInfo.create({ default: false, hidden: true, name: 'test' });
+        expect(view.isVisible).toBeFalsy();
+        view = ViewInfo.create({ default: false, hidden: false, name: '~~DETAILS~~' });
+        expect(view.isVisible).toBeFalsy();
+        view = ViewInfo.create({ default: false, hidden: false, name: ViewInfo.BIO_DETAIL_NAME });
+        expect(view.isVisible).toBeFalsy();
+    });
+});

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -119,7 +119,7 @@ export class ViewInfo extends Record({
         json.filter = viewInfo.filters.map(filter => {
             return {
                 fieldKey: filter.getColumnName(),
-                value: filter.getValue(),
+                value: filter.getURLParameterValue(),
                 op: filter.getFilterType().getURLSuffix(),
             };
         });

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -109,6 +109,29 @@ export class ViewInfo extends Record({
         );
     }
 
+    static serialize(viewInfo: ViewInfo): any {
+        const json = viewInfo.toJS();
+
+        json.filter = viewInfo.filters.map(filter => {
+            return {
+                fieldKey: filter.getColumnName(),
+                value: filter.getValue(),
+                op: filter.getFilterType().getURLSuffix(),
+            };
+        });
+        delete json.filters;
+
+        json.sort = viewInfo.sorts.map(sort => {
+            return {
+                fieldKey: sort.fieldKey,
+                dir: sort.dir,
+            };
+        });
+        delete json.sorts;
+
+        return json;
+    }
+
     get isVisible(): boolean {
         // Issue 42628: Hide Biologics details view override in view menu
         return (

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -112,6 +112,10 @@ export class ViewInfo extends Record({
     static serialize(viewInfo: ViewInfo): any {
         const json = viewInfo.toJS();
 
+        if (json.name === this.DEFAULT_NAME) {
+            json.name = '';
+        }
+
         json.filter = viewInfo.filters.map(filter => {
             return {
                 fieldKey: filter.getColumnName(),

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -10,8 +10,8 @@ function getFiltersFromView(rawViewInfo): List<Filter.IFilter> {
     if (rawViewInfo && rawViewInfo.filter) {
         const rawFilters: Array<{
             fieldKey: string;
-            value: any;
             op: string;
+            value: any;
         }> = rawViewInfo.filter;
 
         for (let i = 0; i < rawFilters.length; i++) {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2529,32 +2529,27 @@ export function incrementClientSideMetricCount(featureArea: string, metricName: 
     });
 }
 
-export function saveAsSessionView(
-    schemaQuery: SchemaQuery,
-    columns: any,
-    containerPath: string,
-    name: string,
-    hidden: boolean
-): Promise<void> {
-    return saveGridView(schemaQuery, columns, containerPath, name, true, hidden);
+export function saveAsSessionView(schemaQuery: SchemaQuery, containerPath: string, viewInfo: ViewInfo): Promise<void> {
+    // See DataRegion.js _updateSessionCustomView(), this set of hard coded booleans matches that set
+    return saveGridView(schemaQuery, containerPath, viewInfo, true, true, false, false, false);
 }
 
 export function saveGridView(
     schemaQuery: SchemaQuery,
     containerPath: string,
-    name: string,
-    session?: boolean,
-    hidden?: boolean,
-    inherit?: boolean,
-    replace = true,
-    shared?: boolean
+    viewInfo: ViewInfo,
+    replace: boolean,
+    session: boolean,
+    hidden: boolean,
+    inherit: boolean,
+    shared: boolean
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         Query.saveQueryViews({
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             containerPath,
-            views: [{ name, columns, session, inherit, replace, shared, hidden }],
+            views: [{ ...ViewInfo.serialize(viewInfo), replace, session, hidden, inherit, shared }],
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);
                 resolve();

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2374,7 +2374,7 @@ export function incrementClientSideMetricCount(featureArea: string, metricName: 
 
 export function saveAsSessionView(schemaQuery: SchemaQuery, containerPath: string, viewInfo: ViewInfo): Promise<void> {
     // See DataRegion.js _updateSessionCustomView(), this set of hard coded booleans matches that set
-    return saveGridView(schemaQuery, containerPath, viewInfo, true, true, false, false, false);
+    return saveGridView(schemaQuery, containerPath, viewInfo, true, true, false, false);
 }
 
 export function saveGridView(
@@ -2383,7 +2383,6 @@ export function saveGridView(
     viewInfo: ViewInfo,
     replace: boolean,
     session: boolean,
-    hidden: boolean, // TODO is this every not false?
     inherit: boolean,
     shared: boolean
 ): Promise<void> {
@@ -2392,7 +2391,7 @@ export function saveGridView(
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             containerPath,
-            views: [{ ...ViewInfo.serialize(viewInfo), replace, session, hidden, inherit, shared }],
+            views: [{ ...ViewInfo.serialize(viewInfo), replace, session, inherit, shared, hidden: false }],
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);
                 resolve();
@@ -2413,7 +2412,6 @@ export function saveSessionView(
     newName: string,
     inherit?: boolean,
     shared?: boolean,
-    hidden?: boolean,
     replace?: boolean
 ): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -2425,7 +2423,7 @@ export function saveSessionView(
             newName,
             inherit,
             shared,
-            hidden,
+            hidden: false,
             replace,
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2540,7 +2540,7 @@ export function saveGridView(
     viewInfo: ViewInfo,
     replace: boolean,
     session: boolean,
-    hidden: boolean,
+    hidden: boolean, // TODO is this every not false?
     inherit: boolean,
     shared: boolean
 ): Promise<void> {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -32,6 +32,7 @@ import {
     QueryInfo,
     resolveKey,
     SchemaQuery,
+    ViewInfo,
 } from '..';
 
 import { getQueryDetails, selectRowsDeprecated } from './query/api';
@@ -2530,16 +2531,16 @@ export function incrementClientSideMetricCount(featureArea: string, metricName: 
 
 export function saveSessionGridView(
     schemaQuery: SchemaQuery,
-    columns: any,
     containerPath: string,
-    name: string
+    viewInfo: ViewInfo
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         Query.saveQueryViews({
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             containerPath,
-            views: [{ name, columns, session: true }],
+            // See DataRegion.js _updateSessionCustomView(), this set of hard coded booleans matches that set
+            views: [{ ...ViewInfo.serialize(viewInfo), shared: false, inherit: false, session: true }],
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);
                 resolve();

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -20,19 +20,20 @@ import { FieldFilter } from './models';
 import { isChooseValuesFilter } from './utils';
 
 enum FieldFilterTabs {
-    Filter = 'Filter',
     ChooseValues = 'ChooseValues',
+    Filter = 'Filter',
 }
 
 const DEFAULT_VIEW_NAME = ''; // always use default view for selection, if none provided
 const CHOOSE_VALUES_TAB_KEY = 'Choose values';
 
 interface Props {
-    asRow?: boolean;
     api?: ComponentsAPIWrapper;
+    asRow?: boolean;
     emptyMsg?: string;
     entityDataType?: EntityDataType; // used for Sample Finder use case
     fieldKey?: string;
+    filterTypesToExclude?: string[];
     filters: { [key: string]: FieldFilter[] };
     fullWidth?: boolean;
     metricFeatureArea?: string;
@@ -42,7 +43,6 @@ interface Props {
     skipDefaultViewCheck?: boolean;
     validFilterField?: (field: QueryColumn, queryInfo: QueryInfo, exprColumnsWithSubSelect?: string[]) => boolean;
     viewName?: string;
-    filterTypesToExclude?: string[];
 }
 
 export const QueryFilterPanel: FC<Props> = memo(props => {

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -264,7 +264,6 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                                     column: activeFieldKey,
                                                     schemaName: queryInfo.schemaName,
                                                     queryName,
-                                                    viewName,
                                                     filterArray: fieldDistinctValueFilters,
                                                 }}
                                                 fieldFilters={currentFieldFilters?.map(filter => filter.filter)}

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -12,12 +12,13 @@ import { SchemaQuery } from '../public/SchemaQuery';
 
 import { QuerySort } from '../public/QuerySort';
 
+import { QueryInfo } from '../public/QueryInfo';
+
 import { HeaderCellDropdown, isFilterColumnNameMatch } from './renderers';
 import { GridColumn } from './components/base/models/GridColumn';
 import { LabelHelpTip } from './components/base/LabelHelpTip';
 import { CustomToggle } from './components/base/CustomToggle';
 import { ViewInfo } from './ViewInfo';
-import { QueryInfo } from '../public/QueryInfo';
 
 describe('isFilterColumnNameMatch', () => {
     const filter = Filter.create('Column', 'Value');
@@ -260,7 +261,7 @@ describe('HeaderCellDropdown', () => {
     test('isSortAsc via view sort', () => {
         const sortObj = { fieldKey: 'column', dir: '+' };
         const view = ViewInfo.create({ sort: [sortObj] });
-        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
             sorts: [],
@@ -306,7 +307,7 @@ describe('HeaderCellDropdown', () => {
     test('isSortDesc via view sort', () => {
         const sortObj = { fieldKey: 'column', dir: '-' };
         const view = ViewInfo.create({ sort: [sortObj] });
-        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
             sorts: [],
@@ -346,7 +347,7 @@ describe('HeaderCellDropdown', () => {
     test('view filter', () => {
         const filterObj = { fieldKey: 'column', value: 'val', op: 'contains' };
         const view = ViewInfo.create({ filter: [filterObj] });
-        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
             filterArray: [],
@@ -365,12 +366,10 @@ describe('HeaderCellDropdown', () => {
     test('multiple colFilters, one being a view filter', () => {
         const filterObj = { fieldKey: 'column', value: 'val', op: 'contains' };
         const view = ViewInfo.create({ filter: [filterObj] });
-        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
-            filterArray: [
-                Filter.create('column', 'value', Filter.Types.EQUALS),
-            ],
+            filterArray: [Filter.create('column', 'value', Filter.Types.EQUALS)],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
         validate(wrapper, 1, 6);

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import { mount, ReactWrapper } from 'enzyme';
+import { fromJS } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { QueryColumn } from '../public/QueryColumn';
@@ -15,6 +16,8 @@ import { HeaderCellDropdown, isFilterColumnNameMatch } from './renderers';
 import { GridColumn } from './components/base/models/GridColumn';
 import { LabelHelpTip } from './components/base/LabelHelpTip';
 import { CustomToggle } from './components/base/CustomToggle';
+import { ViewInfo } from './ViewInfo';
+import { QueryInfo } from '../public/QueryInfo';
 
 describe('isFilterColumnNameMatch', () => {
     const filter = Filter.create('Column', 'Value');
@@ -254,9 +257,59 @@ describe('HeaderCellDropdown', () => {
         wrapper.unmount();
     });
 
+    test('isSortAsc via view sort', () => {
+        const sortObj = { fieldKey: 'column', dir: '+' };
+        const view = ViewInfo.create({ sort: [sortObj] });
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+
+        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+            sorts: [],
+        });
+        const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
+        validate(wrapper, 1, 6);
+        expect(wrapper.find('.fa-filter')).toHaveLength(1);
+        expect(wrapper.find('.fa-sort-amount-asc')).toHaveLength(2);
+        expect(wrapper.find('.fa-sort-amount-desc')).toHaveLength(1);
+        const sortAscItem = wrapper.find(MenuItem).at(3);
+        expect(sortAscItem.text()).toContain('Sort ascending');
+        expect(sortAscItem.prop('disabled')).toBe(true);
+        const sortDescItem = wrapper.find(MenuItem).at(4);
+        expect(sortDescItem.text()).toContain('Sort descending');
+        expect(sortDescItem.prop('disabled')).toBe(false);
+        const clearSortItem = wrapper.find(MenuItem).at(5);
+        expect(clearSortItem.text()).toContain('Clear sort');
+        expect(clearSortItem.prop('disabled')).toBe(false);
+        wrapper.unmount();
+    });
+
     test('isSortDesc', () => {
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
             sorts: [new QuerySort({ fieldKey: 'column', dir: '-' })],
+        });
+        const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
+        validate(wrapper, 1, 6);
+        expect(wrapper.find('.fa-filter')).toHaveLength(1);
+        expect(wrapper.find('.fa-sort-amount-asc')).toHaveLength(1);
+        expect(wrapper.find('.fa-sort-amount-desc')).toHaveLength(2);
+        const sortAscItem = wrapper.find(MenuItem).at(3);
+        expect(sortAscItem.text()).toContain('Sort ascending');
+        expect(sortAscItem.prop('disabled')).toBe(false);
+        const sortDescItem = wrapper.find(MenuItem).at(4);
+        expect(sortDescItem.text()).toContain('Sort descending');
+        expect(sortDescItem.prop('disabled')).toBe(true);
+        const clearSortItem = wrapper.find(MenuItem).at(5);
+        expect(clearSortItem.text()).toContain('Clear sort');
+        expect(clearSortItem.prop('disabled')).toBe(false);
+        wrapper.unmount();
+    });
+
+    test('isSortDesc via view sort', () => {
+        const sortObj = { fieldKey: 'column', dir: '-' };
+        const view = ViewInfo.create({ sort: [sortObj] });
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+
+        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+            sorts: [],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
         validate(wrapper, 1, 6);
@@ -290,11 +343,33 @@ describe('HeaderCellDropdown', () => {
         wrapper.unmount();
     });
 
-    test('multiple colFilters', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+    test('view filter', () => {
+        const filterObj = { fieldKey: 'column', value: 'val', op: 'contains' };
+        const view = ViewInfo.create({ filter: [filterObj] });
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+
+        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+            filterArray: [],
+        });
+        const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
+        validate(wrapper, 1, 6);
+        expect(wrapper.find('.fa-filter')).toHaveLength(2);
+        expect(wrapper.find('.fa-sort-amount-asc')).toHaveLength(1);
+        expect(wrapper.find('.fa-sort-amount-desc')).toHaveLength(1);
+        const removeFilterItem = wrapper.find(MenuItem).at(1);
+        expect(removeFilterItem.text()).toBe('  Remove filter');
+        expect(removeFilterItem.prop('disabled')).toBe(false);
+        wrapper.unmount();
+    });
+
+    test('multiple colFilters, one being a view filter', () => {
+        const filterObj = { fieldKey: 'column', value: 'val', op: 'contains' };
+        const view = ViewInfo.create({ filter: [filterObj] });
+        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view })});
+
+        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
             filterArray: [
                 Filter.create('column', 'value', Filter.Types.EQUALS),
-                Filter.create('column', 'value', Filter.Types.ISBLANK),
             ],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -31,15 +31,15 @@ export function isFilterColumnNameMatch(filter: Filter.IFilter, col: QueryColumn
 }
 
 interface HeaderCellDropdownProps {
-    i: number;
     column: GridColumn;
-    selectable?: boolean;
     columnCount?: number;
-    handleSort?: (column: QueryColumn, dir?: string) => void;
     handleFilter?: (column: QueryColumn, remove?: boolean) => void;
     handleHideColumn?: (column: QueryColumn) => void;
+    handleSort?: (column: QueryColumn, dir?: string) => void;
     headerClickCount?: number;
+    i: number;
     model?: QueryModel;
+    selectable?: boolean;
 }
 
 // exported for jest testing

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -19,9 +19,10 @@ import sampleSetQueryInfo from '../test/data/sampleSet-getQueryDetails.json';
 import sampleSet3QueryColumn from '../test/data/SampleSet3Parent-QueryColumn.json';
 import nameExpSetQueryColumn from '../test/data/NameExprParent-QueryColumn.json';
 
+import { ViewInfo } from '../internal/ViewInfo';
+
 import { QueryInfo } from './QueryInfo';
 import { QueryColumn } from './QueryColumn';
-import { ViewInfo } from '../internal/ViewInfo';
 
 describe('getColumnFieldKeys', () => {
     test('missing params', () => {

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -242,7 +242,7 @@ describe('QueryInfo', () => {
 
         expect(queryInfo.getView(undefined)?.name).toBe(undefined);
         expect(queryInfo.getView(undefined, true)?.name).toBe('default');
-        expect(queryInfo.getView('')?.name).toBe(undefined);
+        expect(queryInfo.getView('')?.name).toBe('default');
         expect(queryInfo.getView('', true)?.name).toBe('default');
 
         expect(queryInfo.getView('bogus')?.name).toBe(undefined);

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List, OrderedMap } from 'immutable';
+import { fromJS, List, OrderedMap } from 'immutable';
 
 import sampleSetQueryInfo from '../test/data/sampleSet-getQueryDetails.json';
 import sampleSet3QueryColumn from '../test/data/SampleSet3Parent-QueryColumn.json';
@@ -21,6 +21,7 @@ import nameExpSetQueryColumn from '../test/data/NameExprParent-QueryColumn.json'
 
 import { QueryInfo } from './QueryInfo';
 import { QueryColumn } from './QueryColumn';
+import { ViewInfo } from '../internal/ViewInfo';
 
 describe('getColumnFieldKeys', () => {
     test('missing params', () => {
@@ -227,5 +228,46 @@ describe('QueryInfo', () => {
             expect((qi.set('insertUrlDisabled', true) as QueryInfo).getShowInsertNewButton()).toBe(false);
             expect((qi.set('showInsertNewButton', false) as QueryInfo).getShowInsertNewButton()).toBe(false);
         });
+    });
+
+    describe('getView', () => {
+        let queryInfo = QueryInfo.create({
+            views: fromJS({
+                [ViewInfo.DEFAULT_NAME.toLowerCase()]: ViewInfo.create({ name: 'default' }),
+                [ViewInfo.DETAIL_NAME.toLowerCase()]: ViewInfo.create({ name: 'detail' }),
+                view1: ViewInfo.create({ name: 'view1' }),
+                view2: ViewInfo.create({ name: 'view2' }),
+            }),
+        });
+
+        expect(queryInfo.getView(undefined)?.name).toBe(undefined);
+        expect(queryInfo.getView(undefined, true)?.name).toBe('default');
+        expect(queryInfo.getView('')?.name).toBe(undefined);
+        expect(queryInfo.getView('', true)?.name).toBe('default');
+
+        expect(queryInfo.getView('bogus')?.name).toBe(undefined);
+        expect(queryInfo.getView('bogus', false)?.name).toBe(undefined);
+        expect(queryInfo.getView('bogus', true)?.name).toBe('default');
+
+        expect(queryInfo.getView('view1')?.name).toBe('view1');
+        expect(queryInfo.getView('view2')?.name).toBe('view2');
+        expect(queryInfo.getView('view2', true)?.name).toBe('view2');
+
+        expect(queryInfo.getView(ViewInfo.DEFAULT_NAME)?.name).toBe('default');
+        expect(queryInfo.getView('~~default~~')?.name).toBe('default');
+
+        expect(queryInfo.getView(ViewInfo.DETAIL_NAME)?.name).toBe('detail');
+        expect(queryInfo.getView('~~details~~')?.name).toBe('detail');
+
+        queryInfo = QueryInfo.create({
+            views: fromJS({
+                [ViewInfo.DEFAULT_NAME.toLowerCase()]: ViewInfo.create({ name: 'default' }),
+                [ViewInfo.DETAIL_NAME.toLowerCase()]: ViewInfo.create({ name: 'detail' }),
+                [ViewInfo.BIO_DETAIL_NAME.toLowerCase()]: ViewInfo.create({ name: 'LKB detail' }),
+            }),
+        });
+        expect(queryInfo.getView(ViewInfo.BIO_DETAIL_NAME)?.name).toBe('LKB detail');
+        expect(queryInfo.getView(ViewInfo.DETAIL_NAME)?.name).toBe('LKB detail');
+        expect(queryInfo.getView('~~details~~')?.name).toBe('LKB detail');
     });
 });

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -332,19 +332,23 @@ export class QueryInfo extends Record({
             .toArray();
     }
 
-    getView(view: string): ViewInfo {
-        const _view = view.toLowerCase();
+    getView(viewName: string, defaultToDefault = false): ViewInfo {
+        if (viewName) {
+            const _viewName = viewName.toLowerCase();
 
-        // see if there is a specific detail view override
-        if (_view === ViewInfo.DETAIL_NAME.toLowerCase()) {
-            const details = this.views.get(ViewInfo.BIO_DETAIL_NAME.toLowerCase());
-
-            if (details) {
-                return details;
+            // see if there is a specific detail view override
+            if (_viewName === ViewInfo.DETAIL_NAME.toLowerCase()) {
+                const details = this.views.get(ViewInfo.BIO_DETAIL_NAME.toLowerCase());
+                if (details) {
+                    return details;
+                }
             }
+
+            const view = this.views.get(_viewName);
+            if (view) return view;
         }
 
-        return this.views.get(_view);
+        return defaultToDefault ? this.views.get(ViewInfo.DEFAULT_NAME.toLowerCase()) : undefined;
     }
 
     /**

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -333,9 +333,10 @@ export class QueryInfo extends Record({
     }
 
     getView(viewName: string, defaultToDefault = false): ViewInfo {
-        if (viewName) {
-            const _viewName = viewName.toLowerCase();
+        let _viewName = viewName?.toLowerCase();
+        if (_viewName === '') _viewName = ViewInfo.DEFAULT_NAME.toLowerCase();
 
+        if (_viewName) {
             // see if there is a specific detail view override
             if (_viewName === ViewInfo.DETAIL_NAME.toLowerCase()) {
                 const details = this.views.get(ViewInfo.BIO_DETAIL_NAME.toLowerCase());

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -295,7 +295,10 @@ describe('GridPanel', () => {
             filter: [nameFilter, expirFilter],
             sort: [nameSort],
         });
-        const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
+        const queryInfo = QueryInfo.create({
+            columns: QUERY_INFO.columns,
+            views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }),
+        });
         const model = makeTestQueryModel(SCHEMA_QUERY, queryInfo, {}, [], 0);
         const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
 
@@ -305,8 +308,8 @@ describe('GridPanel', () => {
             'Name ASC',
             'expirationTime DESC',
             '"Name" = DMXP',
-            '"expirationTime" = 1',
-            '"expirationTime" = 2',
+            '"Expiration Time" = 1',
+            '"Expiration Time" = 2',
         ]);
 
         // verify that the view based filters are locked and model filters are not

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -384,16 +384,20 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         const _sorts = view ? sorts.concat(view.sorts.toArray()) : sorts;
         _sorts.forEach((sort): void => {
             const column = model.getColumn(sort.fieldKey);
-            actionValues.push(this.gridActions.sort.actionValueFromSort(sort, column?.shortCaption));
+            if (column) {
+                actionValues.push(this.gridActions.sort.actionValueFromSort(sort, column?.shortCaption));
+            }
         });
 
         // handle the view's saved filters (which will be shown as read only)
         if (view && view.filters.size) {
             view.filters.forEach((filter): void => {
                 const column = model.getColumn(filter.getColumnName());
-                actionValues.push(
-                    this.gridActions.filter.actionValueFromFilter(filter, column, 'Locked (saved with view)')
-                );
+                if (column) {
+                    actionValues.push(
+                        this.gridActions.filter.actionValueFromFilter(filter, column, 'Locked (saved with view)')
+                    );
+                }
             });
         }
 
@@ -403,7 +407,9 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 actionValues.push(this.gridActions.search.actionValueFromFilter(filter));
             } else {
                 const column = model.getColumn(filter.getColumnName());
-                actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
+                if (column) {
+                    actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
+                }
             }
         });
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -391,7 +391,9 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         if (view && view.filters.size) {
             view.filters.forEach((filter): void => {
                 const column = model.getColumn(filter.getColumnName());
-                actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column, true));
+                actionValues.push(
+                    this.gridActions.filter.actionValueFromFilter(filter, column, 'Locked (saved with view)')
+                );
             });
         }
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -448,16 +448,15 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         return this.props.model.queryInfo;
     };
 
-    getSelectDistinctOptions = (column: string, allFilters = true): Query.SelectDistinctOptions => {
+    getSelectDistinctOptions = (): Query.SelectDistinctOptions => {
         const { model } = this.props;
         return {
-            column,
+            column: undefined,
             containerFilter: model.containerFilter,
             containerPath: model.containerPath,
             schemaName: model.schemaName,
             queryName: model.queryName,
-            viewName: model.viewName,
-            filterArray: allFilters ? model.filters : model.modelFilters,
+            filterArray: model.modelFilters,
             parameters: model.queryParameters,
         };
     };
@@ -760,7 +759,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         return List<number>([model.orderedRows.indexOf(lastSelectedId)]);
     }
 
-    render (): ReactNode {
+    render(): ReactNode {
         const {
             actions,
             allowSelections,
@@ -864,7 +863,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 {showFilterModalFieldKey && (
                     <GridFilterModal
                         fieldKey={showFilterModalFieldKey}
-                        selectDistinctOptions={this.getSelectDistinctOptions(undefined, false)}
+                        selectDistinctOptions={this.getSelectDistinctOptions()}
                         initFilters={model.filterArray} // using filterArray to indicate user-defined filters only
                         model={model}
                         onApply={this.handleApplyFilters}

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -346,11 +346,11 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
 
 interface State {
     actionValues: ActionValue[];
+    errorMsg: React.ReactNode;
+    headerClickCount: { [key: string]: number };
+    isViewSaved?: boolean;
     showFilterModalFieldKey: string;
     showSaveViewModal: boolean;
-    headerClickCount: { [key: string]: number };
-    errorMsg: React.ReactNode;
-    isViewSaved?: boolean;
 }
 
 /**
@@ -835,7 +835,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         if (viewName !== undefined) {
             if (viewName !== model.viewName) {
                 // Only trigger view change if the viewName has changed
-                updateViewCallback = () => actions.setView(model.id, viewName, allowSelections)
+                updateViewCallback = () => actions.setView(model.id, viewName, allowSelections);
             }
         } else {
             updateViewCallback = () => actions.setView(model.id, undefined, allowSelections);

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -54,49 +54,49 @@ import { FilterStatus } from './FilterStatus';
 import { SaveViewModal } from './SaveViewModal';
 
 export interface GridPanelProps<ButtonsComponentProps> {
+    ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
+    ButtonsComponentRight?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
+    advancedExportOptions?: { [key: string]: any };
+    allowFiltering?: boolean;
     allowSelections?: boolean;
     allowSorting?: boolean;
-    allowFiltering?: boolean;
     allowViewCustomization?: boolean;
     asPanel?: boolean;
-    advancedExportOptions?: { [key: string]: any };
-    ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
     buttonsComponentProps?: ButtonsComponentProps;
-    ButtonsComponentRight?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
     emptyText?: string;
     getEmptyText?: (model: QueryModel) => string;
+    getFilterDisplayValue?: (columnName: string, rawValue: string) => string;
     hasHeader?: boolean;
     hideEmptyChartMenu?: boolean;
     hideEmptyViewMenu?: boolean;
+    highlightLastSelectedRow?: boolean;
     loadOnMount?: boolean;
     onChartClicked?: (chart: DataViewInfo) => boolean;
     onCreateReportClicked?: (type: DataViewInfoTypes) => void;
     onExport?: { [key: string]: () => any };
     pageSizes?: number[];
-    title?: string;
     showButtonBar?: boolean;
     showChartMenu?: boolean;
     showExport?: boolean;
-    showFiltersButton?: boolean;
     showFilterStatus?: boolean;
+    showFiltersButton?: boolean;
+    showHeader?: boolean;
     showPagination?: boolean;
     showSampleComparisonReports?: boolean;
     showSearchInput?: boolean;
     showViewMenu?: boolean;
-    showHeader?: boolean;
     supportedExportTypes?: Set<EXPORT_TYPES>;
-    getFilterDisplayValue?: (columnName: string, rawValue: string) => string;
-    highlightLastSelectedRow?: boolean;
+    title?: string;
 }
 
 type Props<T> = GridPanelProps<T> & RequiresModelAndActions;
 
 interface GridBarProps<T> extends Props<T> {
     actionValues: ActionValue[];
-    onViewSelect: (viewName: string) => void;
-    onSearch: (token: string) => void;
     onFilter: () => void;
     onSaveView: () => void;
+    onSearch: (token: string) => void;
+    onViewSelect: (viewName: string) => void;
 }
 
 class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
@@ -256,16 +256,16 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
 }
 
 interface GridTitleProps {
-    title?: string;
-    model: QueryModel;
     actions: Actions;
     allowSelections: boolean;
     allowViewCustomization: boolean;
-    onRevertView?: () => void;
-    onSaveView?: (canSaveShared) => void;
-    onSaveNewView?: () => void;
-    view?: ViewInfo;
     isUpdated?: boolean;
+    model: QueryModel;
+    onRevertView?: () => void;
+    onSaveNewView?: () => void;
+    onSaveView?: (canSaveShared) => void;
+    title?: string;
+    view?: ViewInfo;
 }
 
 export const GridTitle: FC<GridTitleProps> = memo(props => {
@@ -284,7 +284,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
     const { queryInfo, viewName } = model;
 
     // TODO: unable to get jest to pass with useServerContext() due to GridPanel being Component instead of FC
-    // const user = user ?? getServerContext().user;
+    // const { user } = useServerContext();
     const user = hasServerContext() ? useServerContext().user : getServerContext().user;
 
     const currentView = view ?? queryInfo?.getView(viewName, true);

--- a/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
@@ -64,7 +64,7 @@ describe('SaveViewModal', () => {
 
         expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
         expect(wrapper.find(ModalBody).text()).toContain(
-            'Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
+            'Sort order and filters will be saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
         );
         expect(wrapper.find('input[name="gridViewName"]').prop('value')).toBe('');
         expect(wrapper.find('input[name="setDefaultView"]').prop('checked')).toBe(true);
@@ -81,7 +81,7 @@ describe('SaveViewModal', () => {
 
         expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
         expect(wrapper.find(ModalBody).text()).toContain(
-            'Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
+            'Sort order and filters will be saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
         );
         expect(wrapper.find('input[name="gridViewName"]').prop('value')).toBe('View1');
         expect(wrapper.find('input[name="setDefaultView"]').prop('checked')).toBe(false);
@@ -98,7 +98,7 @@ describe('SaveViewModal', () => {
 
         expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
         expect(wrapper.find(ModalBody).text()).toContain(
-            'Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
+            'Sort order and filters will be saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
         );
         expect(wrapper.find('input[name="gridViewName"]').prop('value')).toBe('View2');
         expect(wrapper.find('input[name="setDefaultView"]').length).toEqual(0);

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -67,7 +67,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
                 <form onSubmit={saveView}>
                     <div className="form-group">
                         <div className="bottom-spacing">
-                            Sort order and filters are not saved as part of custom grid views. Once saved, this view
+                            Sort order and filters will be saved as part of custom grid views. Once saved, this view
                             will be available for all {gridLabel} grids throughout the application. Learn more about{' '}
                             <HelpLink topic={CUSTOM_VIEW}>custom grid views</HelpLink> in LabKey.
                         </div>
@@ -84,7 +84,6 @@ export const SaveViewModal: FC<Props> = memo(props => {
                             />
                         </div>
                         <RequiresPermission perms={PermissionTypes.Admin}>
-                            {' '}
                             {/* Only allow admins to create custom default views in app. Note this is different from LKS*/}
                             <div className="form-check bottom-spacing">
                                 <input

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -73,6 +73,10 @@ export interface TabbedGridPanelProps<T = {}> extends GridPanelProps<T> {
      */
     asPanel?: boolean;
     /**
+     * Optional value to use as the filename prefix for the exported file, otherwise will default to 'Data'
+     */
+    exportFilename?: string;
+    /**
      * Optional, if used the TabbedGridPanel will act as a controlled component, requiring you to always pass the
      * activeModelId. If not passed the TabbedGridPanel will maintain the activeModelId state internally.
      * @param string
@@ -97,10 +101,6 @@ export interface TabbedGridPanelProps<T = {}> extends GridPanelProps<T> {
      * The title to render, only used if asPanel is true.
      */
     title?: string;
-    /**
-     * Optional value to use as the filename prefix for the exported file, otherwise will default to 'Data'
-     */
-    exportFilename?: string;
 }
 
 export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = memo(props => {

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -21,7 +21,7 @@ import { EXPORT_TYPES } from '../../internal/constants';
 import { createNotification } from '../../internal/components/notifications/actions';
 import { exportTabsXlsx } from '../../internal/actions';
 
-import { GridPanel, GridPanelProps, GridTitle } from './GridPanel';
+import { GridPanel, GridPanelProps } from './GridPanel';
 import { InjectedQueryModels } from './withQueryModels';
 import { QueryModel } from './QueryModel';
 import { getQueryModelExportParams } from './utils';

--- a/packages/components/src/public/QueryModel/grid/Value.spec.tsx
+++ b/packages/components/src/public/QueryModel/grid/Value.spec.tsx
@@ -26,7 +26,7 @@ const readOnlyAction = {
     ),
     value: 'test',
     valueObject: Filter.create('A', 'test', Filter.Types.EQUAL),
-    isReadOnly: true,
+    isReadOnly: 'Filter is read only',
 };
 const nonRemovableAction = {
     action: new FilterAction(

--- a/packages/components/src/public/QueryModel/grid/Value.tsx
+++ b/packages/components/src/public/QueryModel/grid/Value.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { ActionValue } from './actions/Action';
@@ -42,35 +42,35 @@ export class Value extends React.Component<ValueProps, ValueState> {
         };
     }
 
-    onClick(event) {
+    onClick = (event): void => {
         event.stopPropagation();
         event.preventDefault();
-        if (this.props.onClick && !this.props.actionValue.isReadOnly) {
+        if (this.props.onClick && this.props.actionValue.isReadOnly === undefined) {
             this.props.onClick(this.props.actionValue, event);
         }
-    }
+    };
 
-    onIconClick(event) {
+    onIconClick = (event): void => {
         event.stopPropagation();
         event.preventDefault();
         if (this.props.onRemove && this.props.actionValue.isRemovable !== false) {
             this.props.onRemove(this.props.index, event);
         }
-    }
+    };
 
-    onMouseEnter() {
+    onMouseEnter = (): void => {
         this.setState({
             isActive: true,
         });
-    }
+    };
 
-    onMouseLeave() {
+    onMouseLeave = (): void => {
         this.setState({
             isActive: false,
         });
-    }
+    };
 
-    render() {
+    render(): ReactNode {
         const { actionValue } = this.props;
         const { action, value, displayValue, isReadOnly, isRemovable } = actionValue;
         const showRemoveIcon = this.state.isActive && isRemovable !== false && actionValue.action.keyword !== 'view';
@@ -78,7 +78,7 @@ export class Value extends React.Component<ValueProps, ValueState> {
         const className = classNames(valueClassName, {
             'is-active': this.state.isActive,
             'is-disabled': this.state.isDisabled,
-            'is-readonly': isReadOnly,
+            'is-readonly': isReadOnly !== undefined,
         });
 
         const iconClassNames = classNames(
@@ -90,12 +90,12 @@ export class Value extends React.Component<ValueProps, ValueState> {
         return (
             <div
                 className={className}
-                onClick={this.onClick.bind(this)}
-                onMouseEnter={this.onMouseEnter.bind(this)}
-                onMouseLeave={this.onMouseLeave.bind(this)}
+                onClick={this.onClick}
+                onMouseEnter={this.onMouseEnter}
+                onMouseLeave={this.onMouseLeave}
             >
-                <i className={iconClassNames} onClick={this.onIconClick.bind(this)} />
-                {isReadOnly ? <i className="read-lock fa fa-lock" title="locked (read only)" /> : null}
+                <i className={iconClassNames} onClick={this.onIconClick} />
+                {isReadOnly ? <i className="read-lock fa fa-lock" title={isReadOnly} /> : null}
                 <span>{displayValue ?? value}</span>
             </div>
         );

--- a/packages/components/src/public/QueryModel/grid/actions/Action.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Action.ts
@@ -43,7 +43,7 @@ export interface Value {
     value: string;
     valueObject?: any;
     displayValue?: string;
-    isReadOnly?: boolean;
+    isReadOnly?: string;
     isRemovable?: boolean;
     isValid?: boolean;
     param?: any;

--- a/packages/components/src/public/QueryModel/grid/actions/Action.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Action.ts
@@ -21,6 +21,12 @@
  */
 export interface Action {
     /**
+     * This is a shorthand font awesome icon class. E.g. "globe" would apply the icon fa-globe.
+     * http://fontawesome.io/icons
+     */
+    iconCls: string;
+
+    /**
      * Special case to allow an action to be the default if no keyword is provided. Note the first action with this
      * set, if there are multiple, will be the default.
      */
@@ -31,22 +37,16 @@ export interface Action {
      * with no spaces.
      */
     keyword: string;
-
-    /**
-     * This is a shorthand font awesome icon class. E.g. "globe" would apply the icon fa-globe.
-     * http://fontawesome.io/icons
-     */
-    iconCls: string;
 }
 
 export interface Value {
-    value: string;
-    valueObject?: any;
     displayValue?: string;
     isReadOnly?: string;
     isRemovable?: boolean;
     isValid?: boolean;
     param?: any;
+    value: string;
+    valueObject?: any;
 }
 
 export interface ActionValue extends Value {
@@ -54,15 +54,14 @@ export interface ActionValue extends Value {
 }
 
 export interface ActionOption {
-    label: string;
-
     action?: Action;
-    value?: string;
     appendValue?: boolean;
     isAction?: boolean;
     isComplete?: boolean;
-    isSelected?: boolean;
     isOverwrite?: boolean;
+    isSelected?: boolean;
+    label: string;
     nextLabel?: string;
     selectable?: boolean;
+    value?: string;
 }

--- a/packages/components/src/public/QueryModel/grid/actions/Filter.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Filter.ts
@@ -168,9 +168,7 @@ export class FilterAction implements Action {
         columnName: string,
         filterType: Filter.IFilterType,
         rawValue: string | string[]
-    ): { displayValue: string; isReadOnly: boolean; inputValue: string } {
-        const isReadOnly = false;
-
+    ): { displayValue: string; inputValue: string } {
         let value: string, inputValue: string;
         const displayParts = [decodePart(columnName), resolveSymbol(filterType)];
         const inputDisplayParts = [`"${displayParts[0]}"`, displayParts[1]]; // need to quote column name for input display
@@ -216,14 +214,10 @@ export class FilterAction implements Action {
             displayParts.push(value);
         }
 
-        return {
-            displayValue: displayParts.join(' '),
-            inputValue,
-            isReadOnly,
-        };
+        return { displayValue: displayParts.join(' '), inputValue };
     }
 
-    actionValueFromFilter(filter: Filter.IFilter, column: QueryColumn): ActionValue {
+    actionValueFromFilter(filter: Filter.IFilter, column: QueryColumn, isReadOnly = false): ActionValue {
         const label = column?.shortCaption;
         const columnName = filter.getColumnName();
         const filterType = filter.getFilterType();
@@ -235,7 +229,7 @@ export class FilterAction implements Action {
             value = getColFormattedDateValue(column, value);
         }
 
-        const { displayValue, isReadOnly, inputValue } = this.getDisplayValue(label ?? columnName, filterType, value);
+        const { displayValue, inputValue } = this.getDisplayValue(label ?? columnName, filterType, value);
 
         return {
             action: this,

--- a/packages/components/src/public/QueryModel/grid/actions/Filter.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Filter.ts
@@ -217,7 +217,7 @@ export class FilterAction implements Action {
         return { displayValue: displayParts.join(' '), inputValue };
     }
 
-    actionValueFromFilter(filter: Filter.IFilter, column: QueryColumn, isReadOnly = false): ActionValue {
+    actionValueFromFilter(filter: Filter.IFilter, column: QueryColumn, isReadOnly?: string): ActionValue {
         const label = column?.shortCaption;
         const columnName = filter.getColumnName();
         const filterType = filter.getFilterType();

--- a/packages/components/src/public/QueryModel/grid/utils.spec.ts
+++ b/packages/components/src/public/QueryModel/grid/utils.spec.ts
@@ -2,14 +2,11 @@ import { List } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { QueryInfo } from '../../QueryInfo';
-import { QuerySort } from '../../QuerySort';
 
-import { removeActionValue, replaceSearchValue } from './utils';
+import { getSearchValueAction } from './utils';
 import { ChangeType } from './model';
 import { FilterAction } from './actions/Filter';
 import { SearchAction } from './actions/Search';
-import { ViewAction } from './actions/View';
-import { SortAction } from './actions/Sort';
 
 const filterAction = {
     action: new FilterAction(
@@ -25,56 +22,20 @@ const searchAction = {
     value: 'foo',
     valueObject: Filter.create('*', 'foo', Filter.Types.Q),
 };
-const sortAction = {
-    action: new SortAction('query', () => List()),
-    value: 'A',
-    valueObject: new QuerySort({ fieldKey: 'A', dir: '' }),
-};
-const viewAction = {
-    action: new ViewAction(
-        'query',
-        () => List(),
-        () => QueryInfo.create({})
-    ),
-    value: 'view',
-};
-
-describe('removeActionValue', () => {
-    test('invalid index', () => {
-        expect(removeActionValue([], 1)).toStrictEqual([]);
-        expect(removeActionValue([filterAction], 2)).toStrictEqual([filterAction]);
-    });
-
-    test('remove at index', () => {
-        expect(removeActionValue([filterAction, searchAction, sortAction, viewAction], 1)).toStrictEqual([
-            filterAction,
-            sortAction,
-            viewAction,
-        ]);
-    });
-});
 
 describe('replaceSearchValue', () => {
     test('add', () => {
-        const { actionValues, change } = replaceSearchValue([filterAction], 'bar', searchAction.action);
+        const change = getSearchValueAction([filterAction], 'bar');
         expect(change.type).toBe(ChangeType.add);
-        expect(actionValues.length).toBe(2);
-        expect(actionValues[1].action).toBe(searchAction.action);
-        expect(actionValues[1].value).toBe('bar');
     });
 
     test('modify', () => {
-        const { actionValues, change } = replaceSearchValue([filterAction, searchAction], 'bar', searchAction.action);
+        const change = getSearchValueAction([filterAction, searchAction], 'bar');
         expect(change.type).toBe(ChangeType.modify);
-        expect(actionValues.length).toBe(2);
-        expect(actionValues[1].action).toBe(searchAction.action);
-        expect(actionValues[1].value).toBe('bar');
     });
 
     test('remove', () => {
-        const { actionValues, change } = replaceSearchValue([filterAction, searchAction], '', searchAction.action);
+        const change = getSearchValueAction([filterAction, searchAction], '');
         expect(change.type).toBe(ChangeType.remove);
-        expect(actionValues.length).toBe(1);
-        expect(actionValues[0].action).toBe(filterAction.action);
     });
 });

--- a/packages/components/src/public/QueryModel/grid/utils.ts
+++ b/packages/components/src/public/QueryModel/grid/utils.ts
@@ -54,31 +54,9 @@ export function resolveFieldKey(columnName: string, column?: QueryColumn): strin
     return column?.resolveFieldKey() ?? columnName;
 }
 
-export function removeActionValue(actionValues: ActionValue[], indexToRemove: number): ActionValue[] {
-    if (indexToRemove < actionValues.length) {
-        const newActionValues = [...actionValues];
-        newActionValues.splice(indexToRemove, 1);
-        return newActionValues;
-    }
-
-    return actionValues;
-}
-
-export function replaceSearchValue(
-    actionValues: ActionValue[],
-    value: string,
-    searchAction: SearchAction
-): { actionValues: ActionValue[]; change: Change } {
+export function getSearchValueAction(actionValues: ActionValue[], value: string): Change {
     const hasNewSearch = value?.length > 0;
     const existingSearchIndex = actionValues.findIndex(actionValue => actionValue.action.keyword === 'search');
-    const newActionValues = actionValues.filter(actionValue => actionValue.action.keyword !== 'search');
-    if (hasNewSearch) {
-        newActionValues.push({
-            action: searchAction,
-            value,
-            valueObject: Filter.create('*', value, Filter.Types.Q),
-        });
-    }
 
     let change = hasNewSearch ? ({ type: ChangeType.add } as Change) : undefined;
     if (existingSearchIndex > -1) {
@@ -88,8 +66,7 @@ export function replaceSearchValue(
             change = { type: ChangeType.remove, index: existingSearchIndex };
         }
     }
-
-    return { actionValues: newActionValues, change };
+    return change;
 }
 
 export function filterActionValuesByType(actionValues: ActionValue[], keyword: string): ActionValue[] {


### PR DESCRIPTION
#### Rationale
As part of the epic to add view customization to the app grids, we want to make sure that users know all of the sorts and filters that are being applied to the grid they are looking at. This PR updates the GridPanel related to sorts and filters that are saved with a given view. We now will include the view filters in the filter display and the view sorts in the column header icons/menus. These sorts and filters are still updatable (filters can be removed, sorts can be removed or changed) and an update to one of these saved sorts or filters will put the view into "Edited" mode.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/852
* https://github.com/LabKey/sampleManagement/pull/978
* https://github.com/LabKey/inventory/pull/444
* https://github.com/LabKey/biologics/pull/1348
* https://github.com/LabKey/platform/pull/3404

#### Changes
* Show saved view filters in the grid panel filter display section
* Show saved view sorts in the grid column header icons
* Allow for saved view sorts and filters to be updated/remove alongside the user-defined sorts/filters
