### PR TITLE
Remove experimental feature flag for ELN in LKSM

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.2-removeELNinLKSMEFlag.0",
+  "version": "2.179.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.179.1",
+  "version": "2.179.2-removeELNinLKSMEFlag.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Remove experimental feature flag for ELN in LKSM
+
 ### version 2.179.1
 *Released*: 6 June 2022
 * Update `@labkey/api` and `@labkey/eslint-config-react` dependencies

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.179.2
+*Released*: 9 June 2022
 * Remove experimental feature flag for ELN in LKSM
 
 ### version 2.179.1

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -86,7 +86,6 @@ export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';
 export const EXPERIMENTAL_SAMPLE_FINDER = 'experimental-biologics-sample-finder';
 export const EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR = 'experimental-sample-aliquot-selector';
-export const EXPERIMENTAL_LKSM_ELN = 'experimental-lksm-eln';
 export const EXPERIMENTAL_CUSTOMIZE_VIEWS_IN_APPS = 'canCustomizeViewsFromApp';
 
 export const BIOLOGICS_APP_PROPERTIES: AppProperties = {

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -1,9 +1,8 @@
-import React, { FC } from 'react';
-import { mount } from 'enzyme';
+import React from 'react';
 
 import { List, Map } from 'immutable';
 
-import { MenuSectionConfig, User } from '../..';
+import { MenuSectionConfig } from '../..';
 
 import {
     TEST_USER_APP_ADMIN,
@@ -22,14 +21,15 @@ import {
     addSamplesSectionConfig,
     addSourcesSectionConfig,
     biologicsIsPrimaryApp,
-    getProjectPath,
     getCurrentAppProperties,
     getMenuSectionConfigs,
     getPrimaryAppProperties,
+    getProjectPath,
     getStorageSectionConfig,
     hasPremiumModule,
     isBiologicsEnabled,
     isCommunityDistribution,
+    isELNEnabledInLKSM,
     isFreezerManagementEnabled,
     isPremiumProductEnabled,
     isProductNavigationEnabled,
@@ -40,12 +40,10 @@ import {
     userCanDesignLocations,
     userCanDesignSourceTypes,
     userCanEditStorageData,
-    isELNEnabledInLKSM,
 } from './utils';
 import {
     ASSAYS_KEY,
     BIOLOGICS_APP_PROPERTIES,
-    EXPERIMENTAL_LKSM_ELN,
     EXPERIMENTAL_REQUESTS_MENU,
     FREEZER_MANAGER_APP_PROPERTIES,
     FREEZERS_KEY,
@@ -248,12 +246,10 @@ describe('utils', () => {
     test('isELNEnabledInLKSM', () => {
         LABKEY.moduleContext = {
             api: { moduleNames: [] },
-            samplemanagement: { [EXPERIMENTAL_LKSM_ELN]: true },
         };
         expect(isELNEnabledInLKSM()).toBeFalsy();
         LABKEY.moduleContext = {
             api: { moduleNames: ['labbook'] },
-            samplemanagement: { [EXPERIMENTAL_LKSM_ELN]: true },
         };
         expect(isELNEnabledInLKSM()).toBeTruthy();
     });
@@ -785,7 +781,7 @@ describe('getMenuSectionConfigs', () => {
         const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
             api: { moduleNames: ['labbook'] },
             inventory: {},
-            samplemanagement: { [EXPERIMENTAL_LKSM_ELN]: true },
+            samplemanagement: { },
         });
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, SOURCES_KEY])).toBeDefined();
@@ -807,7 +803,7 @@ describe('getMenuSectionConfigs', () => {
         const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
             api: { moduleNames: [] },
             inventory: {},
-            samplemanagement: { [EXPERIMENTAL_LKSM_ELN]: true },
+            samplemanagement: { },
         });
         expect(configs.size).toBe(5);
         expect(configs.getIn([0, SOURCES_KEY])).toBeDefined();
@@ -829,7 +825,6 @@ describe('getMenuSectionConfigs', () => {
         const configs = getMenuSectionConfigs(TEST_USER_READER, SAMPLE_MANAGER_APP_PROPERTIES.productId, {
             api: { moduleNames: ['labbook'] },
             inventory: {},
-            samplemanagement: { [EXPERIMENTAL_LKSM_ELN]: true },
             biologics: {},
         });
         expect(configs.size).toBe(5);

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -20,7 +20,6 @@ import {
     ASSAYS_KEY,
     BIOLOGICS_APP_PROPERTIES,
     EXPERIMENTAL_CUSTOMIZE_VIEWS_IN_APPS,
-    EXPERIMENTAL_LKSM_ELN,
     EXPERIMENTAL_REQUESTS_MENU,
     EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR,
     EXPERIMENTAL_SAMPLE_FINDER,
@@ -229,10 +228,7 @@ export function getPrimaryAppProperties(moduleContext?: any): AppProperties {
 }
 
 export function isELNEnabledInLKSM(moduleContext?: any): boolean {
-    return (
-        hasModule('LabBook', moduleContext) &&
-        (moduleContext ?? getServerContext().moduleContext)?.samplemanagement?.[EXPERIMENTAL_LKSM_ELN] === true
-    );
+    return hasModule('LabBook', moduleContext);
 }
 
 export function isRequestsEnabled(moduleContext?: any): boolean {


### PR DESCRIPTION
#### Rationale
We are launching ELN in LKSM in 22.7 so the experimental feature flag is no longer needed.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Remove experimental feature flag checks.
