### PR TITLE
Add ignoreShow option to SubNav

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.186.1",
+  "version": "2.184.0-fb-sticky-toolbar.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.186.0-fb-sticky-toolbar.0",
+  "version": "2.187.0-fb-sticky-toolbar.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.184.0-fb-sticky-toolbar.0",
+  "version": "2.186.0-fb-sticky-toolbar.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.187.0-fb-sticky-toolbar.0",
+  "version": "2.187.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.187.0
-*Released*: 16th June 2022
+*Released*: 21 June 2022
 * SubNav: Add ignoreShow prop
 * SubNavWithContext: Add ignoreShowProp and setIgnoreShow setter
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.187.0
+*Released*: 16th June 2022
+* SubNav: Add ignoreShow prop
+* SubNavWithContext: Add ignoreShowProp and setIgnoreShow setter
+
 ### version 2.186.1
 *Released*: 21 June 2022
 * Issue 45524: Grid pagination buttons should not disappear when changing to a larger page size

--- a/packages/components/src/internal/components/navigation/SubNav.tsx
+++ b/packages/components/src/internal/components/navigation/SubNav.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import classNames from 'classnames';
 import React, { ReactNode, FC, useRef, useState, useCallback, useEffect } from 'react';
 import { List } from 'immutable';
 import { Button } from 'react-bootstrap';
@@ -23,6 +24,7 @@ import { AppURL, useAppContext, useServerContext } from '../../..';
 import NavItem, { ParentNavItem } from './NavItem';
 
 interface Props {
+    ignoreShow?: boolean; // Forces the SubNav to always be hidden in "scrolled" mode
     noun?: ITab;
     tabs: List<ITab>;
 }
@@ -33,7 +35,7 @@ export interface ITab {
     url: string | AppURL;
 }
 
-export const SubNav: FC<Props> = ({ noun, tabs }) => {
+export const SubNav: FC<Props> = ({ ignoreShow, noun, tabs }) => {
     const scrollable = useRef<HTMLDivElement>();
     const { navigation } = useAppContext();
     const { container } = useServerContext();
@@ -84,8 +86,10 @@ export const SubNav: FC<Props> = ({ noun, tabs }) => {
         calculateIsScrollable();
     }, [calculateIsScrollable, tabs]);
 
+    const className = classNames('navbar navbar-inverse no-margin-bottom sub-nav', { 'sub-nav--ignore-show': ignoreShow });
+
     return (
-        <nav className="navbar navbar-inverse no-margin-bottom sub-nav">
+        <nav className={className}>
             <div className="container">
                 {noun && <ParentNavItem to={noun.url}>{noun.text}</ParentNavItem>}
 

--- a/packages/components/src/internal/components/navigation/SubNavWithContext.tsx
+++ b/packages/components/src/internal/components/navigation/SubNavWithContext.tsx
@@ -5,7 +5,9 @@ import { ITab, SubNav } from './SubNav';
 
 export interface SubNavState {
     clearNav: () => void;
+    ignoreShow: boolean;
     noun: ITab;
+    setIgnoreShow: (ignoreScrolled: boolean) => void;
     setNoun: (noun: ITab) => void;
     setTabs: (tabs: List<ITab>) => void;
     tabs: List<ITab>;
@@ -24,13 +26,15 @@ export const useSubNavContext = (): SubNavState => {
 export const SubNavContextProvider: FC = memo(({ children }) => {
     const [noun, setNoun] = useState<ITab>(undefined);
     const [tabs, setTabs] = useState<List<ITab>>(List());
+    const [ignoreShow, setIgnoreShow] = useState<boolean>(false);
     const clearNav = useCallback(() => {
         setNoun(undefined);
         setTabs(List());
+        setIgnoreShow(false);
     }, []);
     const subNavContext = useMemo<SubNavState>(
-        () => ({ clearNav, noun, setNoun, setTabs, tabs }),
-        [clearNav, noun, tabs]
+        () => ({ clearNav, ignoreShow, noun, setIgnoreShow, setNoun, setTabs, tabs }),
+        [clearNav, ignoreShow, noun, tabs]
     );
 
     return <SubNavContext.Provider value={subNavContext}>{children}</SubNavContext.Provider>;
@@ -41,11 +45,11 @@ export const SubNavContextProvider: FC = memo(({ children }) => {
  * you need to update the SubNav based on data you load asynchronously after the page loads.
  */
 export const SubNavWithContext: FC<SubNavState> = memo(() => {
-    const { noun, tabs } = useSubNavContext();
+    const { ignoreShow, noun, tabs } = useSubNavContext();
 
     if (tabs.size === 0 && noun === undefined) {
         return null;
     }
 
-    return <SubNav tabs={tabs} noun={noun} />;
+    return <SubNav ignoreShow={ignoreShow} noun={noun} tabs={tabs} />;
 });

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -21,6 +21,9 @@
         box-shadow: 0 2px 4px darkgrey;
         display: block;
       }
+      & > .sub-nav.sub-nav--ignore-show {
+          display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
#### Rationale
This PR adds an optional ignoreShow prop to SubNav (and SubNavWithContext) to hide SubNav even when the "show-sub-nav" class is present on the app header wrapper. We need this option because we want to render the ELN formatting toolbar as `position: sticky` but the sub nav covers it.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/213
* https://github.com/LabKey/biologics/pull/1379
* https://github.com/LabKey/sampleManagement/pull/1004

#### Changes
* Add ignoreShow prop to SubNav
* Add ignoreShow to SubNavWithContext
