### PR TITLE
Issue 45325: SamplesTabbedGridPanel shouldn't call afterSampleActionComplete when going from bulk edit modal to grid edit

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.3",
+  "version": "2.179.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.178.0",
+  "version": "2.178.0-fb-workflowGridEdit45325.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.179.4
+*Released*: 10 June May 2022
 * Issue 45325: SamplesTabbedGridPanel shouldn't call afterSampleActionComplete when going from bulk edit modal to grid edit
 
 ### version 2.179.3

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45325: SamplesTabbedGridPanel shouldn't call afterSampleActionComplete when going from bulk edit modal to grid edit
+
 ### version 2.178.0
 *Released*: 31 May 2022
 * Issue 45270: Show settings page to all admins

--- a/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
@@ -37,20 +37,20 @@ import { SampleGridButtonProps } from './models';
 const EXPORT_TYPES_WITH_LABEL = Set.of(EXPORT_TYPES.CSV, EXPORT_TYPES.EXCEL, EXPORT_TYPES.TSV, EXPORT_TYPES.LABEL);
 
 interface Props extends InjectedQueryModels {
-    asPanel?: boolean;
     afterSampleActionComplete?: (hasDelete?: boolean) => void;
+    asPanel?: boolean;
     canPrintLabels?: boolean;
-    createBtnParentType?: string;
     createBtnParentKey?: string;
-    initialTabId?: string; // use if you have multiple tabs but want to start on something other than the first one
-    onPrintLabel?: () => void;
-    modelId?: string; // if a usage wants to just show a single GridPanel, they should provide a modelId prop
-    sampleAliquotType?: ALIQUOT_FILTER_MODE; // the init sampleAliquotType, requires all query models to have completed loading queryInfo prior to rendering of the component
-    tabbedGridPanelProps?: Partial<TabbedGridPanelProps>;
-    samplesEditableGridProps: Partial<SamplesEditableGridProps>;
-    gridButtons?: ComponentType<SampleGridButtonProps & RequiresModelAndActions>;
-    gridButtonProps?: any;
+    createBtnParentType?: string;
     getSampleAuditBehaviorType: () => AuditBehaviorTypes;
+    gridButtonProps?: any;
+    gridButtons?: ComponentType<SampleGridButtonProps & RequiresModelAndActions>;
+    initialTabId?: string; // use if you have multiple tabs but want to start on something other than the first one
+    modelId?: string; // if a usage wants to just show a single GridPanel, they should provide a modelId prop
+    onPrintLabel?: () => void;
+    sampleAliquotType?: ALIQUOT_FILTER_MODE; // the init sampleAliquotType, requires all query models to have completed loading queryInfo prior to rendering of the component
+    samplesEditableGridProps: Partial<SamplesEditableGridProps>;
+    tabbedGridPanelProps?: Partial<TabbedGridPanelProps>;
     user: User;
     withTitle?: boolean;
 }
@@ -187,12 +187,15 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
         resetState();
     }, [afterSampleActionComplete, resetState]);
 
-    const _afterSampleActionComplete = useCallback((hasDelete?: boolean) => {
-        dismissNotifications();
-        actions.loadModel(activeModel.id, true);
-        afterSampleActionComplete?.(hasDelete);
-        resetState();
-    }, [actions, activeModel.id, afterSampleActionComplete, resetState]);
+    const _afterSampleActionComplete = useCallback(
+        (hasDelete?: boolean) => {
+            dismissNotifications();
+            actions.loadModel(activeModel.id, true);
+            afterSampleActionComplete?.(hasDelete);
+            resetState();
+        },
+        [actions, activeModel.id, afterSampleActionComplete, resetState]
+    );
 
     const afterSampleDelete = useCallback(
         (rowsToKeep: any[]) => {

--- a/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
@@ -38,7 +38,7 @@ const EXPORT_TYPES_WITH_LABEL = Set.of(EXPORT_TYPES.CSV, EXPORT_TYPES.EXCEL, EXP
 
 interface Props extends InjectedQueryModels {
     asPanel?: boolean;
-    afterSampleActionComplete?: () => void;
+    afterSampleActionComplete?: (hasDelete?: boolean) => void;
     canPrintLabels?: boolean;
     createBtnParentType?: string;
     createBtnParentKey?: string;
@@ -158,8 +158,10 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
         (data: Map<string, any>, submitForEdit = false) => {
             setShowBulkUpdate(false);
             setSelectionData(submitForEdit ? data : undefined);
-            actions.loadModel(activeModel.id, true);
-            afterSampleActionComplete?.();
+            if (!submitForEdit) {
+                actions.loadModel(activeModel.id, true);
+                afterSampleActionComplete?.();
+            }
         },
         [actions, activeModel.id, afterSampleActionComplete]
     );
@@ -185,10 +187,10 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
         resetState();
     }, [afterSampleActionComplete, resetState]);
 
-    const _afterSampleActionComplete = useCallback(() => {
+    const _afterSampleActionComplete = useCallback((hasDelete?: boolean) => {
         dismissNotifications();
         actions.loadModel(activeModel.id, true);
-        afterSampleActionComplete?.();
+        afterSampleActionComplete?.(hasDelete);
         resetState();
     }, [actions, activeModel.id, afterSampleActionComplete, resetState]);
 
@@ -202,7 +204,7 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             }
             actions.replaceSelections(activeModel.id, ids);
 
-            _afterSampleActionComplete();
+            _afterSampleActionComplete(true);
         },
         [actions, activeModel, _afterSampleActionComplete]
     );


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45325

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/854
* https://github.com/LabKey/sampleManagement/pull/982
* https://github.com/LabKey/biologics/pull/1354
* https://github.com/LabKey/inventory/pull/446

#### Changes
* SamplesTabbedGridPanel only call afterSampleActionComplete when `!submitForEdit`
* include optional hasDelete param to afterSampleActionComplete() call
