### PR TITLE
Item 10375: Save Grid Views - Save view dialog

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.6",
+  "version": "2.179.0-fb-smSaveGridViews.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.3",
+  "version": "2.179.0-fb-smSaveGridViews.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.14.1-fb-smSaveGridViews.4",
+    "@labkey/api": "1.14.1",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.1",
+  "version": "2.179.0-fb-smSaveGridViews.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.178.0",
+  "version": "2.179.0-fb-smSaveGridViews.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.7",
+  "version": "2.179.0-fb-smSaveGridViews.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.2",
+  "version": "2.179.0-fb-smSaveGridViews.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.8",
+  "version": "2.179.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.14.1-fb-smSaveGridViews.3",
+    "@labkey/api": "1.14.1-fb-smSaveGridViews.4",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.4",
+  "version": "2.179.0-fb-smSaveGridViews.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.1.15",
-    "@labkey/api": "1.13.0",
+    "@labkey/api": "1.14.1-fb-smSaveGridViews.3",
     "bootstrap": "3.4.1",
     "classnames": "2.3.1",
     "font-awesome": "4.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.0-fb-smSaveGridViews.5",
+  "version": "2.179.0-fb-smSaveGridViews.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.XX
 *Released*: XX 2022
 * Item 10375: Save Grid Views - Save view dialog
-  * TODO
+  * Enable Save action for edited views
+  * Add 'Save as custom view' option to views menu
+  * Add SaveViewModal component
 
 ### version 2.178.0
 *Released*: 31 May 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.XX
-*Released*: XX 2022
+### version 2.179.0
+*Released*: 6 June 2022
 * Item 10375: Save Grid Views - Save view dialog
   * Enable Save action for edited views
   * Add 'Save as custom view' option to views menu

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.XX
+*Released*: XX 2022
+* Item 10375: Save Grid Views - Save view dialog
+  * TODO
+
 ### version 2.178.0
 *Released*: 31 May 2022
 * Issue 45270: Show settings page to all admins

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -51,7 +51,7 @@ export class ViewInfo extends Record({
     // editable: false,
     filters: List<Filter.IFilter>(),
     hidden: false,
-    // inherit: false,
+    inherit: false,
     isDefault: false,
     label: undefined,
     name: undefined,
@@ -68,7 +68,7 @@ export class ViewInfo extends Record({
     // declare editable: boolean;
     declare filters: List<Filter.IFilter>;
     declare hidden: boolean;
-    // declare inherit: boolean;
+    declare inherit: boolean;
     declare isDefault: boolean; // 'default' is a JavaScript keyword
     declare label: string;
     declare name: string;

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2609,12 +2609,10 @@ export function getGridView(
             queryName: schemaQuery.queryName,
             viewName,
             excludeSessionView,
-            success: (response) => {
+            success: response => {
                 const view = response.views?.[0];
-                if (view)
-                    resolve(ViewInfo.create(view));
-                else
-                    reject('Unable to load the view.')
+                if (view) resolve(ViewInfo.create(view));
+                else reject('Unable to load the view.');
             },
             failure: response => {
                 console.error(response);

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2544,14 +2544,15 @@ export function saveGridView(
     name: string,
     session?: boolean,
     inherit?: boolean,
-    replace = true
+    replace = true,
+    shared?: boolean
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         Query.saveQueryViews({
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             containerPath,
-            views: [{ name, columns, session, inherit, replace }],
+            views: [{ name, columns, session, inherit, replace, shared }],
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);
                 resolve();

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2544,7 +2544,7 @@ export function saveGridView(
     name: string,
     session?: boolean,
     inherit?: boolean,
-    replace : boolean = true
+    replace = true
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         Query.saveQueryViews({

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2575,7 +2575,9 @@ export function saveSessionView(
     viewName: string,
     newName: string,
     inherit?: boolean,
-    shared?: boolean
+    shared?: boolean,
+    hidden?: boolean,
+    replace?: boolean
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         Query.saveSessionView({
@@ -2586,6 +2588,8 @@ export function saveSessionView(
             newName,
             inherit,
             shared,
+            hidden,
+            replace,
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);
                 resolve();

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -2534,12 +2534,24 @@ export function saveSessionGridView(
     containerPath: string,
     name: string
 ): Promise<void> {
+    return saveGridView(schemaQuery, columns, containerPath, name, true);
+}
+
+export function saveGridView(
+    schemaQuery: SchemaQuery,
+    columns: any,
+    containerPath: string,
+    name: string,
+    session?: boolean,
+    inherit?: boolean,
+    replace : boolean = true
+): Promise<void> {
     return new Promise((resolve, reject) => {
         Query.saveQueryViews({
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             containerPath,
-            views: [{ name, columns, session: true }],
+            views: [{ name, columns, session, inherit, replace }],
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);
                 resolve();

--- a/packages/components/src/internal/components/administration/BasePermissions.tsx
+++ b/packages/components/src/internal/components/administration/BasePermissions.tsx
@@ -6,6 +6,8 @@ import React, { FC, memo, ReactNode, useCallback, useEffect, useMemo, useState }
 import { MenuItem } from 'react-bootstrap';
 import { Map } from 'immutable';
 
+import { getServerContext } from '@labkey/api';
+
 import { isLoading, LoadingState } from '../../../public/LoadingState';
 import { resolveErrorMessage } from '../../util/messaging';
 import { SecurityPolicy } from '../permissions/models';
@@ -26,7 +28,6 @@ import { PermissionAssignments } from '../permissions/PermissionAssignments';
 import { AppContext, useAppContext } from '../../AppContext';
 
 import { getUpdatedPolicyRoles, getUpdatedPolicyRolesByUniqueName } from './actions';
-import { getServerContext } from '@labkey/api';
 
 interface OwnProps {
     containerId: string;
@@ -77,8 +78,7 @@ export const BasePermissionsImpl: FC<BasePermissionsImplProps> = memo(props => {
             try {
                 const policy_ = await api.security.fetchPolicy(containerId, principalsById, inactiveUsersById);
                 setPolicy(policy_);
-            }
-            catch (e) {
+            } catch (e) {
                 setError(resolveErrorMessage(e) ?? 'Failed to load security policy');
             }
         }

--- a/packages/components/src/internal/components/base/ServerContext.tsx
+++ b/packages/components/src/internal/components/base/ServerContext.tsx
@@ -47,7 +47,7 @@ export const ServerContextProvider: FC<ServerContextProviderProps> = ({ children
 };
 
 export const hasServerContext = (): boolean => {
-    return !!useContext(Context)
+    return !!useContext(Context);
 };
 
 export const useServerContext = (): ServerContext => {

--- a/packages/components/src/internal/components/base/ServerContext.tsx
+++ b/packages/components/src/internal/components/base/ServerContext.tsx
@@ -46,6 +46,10 @@ export const ServerContextProvider: FC<ServerContextProviderProps> = ({ children
     );
 };
 
+export const hasServerContext = (): boolean => {
+    return !!useContext(Context)
+};
+
 export const useServerContext = (): ServerContext => {
     const context = useContext(Context);
     if (context === undefined) {

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
@@ -8,10 +8,11 @@ import { initUnitTestMocks } from '../../../test/testHelperMocks';
 
 import { GridPanel, SelectInput } from '../../..';
 
+import { TEST_USER_READER } from '../../userFixtures';
+
 import { IEntityTypeOption } from './models';
 import { DataClassDataType } from './constants';
 import { SingleParentEntityPanel } from './SingleParentEntityPanel';
-import { TEST_USER_READER } from "../../userFixtures";
 
 beforeAll(() => {
     initUnitTestMocks();

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
@@ -91,7 +91,6 @@ describe('<SingleParentEntityPanel>', () => {
                 onRemoveParentType={() => {
                     console.log('No really removing anything.');
                 }}
-                user={TEST_USER_READER}
             />
         );
         expect(wrapper.find(GridPanel)).toHaveLength(1);

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.spec.tsx
@@ -11,6 +11,7 @@ import { GridPanel, SelectInput } from '../../..';
 import { IEntityTypeOption } from './models';
 import { DataClassDataType } from './constants';
 import { SingleParentEntityPanel } from './SingleParentEntityPanel';
+import { TEST_USER_READER } from "../../userFixtures";
 
 beforeAll(() => {
     initUnitTestMocks();
@@ -89,6 +90,7 @@ describe('<SingleParentEntityPanel>', () => {
                 onRemoveParentType={() => {
                     console.log('No really removing anything.');
                 }}
+                user={TEST_USER_READER}
             />
         );
         expect(wrapper.find(GridPanel)).toHaveLength(1);

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -54,7 +54,6 @@ interface Props {
     parentLSIDs?: string[];
     parentTypeOptions?: List<IEntityTypeOption>;
     parentEntityType?: IEntityTypeOption;
-    user?: User; // used for jest for GridPanel, remove when GridPanel is converted to FC
 }
 
 type SingleParentEntityProps = Props & InjectedQueryModels & OwnProps;
@@ -226,7 +225,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
     }
 
     render() {
-        const { actions, editing, index, queryModels, user } = this.props;
+        const { actions, editing, index, queryModels } = this.props;
         const { model } = queryModels;
 
         if (editing) {
@@ -246,7 +245,6 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
                         showChartMenu={false}
                         showExport={false}
                         allowFiltering={false}
-                        user={user}
                     />
                 )}
             </div>

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -17,6 +17,7 @@ import {
     SampleOperation,
     SchemaQuery,
     SelectInput,
+    User,
 } from '../../..';
 
 import { InjectedQueryModels, QueryConfigMap, withQueryModels } from '../../../public/QueryModel/withQueryModels';
@@ -52,6 +53,7 @@ interface Props {
     parentLSIDs?: string[];
     parentTypeOptions?: List<IEntityTypeOption>;
     parentEntityType?: IEntityTypeOption;
+    user?: User; // used for jest for GridPanel, remove when GridPanel is converted to FC
 }
 
 type SingleParentEntityProps = Props & InjectedQueryModels & OwnProps;
@@ -222,7 +224,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
     }
 
     render() {
-        const { actions, editing, index, queryModels } = this.props;
+        const { actions, editing, index, queryModels, user } = this.props;
         const { model } = queryModels;
 
         if (editing) {
@@ -242,6 +244,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
                         showChartMenu={false}
                         showExport={false}
                         allowFiltering={false}
+                        user={user}
                     />
                 )}
             </div>

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -29,9 +29,10 @@ import { DELIMITER } from '../forms/input/SelectInput';
 import { isSampleStatusEnabled } from '../../app/utils';
 import { getFilterForSampleOperation } from '../samples/utils';
 
+import { quoteValueWithDelimiters } from '../../util/utils';
+
 import { IEntityTypeOption } from './models';
 import { isSampleEntity } from './utils';
-import { quoteValueWithDelimiters } from '../../util/utils';
 
 interface OwnProps {
     chosenType: IEntityTypeOption;
@@ -208,7 +209,8 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
                         <tr key="type-name">
                             <td>{parentDataType.typeNounAsParentSingular}</td>
                             <td>
-                                No {parentDataType.typeNounAsParentSingular.toLowerCase()} has been set for this {lcChildNoun}.
+                                No {parentDataType.typeNounAsParentSingular.toLowerCase()} has been set for this{' '}
+                                {lcChildNoun}.
                             </td>
                         </tr>
                         <tr key="parent-id">

--- a/packages/components/src/internal/components/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
@@ -5103,7 +5103,8 @@ exports[`ParentEntityEditPanel error state 1`] = `
                                 <td>
                                   No 
                                   data type
-                                   has been set for this 
+                                   has been set for this
+                                   
                                   testing
                                   .
                                 </td>

--- a/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -5698,6 +5698,36 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
       },
     ]
   }
+  user={
+    Immutable.Record {
+      "id": 1200,
+      "canDelete": false,
+      "canDeleteOwn": false,
+      "canInsert": false,
+      "canUpdate": false,
+      "canUpdateOwn": false,
+      "displayName": "ReaderDisplayName",
+      "email": "guest",
+      "phone": null,
+      "avatar": "/labkey/_images/defaultavatar.png",
+      "isAdmin": false,
+      "isAnalyst": false,
+      "isDeveloper": false,
+      "isGuest": false,
+      "isRootAdmin": false,
+      "isSignedIn": true,
+      "isSystemAdmin": false,
+      "isTrusted": false,
+      "maxAllowedPhi": undefined,
+      "permissionsList": Immutable.List [
+        "org.labkey.api.security.permissions.ReadPermission",
+        "org.labkey.api.security.permissions.DataClassReadPermission",
+        "org.labkey.api.security.permissions.AssayReadPermission",
+        "org.labkey.api.security.permissions.MediaReadPermission",
+        "org.labkey.api.security.permissions.NotebookReadPermission",
+      ],
+    }
+  }
 >
   <withRouter(ComponentWithQueryModels)
     childNounSingular="Sample"
@@ -5833,6 +5863,36 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             "viewName": undefined,
           },
         },
+      }
+    }
+    user={
+      Immutable.Record {
+        "id": 1200,
+        "canDelete": false,
+        "canDeleteOwn": false,
+        "canInsert": false,
+        "canUpdate": false,
+        "canUpdateOwn": false,
+        "displayName": "ReaderDisplayName",
+        "email": "guest",
+        "phone": null,
+        "avatar": "/labkey/_images/defaultavatar.png",
+        "isAdmin": false,
+        "isAnalyst": false,
+        "isDeveloper": false,
+        "isGuest": false,
+        "isRootAdmin": false,
+        "isSignedIn": true,
+        "isSystemAdmin": false,
+        "isTrusted": false,
+        "maxAllowedPhi": undefined,
+        "permissionsList": Immutable.List [
+          "org.labkey.api.security.permissions.ReadPermission",
+          "org.labkey.api.security.permissions.DataClassReadPermission",
+          "org.labkey.api.security.permissions.AssayReadPermission",
+          "org.labkey.api.security.permissions.MediaReadPermission",
+          "org.labkey.api.security.permissions.NotebookReadPermission",
+        ],
       }
     }
   >
@@ -5983,6 +6043,36 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
               "viewName": undefined,
             },
           },
+        }
+      }
+      user={
+        Immutable.Record {
+          "id": 1200,
+          "canDelete": false,
+          "canDeleteOwn": false,
+          "canInsert": false,
+          "canUpdate": false,
+          "canUpdateOwn": false,
+          "displayName": "ReaderDisplayName",
+          "email": "guest",
+          "phone": null,
+          "avatar": "/labkey/_images/defaultavatar.png",
+          "isAdmin": false,
+          "isAnalyst": false,
+          "isDeveloper": false,
+          "isGuest": false,
+          "isRootAdmin": false,
+          "isSignedIn": true,
+          "isSystemAdmin": false,
+          "isTrusted": false,
+          "maxAllowedPhi": undefined,
+          "permissionsList": Immutable.List [
+            "org.labkey.api.security.permissions.ReadPermission",
+            "org.labkey.api.security.permissions.DataClassReadPermission",
+            "org.labkey.api.security.permissions.AssayReadPermission",
+            "org.labkey.api.security.permissions.MediaReadPermission",
+            "org.labkey.api.security.permissions.NotebookReadPermission",
+          ],
         }
       }
     >
@@ -6180,6 +6270,36 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             },
           }
         }
+        user={
+          Immutable.Record {
+            "id": 1200,
+            "canDelete": false,
+            "canDeleteOwn": false,
+            "canInsert": false,
+            "canUpdate": false,
+            "canUpdateOwn": false,
+            "displayName": "ReaderDisplayName",
+            "email": "guest",
+            "phone": null,
+            "avatar": "/labkey/_images/defaultavatar.png",
+            "isAdmin": false,
+            "isAnalyst": false,
+            "isDeveloper": false,
+            "isGuest": false,
+            "isRootAdmin": false,
+            "isSignedIn": true,
+            "isSystemAdmin": false,
+            "isTrusted": false,
+            "maxAllowedPhi": undefined,
+            "permissionsList": Immutable.List [
+              "org.labkey.api.security.permissions.ReadPermission",
+              "org.labkey.api.security.permissions.DataClassReadPermission",
+              "org.labkey.api.security.permissions.AssayReadPermission",
+              "org.labkey.api.security.permissions.MediaReadPermission",
+              "org.labkey.api.security.permissions.NotebookReadPermission",
+            ],
+          }
+        }
       >
         <div
           className="top-spacing"
@@ -6320,6 +6440,36 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             showSampleComparisonReports={false}
             showSearchInput={true}
             showViewMenu={true}
+            user={
+              Immutable.Record {
+                "id": 1200,
+                "canDelete": false,
+                "canDeleteOwn": false,
+                "canInsert": false,
+                "canUpdate": false,
+                "canUpdateOwn": false,
+                "displayName": "ReaderDisplayName",
+                "email": "guest",
+                "phone": null,
+                "avatar": "/labkey/_images/defaultavatar.png",
+                "isAdmin": false,
+                "isAnalyst": false,
+                "isDeveloper": false,
+                "isGuest": false,
+                "isRootAdmin": false,
+                "isSignedIn": true,
+                "isSystemAdmin": false,
+                "isTrusted": false,
+                "maxAllowedPhi": undefined,
+                "permissionsList": Immutable.List [
+                  "org.labkey.api.security.permissions.ReadPermission",
+                  "org.labkey.api.security.permissions.DataClassReadPermission",
+                  "org.labkey.api.security.permissions.AssayReadPermission",
+                  "org.labkey.api.security.permissions.MediaReadPermission",
+                  "org.labkey.api.security.permissions.NotebookReadPermission",
+                ],
+              }
+            }
           >
             <div
               className="grid-panel"
@@ -6353,6 +6503,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                 }
                 allowSelections={false}
                 allowViewCustomization={true}
+                isUpdated={false}
                 model={
                   QueryModel {
                     "baseFilters": Array [
@@ -6425,6 +6576,36 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                 onRevertView={[Function]}
                 onSaveNewView={[Function]}
                 onSaveView={[Function]}
+                user={
+                  Immutable.Record {
+                    "id": 1200,
+                    "canDelete": false,
+                    "canDeleteOwn": false,
+                    "canInsert": false,
+                    "canUpdate": false,
+                    "canUpdateOwn": false,
+                    "displayName": "ReaderDisplayName",
+                    "email": "guest",
+                    "phone": null,
+                    "avatar": "/labkey/_images/defaultavatar.png",
+                    "isAdmin": false,
+                    "isAnalyst": false,
+                    "isDeveloper": false,
+                    "isGuest": false,
+                    "isRootAdmin": false,
+                    "isSignedIn": true,
+                    "isSystemAdmin": false,
+                    "isTrusted": false,
+                    "maxAllowedPhi": undefined,
+                    "permissionsList": Immutable.List [
+                      "org.labkey.api.security.permissions.ReadPermission",
+                      "org.labkey.api.security.permissions.DataClassReadPermission",
+                      "org.labkey.api.security.permissions.AssayReadPermission",
+                      "org.labkey.api.security.permissions.MediaReadPermission",
+                      "org.labkey.api.security.permissions.NotebookReadPermission",
+                    ],
+                  }
+                }
               />
               <div
                 className="grid-panel__body top-spacing"

--- a/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -5585,7 +5585,8 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
                 <td>
                   No 
                   data type
-                   has been set for this 
+                   has been set for this
+                   
                   sample
                   .
                 </td>
@@ -5697,36 +5698,6 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
         "value": "vendor 3",
       },
     ]
-  }
-  user={
-    Immutable.Record {
-      "id": 1200,
-      "canDelete": false,
-      "canDeleteOwn": false,
-      "canInsert": false,
-      "canUpdate": false,
-      "canUpdateOwn": false,
-      "displayName": "ReaderDisplayName",
-      "email": "guest",
-      "phone": null,
-      "avatar": "/labkey/_images/defaultavatar.png",
-      "isAdmin": false,
-      "isAnalyst": false,
-      "isDeveloper": false,
-      "isGuest": false,
-      "isRootAdmin": false,
-      "isSignedIn": true,
-      "isSystemAdmin": false,
-      "isTrusted": false,
-      "maxAllowedPhi": undefined,
-      "permissionsList": Immutable.List [
-        "org.labkey.api.security.permissions.ReadPermission",
-        "org.labkey.api.security.permissions.DataClassReadPermission",
-        "org.labkey.api.security.permissions.AssayReadPermission",
-        "org.labkey.api.security.permissions.MediaReadPermission",
-        "org.labkey.api.security.permissions.NotebookReadPermission",
-      ],
-    }
   }
 >
   <withRouter(ComponentWithQueryModels)
@@ -5863,36 +5834,6 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             "viewName": undefined,
           },
         },
-      }
-    }
-    user={
-      Immutable.Record {
-        "id": 1200,
-        "canDelete": false,
-        "canDeleteOwn": false,
-        "canInsert": false,
-        "canUpdate": false,
-        "canUpdateOwn": false,
-        "displayName": "ReaderDisplayName",
-        "email": "guest",
-        "phone": null,
-        "avatar": "/labkey/_images/defaultavatar.png",
-        "isAdmin": false,
-        "isAnalyst": false,
-        "isDeveloper": false,
-        "isGuest": false,
-        "isRootAdmin": false,
-        "isSignedIn": true,
-        "isSystemAdmin": false,
-        "isTrusted": false,
-        "maxAllowedPhi": undefined,
-        "permissionsList": Immutable.List [
-          "org.labkey.api.security.permissions.ReadPermission",
-          "org.labkey.api.security.permissions.DataClassReadPermission",
-          "org.labkey.api.security.permissions.AssayReadPermission",
-          "org.labkey.api.security.permissions.MediaReadPermission",
-          "org.labkey.api.security.permissions.NotebookReadPermission",
-        ],
       }
     }
   >
@@ -6043,36 +5984,6 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
               "viewName": undefined,
             },
           },
-        }
-      }
-      user={
-        Immutable.Record {
-          "id": 1200,
-          "canDelete": false,
-          "canDeleteOwn": false,
-          "canInsert": false,
-          "canUpdate": false,
-          "canUpdateOwn": false,
-          "displayName": "ReaderDisplayName",
-          "email": "guest",
-          "phone": null,
-          "avatar": "/labkey/_images/defaultavatar.png",
-          "isAdmin": false,
-          "isAnalyst": false,
-          "isDeveloper": false,
-          "isGuest": false,
-          "isRootAdmin": false,
-          "isSignedIn": true,
-          "isSystemAdmin": false,
-          "isTrusted": false,
-          "maxAllowedPhi": undefined,
-          "permissionsList": Immutable.List [
-            "org.labkey.api.security.permissions.ReadPermission",
-            "org.labkey.api.security.permissions.DataClassReadPermission",
-            "org.labkey.api.security.permissions.AssayReadPermission",
-            "org.labkey.api.security.permissions.MediaReadPermission",
-            "org.labkey.api.security.permissions.NotebookReadPermission",
-          ],
         }
       }
     >
@@ -6270,36 +6181,6 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             },
           }
         }
-        user={
-          Immutable.Record {
-            "id": 1200,
-            "canDelete": false,
-            "canDeleteOwn": false,
-            "canInsert": false,
-            "canUpdate": false,
-            "canUpdateOwn": false,
-            "displayName": "ReaderDisplayName",
-            "email": "guest",
-            "phone": null,
-            "avatar": "/labkey/_images/defaultavatar.png",
-            "isAdmin": false,
-            "isAnalyst": false,
-            "isDeveloper": false,
-            "isGuest": false,
-            "isRootAdmin": false,
-            "isSignedIn": true,
-            "isSystemAdmin": false,
-            "isTrusted": false,
-            "maxAllowedPhi": undefined,
-            "permissionsList": Immutable.List [
-              "org.labkey.api.security.permissions.ReadPermission",
-              "org.labkey.api.security.permissions.DataClassReadPermission",
-              "org.labkey.api.security.permissions.AssayReadPermission",
-              "org.labkey.api.security.permissions.MediaReadPermission",
-              "org.labkey.api.security.permissions.NotebookReadPermission",
-            ],
-          }
-        }
       >
         <div
           className="top-spacing"
@@ -6440,36 +6321,6 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             showSampleComparisonReports={false}
             showSearchInput={true}
             showViewMenu={true}
-            user={
-              Immutable.Record {
-                "id": 1200,
-                "canDelete": false,
-                "canDeleteOwn": false,
-                "canInsert": false,
-                "canUpdate": false,
-                "canUpdateOwn": false,
-                "displayName": "ReaderDisplayName",
-                "email": "guest",
-                "phone": null,
-                "avatar": "/labkey/_images/defaultavatar.png",
-                "isAdmin": false,
-                "isAnalyst": false,
-                "isDeveloper": false,
-                "isGuest": false,
-                "isRootAdmin": false,
-                "isSignedIn": true,
-                "isSystemAdmin": false,
-                "isTrusted": false,
-                "maxAllowedPhi": undefined,
-                "permissionsList": Immutable.List [
-                  "org.labkey.api.security.permissions.ReadPermission",
-                  "org.labkey.api.security.permissions.DataClassReadPermission",
-                  "org.labkey.api.security.permissions.AssayReadPermission",
-                  "org.labkey.api.security.permissions.MediaReadPermission",
-                  "org.labkey.api.security.permissions.NotebookReadPermission",
-                ],
-              }
-            }
           >
             <div
               className="grid-panel"
@@ -6576,36 +6427,6 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                 onRevertView={[Function]}
                 onSaveNewView={[Function]}
                 onSaveView={[Function]}
-                user={
-                  Immutable.Record {
-                    "id": 1200,
-                    "canDelete": false,
-                    "canDeleteOwn": false,
-                    "canInsert": false,
-                    "canUpdate": false,
-                    "canUpdateOwn": false,
-                    "displayName": "ReaderDisplayName",
-                    "email": "guest",
-                    "phone": null,
-                    "avatar": "/labkey/_images/defaultavatar.png",
-                    "isAdmin": false,
-                    "isAnalyst": false,
-                    "isDeveloper": false,
-                    "isGuest": false,
-                    "isRootAdmin": false,
-                    "isSignedIn": true,
-                    "isSystemAdmin": false,
-                    "isTrusted": false,
-                    "maxAllowedPhi": undefined,
-                    "permissionsList": Immutable.List [
-                      "org.labkey.api.security.permissions.ReadPermission",
-                      "org.labkey.api.security.permissions.DataClassReadPermission",
-                      "org.labkey.api.security.permissions.AssayReadPermission",
-                      "org.labkey.api.security.permissions.MediaReadPermission",
-                      "org.labkey.api.security.permissions.NotebookReadPermission",
-                    ],
-                  }
-                }
               />
               <div
                 className="grid-panel__body top-spacing"

--- a/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -6423,6 +6423,8 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                   }
                 }
                 onRevertView={[Function]}
+                onSaveNewView={[Function]}
+                onSaveView={[Function]}
               />
               <div
                 className="grid-panel__body top-spacing"

--- a/packages/components/src/internal/util/helpLinks.tsx
+++ b/packages/components/src/internal/util/helpLinks.tsx
@@ -41,6 +41,8 @@ export const SAMPLE_ALIQUOT_TOPIC = 'aliquot';
 
 export const UNIQUE_IDS_TOPIC = 'uniqueStorageIds';
 
+export const CUSTOM_VIEW = 'customView'
+
 // See HelpTopic.java Referrer enum
 export enum HELP_LINK_REFERRER {
     DEV_MENU = 'devMenu',

--- a/packages/components/src/internal/util/helpLinks.tsx
+++ b/packages/components/src/internal/util/helpLinks.tsx
@@ -41,7 +41,7 @@ export const SAMPLE_ALIQUOT_TOPIC = 'aliquot';
 
 export const UNIQUE_IDS_TOPIC = 'uniqueStorageIds';
 
-export const CUSTOM_VIEW = 'customView'
+export const CUSTOM_VIEW = 'customView';
 
 // See HelpTopic.java Referrer enum
 export enum HELP_LINK_REFERRER {

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -7,14 +7,11 @@ import renderer from 'react-test-renderer';
 
 import { GRID_CHECKBOX_OPTIONS, GridPanel, LoadingState, QueryInfo, QueryModel, QuerySort, SchemaQuery } from '../..';
 
-import {
-    initUnitTests,
-    makeQueryInfo,
-    makeTestData,
-    mountWithServerContext
-} from '../../internal/testHelpers';
+import { initUnitTests, makeQueryInfo, makeTestData, mountWithServerContext } from '../../internal/testHelpers';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 import mixturesQuery from '../../test/data/mixtures-getQueryPaging.json';
+
+import { TEST_USER_EDITOR, TEST_USER_PROJECT_ADMIN, TEST_USER_READER } from '../../internal/userFixtures';
 
 import { ActionValue } from './grid/actions/Action';
 
@@ -22,7 +19,6 @@ import { RequiresModelAndActions } from './withQueryModels';
 import { RowsResponse } from './QueryModelLoader';
 import { makeTestActions, makeTestQueryModel } from './testUtils';
 import { GridTitle } from './GridPanel';
-import {TEST_USER_EDITOR, TEST_USER_PROJECT_ADMIN, TEST_USER_READER} from "../../internal/userFixtures";
 
 // The wrapper's return type for mount<GridPanel>(<GridPanel ... />)
 type GridPanelWrapper = ReactWrapper<Readonly<GridPanel['props']>, Readonly<GridPanel['state']>, GridPanel>;
@@ -266,7 +262,7 @@ describe('GridPanel', () => {
         // happens when bindURL is true and there is a URL change.
         const { rows, orderedRows, rowCount } = DATA;
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO, rows, orderedRows.slice(0, 20), rowCount);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_PROJECT_ADMIN}/>);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_PROJECT_ADMIN} />);
         const nameSort = new QuerySort({ fieldKey: 'Name' });
         const nameFilter = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
         const expirFilter = Filter.create('expirationTime', '1', Filter.Types.EQUAL);
@@ -429,10 +425,10 @@ describe('GridTitle', () => {
     const testTitle = 'Test title';
     const GRID_TITLE_PROPS = {
         title: testTitle,
-        actions: actions,
+        actions,
         allowSelections: true,
         allowViewCustomization: false,
-    }
+    };
 
     function validate(
         wrapper: ReactWrapper,
@@ -449,14 +445,11 @@ describe('GridTitle', () => {
             expect(editedTag.text()).toBe('Edited');
             const buttons = wrapper.find('button');
             let btnCount = 0;
-            if (allowCustomization)
-            {
+            if (allowCustomization) {
                 btnCount++;
-                if ((!isDefaultView) && !isHidden) {
+                if (!isDefaultView && !isHidden) {
                     btnCount += 2;
-                }
-                else
-                    btnCount += 1;
+                } else btnCount += 1;
             }
 
             expect(buttons).toHaveLength(btnCount);
@@ -471,12 +464,9 @@ describe('GridTitle', () => {
     });
 
     test('title, no view', () => {
-        const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={model}
-            />
-            , {user: TEST_USER_EDITOR});
+        const wrapper = mountWithServerContext(<GridTitle {...GRID_TITLE_PROPS} model={model} />, {
+            user: TEST_USER_EDITOR,
+        });
         validate(wrapper, testTitle, false, false);
         wrapper.unmount();
     });
@@ -484,12 +474,9 @@ describe('GridTitle', () => {
     test('view, no title', () => {
         const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
         const modelWithView = makeTestQueryModel(viewSchemaQuery, QUERY_INFO);
-        const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={modelWithView}
-            />
-            , {user: TEST_USER_EDITOR});
+        const wrapper = mountWithServerContext(<GridTitle {...GRID_TITLE_PROPS} model={modelWithView} />, {
+            user: TEST_USER_EDITOR,
+        });
         validate(wrapper, 'No Extra Column', false, false);
         wrapper.unmount();
     });
@@ -497,12 +484,9 @@ describe('GridTitle', () => {
     test('title and view', () => {
         const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
         const modelWithView = makeTestQueryModel(viewSchemaQuery, QUERY_INFO);
-        const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={modelWithView}
-            />
-            , {user: TEST_USER_EDITOR});
+        const wrapper = mountWithServerContext(<GridTitle {...GRID_TITLE_PROPS} model={modelWithView} />, {
+            user: TEST_USER_EDITOR,
+        });
         validate(wrapper, testTitle + ' - No Extra Column', false, false);
         wrapper.unmount();
     });
@@ -514,12 +498,9 @@ describe('GridTitle', () => {
         ) as QueryInfo;
         const model = makeTestQueryModel(SCHEMA_QUERY, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={model}
-                allowViewCustomization={true}
-            />
-            , {user: TEST_USER_PROJECT_ADMIN});
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            { user: TEST_USER_PROJECT_ADMIN }
+        );
         validate(wrapper, testTitle, true, true, true, false);
         wrapper.unmount();
     });
@@ -532,12 +513,9 @@ describe('GridTitle', () => {
         const model = makeTestQueryModel(SCHEMA_QUERY, sessionQueryInfo);
 
         const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={model}
-                allowViewCustomization={false}
-            />
-            , {user: TEST_USER_READER});
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={false} />,
+            { user: TEST_USER_READER }
+        );
         validate(wrapper, testTitle, true, false, true, false);
         wrapper.unmount();
     });
@@ -550,12 +528,9 @@ describe('GridTitle', () => {
         ) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={model}
-                allowViewCustomization={true}
-            />
-            , {user: TEST_USER_PROJECT_ADMIN});
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            { user: TEST_USER_PROJECT_ADMIN }
+        );
         validate(wrapper, 'No Extra Column', true, true, false, false);
         wrapper.unmount();
     });
@@ -568,12 +543,9 @@ describe('GridTitle', () => {
         ) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={model}
-                allowViewCustomization={true}
-            />
-            , {user: TEST_USER_READER});
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            { user: TEST_USER_READER }
+        );
         validate(wrapper, testTitle + ' - No Extra Column', true, true, false, false);
         wrapper.unmount();
     });
@@ -585,12 +557,9 @@ describe('GridTitle', () => {
             .setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle
-                {...GRID_TITLE_PROPS}
-                model={model}
-                allowViewCustomization={true}
-            />
-        , {user: TEST_USER_READER});
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            { user: TEST_USER_READER }
+        );
         validate(wrapper, testTitle, true, true, false, true);
         wrapper.unmount();
     });
@@ -602,14 +571,10 @@ describe('GridTitle', () => {
             .setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle
-                actions={actions}
-                allowSelections={true}
-                model={model}
-                allowViewCustomization={true}
-            />
-            , {user: TEST_USER_READER});
-        validate(wrapper, "EditedDefault ViewUndoSave", true, true, false, true);
+            <GridTitle actions={actions} allowSelections={true} model={model} allowViewCustomization={true} />,
+            { user: TEST_USER_READER }
+        );
+        validate(wrapper, 'EditedDefault ViewUndoSave', true, true, false, true);
         wrapper.unmount();
     });
 
@@ -618,7 +583,15 @@ describe('GridTitle', () => {
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const tree = renderer
-            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} user={TEST_USER_PROJECT_ADMIN}/>)
+            .create(
+                <GridTitle
+                    model={model}
+                    actions={actions}
+                    allowSelections={true}
+                    allowViewCustomization={false}
+                    user={TEST_USER_PROJECT_ADMIN}
+                />
+            )
             .toJSON();
         expect(tree).toBeNull();
     });

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -266,7 +266,7 @@ describe('GridPanel', () => {
         // happens when bindURL is true and there is a URL change.
         const { rows, orderedRows, rowCount } = DATA;
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO, rows, orderedRows.slice(0, 20), rowCount);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_PROJECT_ADMIN}/>);
         const nameSort = new QuerySort({ fieldKey: 'Name' });
         const nameFilter = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
         const expirFilter = Filter.create('expirationTime', '1', Filter.Types.EQUAL);
@@ -440,7 +440,7 @@ describe('GridTitle', () => {
         isEdited: boolean,
         allowCustomization: boolean,
         isDefaultView?: boolean,
-        isAdmin?: boolean
+        isHidden?: boolean
     ): void {
         expect(wrapper.text()).toContain(expectedTitle);
         if (isEdited) {
@@ -452,7 +452,7 @@ describe('GridTitle', () => {
             if (allowCustomization)
             {
                 btnCount++;
-                if (!isDefaultView || isAdmin) {
+                if ((!isDefaultView) && !isHidden) {
                     btnCount += 2;
                 }
                 else
@@ -520,7 +520,7 @@ describe('GridTitle', () => {
                 allowViewCustomization={true}
             />
             , {user: TEST_USER_PROJECT_ADMIN});
-        validate(wrapper, testTitle, true, true, true, true);
+        validate(wrapper, testTitle, true, true, true, false);
         wrapper.unmount();
     });
 
@@ -556,7 +556,7 @@ describe('GridTitle', () => {
                 allowViewCustomization={true}
             />
             , {user: TEST_USER_PROJECT_ADMIN});
-        validate(wrapper, 'No Extra Column', true, true, false, true);
+        validate(wrapper, 'No Extra Column', true, true, false, false);
         wrapper.unmount();
     });
 
@@ -591,7 +591,7 @@ describe('GridTitle', () => {
                 allowViewCustomization={true}
             />
         , {user: TEST_USER_READER});
-        validate(wrapper, testTitle, false, false, false, false);
+        validate(wrapper, testTitle, true, true, false, true);
         wrapper.unmount();
     });
 
@@ -601,10 +601,16 @@ describe('GridTitle', () => {
             .setIn(['views', 'noextracolumn', 'revertable'], true)
             .setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
-        const tree = renderer
-            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} />)
-            .toJSON();
-        expect(tree).toBeNull();
+        const wrapper = mountWithServerContext(
+            <GridTitle
+                actions={actions}
+                allowSelections={true}
+                model={model}
+                allowViewCustomization={true}
+            />
+            , {user: TEST_USER_READER});
+        validate(wrapper, "EditedDefault ViewUndoSave", true, true, false, true);
+        wrapper.unmount();
     });
 
     test('hidden view, not edited, no title', () => {
@@ -612,7 +618,7 @@ describe('GridTitle', () => {
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const tree = renderer
-            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} />)
+            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} user={TEST_USER_PROJECT_ADMIN}/>)
             .toJSON();
         expect(tree).toBeNull();
     });

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -37,6 +37,7 @@ beforeAll(() => {
     initUnitTests();
     QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
     DATA = makeTestData(mixturesQuery);
+    LABKEY.user = TEST_USER_READER;
 });
 
 const CHART_MENU_SELECTOR = '.chart-menu';
@@ -117,7 +118,7 @@ describe('GridPanel', () => {
 
         // Model is loading QueryInfo and Rows, should render loading, no ChartMenu/Pagination/ViewMenu.
         let model = makeTestQueryModel(SCHEMA_QUERY);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
         expectNoQueryInfo(wrapper);
 
         // Model is loading Rows, but not QueryInfo, should not render pagination, should render disabled ViewMenu.
@@ -262,7 +263,7 @@ describe('GridPanel', () => {
         // happens when bindURL is true and there is a URL change.
         const { rows, orderedRows, rowCount } = DATA;
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO, rows, orderedRows.slice(0, 20), rowCount);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_PROJECT_ADMIN} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
         const nameSort = new QuerySort({ fieldKey: 'Name' });
         const nameFilter = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
         const expirFilter = Filter.create('expirationTime', '1', Filter.Types.EQUAL);
@@ -383,7 +384,7 @@ describe('GridPanel', () => {
             selections: new Set(),
             selectionsLoadingState: LoadingState.LOADED,
         });
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
 
         // Check that with no selections the header checkbox is not selected.
         expectHeaderSelectionStatus(wrapper, false);
@@ -464,7 +465,6 @@ describe('GridTitle', () => {
                     actions={actions}
                     allowSelections={true}
                     allowViewCustomization={false}
-                    user={TEST_USER_PROJECT_ADMIN}
                 />
             )
             .toJSON();
@@ -597,7 +597,6 @@ describe('GridTitle', () => {
                     actions={actions}
                     allowSelections={true}
                     allowViewCustomization={false}
-                    user={TEST_USER_PROJECT_ADMIN}
                 />
             )
             .toJSON();

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -117,7 +117,7 @@ describe('GridPanel', () => {
 
         // Model is loading QueryInfo and Rows, should render loading, no ChartMenu/Pagination/ViewMenu.
         let model = makeTestQueryModel(SCHEMA_QUERY);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER}/>);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER} />);
         expectNoQueryInfo(wrapper);
 
         // Model is loading Rows, but not QueryInfo, should not render pagination, should render disabled ViewMenu.
@@ -383,7 +383,7 @@ describe('GridPanel', () => {
             selections: new Set(),
             selectionsLoadingState: LoadingState.LOADED,
         });
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER}/>);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER} />);
 
         // Check that with no selections the header checkbox is not selected.
         expectHeaderSelectionStatus(wrapper, false);
@@ -458,7 +458,15 @@ describe('GridTitle', () => {
 
     test('no title, no view', () => {
         const tree = renderer
-            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} user={TEST_USER_PROJECT_ADMIN}/>)
+            .create(
+                <GridTitle
+                    model={model}
+                    actions={actions}
+                    allowSelections={true}
+                    allowViewCustomization={false}
+                    user={TEST_USER_PROJECT_ADMIN}
+                />
+            )
             .toJSON();
         expect(tree).toBeNull();
     });

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -459,14 +459,7 @@ describe('GridTitle', () => {
 
     test('no title, no view', () => {
         const tree = renderer
-            .create(
-                <GridTitle
-                    model={model}
-                    actions={actions}
-                    allowSelections={true}
-                    allowViewCustomization={false}
-                />
-            )
+            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} />)
             .toJSON();
         expect(tree).toBeNull();
     });
@@ -591,14 +584,7 @@ describe('GridTitle', () => {
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const tree = renderer
-            .create(
-                <GridTitle
-                    model={model}
-                    actions={actions}
-                    allowSelections={true}
-                    allowViewCustomization={false}
-                />
-            )
+            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} />)
             .toJSON();
         expect(tree).toBeNull();
     });

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -117,7 +117,7 @@ describe('GridPanel', () => {
 
         // Model is loading QueryInfo and Rows, should render loading, no ChartMenu/Pagination/ViewMenu.
         let model = makeTestQueryModel(SCHEMA_QUERY);
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER}/>);
         expectNoQueryInfo(wrapper);
 
         // Model is loading Rows, but not QueryInfo, should not render pagination, should render disabled ViewMenu.
@@ -383,7 +383,7 @@ describe('GridPanel', () => {
             selections: new Set(),
             selectionsLoadingState: LoadingState.LOADED,
         });
-        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} />);
+        const wrapper = mount<GridPanel>(<GridPanel actions={actions} model={model} user={TEST_USER_READER}/>);
 
         // Check that with no selections the header checkbox is not selected.
         expectHeaderSelectionStatus(wrapper, false);
@@ -458,7 +458,7 @@ describe('GridTitle', () => {
 
     test('no title, no view', () => {
         const tree = renderer
-            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} />)
+            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} user={TEST_USER_PROJECT_ADMIN}/>)
             .toJSON();
         expect(tree).toBeNull();
     });

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, FC, memo, PureComponent, ReactNode, useCallback, useMemo } from 'react';
 import classNames from 'classnames';
 import { fromJS, List, Set } from 'immutable';
-import {Filter, getServerContext, Query} from '@labkey/api';
+import { Filter, getServerContext, Query } from '@labkey/api';
 
 import { MenuItem, SplitButton } from 'react-bootstrap';
 
@@ -29,6 +29,8 @@ import { headerCell, headerSelectionCell, isFilterColumnNameMatch } from '../../
 
 import { getGridView, revertViewEdit, saveGridView, saveAsSessionView, saveSessionView } from '../../internal/actions';
 
+import { hasServerContext } from '../../internal/components/base/ServerContext';
+
 import { ActionValue } from './grid/actions/Action';
 import { FilterAction } from './grid/actions/Filter';
 import { SearchAction } from './grid/actions/Search';
@@ -51,7 +53,6 @@ import { GridFilterModal } from './GridFilterModal';
 import { FiltersButton } from './FiltersButton';
 import { FilterStatus } from './FilterStatus';
 import { SaveViewModal } from './SaveViewModal';
-import {hasServerContext} from "../../internal/components/base/ServerContext";
 
 export interface GridPanelProps<ButtonsComponentProps> {
     allowSelections?: boolean;
@@ -279,7 +280,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
         actions,
         allowSelections,
         allowViewCustomization,
-        isUpdated
+        isUpdated,
     } = props;
     const { queryInfo, viewName } = model;
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -925,7 +925,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 displayTitle = displayTitle ? displayTitle + ' - ' + label : label;
             }
         } else {
-            view = queryInfo?.views.get(ViewInfo.DEFAULT_NAME.toLowerCase());
+            view = queryInfo.views.get(ViewInfo.DEFAULT_NAME.toLowerCase());
         }
 
         return (
@@ -1010,7 +1010,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 )}
                 {showSaveViewModal && (
                     <SaveViewModal
-                        viewLabel={displayTitle}
+                        gridLabel={queryInfo?.schemaQuery?.queryName}
                         currentView={view}
                         onCancel={this.closeSaveViewModal}
                         onConfirmSave={this.onSaveView}

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -3,6 +3,8 @@ import classNames from 'classnames';
 import { fromJS, List, Set } from 'immutable';
 import { Filter, Query } from '@labkey/api';
 
+import { MenuItem, SplitButton } from 'react-bootstrap';
+
 import {
     Actions,
     Alert,
@@ -23,7 +25,7 @@ import { GRID_SELECTION_INDEX } from '../../internal/constants';
 import { DataViewInfo } from '../../internal/models';
 import { headerCell, headerSelectionCell, isFilterColumnNameMatch } from '../../internal/renderers';
 
-import {revertViewEdit, saveGridView, saveSessionGridView} from '../../internal/actions';
+import { revertViewEdit, saveGridView, saveSessionGridView } from '../../internal/actions';
 
 import { ActionValue } from './grid/actions/Action';
 import { FilterAction } from './grid/actions/Filter';
@@ -46,8 +48,7 @@ import { actionValuesToString, filtersEqual, sortsEqual } from './utils';
 import { GridFilterModal } from './GridFilterModal';
 import { FiltersButton } from './FiltersButton';
 import { FilterStatus } from './FilterStatus';
-import { MenuItem, SplitButton } from "react-bootstrap";
-import { SaveViewModal } from "./SaveViewModal";
+import { SaveViewModal } from './SaveViewModal';
 
 export interface GridPanelProps<ButtonsComponentProps> {
     allowSelections?: boolean;
@@ -266,7 +267,18 @@ interface GridTitleProps {
 }
 
 export const GridTitle: FC<GridTitleProps> = memo(props => {
-    const { displayTitle, view, model, onRevertView, onSaveView, onSaveNewView, actions, allowSelections, allowViewCustomization, allowSavingDefaultView } = props;
+    const {
+        displayTitle,
+        view,
+        model,
+        onRevertView,
+        onSaveView,
+        onSaveNewView,
+        actions,
+        allowSelections,
+        allowViewCustomization,
+        allowSavingDefaultView,
+    } = props;
     const { viewName } = model;
 
     const isEdited = view?.session && !view?.hidden;
@@ -293,23 +305,18 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
                     Undo
                 </button>
             )}
-            {showSave && !canSaveCurrent && <button className="btn btn-success button-left-spacing" onClick={onSaveView}>Save</button>}
-            {showSave && canSaveCurrent &&
-                <SplitButton
-                    id="saveViewDropdown"
-                    bsStyle="success"
-                    onClick={onSaveView}
-                    title="Save"
-                >
-                    <MenuItem
-                        title="Save as new view"
-                        onClick={onSaveNewView}
-                        key="saveNewGridView"
-                    >
+            {showSave && !canSaveCurrent && (
+                <button className="btn btn-success button-left-spacing" onClick={onSaveView}>
+                    Save
+                </button>
+            )}
+            {showSave && canSaveCurrent && (
+                <SplitButton id="saveViewDropdown" bsStyle="success" onClick={onSaveView} title="Save">
+                    <MenuItem title="Save as new view" onClick={onSaveNewView} key="saveNewGridView">
                         Save as a new
                     </MenuItem>
                 </SplitButton>
-            }
+            )}
         </div>
     );
 });
@@ -758,12 +765,12 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
         return new Promise((resolve, reject) => {
             saveGridView(model.schemaQuery, model.displayColumns, model.containerPath, name, false, inherit, replace)
-                .then((response) => {
+                .then(response => {
                     actions.loadModel(model.id, allowSelections);
                     resolve(response);
                 })
                 .catch(errorMsg => {
-                    reject(errorMsg)
+                    reject(errorMsg);
                 });
         });
     };
@@ -885,8 +892,17 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             title,
         } = this.props;
         const { showFilterModalFieldKey, showSaveViewModal, actionValues, errorMsg } = this.state;
-        const { hasData, id, isLoading, isLoadingSelections, rowsError, selectionsError, messages, queryInfoError, queryInfo } =
-            model;
+        const {
+            hasData,
+            id,
+            isLoading,
+            isLoadingSelections,
+            rowsError,
+            selectionsError,
+            messages,
+            queryInfoError,
+            queryInfo,
+        } = model;
         const hasGridError = queryInfoError !== undefined || rowsError !== undefined;
         const hasError = hasGridError || selectionsError !== undefined || errorMsg;
         let loadingMessage;

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -27,13 +27,7 @@ import { GRID_SELECTION_INDEX } from '../../internal/constants';
 import { DataViewInfo } from '../../internal/models';
 import { headerCell, headerSelectionCell, isFilterColumnNameMatch } from '../../internal/renderers';
 
-import {
-    getGridView,
-    revertViewEdit,
-    saveGridView,
-    saveAsSessionView,
-    saveSessionView
-} from '../../internal/actions';
+import { getGridView, revertViewEdit, saveGridView, saveAsSessionView, saveSessionView } from '../../internal/actions';
 
 import { ActionValue } from './grid/actions/Action';
 import { FilterAction } from './grid/actions/Filter';
@@ -92,7 +86,7 @@ export interface GridPanelProps<ButtonsComponentProps> {
     supportedExportTypes?: Set<EXPORT_TYPES>;
     getFilterDisplayValue?: (columnName: string, rawValue: string) => string;
     highlightLastSelectedRow?: boolean;
-    user?: User
+    user?: User;
 }
 
 type Props<T> = GridPanelProps<T> & RequiresModelAndActions;
@@ -271,8 +265,8 @@ interface GridTitleProps {
     onSaveView?: () => void;
     onSaveNewView?: () => void;
     view?: ViewInfo;
-    isUpdated?: boolean,
-    user?: User
+    isUpdated?: boolean;
+    user?: User;
 }
 
 export const GridTitle: FC<GridTitleProps> = memo(props => {
@@ -287,7 +281,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
         allowSelections,
         allowViewCustomization,
         isUpdated,
-        user
+        user,
     } = props;
     const { queryInfo, viewName } = model;
 
@@ -297,8 +291,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
     if (!currentView) {
         if (viewName) {
             currentView = queryInfo.views.get(viewName.toLowerCase());
-        }
-        else {
+        } else {
             currentView = queryInfo?.views.get(ViewInfo.DEFAULT_NAME.toLowerCase());
         }
     }
@@ -313,7 +306,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
 
     let canSaveCurrent = false;
 
-    if (!!viewName) {
+    if (viewName) {
         const currentUser = user ?? useServerContext().user; // call useServerContext in if block to avoid ServerContext for GridPanel jest tests
         canSaveCurrent = !currentUser.isGuest && !currentView?.hidden;
     }
@@ -360,7 +353,7 @@ interface State {
     showSaveViewModal: boolean;
     headerClickCount: { [key: string]: number };
     errorMsg: React.ReactNode;
-    isViewSaved?: boolean
+    isViewSaved?: boolean;
 }
 
 /**
@@ -386,7 +379,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         showSampleComparisonReports: false,
         showSearchInput: true,
         showViewMenu: true,
-        showHeader: true
+        showHeader: true,
     };
 
     constructor(props) {
@@ -406,7 +399,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             showSaveViewModal: false,
             headerClickCount: {},
             errorMsg: undefined,
-            isViewSaved: false
+            isViewSaved: false,
         };
     }
 
@@ -765,7 +758,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
     hideColumn = (columnToHide: QueryColumn): void => {
         const { actions, model, allowSelections } = this.props;
-        const {queryInfo, viewName} = model;
+        const { queryInfo, viewName } = model;
 
         const view = queryInfo?.views?.get(viewName ? viewName.toLowerCase() : ViewInfo.DEFAULT_NAME.toLowerCase());
 
@@ -784,18 +777,16 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     };
 
     onSaveCurrentView = async () => {
-        const {model} = this.props;
-        const {queryInfo, viewName} = model;
+        const { model } = this.props;
+        const { queryInfo, viewName } = model;
 
         const view = queryInfo?.views?.get(viewName ? viewName.toLowerCase() : ViewInfo.DEFAULT_NAME.toLowerCase());
 
-        let currentView = view
+        let currentView = view;
         try {
-            if (view.session)
-                currentView = await getGridView(queryInfo.schemaQuery, viewName, true);
+            if (view.session) currentView = await getGridView(queryInfo.schemaQuery, viewName, true);
             await this.onSaveView(viewName, currentView?.inherit, true, currentView?.shared);
-        }
-        catch (errorMsg) {
+        } catch (errorMsg) {
             this.setState({ errorMsg });
         }
     };
@@ -815,8 +806,19 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
             (view.session
                 ? saveSessionView(model.schemaQuery, model.containerPath, viewName, newName, inherit, shared)
-                : saveGridView(model.schemaQuery, model.displayColumns, model.containerPath, newName, inherit, shared, inherit, replace, shared)
-            ).then(response => {
+                : saveGridView(
+                      model.schemaQuery,
+                      model.displayColumns,
+                      model.containerPath,
+                      newName,
+                      inherit,
+                      shared,
+                      inherit,
+                      replace,
+                      shared
+                  )
+            )
+                .then(response => {
                     actions.loadModel(model.id, allowSelections);
 
                     if (showSaveViewModal) {
@@ -835,15 +837,14 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
     showViewSavedIndicator = (): void => {
         this.setState({
-            isViewSaved: true
+            isViewSaved: true,
         });
 
         setTimeout(() => {
             this.setState({
-                isViewSaved: false
+                isViewSaved: false,
             });
         }, 5000);
-
     };
 
     closeSaveViewModal = (): void => {
@@ -956,7 +957,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             showFilterStatus,
             showHeader,
             title,
-            user
+            user,
         } = this.props;
         const { showFilterModalFieldKey, showSaveViewModal, actionValues, errorMsg, isViewSaved } = this.state;
         const {

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -811,7 +811,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             const view = queryInfo?.views?.get(viewName ? viewName.toLowerCase() : ViewInfo.DEFAULT_NAME.toLowerCase());
 
             (view.session
-                ? saveSessionView(model.schemaQuery, model.containerPath, viewName, newName, inherit, shared)
+                ? saveSessionView(model.schemaQuery, model.containerPath, viewName, newName, inherit, shared, false, replace)
                 : saveGridView(
                       model.schemaQuery,
                       model.displayColumns,

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -782,7 +782,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             });
     };
 
-    onSaveCurrentView = async (canSaveShared) => {
+    onSaveCurrentView = async canSaveShared => {
         const { model } = this.props;
         const { queryInfo, viewName } = model;
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -334,7 +334,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
             {showSave && canSaveCurrent && (
                 <SplitButton id="saveViewDropdown" bsStyle="success" onClick={onSaveView} title="Save">
                     <MenuItem title="Save as new view" onClick={onSaveNewView} key="saveNewGridView">
-                        Save as a new
+                        Save as
                     </MenuItem>
                 </SplitButton>
             )}
@@ -784,11 +784,11 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         this.setState({ showSaveViewModal: true });
     };
 
-    onSaveView = (name: string, inherit: boolean, replace: boolean): Promise<any> => {
+    onSaveView = (name: string, inherit: boolean, replace: boolean, shared: boolean): Promise<any> => {
         const { model, actions, allowSelections } = this.props;
 
         return new Promise((resolve, reject) => {
-            saveGridView(model.schemaQuery, model.displayColumns, model.containerPath, name, false, inherit, replace)
+            saveGridView(model.schemaQuery, model.displayColumns, model.containerPath, name, false, inherit, replace, shared)
                 .then(response => {
                     actions.loadModel(model.id, allowSelections);
                     resolve(response);

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -811,7 +811,16 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             const view = queryInfo?.views?.get(viewName ? viewName.toLowerCase() : ViewInfo.DEFAULT_NAME.toLowerCase());
 
             (view.session
-                ? saveSessionView(model.schemaQuery, model.containerPath, viewName, newName, inherit, shared, false, replace)
+                ? saveSessionView(
+                      model.schemaQuery,
+                      model.containerPath,
+                      viewName,
+                      newName,
+                      inherit,
+                      shared,
+                      false,
+                      replace
+                  )
                 : saveGridView(
                       model.schemaQuery,
                       model.displayColumns,

--- a/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 
+import { ModalBody } from 'react-bootstrap';
+
+import { ViewInfo } from '../../internal/ViewInfo';
+
+import { mountWithServerContext } from '../../internal/testHelpers';
+import { TEST_USER_APP_ADMIN, TEST_USER_EDITOR } from '../../internal/userFixtures';
+
 import { SaveViewModal } from './SaveViewModal';
-import { ViewInfo } from "../../internal/ViewInfo";
-import {mountWithServerContext} from "../../internal/testHelpers";
-import {TEST_USER_APP_ADMIN, TEST_USER_EDITOR} from "../../internal/userFixtures";
-import {ModalBody} from "react-bootstrap";
 
 beforeAll(() => {
     LABKEY.moduleContext = {
         query: {
-            isSubfolderDataEnabled: true
-        }
-    }
+            isSubfolderDataEnabled: true,
+        },
+    };
 });
 
 describe('SaveViewModal', () => {
@@ -19,7 +22,7 @@ describe('SaveViewModal', () => {
         gridLabel: 'Blood Samples',
         onCancel: jest.fn(),
         onConfirmSave: jest.fn(),
-        afterSave: jest.fn()
+        afterSave: jest.fn(),
     };
 
     const DEFAULT_VIEW = ViewInfo.create({
@@ -27,7 +30,7 @@ describe('SaveViewModal', () => {
         filters: [],
         default: true,
         name: '',
-        inherit: true
+        inherit: true,
     });
 
     const VIEW_1 = ViewInfo.create({
@@ -36,7 +39,7 @@ describe('SaveViewModal', () => {
         default: false,
         label: 'View 1',
         name: 'View1',
-        inherit: false
+        inherit: false,
     });
 
     const VIEW_2 = ViewInfo.create({
@@ -45,22 +48,20 @@ describe('SaveViewModal', () => {
         default: false,
         label: 'View 2',
         name: 'View2',
-        inherit: true
+        inherit: true,
     });
 
     const moduleContext = {
         query: {
-            isSubfolderDataEnabled: true
+            isSubfolderDataEnabled: true,
         },
     };
 
     test('current view is default', async () => {
-        const wrapper = mountWithServerContext(
-            <SaveViewModal
-                {...DEFAULT_PROPS}
-                currentView={DEFAULT_VIEW}
-            />, { user: TEST_USER_APP_ADMIN, moduleContext }
-        );
+        const wrapper = mountWithServerContext(<SaveViewModal {...DEFAULT_PROPS} currentView={DEFAULT_VIEW} />, {
+            user: TEST_USER_APP_ADMIN,
+            moduleContext,
+        });
 
         expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
         expect(wrapper.find(ModalBody).text()).toContain(
@@ -74,12 +75,10 @@ describe('SaveViewModal', () => {
     });
 
     test('current view is a customized view', async () => {
-        const wrapper = mountWithServerContext(
-            <SaveViewModal
-                {...DEFAULT_PROPS}
-                currentView={VIEW_1}
-            />, { user: TEST_USER_APP_ADMIN, moduleContext }
-        );
+        const wrapper = mountWithServerContext(<SaveViewModal {...DEFAULT_PROPS} currentView={VIEW_1} />, {
+            user: TEST_USER_APP_ADMIN,
+            moduleContext,
+        });
 
         expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
         expect(wrapper.find(ModalBody).text()).toContain(
@@ -93,12 +92,10 @@ describe('SaveViewModal', () => {
     });
 
     test('no admin perm', async () => {
-        const wrapper = mountWithServerContext(
-            <SaveViewModal
-                {...DEFAULT_PROPS}
-                currentView={VIEW_2}
-            />, { user: TEST_USER_EDITOR, moduleContext }
-        );
+        const wrapper = mountWithServerContext(<SaveViewModal {...DEFAULT_PROPS} currentView={VIEW_2} />, {
+            user: TEST_USER_EDITOR,
+            moduleContext,
+        });
 
         expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
         expect(wrapper.find(ModalBody).text()).toContain(
@@ -110,5 +107,4 @@ describe('SaveViewModal', () => {
 
         wrapper.unmount();
     });
-
 });

--- a/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
@@ -5,7 +5,7 @@ import { ModalBody } from 'react-bootstrap';
 import { ViewInfo } from '../../internal/ViewInfo';
 
 import { mountWithServerContext } from '../../internal/testHelpers';
-import {TEST_USER_APP_ADMIN, TEST_USER_EDITOR, TEST_USER_PROJECT_ADMIN} from '../../internal/userFixtures';
+import { TEST_USER_APP_ADMIN, TEST_USER_EDITOR, TEST_USER_PROJECT_ADMIN } from '../../internal/userFixtures';
 
 import { SaveViewModal } from './SaveViewModal';
 

--- a/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
@@ -22,7 +22,6 @@ describe('SaveViewModal', () => {
         gridLabel: 'Blood Samples',
         onCancel: jest.fn(),
         onConfirmSave: jest.fn(),
-        afterSave: jest.fn(),
     };
 
     const DEFAULT_VIEW = ViewInfo.create({

--- a/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import { SaveViewModal } from './SaveViewModal';
+import { ViewInfo } from "../../internal/ViewInfo";
+import {mountWithServerContext} from "../../internal/testHelpers";
+import {TEST_USER_APP_ADMIN, TEST_USER_EDITOR} from "../../internal/userFixtures";
+import {ModalBody} from "react-bootstrap";
+
+beforeAll(() => {
+    LABKEY.moduleContext = {
+        query: {
+            isSubfolderDataEnabled: true
+        }
+    }
+});
+
+describe('SaveViewModal', () => {
+    const DEFAULT_PROPS = {
+        gridLabel: 'Blood Samples',
+        onCancel: jest.fn(),
+        onConfirmSave: jest.fn(),
+        afterSave: jest.fn()
+    };
+
+    const DEFAULT_VIEW = ViewInfo.create({
+        columns: [],
+        filters: [],
+        default: true,
+        name: '',
+        inherit: true
+    });
+
+    const VIEW_1 = ViewInfo.create({
+        columns: [],
+        filters: [],
+        default: false,
+        label: 'View 1',
+        name: 'View1',
+        inherit: false
+    });
+
+    const VIEW_2 = ViewInfo.create({
+        columns: [],
+        filters: [],
+        default: false,
+        label: 'View 2',
+        name: 'View2',
+        inherit: true
+    });
+
+    const moduleContext = {
+        query: {
+            isSubfolderDataEnabled: true
+        },
+    };
+
+    test('current view is default', async () => {
+        const wrapper = mountWithServerContext(
+            <SaveViewModal
+                {...DEFAULT_PROPS}
+                currentView={DEFAULT_VIEW}
+            />, { user: TEST_USER_APP_ADMIN, moduleContext }
+        );
+
+        expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
+        expect(wrapper.find(ModalBody).text()).toContain(
+            'Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
+        );
+        expect(wrapper.find('input[name="gridViewName"]').prop('value')).toBe('');
+        expect(wrapper.find('input[name="setDefaultView"]').prop('checked')).toBe(true);
+        expect(wrapper.find('input[name="setInherit"]').prop('checked')).toBe(true);
+
+        wrapper.unmount();
+    });
+
+    test('current view is a customized view', async () => {
+        const wrapper = mountWithServerContext(
+            <SaveViewModal
+                {...DEFAULT_PROPS}
+                currentView={VIEW_1}
+            />, { user: TEST_USER_APP_ADMIN, moduleContext }
+        );
+
+        expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
+        expect(wrapper.find(ModalBody).text()).toContain(
+            'Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
+        );
+        expect(wrapper.find('input[name="gridViewName"]').prop('value')).toBe('View1');
+        expect(wrapper.find('input[name="setDefaultView"]').prop('checked')).toBe(false);
+        expect(wrapper.find('input[name="setInherit"]').prop('checked')).toBe(false);
+
+        wrapper.unmount();
+    });
+
+    test('no admin perm', async () => {
+        const wrapper = mountWithServerContext(
+            <SaveViewModal
+                {...DEFAULT_PROPS}
+                currentView={VIEW_2}
+            />, { user: TEST_USER_EDITOR, moduleContext }
+        );
+
+        expect(wrapper.find('ModalTitle').text()).toBe('Save Grid View');
+        expect(wrapper.find(ModalBody).text()).toContain(
+            'Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available for all Blood Samples grids throughout the application.'
+        );
+        expect(wrapper.find('input[name="gridViewName"]').prop('value')).toBe('View2');
+        expect(wrapper.find('input[name="setDefaultView"]').length).toEqual(0);
+        expect(wrapper.find('input[name="setInherit"]').prop('checked')).toBe(true);
+
+        wrapper.unmount();
+    });
+
+});

--- a/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.spec.tsx
@@ -5,7 +5,7 @@ import { ModalBody } from 'react-bootstrap';
 import { ViewInfo } from '../../internal/ViewInfo';
 
 import { mountWithServerContext } from '../../internal/testHelpers';
-import { TEST_USER_APP_ADMIN, TEST_USER_EDITOR } from '../../internal/userFixtures';
+import {TEST_USER_APP_ADMIN, TEST_USER_EDITOR, TEST_USER_PROJECT_ADMIN} from '../../internal/userFixtures';
 
 import { SaveViewModal } from './SaveViewModal';
 
@@ -76,7 +76,7 @@ describe('SaveViewModal', () => {
 
     test('current view is a customized view', async () => {
         const wrapper = mountWithServerContext(<SaveViewModal {...DEFAULT_PROPS} currentView={VIEW_1} />, {
-            user: TEST_USER_APP_ADMIN,
+            user: TEST_USER_PROJECT_ADMIN,
             moduleContext,
         });
 

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -1,15 +1,15 @@
 import React, { ChangeEvent, FC, memo, useCallback, useState } from 'react';
 import { Modal } from 'react-bootstrap';
 
-import {PermissionTypes} from "@labkey/api";
+import { PermissionTypes } from '@labkey/api';
 
 import { WizardNavButtons } from '../../internal/components/buttons/WizardNavButtons';
-import { ViewInfo } from "../../internal/ViewInfo";
-import { Alert } from "../../internal/components/base/Alert";
-import {resolveErrorMessage} from "../../internal/util/messaging";
-import {CUSTOM_VIEW,HelpLink} from "../../internal/util/helpLinks";
-import {RequiresPermission} from "../../internal/components/base/Permissions";
-import {isSubfolderDataEnabled} from "../../internal/app/utils";
+import { ViewInfo } from '../../internal/ViewInfo';
+import { Alert } from '../../internal/components/base/Alert';
+import { resolveErrorMessage } from '../../internal/util/messaging';
+import { CUSTOM_VIEW, HelpLink } from '../../internal/util/helpLinks';
+import { RequiresPermission } from '../../internal/components/base/Permissions';
+import { isSubfolderDataEnabled } from '../../internal/app/utils';
 
 export interface Props {
     currentView: ViewInfo;
@@ -49,7 +49,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
     const onViewNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setViewName(evt.target.value), []);
 
     const toggleDefaultView = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
-        setIsDefaultView(evt.target.checked)
+        setIsDefaultView(evt.target.checked);
     }, []);
 
     const toggleInherit = useCallback((evt: ChangeEvent<HTMLInputElement>) => setCanInherit(evt.target.checked), []);
@@ -64,8 +64,9 @@ export const SaveViewModal: FC<Props> = memo(props => {
                 <form onSubmit={saveView}>
                     <div className="form-group">
                         <div className="bottom-spacing">
-                            Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available on {viewLabel ?? currentView.name} grids throughout the application.
-                            Learn more about <HelpLink topic={CUSTOM_VIEW}>custom grid views</HelpLink> in LabKey.
+                            Sort order and filters are not saved as part of custom grid views. Once saved, this view
+                            will be available on {viewLabel ?? currentView.name} grids throughout the application. Learn
+                            more about <HelpLink topic={CUSTOM_VIEW}>custom grid views</HelpLink> in LabKey.
                         </div>
                         <div className="bottom-spacing">
                             <input
@@ -79,16 +80,28 @@ export const SaveViewModal: FC<Props> = memo(props => {
                         </div>
                         <RequiresPermission perms={PermissionTypes.Admin}>
                             <div className="form-check bottom-spacing">
-                                <input className="form-check-input" type="checkbox" id="setDefaultView" onChange={toggleDefaultView} checked={isDefaultView}/>
+                                <input
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    id="setDefaultView"
+                                    onChange={toggleDefaultView}
+                                    checked={isDefaultView}
+                                />
                                 <span className="margin-left">Make this the default grid view</span>
                             </div>
                         </RequiresPermission>
-                        {isSubfolderDataEnabled() &&
+                        {isSubfolderDataEnabled() && (
                             <div className="form-check">
-                                <input className="form-check-input" type="checkbox" id="setInherit" onChange={toggleInherit} checked={canInherit}/>
+                                <input
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    id="setInherit"
+                                    onChange={toggleInherit}
+                                    checked={canInherit}
+                                />
                                 <span className="margin-left">Make this grid view available in child folders</span>
                             </div>
-                        }
+                        )}
                     </div>
                 </form>
             </Modal.Body>

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -1,0 +1,110 @@
+import React, { ChangeEvent, FC, memo, useCallback, useState } from 'react';
+import { Modal } from 'react-bootstrap';
+
+import {PermissionTypes} from "@labkey/api";
+
+import { WizardNavButtons } from '../../internal/components/buttons/WizardNavButtons';
+import { ViewInfo } from "../../internal/ViewInfo";
+import { Alert } from "../../internal/components/base/Alert";
+import {resolveErrorMessage} from "../../internal/util/messaging";
+import {CUSTOM_VIEW,HelpLink} from "../../internal/util/helpLinks";
+import {RequiresPermission} from "../../internal/components/base/Permissions";
+import {isSubfolderDataEnabled} from "../../internal/app/utils";
+
+export interface Props {
+    currentView: ViewInfo;
+    onCancel: () => void;
+    onConfirmSave?: (viewName, canInherit, replace) => Promise<any>;
+    afterSave?: (viewName: string) => void;
+    viewLabel?: string;
+}
+
+export const SaveViewModal: FC<Props> = memo(props => {
+    const { onConfirmSave, currentView, onCancel, afterSave, viewLabel } = props;
+
+    const [viewName, setViewName] = useState<string>(currentView?.name);
+    const [isDefaultView, setIsDefaultView] = useState<boolean>();
+    const [canInherit, setCanInherit] = useState<boolean>();
+    const [errorMessage, setErrorMessage] = useState<string>();
+    const [isSubmitting, setIsSubmitting] = useState<boolean>();
+
+    const saveView = useCallback(async () => {
+        if (!viewName && !isDefaultView) return;
+
+        setErrorMessage(undefined);
+        setIsSubmitting(true);
+
+        try {
+            const isCurrentView = viewName?.toLowerCase() === currentView?.name?.toLowerCase();
+            const name = isDefaultView ? '' : viewName;
+            await onConfirmSave(name, canInherit, isCurrentView);
+            afterSave(name);
+        } catch (error) {
+            setErrorMessage(resolveErrorMessage(error));
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [viewName]);
+
+    const onViewNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setViewName(evt.target.value), []);
+
+    const toggleDefaultView = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
+        setIsDefaultView(evt.target.checked)
+    }, []);
+
+    const toggleInherit = useCallback((evt: ChangeEvent<HTMLInputElement>) => setCanInherit(evt.target.checked), []);
+
+    return (
+        <Modal onHide={onCancel} show>
+            <Modal.Header closeButton>
+                <Modal.Title>Save Grid View</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Alert>{errorMessage}</Alert>
+                <form onSubmit={saveView}>
+                    <div className="form-group">
+                        <div className="bottom-spacing">
+                            Sort order and filters are not saved as part of custom grid views. Once saved, this view will be available on {viewLabel ?? currentView.name} grids throughout the application.
+                            Learn more about <HelpLink topic={CUSTOM_VIEW}>custom grid views</HelpLink> in LabKey.
+                        </div>
+                        <div className="bottom-spacing">
+                            <input
+                                placeholder="Give this search a name"
+                                className="form-control"
+                                value={viewName}
+                                onChange={onViewNameChange}
+                                disabled={isDefaultView}
+                                type="text"
+                            />
+                        </div>
+                        <RequiresPermission perms={PermissionTypes.Admin}>
+                            <div className="form-check bottom-spacing">
+                                <input className="form-check-input" type="checkbox" id="setDefaultView" onChange={toggleDefaultView} checked={isDefaultView}/>
+                                <span className="margin-left">Make this the default grid view</span>
+                            </div>
+                        </RequiresPermission>
+                        {isSubfolderDataEnabled() &&
+                            <div className="form-check">
+                                <input className="form-check-input" type="checkbox" id="setInherit" onChange={toggleInherit} checked={canInherit}/>
+                                <span className="margin-left">Make this grid view available in child folders</span>
+                            </div>
+                        }
+                    </div>
+                </form>
+            </Modal.Body>
+            <Modal.Footer>
+                <WizardNavButtons
+                    cancel={onCancel}
+                    cancelText="Cancel"
+                    canFinish={!!viewName || isDefaultView}
+                    containerClassName=""
+                    isFinishing={isSubmitting}
+                    isFinishingText="Saving..."
+                    finish
+                    finishText="Save"
+                    nextStep={saveView}
+                />
+            </Modal.Footer>
+        </Modal>
+    );
+});

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -13,18 +13,18 @@ import { isSubfolderDataEnabled } from '../../internal/app/utils';
 
 export interface Props {
     currentView: ViewInfo;
+    gridLabel: string;
     onCancel: () => void;
-    onConfirmSave?: (viewName, canInherit, replace) => Promise<any>;
-    afterSave?: (viewName: string) => void;
-    viewLabel?: string;
+    onConfirmSave: (viewName, canInherit, replace) => Promise<any>;
+    afterSave: (viewName: string) => void;
 }
 
 export const SaveViewModal: FC<Props> = memo(props => {
-    const { onConfirmSave, currentView, onCancel, afterSave, viewLabel } = props;
+    const { onConfirmSave, currentView, onCancel, afterSave, gridLabel } = props;
 
-    const [viewName, setViewName] = useState<string>(currentView?.name);
-    const [isDefaultView, setIsDefaultView] = useState<boolean>();
-    const [canInherit, setCanInherit] = useState<boolean>();
+    const [viewName, setViewName] = useState<string>(currentView?.isDefault ? '' : currentView?.name);
+    const [isDefaultView, setIsDefaultView] = useState<boolean>(currentView?.isDefault);
+    const [canInherit, setCanInherit] = useState<boolean>(currentView?.inherit);
     const [errorMessage, setErrorMessage] = useState<string>();
     const [isSubmitting, setIsSubmitting] = useState<boolean>();
 
@@ -35,8 +35,8 @@ export const SaveViewModal: FC<Props> = memo(props => {
         setIsSubmitting(true);
 
         try {
-            const isCurrentView = viewName?.toLowerCase() === currentView?.name?.toLowerCase();
-            const name = isDefaultView ? '' : viewName;
+            const name = isDefaultView ? '' : viewName.trim();
+            const isCurrentView = name?.toLowerCase() === currentView?.name?.toLowerCase();
             await onConfirmSave(name, canInherit, isCurrentView);
             afterSave(name);
         } catch (error) {
@@ -65,12 +65,13 @@ export const SaveViewModal: FC<Props> = memo(props => {
                     <div className="form-group">
                         <div className="bottom-spacing">
                             Sort order and filters are not saved as part of custom grid views. Once saved, this view
-                            will be available on {viewLabel ?? currentView.name} grids throughout the application. Learn
+                            will be available for all {gridLabel} grids throughout the application. Learn
                             more about <HelpLink topic={CUSTOM_VIEW}>custom grid views</HelpLink> in LabKey.
                         </div>
                         <div className="bottom-spacing">
                             <input
-                                placeholder="Give this search a name"
+                                name="gridViewName"
+                                placeholder="Grid View Name"
                                 className="form-control"
                                 value={viewName}
                                 onChange={onViewNameChange}
@@ -83,7 +84,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
                                 <input
                                     className="form-check-input"
                                     type="checkbox"
-                                    id="setDefaultView"
+                                    name="setDefaultView"
                                     onChange={toggleDefaultView}
                                     checked={isDefaultView}
                                 />
@@ -95,7 +96,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
                                 <input
                                     className="form-check-input"
                                     type="checkbox"
-                                    id="setInherit"
+                                    name="setInherit"
                                     onChange={toggleInherit}
                                     checked={canInherit}
                                 />

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -80,7 +80,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
                                 onChange={onViewNameChange}
                                 disabled={isDefaultView}
                                 type="text"
-                                width={50}
+                                maxLength={50}
                             />
                         </div>
                         <RequiresPermission perms={PermissionTypes.Admin}>

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -16,11 +16,10 @@ export interface Props {
     gridLabel: string;
     onCancel: () => void;
     onConfirmSave: (viewName, canInherit, replace, shared) => Promise<any>;
-    afterSave: (viewName: string) => void;
 }
 
 export const SaveViewModal: FC<Props> = memo(props => {
-    const { onConfirmSave, currentView, onCancel, afterSave, gridLabel } = props;
+    const { onConfirmSave, currentView, onCancel, gridLabel } = props;
 
     const [viewName, setViewName] = useState<string>(currentView?.isDefault ? '' : currentView?.name);
     const [isDefaultView, setIsDefaultView] = useState<boolean>(currentView?.isDefault);
@@ -38,13 +37,12 @@ export const SaveViewModal: FC<Props> = memo(props => {
             const name = isDefaultView ? '' : viewName.trim();
             const isCurrentView = name?.toLowerCase() === currentView?.name?.toLowerCase();
             await onConfirmSave(name, canInherit, isCurrentView, isDefaultView);
-            afterSave(name);
         } catch (error) {
             setErrorMessage(resolveErrorMessage(error));
         } finally {
             setIsSubmitting(false);
         }
-    }, [viewName]);
+    }, [viewName, isDefaultView, canInherit]);
 
     const onViewNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setViewName(evt.target.value), []);
 
@@ -79,7 +77,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
                                 type="text"
                             />
                         </div>
-                        <RequiresPermission perms={PermissionTypes.Admin}>
+                        <RequiresPermission perms={PermissionTypes.Admin}> {/* Only allow admins to create custom default views in app. Note this is different from LKS*/}
                             <div className="form-check bottom-spacing">
                                 <input
                                     className="form-check-input"

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -15,7 +15,7 @@ export interface Props {
     currentView: ViewInfo;
     gridLabel: string;
     onCancel: () => void;
-    onConfirmSave: (viewName, canInherit, replace) => Promise<any>;
+    onConfirmSave: (viewName, canInherit, replace, shared) => Promise<any>;
     afterSave: (viewName: string) => void;
 }
 
@@ -37,7 +37,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
         try {
             const name = isDefaultView ? '' : viewName.trim();
             const isCurrentView = name?.toLowerCase() === currentView?.name?.toLowerCase();
-            await onConfirmSave(name, canInherit, isCurrentView);
+            await onConfirmSave(name, canInherit, isCurrentView, isDefaultView);
             afterSave(name);
         } catch (error) {
             setErrorMessage(resolveErrorMessage(error));
@@ -88,7 +88,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
                                     onChange={toggleDefaultView}
                                     checked={isDefaultView}
                                 />
-                                <span className="margin-left">Make this the default grid view</span>
+                                <span className="margin-left">Make default view for all users</span>
                             </div>
                         </RequiresPermission>
                         {isSubfolderDataEnabled() && (

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, FC, memo, useCallback, useEffect, useState} from 'react';
+import React, { ChangeEvent, FC, memo, useCallback, useEffect, useState } from 'react';
 import { Modal } from 'react-bootstrap';
 
 import { PermissionTypes } from '@labkey/api';
@@ -10,7 +10,7 @@ import { resolveErrorMessage } from '../../internal/util/messaging';
 import { CUSTOM_VIEW, HelpLink } from '../../internal/util/helpLinks';
 import { RequiresPermission } from '../../internal/components/base/Permissions';
 import { isSubfolderDataEnabled } from '../../internal/app/utils';
-import { useServerContext } from "../../internal/components/base/ServerContext";
+import { useServerContext } from '../../internal/components/base/ServerContext';
 
 export interface Props {
     currentView: ViewInfo;
@@ -22,9 +22,11 @@ export interface Props {
 export const SaveViewModal: FC<Props> = memo(props => {
     const { onConfirmSave, currentView, onCancel, gridLabel } = props;
 
-    const { user}  = useServerContext();
+    const { user } = useServerContext();
 
-    const [viewName, setViewName] = useState<string>(currentView?.isDefault || currentView?.hidden ? '' : currentView?.name);
+    const [viewName, setViewName] = useState<string>(
+        currentView?.isDefault || currentView?.hidden ? '' : currentView?.name
+    );
     const [isDefaultView, setIsDefaultView] = useState<boolean>(user.hasAdminPermission() && currentView?.isDefault);
     const [canInherit, setCanInherit] = useState<boolean>(currentView?.inherit);
     const [errorMessage, setErrorMessage] = useState<string>();
@@ -81,7 +83,9 @@ export const SaveViewModal: FC<Props> = memo(props => {
                                 width={50}
                             />
                         </div>
-                        <RequiresPermission perms={PermissionTypes.Admin}> {/* Only allow admins to create custom default views in app. Note this is different from LKS*/}
+                        <RequiresPermission perms={PermissionTypes.Admin}>
+                            {' '}
+                            {/* Only allow admins to create custom default views in app. Note this is different from LKS*/}
                             <div className="form-check bottom-spacing">
                                 <input
                                     className="form-check-input"

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -65,8 +65,8 @@ export const SaveViewModal: FC<Props> = memo(props => {
                     <div className="form-group">
                         <div className="bottom-spacing">
                             Sort order and filters are not saved as part of custom grid views. Once saved, this view
-                            will be available for all {gridLabel} grids throughout the application. Learn
-                            more about <HelpLink topic={CUSTOM_VIEW}>custom grid views</HelpLink> in LabKey.
+                            will be available for all {gridLabel} grids throughout the application. Learn more about{' '}
+                            <HelpLink topic={CUSTOM_VIEW}>custom grid views</HelpLink> in LabKey.
                         </div>
                         <div className="bottom-spacing">
                             <input

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, memo, useCallback, useState } from 'react';
+import React, {ChangeEvent, FC, memo, useCallback, useEffect, useState} from 'react';
 import { Modal } from 'react-bootstrap';
 
 import { PermissionTypes } from '@labkey/api';
@@ -10,6 +10,7 @@ import { resolveErrorMessage } from '../../internal/util/messaging';
 import { CUSTOM_VIEW, HelpLink } from '../../internal/util/helpLinks';
 import { RequiresPermission } from '../../internal/components/base/Permissions';
 import { isSubfolderDataEnabled } from '../../internal/app/utils';
+import { useServerContext } from "../../internal/components/base/ServerContext";
 
 export interface Props {
     currentView: ViewInfo;
@@ -21,8 +22,10 @@ export interface Props {
 export const SaveViewModal: FC<Props> = memo(props => {
     const { onConfirmSave, currentView, onCancel, gridLabel } = props;
 
-    const [viewName, setViewName] = useState<string>(currentView?.isDefault ? '' : currentView?.name);
-    const [isDefaultView, setIsDefaultView] = useState<boolean>(currentView?.isDefault);
+    const { user}  = useServerContext();
+
+    const [viewName, setViewName] = useState<string>(currentView?.isDefault || currentView?.hidden ? '' : currentView?.name);
+    const [isDefaultView, setIsDefaultView] = useState<boolean>(user.hasAdminPermission() && currentView?.isDefault);
     const [canInherit, setCanInherit] = useState<boolean>(currentView?.inherit);
     const [errorMessage, setErrorMessage] = useState<string>();
     const [isSubmitting, setIsSubmitting] = useState<boolean>();
@@ -75,6 +78,7 @@ export const SaveViewModal: FC<Props> = memo(props => {
                                 onChange={onViewNameChange}
                                 disabled={isDefaultView}
                                 type="text"
+                                width={50}
                             />
                         </div>
                         <RequiresPermission perms={PermissionTypes.Admin}> {/* Only allow admins to create custom default views in app. Note this is different from LKS*/}

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
@@ -9,12 +9,13 @@ import mixturesQuery from '../../test/data/mixtures-getQueryPaging.json';
 import { QueryInfo } from '../QueryInfo';
 import { SchemaQuery } from '../SchemaQuery';
 
+import { TEST_USER_READER } from '../../internal/userFixtures';
+
 import { QueryModel } from './QueryModel';
 
 import { RowsResponse } from './QueryModelLoader';
 import { TabbedGridPanel } from './TabbedGridPanel';
 import { makeTestActions, makeTestQueryModel } from './testUtils';
-import {TEST_USER_READER} from "../../internal/userFixtures";
 
 let MIXTURES_QUERY_INFO: QueryInfo;
 let MIXTURES_DATA: RowsResponse;
@@ -84,7 +85,9 @@ describe('TabbedGridPanel', () => {
     };
 
     test('default render', () => {
-        const wrapper = mount(<TabbedGridPanel tabOrder={tabOrder} queryModels={queryModels} actions={actions} user={TEST_USER_READER}/>);
+        const wrapper = mount(
+            <TabbedGridPanel tabOrder={tabOrder} queryModels={queryModels} actions={actions} user={TEST_USER_READER} />
+        );
         const tabs = wrapper.find(TABS_SELECTOR);
 
         // Here we test that tab order is honored, and that by default we set the first tab to active
@@ -115,7 +118,13 @@ describe('TabbedGridPanel', () => {
     test('asPanel', () => {
         const title = 'My Tabbed Grid';
         const wrapper = mount(
-            <TabbedGridPanel tabOrder={tabOrder} title={title} queryModels={queryModels} actions={actions} user={TEST_USER_READER}/>
+            <TabbedGridPanel
+                tabOrder={tabOrder}
+                title={title}
+                queryModels={queryModels}
+                actions={actions}
+                user={TEST_USER_READER}
+            />
         );
 
         // When asPanel is true, we use appropriate styling classes
@@ -130,7 +139,12 @@ describe('TabbedGridPanel', () => {
 
     test('single model', () => {
         const wrapper = mount(
-            <TabbedGridPanel tabOrder={['mixtures']} queryModels={{ mixtures: mixturesModel }} actions={actions} user={TEST_USER_READER}/>
+            <TabbedGridPanel
+                tabOrder={['mixtures']}
+                queryModels={{ mixtures: mixturesModel }}
+                actions={actions}
+                user={TEST_USER_READER}
+            />
         );
 
         // Hide the tabs if we only have one model.

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
@@ -9,8 +9,6 @@ import mixturesQuery from '../../test/data/mixtures-getQueryPaging.json';
 import { QueryInfo } from '../QueryInfo';
 import { SchemaQuery } from '../SchemaQuery';
 
-import { TEST_USER_READER } from '../../internal/userFixtures';
-
 import { QueryModel } from './QueryModel';
 
 import { RowsResponse } from './QueryModelLoader';
@@ -86,7 +84,7 @@ describe('TabbedGridPanel', () => {
 
     test('default render', () => {
         const wrapper = mount(
-            <TabbedGridPanel tabOrder={tabOrder} queryModels={queryModels} actions={actions} user={TEST_USER_READER} />
+            <TabbedGridPanel tabOrder={tabOrder} queryModels={queryModels} actions={actions} />
         );
         const tabs = wrapper.find(TABS_SELECTOR);
 
@@ -106,7 +104,6 @@ describe('TabbedGridPanel', () => {
                 tabOrder={tabOrder}
                 queryModels={queryModels}
                 actions={actions}
-                user={TEST_USER_READER}
             />
         );
 
@@ -123,7 +120,6 @@ describe('TabbedGridPanel', () => {
                 title={title}
                 queryModels={queryModels}
                 actions={actions}
-                user={TEST_USER_READER}
             />
         );
 
@@ -143,7 +139,6 @@ describe('TabbedGridPanel', () => {
                 tabOrder={['mixtures']}
                 queryModels={{ mixtures: mixturesModel }}
                 actions={actions}
-                user={TEST_USER_READER}
             />
         );
 
@@ -160,7 +155,6 @@ describe('TabbedGridPanel', () => {
                 onTabSelect={onTabSelect}
                 queryModels={queryModels}
                 tabOrder={tabOrder}
-                user={TEST_USER_READER}
             />
         );
         expectTabs(wrapper, AMINO_ACIDS_TITLE);
@@ -181,7 +175,6 @@ describe('TabbedGridPanel', () => {
                 queryModels={queryModels}
                 showRowCountOnTabs
                 tabOrder={tabOrder}
-                user={TEST_USER_READER}
             />
         );
 

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
@@ -14,6 +14,7 @@ import { QueryModel } from './QueryModel';
 import { RowsResponse } from './QueryModelLoader';
 import { TabbedGridPanel } from './TabbedGridPanel';
 import { makeTestActions, makeTestQueryModel } from './testUtils';
+import {TEST_USER_READER} from "../../internal/userFixtures";
 
 let MIXTURES_QUERY_INFO: QueryInfo;
 let MIXTURES_DATA: RowsResponse;
@@ -83,7 +84,7 @@ describe('TabbedGridPanel', () => {
     };
 
     test('default render', () => {
-        const wrapper = mount(<TabbedGridPanel tabOrder={tabOrder} queryModels={queryModels} actions={actions} />);
+        const wrapper = mount(<TabbedGridPanel tabOrder={tabOrder} queryModels={queryModels} actions={actions} user={TEST_USER_READER}/>);
         const tabs = wrapper.find(TABS_SELECTOR);
 
         // Here we test that tab order is honored, and that by default we set the first tab to active
@@ -102,6 +103,7 @@ describe('TabbedGridPanel', () => {
                 tabOrder={tabOrder}
                 queryModels={queryModels}
                 actions={actions}
+                user={TEST_USER_READER}
             />
         );
 
@@ -113,7 +115,7 @@ describe('TabbedGridPanel', () => {
     test('asPanel', () => {
         const title = 'My Tabbed Grid';
         const wrapper = mount(
-            <TabbedGridPanel tabOrder={tabOrder} title={title} queryModels={queryModels} actions={actions} />
+            <TabbedGridPanel tabOrder={tabOrder} title={title} queryModels={queryModels} actions={actions} user={TEST_USER_READER}/>
         );
 
         // When asPanel is true, we use appropriate styling classes
@@ -128,7 +130,7 @@ describe('TabbedGridPanel', () => {
 
     test('single model', () => {
         const wrapper = mount(
-            <TabbedGridPanel tabOrder={['mixtures']} queryModels={{ mixtures: mixturesModel }} actions={actions} />
+            <TabbedGridPanel tabOrder={['mixtures']} queryModels={{ mixtures: mixturesModel }} actions={actions} user={TEST_USER_READER}/>
         );
 
         // Hide the tabs if we only have one model.
@@ -144,6 +146,7 @@ describe('TabbedGridPanel', () => {
                 onTabSelect={onTabSelect}
                 queryModels={queryModels}
                 tabOrder={tabOrder}
+                user={TEST_USER_READER}
             />
         );
         expectTabs(wrapper, AMINO_ACIDS_TITLE);
@@ -164,6 +167,7 @@ describe('TabbedGridPanel', () => {
                 queryModels={queryModels}
                 showRowCountOnTabs
                 tabOrder={tabOrder}
+                user={TEST_USER_READER}
             />
         );
 

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -189,50 +189,53 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
     const activeModel = queryModels[activeId];
     const hasTabs = tabOrder.length > 1 || alwaysShowTabs;
 
+    const gridDisplay = (
+        <GridPanel
+            allowViewCustomization={allowViewCustomization}
+            key={activeId}
+            actions={actions}
+            hasHeader={!hasTabs}
+            asPanel={!hasTabs}
+            model={activeModel}
+            onExport={exportHandlers}
+            advancedExportOptions={advancedExportOptions}
+            {...rest}
+        />
+    );
+
     return (
-        <div className={classNames('tabbed-grid-panel', { panel: asPanel, 'panel-default': asPanel })}>
-            {!hasTabs && (
-                <GridTitle
-                    title={title}
-                    model={queryModels[activeId]}
-                    actions={actions}
-                    allowSelections={rest.allowSelections}
-                    allowViewCustomization={allowViewCustomization}
-                />
-            )}
-            <div className={classNames('tabbed-grid-panel__body', { 'panel-body': asPanel })}>
-                {hasTabs && (
-                    <ul className="nav nav-tabs">
-                        {tabOrder.map(modelId => {
-                            if (queryModels[modelId]) {
-                                return (
-                                    <GridTab
-                                        key={modelId}
-                                        model={queryModels[modelId]}
-                                        isActive={activeId === modelId}
-                                        onSelect={onSelect}
-                                        pullRight={rightTabs.indexOf(modelId) > -1}
-                                        showRowCount={showRowCountOnTabs}
-                                    />
-                                );
-                            } else {
-                                return null;
-                            }
-                        })}
-                    </ul>
-                )}
-                <GridPanel
-                    allowViewCustomization={allowViewCustomization}
-                    key={activeId}
-                    actions={actions}
-                    hasHeader={!hasTabs}
-                    asPanel={false}
-                    model={activeModel}
-                    onExport={exportHandlers}
-                    advancedExportOptions={advancedExportOptions}
-                    {...rest}
-                />
-            </div>
+        <>
+            {hasTabs &&
+                <div className={classNames('tabbed-grid-panel', { panel: asPanel, 'panel-default': asPanel })}>
+                    <div className={classNames('tabbed-grid-panel__body', {'panel-body': asPanel})}>
+                        {hasTabs && (
+                            <ul className="nav nav-tabs">
+                                {tabOrder.map(modelId => {
+                                    if (queryModels[modelId])
+                                    {
+                                        return (
+                                            <GridTab
+                                                key={modelId}
+                                                model={queryModels[modelId]}
+                                                isActive={activeId === modelId}
+                                                onSelect={onSelect}
+                                                pullRight={rightTabs.indexOf(modelId) > -1}
+                                                showRowCount={showRowCountOnTabs}
+                                            />
+                                        );
+                                    }
+                                    else
+                                    {
+                                        return null;
+                                    }
+                                })}
+                            </ul>
+                        )}
+                        {gridDisplay}
+                    </div>
+                </div>
+            }
+            {!hasTabs && <>{gridDisplay}</>}
             {showExportModal && !!queryModels && (
                 <ExportModal
                     queryModels={queryModels}
@@ -242,6 +245,6 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
                     canExport={canExport}
                 />
             )}
-        </div>
+        </>
     );
 });

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -205,14 +205,13 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
 
     return (
         <>
-            {hasTabs &&
+            {hasTabs && (
                 <div className={classNames('tabbed-grid-panel', { panel: asPanel, 'panel-default': asPanel })}>
-                    <div className={classNames('tabbed-grid-panel__body', {'panel-body': asPanel})}>
+                    <div className={classNames('tabbed-grid-panel__body', { 'panel-body': asPanel })}>
                         {hasTabs && (
                             <ul className="nav nav-tabs">
                                 {tabOrder.map(modelId => {
-                                    if (queryModels[modelId])
-                                    {
+                                    if (queryModels[modelId]) {
                                         return (
                                             <GridTab
                                                 key={modelId}
@@ -223,9 +222,7 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
                                                 showRowCount={showRowCountOnTabs}
                                             />
                                         );
-                                    }
-                                    else
-                                    {
+                                    } else {
                                         return null;
                                     }
                                 })}
@@ -234,7 +231,7 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
                         {gridDisplay}
                     </div>
                 </div>
-            }
+            )}
             {!hasTabs && <>{gridDisplay}</>}
             {showExportModal && !!queryModels && (
                 <ExportModal

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
+import {MenuItem} from " react-bootstrap ";
+
 import { QueryInfo, SchemaQuery } from '../..';
 
 import { initUnitTests, makeQueryInfo } from '../../internal/testHelpers';
@@ -49,6 +51,12 @@ beforeAll(() => {
 
 describe('ViewMenu', () => {
     test('Render', () => {
+        LABKEY.moduleContext = {
+            query: {
+                canCustomizeViewsFromApp: false,
+            },
+        };
+
         // Renders nothing
         let model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_NO_VIEWS, {}, []);
         let tree = renderer.create(<ViewMenu hideEmptyViewMenu model={model} onViewSelect={jest.fn()} />);
@@ -81,7 +89,28 @@ describe('ViewMenu', () => {
         expect(tree.toJSON()).toMatchSnapshot();
     });
 
+    test('Customized view menus', () => {
+        LABKEY.moduleContext = {
+            query: {
+                canCustomizeViewsFromApp: true,
+            },
+        };
+        const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
+        const wrapper = mount(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} />);
+        const items = wrapper.find(MenuItem);
+        expect(items).toHaveLength(3);
+        expect(items.at(2).text()).toBe('Save as custom view');
+
+        wrapper.unmount();
+
+    });
+
     test('Interactivity', () => {
+        LABKEY.moduleContext = {
+            query: {
+                canCustomizeViewsFromApp: false,
+            },
+        };
         const onViewSelect = jest.fn();
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PUBLIC_VIEWS, {}, []);
         const wrapper = mount(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={onViewSelect} />);

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -57,33 +57,33 @@ describe('ViewMenu', () => {
 
         // Renders nothing
         let model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_NO_VIEWS, {}, []);
-        let tree = renderer.create(<ViewMenu hideEmptyViewMenu model={model} onViewSelect={jest.fn()} />);
+        let tree = renderer.create(<ViewMenu hideEmptyViewMenu model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
         expect(tree.toJSON()).toMatchSnapshot();
 
         // Renders empty view selector with disabled dropdown.
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} />);
+        tree = renderer.create(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
         expect(tree.toJSON()).toMatchSnapshot();
 
         // "No Extra Column"  view shows up under "All Saved Views"
         model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PUBLIC_VIEWS, {}, []);
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} />);
+        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
         expect(tree.toJSON()).toMatchSnapshot();
 
         // "No Extra Column" view shows up under "My Saved Views"
         model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PRIVATE_VIEWS, {}, []);
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} />);
+        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
         expect(tree.toJSON()).toMatchSnapshot();
 
         // Same as previous, but the No Extra Column view is set to active.
         model = model.mutate({
             schemaQuery: SchemaQuery.create(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, 'noExtraColumn'),
         });
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} />);
+        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
         expect(tree.toJSON()).toMatchSnapshot();
 
         // "No Extra Column" view is hidden so does not show up
         model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} />);
+        tree = renderer.create(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
         expect(tree.toJSON()).toMatchSnapshot();
     });
 
@@ -94,7 +94,7 @@ describe('ViewMenu', () => {
             },
         };
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} />);
+        const wrapper = mount(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
         const items = wrapper.find('MenuItem');
         expect(items).toHaveLength(3);
         expect(items.at(2).text()).toBe('Save as custom view');
@@ -110,7 +110,7 @@ describe('ViewMenu', () => {
         };
         const onViewSelect = jest.fn();
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PUBLIC_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={onViewSelect} />);
+        const wrapper = mount(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={onViewSelect} onSaveView={jest.fn()} />);
         wrapper.find('MenuItem').last().find('a').simulate('click');
         expect(onViewSelect).toHaveBeenCalledWith('noMixtures');
     });

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -57,33 +57,45 @@ describe('ViewMenu', () => {
 
         // Renders nothing
         let model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_NO_VIEWS, {}, []);
-        let tree = renderer.create(<ViewMenu hideEmptyViewMenu model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
+        let tree = renderer.create(
+            <ViewMenu hideEmptyViewMenu model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />
+        );
         expect(tree.toJSON()).toMatchSnapshot();
 
         // Renders empty view selector with disabled dropdown.
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
+        tree = renderer.create(
+            <ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />
+        );
         expect(tree.toJSON()).toMatchSnapshot();
 
         // "No Extra Column"  view shows up under "All Saved Views"
         model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PUBLIC_VIEWS, {}, []);
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
+        tree = renderer.create(
+            <ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />
+        );
         expect(tree.toJSON()).toMatchSnapshot();
 
         // "No Extra Column" view shows up under "My Saved Views"
         model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PRIVATE_VIEWS, {}, []);
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
+        tree = renderer.create(
+            <ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />
+        );
         expect(tree.toJSON()).toMatchSnapshot();
 
         // Same as previous, but the No Extra Column view is set to active.
         model = model.mutate({
             schemaQuery: SchemaQuery.create(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, 'noExtraColumn'),
         });
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
+        tree = renderer.create(
+            <ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />
+        );
         expect(tree.toJSON()).toMatchSnapshot();
 
         // "No Extra Column" view is hidden so does not show up
         model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
-        tree = renderer.create(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
+        tree = renderer.create(
+            <ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />
+        );
         expect(tree.toJSON()).toMatchSnapshot();
     });
 
@@ -94,7 +106,9 @@ describe('ViewMenu', () => {
             },
         };
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />);
+        const wrapper = mount(
+            <ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} onSaveView={jest.fn()} />
+        );
         const items = wrapper.find('MenuItem');
         expect(items).toHaveLength(3);
         expect(items.at(2).text()).toBe('Save as custom view');
@@ -110,7 +124,9 @@ describe('ViewMenu', () => {
         };
         const onViewSelect = jest.fn();
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PUBLIC_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={onViewSelect} onSaveView={jest.fn()} />);
+        const wrapper = mount(
+            <ViewMenu hideEmptyViewMenu={true} model={model} onViewSelect={onViewSelect} onSaveView={jest.fn()} />
+        );
         wrapper.find('MenuItem').last().find('a').simulate('click');
         expect(onViewSelect).toHaveBeenCalledWith('noMixtures');
     });

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
-import {MenuItem} from " react-bootstrap ";
-
 import { QueryInfo, SchemaQuery } from '../..';
 
 import { initUnitTests, makeQueryInfo } from '../../internal/testHelpers';
@@ -12,6 +10,8 @@ import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 
 import { ViewMenu } from './ViewMenu';
 import { makeTestQueryModel } from './testUtils';
+
+import { MenuItem } from ' react-bootstrap ';
 
 const SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
 let QUERY_INFO_NO_VIEWS: QueryInfo;
@@ -102,7 +102,6 @@ describe('ViewMenu', () => {
         expect(items.at(2).text()).toBe('Save as custom view');
 
         wrapper.unmount();
-
     });
 
     test('Interactivity', () => {

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -11,8 +11,6 @@ import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 import { ViewMenu } from './ViewMenu';
 import { makeTestQueryModel } from './testUtils';
 
-import { MenuItem } from ' react-bootstrap ';
-
 const SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
 let QUERY_INFO_NO_VIEWS: QueryInfo;
 let QUERY_INFO_PUBLIC_VIEWS: QueryInfo;
@@ -97,7 +95,7 @@ describe('ViewMenu', () => {
         };
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
         const wrapper = mount(<ViewMenu hideEmptyViewMenu={false} model={model} onViewSelect={jest.fn()} />);
-        const items = wrapper.find(MenuItem);
+        const items = wrapper.find('MenuItem');
         expect(items).toHaveLength(3);
         expect(items.at(2).text()).toBe('Save as custom view');
 

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -4,16 +4,18 @@ import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { QueryModel, ViewInfo } from '../..';
 import { blurActiveElement } from '../../internal/util/utils';
 import { getQueryMetadata } from '../../internal/global';
+import { isCustomizeViewsInAppEnabled } from "../../internal/app/utils";
 
 interface ViewMenuProps {
     hideEmptyViewMenu: boolean;
     model: QueryModel;
     onViewSelect: (viewName: string) => void;
+    onSaveView: () => void;
 }
 
 export class ViewMenu extends PureComponent<ViewMenuProps> {
     render(): ReactNode {
-        const { model, hideEmptyViewMenu, onViewSelect } = this.props;
+        const { model, hideEmptyViewMenu, onViewSelect, onSaveView } = this.props;
         const { isLoading, views, viewName, visibleViews } = model;
         const activeViewName = viewName ?? ViewInfo.DEFAULT_NAME;
         const defaultView = views.find(view => view.isDefault);
@@ -61,6 +63,14 @@ export class ViewMenu extends PureComponent<ViewMenuProps> {
                     {publicViews.length > 0 && <MenuItem divider />}
                     {publicViews.length > 0 && <MenuItem header>All Saved Views</MenuItem>}
                     {publicViews.length > 0 && publicViews.map(viewMapper)}
+                    {isCustomizeViewsInAppEnabled() && (
+                        <>
+                            <MenuItem divider />
+                            <MenuItem onSelect={onSaveView}>
+                                Save as custom view
+                            </MenuItem>
+                        </>
+                    )}
                 </DropdownButton>
             </div>
         );

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -10,7 +10,7 @@ interface ViewMenuProps {
     hideEmptyViewMenu: boolean;
     model: QueryModel;
     onViewSelect: (viewName: string) => void;
-    onSaveView?: () => void;
+    onSaveView: () => void;
 }
 
 export class ViewMenu extends PureComponent<ViewMenuProps> {

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -4,7 +4,7 @@ import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { QueryModel, ViewInfo } from '../..';
 import { blurActiveElement } from '../../internal/util/utils';
 import { getQueryMetadata } from '../../internal/global';
-import { isCustomizeViewsInAppEnabled } from "../../internal/app/utils";
+import { isCustomizeViewsInAppEnabled } from '../../internal/app/utils';
 
 interface ViewMenuProps {
     hideEmptyViewMenu: boolean;
@@ -66,9 +66,7 @@ export class ViewMenu extends PureComponent<ViewMenuProps> {
                     {isCustomizeViewsInAppEnabled() && (
                         <>
                             <MenuItem divider />
-                            <MenuItem onSelect={onSaveView}>
-                                Save as custom view
-                            </MenuItem>
+                            <MenuItem onSelect={onSaveView}>Save as custom view</MenuItem>
                         </>
                     )}
                 </DropdownButton>

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -10,7 +10,7 @@ interface ViewMenuProps {
     hideEmptyViewMenu: boolean;
     model: QueryModel;
     onViewSelect: (viewName: string) => void;
-    onSaveView: () => void;
+    onSaveView?: () => void;
 }
 
 export class ViewMenu extends PureComponent<ViewMenuProps> {

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.13.0":
-  version "1.13.0"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.13.0.tgz#8cce97cf5e85be67a7adf801877f4449048a2f84"
-  integrity sha1-jM6Xz16FvmenrfgBh39ESQSKL4Q=
+"@labkey/api@1.14.1-fb-smSaveGridViews.3":
+  version "1.14.1-fb-smSaveGridViews.3"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.14.1-fb-smSaveGridViews.3.tgz#e17c0da595ca48f7d60d389d4fe86211f9b63cff"
+  integrity sha1-4XwNpZXKSPfWDTidT+hiEfm2PP8=
 
 "@labkey/build@6.1.3":
   version "6.1.3"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.14.1-fb-smSaveGridViews.3":
-  version "1.14.1-fb-smSaveGridViews.3"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.14.1-fb-smSaveGridViews.3.tgz#e17c0da595ca48f7d60d389d4fe86211f9b63cff"
-  integrity sha1-4XwNpZXKSPfWDTidT+hiEfm2PP8=
+"@labkey/api@1.14.1-fb-smSaveGridViews.4":
+  version "1.14.1-fb-smSaveGridViews.4"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.14.1-fb-smSaveGridViews.4.tgz#e89a43d57804514e9652c395710f629e9bf569dc"
+  integrity sha1-6JpD1XgEUU6WUsOVcQ9inpv1adw=
 
 "@labkey/build@6.1.3":
   version "6.1.3"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1511,10 +1511,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@labkey/api@1.14.1-fb-smSaveGridViews.4":
-  version "1.14.1-fb-smSaveGridViews.4"
-  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.14.1-fb-smSaveGridViews.4.tgz#e89a43d57804514e9652c395710f629e9bf569dc"
-  integrity sha1-6JpD1XgEUU6WUsOVcQ9inpv1adw=
+"@labkey/api@1.14.1":
+  version "1.14.1"
+  resolved "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.14.1.tgz#549e2df22d5902334ee48bad2ca615ca2b6124ea"
+  integrity sha1-VJ4t8i1ZAjNO5IutLKYVyithJOo=
 
 "@labkey/build@6.1.3":
   version "6.1.3"


### PR DESCRIPTION
#### Rationale
As part of the epic to add view customization to the app grids, this PR adds support to allow saving custom views. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/133
* https://github.com/LabKey/labkey-ui-components/pull/853
* https://github.com/LabKey/platform/pull/3405
* https://github.com/LabKey/inventory/pull/445
* https://github.com/LabKey/biologics/pull/1349
* https://github.com/LabKey/sampleManagement/pull/979

#### Changes
* Enable Save action for edited views
* Add 'Save as custom view' option to views menu
* Add SaveViewModal component
