### PR TITLE
Issue 45673: Improve support for "rem" units on LKS pages

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.2.2",
+  "version": "1.2.2-fb-fix-45673.0",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.2.2-fb-fix-45673.0",
+  "version": "1.2.3",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/releaseNotes/themes.md
+++ b/packages/themes/releaseNotes/themes.md
@@ -1,6 +1,10 @@
 # @labkey/themes
 UI themes for LabKey Server.
 
+### version 1.2.3
+*Released*: 17 June 2022
+* Issue 45673: Configure bootstrap scaffolding "html" selector font-size to respect $font-size-base
+
 ### version 1.2.2
 *Released*: 27 May 2022
 * Issue 45170: fix date picker month selection borders

--- a/packages/themes/styles/scss/lib/bootstrap/_bootstrap.scss
+++ b/packages/themes/styles/scss/lib/bootstrap/_bootstrap.scss
@@ -13,7 +13,8 @@
 //@import "~bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
 
 // Core CSS
-@import "~bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
+//@import "~bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
+@import "scaffolding";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/type";
 // Disabled "code" due to CodeMirror and Wiki's already having related styling
 //@import "~bootstrap-sass/assets/stylesheets/bootstrap/code";

--- a/packages/themes/styles/scss/lib/bootstrap/_scaffolding.scss
+++ b/packages/themes/styles/scss/lib/bootstrap/_scaffolding.scss
@@ -1,0 +1,162 @@
+//
+// Scaffolding
+// --------------------------------------------------
+
+
+// Reset the box-sizing
+//
+// Heads up! This reset may cause conflicts with some third-party widgets.
+// For recommendations on resolving such conflicts, see
+// https://getbootstrap.com/docs/3.4/getting-started/#third-box-sizing
+* {
+    @include box-sizing(border-box);
+}
+*:before,
+*:after {
+    @include box-sizing(border-box);
+}
+
+
+// Body reset
+
+html {
+    // Issue 45673: The default html/font-size in LabKey style sheets is not convenient with react
+    font-size: $font-size-base; // originally "10px"
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+body {
+    font-family: $font-family-base;
+    font-size: $font-size-base;
+    line-height: $line-height-base;
+    color: $text-color;
+    background-color: $body-bg;
+}
+
+// Reset fonts for relevant elements
+input,
+button,
+select,
+textarea {
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+}
+
+
+// Links
+
+a {
+    color: $link-color;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+        color: $link-hover-color;
+        text-decoration: $link-hover-decoration;
+    }
+
+    &:focus {
+        @include tab-focus;
+    }
+}
+
+
+// Figures
+//
+// We reset this here because previously Normalize had no `figure` margins. This
+// ensures we don't break anyone's use of the element.
+
+figure {
+    margin: 0;
+}
+
+
+// Images
+
+img {
+    vertical-align: middle;
+}
+
+// Responsive images (ensure images don't scale beyond their parents)
+.img-responsive {
+    @include img-responsive;
+}
+
+// Rounded corners
+.img-rounded {
+    border-radius: $border-radius-large;
+}
+
+// Image thumbnails
+//
+// Heads up! This is mixin-ed into thumbnails.less for `.thumbnail`.
+.img-thumbnail {
+    padding: $thumbnail-padding;
+    line-height: $line-height-base;
+    background-color: $thumbnail-bg;
+    border: 1px solid $thumbnail-border;
+    border-radius: $thumbnail-border-radius;
+    @include transition(all .2s ease-in-out);
+
+    // Keep them at most 100% wide
+    @include img-responsive(inline-block);
+}
+
+// Perfect circle
+.img-circle {
+    border-radius: 50%; // set radius in percents
+}
+
+
+// Horizontal rules
+
+hr {
+    margin-top: $line-height-computed;
+    margin-bottom: $line-height-computed;
+    border: 0;
+    border-top: 1px solid $hr-border;
+}
+
+
+// Only display content to screen readers
+//
+// See: https://a11yproject.com/posts/how-to-hide-content
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+// Use in conjunction with .sr-only to only display content when it's focused.
+// Useful for "Skip to main content" links; see https://www.w3.org/TR/2013/NOTE-WCAG20-TECHS-20130905/G1
+// Credit: HTML5 Boilerplate
+
+.sr-only-focusable {
+    &:active,
+    &:focus {
+        position: static;
+        width: auto;
+        height: auto;
+        margin: 0;
+        overflow: visible;
+        clip: auto;
+    }
+}
+
+
+// iOS "clickable elements" fix for role="button"
+//
+// Fixes "clickability" issue (and more generally, the firing of events such as focus as well)
+// for traditionally non-focusable elements with role="button"
+// see https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
+
+[role="button"] {
+    cursor: pointer;
+}


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45673](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45673) by making the "html" and "body" selectors for bootstrap's CSS reset the same value. This allows for ["rem" units](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#relative_length_units) to be consistent with the body font. See the related client ticket for more information.

Note, these themes are not used in our product applications so this will not effect those.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3451

#### Changes
* Clone bootstrap's `_scaffolding.scss` and change `html { font-size }` property to be `$font-size-base` which is 14px in default bootstrap (and our themes) rather than hard-coded to 10px.
