### PR TITLE
Item 10380: Save Grid Views - Allow removal of addToDisplayView columns

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.186.1-fb-addToDisplayViewChanges.0",
+  "version": "2.186.1-fb-addToDisplayViewChanges.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.0-fb-addToDisplayViewChanges.1",
+  "version": "2.188.0-fb-addToDisplayViewChanges.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.1-fb-addToDisplayViewChanges.0",
+  "version": "2.188.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.186.1",
+  "version": "2.186.1-fb-addToDisplayViewChanges.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.0-fb-addToDisplayViewChanges.0",
+  "version": "2.188.0-fb-addToDisplayViewChanges.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.0",
+  "version": "2.188.0-fb-addToDisplayViewChanges.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.1",
+  "version": "2.188.1-fb-addToDisplayViewChanges.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD June 2022
 * Item 10380: Save Grid Views - Allow removal of addToDisplayView columns
   * Only add "addToDisplayView" fields to view for unsaved default view (i.e. system default view)
+  * only allow default view revert in Manage Saved Views modal if it is not the system default
   * set allowViewCustomization false for a few more cases
 
 ### version 2.186.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD June 2022
+### version 2.188.2
+*Released*: 23 June 2022
 * Item 10380: Save Grid Views - Allow removal of addToDisplayView columns
   * only add "addToDisplayView" fields to view for unsaved default view (i.e. system default view)
   * only allow default view revert in Manage Saved Views modal if it is not the system default

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD June 2022
+* Item 10380: Save Grid Views - Allow removal of addToDisplayView columns
+  * Only add "addToDisplayView" fields to view for unsaved default view (i.e. system default view)
+  * set allowViewCustomization false for a few more cases
+
 ### version 2.186.1
 *Released*: 21 June 2022
 * Issue 45524: Grid pagination buttons should not disappear when changing to a larger page size

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   * only add "addToDisplayView" fields to view for unsaved default view (i.e. system default view)
   * only allow default view revert in Manage Saved Views modal if it is not the system default
   * set allowViewCustomization false for a few more cases
+  * SpecialtyAssayPanel.tsx update to remove usage of dangerouslySetInnerHTML
 
 ### version 2.186.1
 *Released*: 21 June 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD June 2022
 * Item 10380: Save Grid Views - Allow removal of addToDisplayView columns
-  * Only add "addToDisplayView" fields to view for unsaved default view (i.e. system default view)
+  * only add "addToDisplayView" fields to view for unsaved default view (i.e. system default view)
   * only allow default view revert in Manage Saved Views modal if it is not the system default
   * set allowViewCustomization false for a few more cases
 

--- a/packages/components/src/internal/ViewInfo.spec.ts
+++ b/packages/components/src/internal/ViewInfo.spec.ts
@@ -53,4 +53,13 @@ describe('ViewInfo', () => {
         expect(ViewInfo.create({ saved: false }).isSaved).toBeFalsy();
         expect(ViewInfo.create({ saved: true }).isSaved).toBeTruthy();
     });
+
+    test('isSystemView', () => {
+        expect(ViewInfo.create({}).isSystemView).toBeFalsy();
+        expect(ViewInfo.create({ name: 'testing' }).isSystemView).toBeFalsy();
+        expect(ViewInfo.create({ name: ViewInfo.BIO_DETAIL_NAME }).isSystemView).toBeFalsy();
+        expect(ViewInfo.create({ name: ViewInfo.DEFAULT_NAME }).isSystemView).toBeTruthy();
+        expect(ViewInfo.create({ name: ViewInfo.DETAIL_NAME }).isSystemView).toBeTruthy();
+        expect(ViewInfo.create({ name: ViewInfo.UPDATE_NAME }).isSystemView).toBeTruthy();
+    });
 });

--- a/packages/components/src/internal/ViewInfo.spec.ts
+++ b/packages/components/src/internal/ViewInfo.spec.ts
@@ -46,4 +46,11 @@ describe('ViewInfo', () => {
         view = ViewInfo.create({ default: false, hidden: false, name: ViewInfo.BIO_DETAIL_NAME });
         expect(view.isVisible).toBeFalsy();
     });
+
+    test('isSaved', () => {
+        expect(ViewInfo.create({}).isSaved).toBeFalsy();
+        expect(ViewInfo.create({ saved: undefined }).isSaved).toBeFalsy();
+        expect(ViewInfo.create({ saved: false }).isSaved).toBeFalsy();
+        expect(ViewInfo.create({ saved: true }).isSaved).toBeTruthy();
+    });
 });

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -149,6 +149,13 @@ export class ViewInfo extends Record({
         return this.saved === true;
     }
 
+    get isSystemView(): boolean {
+        const lcName = this.name?.toLowerCase();
+        return lcName === ViewInfo.DEFAULT_NAME.toLowerCase()
+            || lcName === ViewInfo.DETAIL_NAME.toLowerCase()
+            || lcName === ViewInfo.UPDATE_NAME.toLowerCase();
+    }
+
     mutate(updates: Partial<ViewInfo>) {
         return new ViewInfo({
             ...this.toJS(),

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -57,7 +57,7 @@ export class ViewInfo extends Record({
     name: undefined,
     revertable: false,
     savable: false,
-    saved: undefined,
+    saved: false,
     session: false,
     shared: false,
     sorts: List<QuerySort>(),

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -151,15 +151,17 @@ export class ViewInfo extends Record({
 
     get isSystemView(): boolean {
         const lcName = this.name?.toLowerCase();
-        return lcName === ViewInfo.DEFAULT_NAME.toLowerCase()
-            || lcName === ViewInfo.DETAIL_NAME.toLowerCase()
-            || lcName === ViewInfo.UPDATE_NAME.toLowerCase();
+        return (
+            lcName === ViewInfo.DEFAULT_NAME.toLowerCase() ||
+            lcName === ViewInfo.DETAIL_NAME.toLowerCase() ||
+            lcName === ViewInfo.UPDATE_NAME.toLowerCase()
+        );
     }
 
     mutate(updates: Partial<ViewInfo>) {
         return new ViewInfo({
             ...this.toJS(),
-            ...updates
+            ...updates,
         });
     }
 }

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -57,6 +57,7 @@ export class ViewInfo extends Record({
     name: undefined,
     revertable: false,
     savable: false,
+    saved: undefined,
     session: false,
     shared: false,
     sorts: List<QuerySort>(),
@@ -74,6 +75,7 @@ export class ViewInfo extends Record({
     declare name: string;
     declare revertable: boolean;
     declare savable: boolean;
+    declare saved: boolean;
     declare session: boolean;
     declare shared: boolean;
     declare sorts: List<QuerySort>;
@@ -141,6 +143,10 @@ export class ViewInfo extends Record({
         return (
             !this.isDefault && !this.hidden && this.name.indexOf('~~') !== 0 && this.name !== ViewInfo.BIO_DETAIL_NAME
         );
+    }
+
+    get isSaved(): boolean {
+        return this.saved === true;
     }
 
     mutate(updates: Partial<ViewInfo>) {

--- a/packages/components/src/internal/components/assay/SpecialtyAssayPanel.tsx
+++ b/packages/components/src/internal/components/assay/SpecialtyAssayPanel.tsx
@@ -66,10 +66,7 @@ export const SpecialtyAssayPanel: FC<SpecialtyAssayPanelProps> = memo(props => {
                                 </select>
                             </div>
 
-                            <div
-                                className="small-margin-bottom"
-                                dangerouslySetInnerHTML={{ __html: selected?.description }}
-                            />
+                            <div className="small-margin-bottom">{selected?.description}</div>
                         </>
                     )}
 

--- a/packages/components/src/internal/components/assay/SpecialtyAssayPanel.tsx
+++ b/packages/components/src/internal/components/assay/SpecialtyAssayPanel.tsx
@@ -6,10 +6,10 @@ import { Alert, GENERAL_ASSAY_PROVIDER_NAME, getHelpLink } from '../../..';
 import { AssayProvider } from './AssayPicker';
 
 interface SpecialtyAssayPanelProps {
+    hasPremium: boolean;
+    onChange: (value: string) => void;
     selected: AssayProvider;
     values: AssayProvider[];
-    onChange: (value: string) => void;
-    hasPremium: boolean;
 }
 
 export const SpecialtyAssayPanel: FC<SpecialtyAssayPanelProps> = memo(props => {

--- a/packages/components/src/internal/components/assay/__snapshots__/AssayPicker.spec.tsx.snap
+++ b/packages/components/src/internal/components/assay/__snapshots__/AssayPicker.spec.tsx.snap
@@ -799,12 +799,9 @@ exports[`AssayPicker AssayPicker 1`] = `
                                           </div>
                                           <div
                                             className="small-margin-bottom"
-                                            dangerouslySetInnerHTML={
-                                              Object {
-                                                "__html": "Imports data from simple Excel or TSV files.",
-                                              }
-                                            }
-                                          />
+                                          >
+                                            Imports data from simple Excel or TSV files.
+                                          </div>
                                         </div>
                                       </Col>
                                     </div>

--- a/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/internal/components/entities/SingleParentEntityPanel.tsx
@@ -236,13 +236,14 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
                 {model && (
                     <GridPanel
                         actions={actions}
+                        model={model}
                         allowSelections={false}
                         asPanel={false}
-                        model={model}
                         showButtonBar={false}
                         showChartMenu={false}
                         showExport={false}
                         allowFiltering={false}
+                        allowViewCustomization={false}
                     />
                 )}
             </div>

--- a/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -6236,7 +6236,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             allowFiltering={false}
             allowSelections={false}
             allowSorting={true}
-            allowViewCustomization={true}
+            allowViewCustomization={false}
             asPanel={false}
             hideEmptyChartMenu={true}
             hideEmptyViewMenu={true}
@@ -6353,7 +6353,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                   }
                 }
                 allowSelections={false}
-                allowViewCustomization={true}
+                allowViewCustomization={false}
                 isUpdated={false}
                 model={
                   QueryModel {

--- a/packages/components/src/internal/components/listing/pages/QueryListingPage.tsx
+++ b/packages/components/src/internal/components/listing/pages/QueryListingPage.tsx
@@ -15,6 +15,7 @@ import {
     PageHeader,
     withQueryModels,
 } from '../../../..';
+import { isCustomizeViewsInAppEnabled } from '../../../app/utils';
 
 interface BodyProps {
     id: string;
@@ -37,7 +38,7 @@ const QueryListingBodyImpl: FC<BodyProps & InjectedQueryModels> = memo(({ action
 
             <PageHeader title={title} />
 
-            <GridPanel actions={actions} model={model} />
+            <GridPanel actions={actions} model={model} hideEmptyViewMenu={!isCustomizeViewsInAppEnabled()} />
         </Page>
     );
 });

--- a/packages/components/src/internal/components/picklist/PicklistListing.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistListing.tsx
@@ -26,25 +26,27 @@ import { PUBLIC_PICKLIST_CATEGORY } from '../domainproperties/list/constants';
 
 import { DisableableButton } from '../buttons/DisableableButton';
 
+import { userCanManagePicklists } from '../../app/utils';
+
+import { MY_PICKLISTS_HREF, TEAM_PICKLISTS_HREF } from '../../app/constants';
+
 import { deletePicklists, getPicklistListingContainerFilter } from './actions';
 import { Picklist } from './models';
 import { PicklistDeleteConfirm } from './PicklistDeleteConfirm';
-import { userCanManagePicklists } from '../../app/utils';
-import { MY_PICKLISTS_HREF, TEAM_PICKLISTS_HREF } from '../../app/constants';
 
 const MY_PICKLISTS_GRID_ID = 'my-picklists';
 const TEAM_PICKLISTS_GRID_ID = 'team-picklists';
 
 interface OwnProps {
-    user: User;
-    initTab?: string;
     CreateButton?: ComponentType<PicklistCreateButtonProps>;
+    initTab?: string;
+    user: User;
 }
 
 interface PicklistGridProps {
-    user: User;
     CreateButton?: ComponentType<PicklistCreateButtonProps>;
     activeTab?: string;
+    user: User;
 }
 
 interface PicklistCreateButtonProps {
@@ -56,8 +58,8 @@ interface PicklistCreateButtonProps {
 const PICKLISTS_CAPTION = 'Manage sample groups for storage and export';
 
 interface ButtonProps {
-    onDelete: () => void;
     activeId: string;
+    onDelete: () => void;
 }
 
 const PicklistGridButtons: FC<ButtonProps & RequiresModelAndActions> = memo(props => {
@@ -92,7 +94,7 @@ const PicklistGridImpl: FC<PicklistGridProps & InjectedQueryModels> = memo(props
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
 
     const onChangeTab = useCallback((tab: string) => {
-        window.location.href = tab === MY_PICKLISTS_GRID_ID ? MY_PICKLISTS_HREF.toHref() : TEAM_PICKLISTS_HREF.toHref()
+        window.location.href = tab === MY_PICKLISTS_GRID_ID ? MY_PICKLISTS_HREF.toHref() : TEAM_PICKLISTS_HREF.toHref();
         setActiveTabId(tab);
     }, []);
 

--- a/packages/components/src/internal/components/picklist/PicklistListing.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistListing.tsx
@@ -147,6 +147,7 @@ const PicklistGridImpl: FC<PicklistGridProps & InjectedQueryModels> = memo(props
                 onTabSelect={onChangeTab}
                 showChartMenu={false}
                 asPanel={false}
+                allowViewCustomization={false}
                 ButtonsComponent={PicklistGridButtons}
                 buttonsComponentProps={{
                     onDelete: showDeleteConfirm,

--- a/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
+++ b/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
@@ -115,6 +115,7 @@ export class PipelineJobsPageImpl extends React.PureComponent<Props & InjectedQu
                     actions={actions}
                     model={model}
                     ButtonsComponent={() => this.renderButtons(refreshOn)}
+                    allowViewCustomization={false}
                 />
             </Page>
         );

--- a/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
+++ b/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Checkbox} from "react-bootstrap";
+import { Checkbox } from 'react-bootstrap';
 
-import { Filter } from '@labkey/api'
+import { Filter } from '@labkey/api';
 
 import {
     GridPanel,
@@ -11,15 +11,15 @@ import {
     PageHeader,
     QuerySort,
     SchemaQuery,
-    withQueryModels
-} from "../../..";
+    withQueryModels,
+} from '../../..';
 
 interface Props {
-    autoRefresh: boolean
-    title?: string
-    gridId?: string
-    interval?: number // in ms
+    autoRefresh: boolean;
     baseFilters?: Filter.IFilter[];
+    gridId?: string;
+    interval?: number;// in ms
+    title?: string;
 }
 
 interface State {
@@ -29,34 +29,33 @@ interface State {
 const DEFAULT_JOBS_GRID_MODEL_ID = 'pipeline-jobs';
 
 export class PipelineJobsPageImpl extends React.PureComponent<Props & InjectedQueryModels, State> {
-    private _interval : any;
+    private _interval: any;
 
     static defaultProps = {
         autoRefresh: true,
         gridId: DEFAULT_JOBS_GRID_MODEL_ID,
         interval: 5000,
-        title: 'Jobs'
+        title: 'Jobs',
     };
 
     constructor(props) {
         super(props);
 
         this.state = {
-            refreshOn: props.autoRefresh !== false
+            refreshOn: props.autoRefresh !== false,
         };
     }
 
     componentDidMount() {
         const { autoRefresh, interval, actions, gridId, baseFilters } = this.props;
-        if (autoRefresh)
-            this._interval = setInterval(this.refresh, interval);
+        if (autoRefresh) this._interval = setInterval(this.refresh, interval);
 
         const queryConfig = {
             id: gridId,
-            schemaQuery: SchemaQuery.create("pipeline", "job"),
+            schemaQuery: SchemaQuery.create('pipeline', 'job'),
             baseFilters,
             sorts: [new QuerySort({ fieldKey: 'Created', dir: '-' })],
-            requiredColumns: ['Provider']
+            requiredColumns: ['Provider'],
         };
         actions.addModel(queryConfig, true);
     }
@@ -69,44 +68,43 @@ export class PipelineJobsPageImpl extends React.PureComponent<Props & InjectedQu
         const { queryModels, actions, gridId } = this.props;
 
         const model = queryModels[gridId];
-        if (model)
-            actions.loadModel(model.id);
-    }
+        if (model) actions.loadModel(model.id);
+    };
 
     toggleAutoRefresh = () => {
         const { interval } = this.props;
 
-        this.setState((state) => ({
-            refreshOn: !state.refreshOn
-        }), () => {
-            const { refreshOn } = this.state;
-            if (refreshOn) {
-                this._interval = setInterval(this.refresh, interval);
+        this.setState(
+            state => ({
+                refreshOn: !state.refreshOn,
+            }),
+            () => {
+                const { refreshOn } = this.state;
+                if (refreshOn) {
+                    this._interval = setInterval(this.refresh, interval);
+                } else this.stopRefresh();
             }
-            else
-                this.stopRefresh();
-        });
-    }
+        );
+    };
 
     stopRefresh = () => {
-        if (this._interval)
-            clearInterval(this._interval);
-    }
+        if (this._interval) clearInterval(this._interval);
+    };
 
     renderButtons = (refreshOn: boolean) => {
-        return (<Checkbox checked={refreshOn} onChange={this.toggleAutoRefresh}>
+        return (
+            <Checkbox checked={refreshOn} onChange={this.toggleAutoRefresh}>
                 Automatically refresh grid
             </Checkbox>
         );
-    }
+    };
 
     render() {
         const { queryModels, actions, gridId, title } = this.props;
         const { refreshOn } = this.state;
 
         const model = queryModels[gridId];
-        if (model === undefined)
-            return <LoadingSpinner/>;
+        if (model === undefined) return <LoadingSpinner />;
 
         return (
             <Page title={title} hasHeader={true}>

--- a/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SampleAliquotsGridPanel.tsx
@@ -175,7 +175,6 @@ export class SampleAliquotsGridPanelImpl extends PureComponent<Props & InjectedQ
                         JobsButtonComponent: jobsButton,
                     }}
                     model={queryModel}
-                    showViewMenu={false}
                 />
 
                 {this.state.showConfirmDelete && (

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -37,6 +37,7 @@ import { UserDeleteConfirmModal } from './UserDeleteConfirmModal';
 import { UserActivateChangeConfirmModal } from './UserActivateChangeConfirmModal';
 import { UserDetailsPanel } from './UserDetailsPanel';
 import { CreateUsersModal } from './CreateUsersModal';
+import { isCustomizeViewsInAppEnabled } from '../../app/utils';
 
 const OMITTED_COLUMNS = [
     'phone',
@@ -343,7 +344,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                                 title={capitalizeFirstChar(usersView) + ' Users'}
                                 ButtonsComponent={() => this.renderButtons()}
                                 highlightLastSelectedRow
-                                allowViewCustomization={false}
+                                hideEmptyViewMenu={!isCustomizeViewsInAppEnabled()}
                             />
                         )}
                     </Col>

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -343,6 +343,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                                 title={capitalizeFirstChar(usersView) + ' Users'}
                                 ButtonsComponent={() => this.renderButtons()}
                                 highlightLastSelectedRow
+                                allowViewCustomization={false}
                             />
                         )}
                     </Col>

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -33,11 +33,12 @@ import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel
 
 import { UserLimitSettings } from '../permissions/actions';
 
+import { isCustomizeViewsInAppEnabled } from '../../app/utils';
+
 import { UserDeleteConfirmModal } from './UserDeleteConfirmModal';
 import { UserActivateChangeConfirmModal } from './UserActivateChangeConfirmModal';
 import { UserDetailsPanel } from './UserDetailsPanel';
 import { CreateUsersModal } from './CreateUsersModal';
-import { isCustomizeViewsInAppEnabled } from '../../app/utils';
 
 const OMITTED_COLUMNS = [
     'phone',

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -145,15 +145,15 @@ describe('HeaderCellDropdown', () => {
                         raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: false }),
                     })
                 }
-                handleHideColumn={jest.fn}
                 handleAddColumn={jest.fn}
+                handleHideColumn={jest.fn}
             />
         );
         validate(wrapper, 0, 2);
         wrapper.unmount();
     });
 
-    test('column not sortable or filterable, can add but not hide', () => {
+    test('column not sortable or filterable, can add and hide', () => {
         LABKEY.moduleContext = {
             query: {
                 canCustomizeViewsFromApp: true,
@@ -170,11 +170,13 @@ describe('HeaderCellDropdown', () => {
                     })
                 }
                 handleAddColumn={jest.fn}
+                handleHideColumn={jest.fn}
             />
         );
         validate(wrapper, 0, 2);
         expect(wrapper.find(DisableableMenuItem)).toHaveLength(1);
-        expect(wrapper.find(DisableableMenuItem).text()).toContain("Hide Column");
+        expect(wrapper.find(DisableableMenuItem).text()).toContain('Hide Column');
+        expect(wrapper.find(DisableableMenuItem).prop('operationPermitted')).toBe(true);
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -103,7 +103,6 @@ describe('HeaderCellDropdown', () => {
         wrapper.unmount();
     });
 
-
     test('no col', () => {
         const wrapper = mount(
             <HeaderCellDropdown {...DEFAULT_PROPS} column={new GridColumn({ index: 'column', title: 'Column' })} />

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -54,8 +54,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
 
     const allowColSort = handleSort && col?.sortable;
     const allowColFilter = handleFilter && col?.filterable;
-    const allowColumnViewChange =
-        (handleHideColumn || handleAddColumn) && model && isCustomizeViewsInAppEnabled() && !col.addToDisplayView;
+    const allowColumnViewChange = (handleHideColumn || handleAddColumn) && model && isCustomizeViewsInAppEnabled();
     const includeDropdown = allowColSort || allowColFilter || allowColumnViewChange;
 
     const onToggleClick = useCallback(

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -123,6 +123,39 @@ describe('QueryInfo', () => {
         });
     });
 
+    describe('getDisplayColumns', () => {
+        const queryInfoWithViews = QueryInfo.fromJSON({
+            columns: [{ fieldKey: 'test1' }, { fieldKey: 'test2', addToDisplayView: true }, { fieldKey: 'test3', addToDisplayView: true }],
+            views: [
+                { name: '', default: true },
+            ],
+        }, true);
+
+        test('system default view with addToDisplayView', () => {
+            const columns = queryInfoWithViews.getDisplayColumns();
+            expect(columns.size).toBe(2);
+            expect(columns.get(0).fieldKey).toBe('test2');
+            expect(columns.get(1).fieldKey).toBe('test3');
+        });
+
+        test('system default view with omittedColumns', () => {
+            const columns = queryInfoWithViews.getDisplayColumns('', List.of('test2'));
+            expect(columns.size).toBe(1);
+            expect(columns.get(0).fieldKey).toBe('test3');
+        });
+
+        test('saved default view should not include addToDisplayView', () => {
+            const qv = QueryInfo.fromJSON({
+                columns: [{ fieldKey: 'test1' }, { fieldKey: 'test2', addToDisplayView: true }, { fieldKey: 'test3', addToDisplayView: true }],
+                views: [
+                    { name: '', default: true, saved: true },
+                ],
+            }, true);
+            const columns = qv.getDisplayColumns();
+            expect(columns.size).toBe(0);
+        });
+    });
+
     describe('getIconURL', () => {
         test('default', () => {
             const queryInfo = QueryInfo.create({ schemaName: 'test', name: 'test' });

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -124,12 +124,17 @@ describe('QueryInfo', () => {
     });
 
     describe('getDisplayColumns', () => {
-        const queryInfoWithViews = QueryInfo.fromJSON({
-            columns: [{ fieldKey: 'test1' }, { fieldKey: 'test2', addToDisplayView: true }, { fieldKey: 'test3', addToDisplayView: true }],
-            views: [
-                { name: '', default: true },
-            ],
-        }, true);
+        const queryInfoWithViews = QueryInfo.fromJSON(
+            {
+                columns: [
+                    { fieldKey: 'test1' },
+                    { fieldKey: 'test2', addToDisplayView: true },
+                    { fieldKey: 'test3', addToDisplayView: true },
+                ],
+                views: [{ name: '', default: true }],
+            },
+            true
+        );
 
         test('system default view with addToDisplayView', () => {
             const columns = queryInfoWithViews.getDisplayColumns();
@@ -145,12 +150,17 @@ describe('QueryInfo', () => {
         });
 
         test('saved default view should not include addToDisplayView', () => {
-            const qv = QueryInfo.fromJSON({
-                columns: [{ fieldKey: 'test1' }, { fieldKey: 'test2', addToDisplayView: true }, { fieldKey: 'test3', addToDisplayView: true }],
-                views: [
-                    { name: '', default: true, saved: true },
-                ],
-            }, true);
+            const qv = QueryInfo.fromJSON(
+                {
+                    columns: [
+                        { fieldKey: 'test1' },
+                        { fieldKey: 'test2', addToDisplayView: true },
+                        { fieldKey: 'test3', addToDisplayView: true },
+                    ],
+                    views: [{ name: '', default: true, saved: true }],
+                },
+                true
+            );
             const columns = qv.getDisplayColumns();
             expect(columns.size).toBe(0);
         });

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -206,16 +206,18 @@ export class QueryInfo extends Record({
                 return list;
             }, List<QueryColumn>());
 
-            // add addToDisplayView columns
-            const columnFieldKeys = viewInfo.columns.reduce((list, col) => {
-                return list.push(col.fieldKey.toLowerCase());
-            }, List<string>());
-            this.columns.forEach(col => {
-                if (col.fieldKey && col.addToDisplayView && !columnFieldKeys.includes(col.fieldKey.toLowerCase())) {
-                    if (!lowerOmit || !lowerOmit.includes(col.fieldKey.toLowerCase()))
-                        displayColumns = displayColumns.push(col);
-                }
-            });
+            // add addToDisplayView columns to unsaved default view (i.e. the default-default view)
+            if (viewInfo.isDefault && !viewInfo.isSaved && !viewInfo.session) {
+                const columnFieldKeys = viewInfo.columns.reduce((list, col) => {
+                    return list.push(col.fieldKey.toLowerCase());
+                }, List<string>());
+                this.columns.forEach(col => {
+                    if (col.fieldKey && col.addToDisplayView && !columnFieldKeys.includes(col.fieldKey.toLowerCase())) {
+                        if (!lowerOmit || !lowerOmit.includes(col.fieldKey.toLowerCase()))
+                            displayColumns = displayColumns.push(col);
+                    }
+                });
+            }
 
             return displayColumns;
         }

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -206,8 +206,8 @@ export class QueryInfo extends Record({
                 return list;
             }, List<QueryColumn>());
 
-            // add addToDisplayView columns to unsaved default view (i.e. the default-default view)
-            if (viewInfo.isDefault && !viewInfo.isSaved && !viewInfo.session) {
+            // add addToDisplayView columns to unsaved system view (i.e. the default-default view, details view, or update view)
+            if ((viewInfo.isDefault || viewInfo.isSystemView) && !viewInfo.isSaved && !viewInfo.session) {
                 const columnFieldKeys = viewInfo.columns.reduce((list, col) => {
                     return list.push(col.fieldKey.toLowerCase());
                 }, List<string>());

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -123,22 +123,14 @@ describe('ColumnChoice', () => {
 });
 
 describe('ColumnInView', () => {
-    function validate(wrapper: ReactWrapper, column: QueryColumn, canBeRemoved: boolean) {
+    function validate(wrapper: ReactWrapper, column: QueryColumn) {
         const fieldName = wrapper.find('.field-name');
         expect(fieldName.text()).toBe(column.caption);
         const removeIcon = wrapper.find('.fa-times');
         expect(removeIcon.exists()).toBeTruthy();
         const iconParent = removeIcon.parent();
-        if (canBeRemoved) {
-            expect(iconParent.prop('className')).toContain('clickable');
-            expect(iconParent.prop('onClick')).toBeDefined();
-        } else {
-            expect(iconParent.prop('className')).toContain('text-muted disabled');
-            expect(iconParent.prop('onClick')).toBeNull();
-        }
-        if (!canBeRemoved) {
-            expect(wrapper.find(OverlayTrigger).exists()).toBeTruthy();
-        }
+        expect(iconParent.prop('className')).toContain('clickable');
+        expect(iconParent.prop('onClick')).toBeDefined();
     }
 
     test('remove enabled', () => {
@@ -153,11 +145,11 @@ describe('ColumnInView', () => {
                 />
             )
         );
-        validate(wrapper, QUERY_COL, true);
+        validate(wrapper, QUERY_COL);
         wrapper.unmount();
     });
 
-    test('remove disabled', () => {
+    test('addToDisplayView can be removed', () => {
         const column = QueryColumn.create({
             name: 'testColumn',
             fieldKey: 'testColumn',
@@ -177,7 +169,7 @@ describe('ColumnInView', () => {
                 />
             )
         );
-        validate(wrapper, column, false);
+        validate(wrapper, column);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -130,9 +130,8 @@ describe('ColumnInView', () => {
         const removeIcon = wrapper.find('.fa-times');
         expect(removeIcon.exists()).toBeTruthy();
         const iconParent = removeIcon.parent();
-        expect(iconParent.prop('className')).toContain('view-field__action disabled');
-        expect(iconParent.prop('onClick')).toBeNull();
-        expect(wrapper.find(OverlayTrigger).exists()).toBeTruthy();
+        expect(iconParent.prop('className')).toContain('view-field__action clickable');
+        expect(iconParent.prop('onClick')).toBeDefined();
         if (dragDisabled) {
             expect(wrapper.find(Draggable).prop("isDragDisabled")).toBe(true);
         }

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -124,22 +124,15 @@ describe('ColumnChoice', () => {
 });
 
 describe('ColumnInView', () => {
-    function validate(wrapper: ReactWrapper, column: QueryColumn, canBeRemoved: boolean, dragDisabled: boolean) {
+    function validate(wrapper: ReactWrapper, column: QueryColumn, dragDisabled: boolean) {
         const fieldName = wrapper.find('.field-name');
         expect(fieldName.text()).toBe(column.caption);
         const removeIcon = wrapper.find('.fa-times');
         expect(removeIcon.exists()).toBeTruthy();
         const iconParent = removeIcon.parent();
-        if (canBeRemoved) {
-            expect(iconParent.prop('className')).toContain('clickable');
-            expect(iconParent.prop('onClick')).toBeDefined();
-        } else {
-            expect(iconParent.prop('className')).toContain('view-field__action disabled');
-            expect(iconParent.prop('onClick')).toBeNull();
-        }
-        if (!canBeRemoved) {
-            expect(wrapper.find(OverlayTrigger).exists()).toBeTruthy();
-        }
+        expect(iconParent.prop('className')).toContain('view-field__action disabled');
+        expect(iconParent.prop('onClick')).toBeNull();
+        expect(wrapper.find(OverlayTrigger).exists()).toBeTruthy();
         if (dragDisabled) {
             expect(wrapper.find(Draggable).prop("isDragDisabled")).toBe(true);
         }
@@ -160,7 +153,7 @@ describe('ColumnInView', () => {
                 />
             )
         );
-        validate(wrapper, QUERY_COL, true, false);
+        validate(wrapper, QUERY_COL, false);
         wrapper.unmount();
     });
 
@@ -187,7 +180,7 @@ describe('ColumnInView', () => {
                 />
             )
         );
-        validate(wrapper, column, false, false);
+        validate(wrapper, column, false);
         wrapper.unmount();
     });
 
@@ -214,7 +207,7 @@ describe('ColumnInView', () => {
                 />
             )
         );
-        validate(wrapper, column, false, false);
+        validate(wrapper, column, false);
         wrapper.unmount();
     });
 

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -6,6 +6,8 @@ import { Modal, OverlayTrigger } from 'react-bootstrap';
 
 import { fromJS } from 'immutable';
 
+import { Draggable } from 'react-beautiful-dnd';
+
 import { SchemaQuery } from '../SchemaQuery';
 import { QueryInfo } from '../QueryInfo';
 import { ViewInfo } from '../../internal/ViewInfo';
@@ -21,7 +23,6 @@ import {
     CustomizeGridViewModal,
     FieldLabelDisplay,
 } from './CustomizeGridViewModal';
-import { Draggable } from 'react-beautiful-dnd';
 
 const QUERY_COL = QueryColumn.create({
     name: 'testColumn',
@@ -133,7 +134,7 @@ describe('ColumnInView', () => {
         expect(iconParent.prop('className')).toContain('view-field__action clickable');
         expect(iconParent.prop('onClick')).toBeDefined();
         if (dragDisabled) {
-            expect(wrapper.find(Draggable).prop("isDragDisabled")).toBe(true);
+            expect(wrapper.find(Draggable).prop('isDragDisabled')).toBe(true);
         }
     }
 
@@ -183,7 +184,7 @@ describe('ColumnInView', () => {
         wrapper.unmount();
     });
 
-    test("drag disabled", () => {
+    test('drag disabled', () => {
         const column = QueryColumn.create({
             name: 'testColumn',
             fieldKey: 'testColumn',
@@ -210,7 +211,7 @@ describe('ColumnInView', () => {
         wrapper.unmount();
     });
 
-    test("Editing", () => {
+    test('Editing', () => {
         const column = QueryColumn.create({
             name: 'testColumn',
             fieldKey: 'testColumn',
@@ -233,9 +234,9 @@ describe('ColumnInView', () => {
                 />
             )
         );
-        wrapper.find(".fa-pencil").simulate("click");
-        expect(wrapper.find(".fa-pencil").exists()).toBeFalsy();
-        expect(wrapper.find("input").exists()).toBe(true);
+        wrapper.find('.fa-pencil').simulate('click');
+        expect(wrapper.find('.fa-pencil').exists()).toBeFalsy();
+        expect(wrapper.find('input').exists()).toBe(true);
         wrapper.unmount();
     });
 });
@@ -411,17 +412,17 @@ describe('FieldLabelDisplay', () => {
     test('not lookup', () => {
         const wrapper = mount(<FieldLabelDisplay column={QUERY_COL} includeFieldKey />);
         expect(wrapper.find('.field-name')).toHaveLength(1);
-        expect(wrapper.find('.field-name').text()).toBe(QUERY_COL.caption)
+        expect(wrapper.find('.field-name').text()).toBe(QUERY_COL.caption);
         expect(wrapper.find(OverlayTrigger)).toHaveLength(0);
-        expect(wrapper.find("input")).toHaveLength(0);
+        expect(wrapper.find('input')).toHaveLength(0);
         wrapper.unmount();
     });
 
     test('is lookup', () => {
         const wrapper = mount(<FieldLabelDisplay column={QUERY_COL_LOOKUP} includeFieldKey />);
         expect(wrapper.find('.field-name')).toHaveLength(1);
-        expect(wrapper.find(OverlayTrigger)).toHaveLength(1)
-        expect(wrapper.find("input")).toHaveLength(0);;
+        expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
+        expect(wrapper.find('input')).toHaveLength(0);
         wrapper.unmount();
     });
 
@@ -429,16 +430,16 @@ describe('FieldLabelDisplay', () => {
         const wrapper = mount(<FieldLabelDisplay column={QUERY_COL_LOOKUP} />);
         expect(wrapper.find('.field-name')).toHaveLength(1);
         expect(wrapper.find(OverlayTrigger)).toHaveLength(0);
-        expect(wrapper.find("input")).toHaveLength(0);
+        expect(wrapper.find('input')).toHaveLength(0);
 
         wrapper.unmount();
     });
 
-    test("is editing", () => {
-       const wrapper = mount(<FieldLabelDisplay column={QUERY_COL} editing />);
-       expect(wrapper.find("input")).toHaveLength(1);
-       expect(wrapper.find("input").prop("defaultValue")).toBe(QUERY_COL.caption);
-       wrapper.unmount();
+    test('is editing', () => {
+        const wrapper = mount(<FieldLabelDisplay column={QUERY_COL} editing />);
+        expect(wrapper.find('input')).toHaveLength(1);
+        expect(wrapper.find('input').prop('defaultValue')).toBe(QUERY_COL.caption);
+        wrapper.unmount();
     });
 });
 

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -173,23 +173,6 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
         onClick(index);
     }, [onClick, index]);
 
-    let overlay;
-    const cannotBeRemoved = column.addToDisplayView === true;
-    const content = (
-        <span
-            className={'pull-right ' + (cannotBeRemoved ? 'text-muted disabled' : 'clickable')}
-            onClick={cannotBeRemoved ? undefined : _onRemoveColumn}
-        >
-            <i className="fa fa-times" />
-        </span>
-    );
-    if (cannotBeRemoved) {
-        overlay = (
-            <Popover id={key + '-disabled-popover'} key={key + '-disabled-warning'}>
-                {APP_FIELD_CANNOT_BE_REMOVED_MESSAGE}
-            </Popover>
-        );
-    }
     return (
         <Draggable key={key} draggableId={key} index={index}>
             {(dragProvided, snapshot) => (
@@ -203,12 +186,9 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
                         <DragDropHandle highlighted={snapshot.isDragging} {...dragProvided.dragHandleProps} />
                     </div>
                     <FieldLabelDisplay column={column} includeFieldKey />
-                    {!cannotBeRemoved && content}
-                    {cannotBeRemoved && (
-                        <OverlayTrigger overlay={overlay} placement="left">
-                            {content}
-                        </OverlayTrigger>
-                    )}
+                    <span className="pull-right clickable" onClick={_onRemoveColumn}>
+                        <i className="fa fa-times" />
+                    </span>
                 </div>
             )}
         </Draggable>

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -227,23 +227,6 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
         onEditTitle();
     }, [onEditTitle]);
 
-    let overlay;
-    const cannotBeRemoved = column.addToDisplayView === true;
-    const removeIconContent = (
-        <span
-            className={'view-field__action ' + (cannotBeRemoved ? 'disabled' : 'clickable')}
-            onClick={cannotBeRemoved ? undefined : _onRemoveColumn}
-        >
-            <i className="fa fa-times" />
-        </span>
-    );
-    if (cannotBeRemoved) {
-        overlay = (
-            <Popover id={key + '-disabled-popover'} key={key + '-disabled-warning'}>
-                {APP_FIELD_CANNOT_BE_REMOVED_MESSAGE}
-            </Popover>
-        );
-    }
     return (
         <Draggable key={key} draggableId={key} index={index} isDragDisabled={isDragDisabled}>
             {(dragProvided, snapshot) => (
@@ -262,12 +245,9 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
                             <span className="edit-inline-field__toggle" onClick={_onEditTitle}>
                                 <i id={'select-' + index} className="fa fa-pencil" />
                             </span>
-                        {!cannotBeRemoved && removeIconContent}
-                        {cannotBeRemoved && (
-                            <OverlayTrigger overlay={overlay} placement="left">
-                                {removeIconContent}
-                            </OverlayTrigger>
-                        )}
+                            <span className="view-field__action clickable" onClick={_onRemoveColumn}>
+                                <i className="fa fa-times" />
+                            </span>
                         </span>
                     )}
                 </div>

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -28,7 +28,7 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
     const initialTitle = useMemo(() => {
         return column.caption ?? column.name;
     }, [column.caption, column.name]);
-    const [ title, setTitle ] = useState<string>(initialTitle);
+    const [title, setTitle] = useState<string>(initialTitle);
     const id = column.index + '-fieldlabel-popover';
     const content = useMemo(() => {
         return <div className="field-name">{initialTitle}</div>;
@@ -36,10 +36,10 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
 
     useEffect(() => {
         setTitle(initialTitle);
-    }, [initialTitle])
+    }, [initialTitle]);
 
     const onTitleChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
-        setTitle(evt.target.value)
+        setTitle(evt.target.value);
     }, []);
 
     const onInputBlur = useCallback(() => {
@@ -61,7 +61,7 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
                 onChange={onTitleChange}
                 type="text"
             />
-        )
+        );
     }
     // only show hover tooltip for lookup child fields
     if (!includeFieldKey || column.index.indexOf('/') === -1) return content;
@@ -124,7 +124,11 @@ export const ColumnChoice: FC<ColumnChoiceProps> = memo(props => {
                 </div>
             )}
             {!isInView && column.selectable && (
-                <div className="pull-right view-field__action" title="Add this field to the view." onClick={_onAddColumn}>
+                <div
+                    className="pull-right view-field__action"
+                    title="Add this field to the view."
+                    onClick={_onAddColumn}
+                >
                     <i className="fa fa-plus" />
                 </div>
             )}
@@ -192,11 +196,11 @@ export const ColumnChoiceGroup: FC<ColumnChoiceLookupProps> = memo(props => {
 
 interface ColumnInViewProps {
     column: QueryColumn;
-    isDragDisabled: boolean;
     index: number;
+    isDragDisabled: boolean;
     onClick: (index: number) => void;
-    onRemoveColumn: (column: QueryColumn) => void;
     onEditTitle: () => void;
+    onRemoveColumn: (column: QueryColumn) => void;
     onUpdateTitle: (column: QueryColumn, title: string) => void;
     selected: boolean;
 }
@@ -205,7 +209,7 @@ interface ColumnInViewProps {
 export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
     const { column, isDragDisabled, onRemoveColumn, onClick, onEditTitle, onUpdateTitle, selected, index } = props;
     const key = column.index;
-    const [ editing, setEditing ] = useState<boolean>(false);
+    const [editing, setEditing] = useState<boolean>(false);
 
     const _onRemoveColumn = useCallback(() => {
         onRemoveColumn(column);
@@ -215,12 +219,15 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
         onClick(index);
     }, [onClick, index]);
 
-    const _onUpdateTitle = useCallback((column: QueryColumn, title: string)  => {
-        setEditing(false);
-        if (column && title) {
-            onUpdateTitle(column, title);
-        }
-    }, [onUpdateTitle]);
+    const _onUpdateTitle = useCallback(
+        (column: QueryColumn, title: string) => {
+            setEditing(false);
+            if (column && title) {
+                onUpdateTitle(column, title);
+            }
+        },
+        [onUpdateTitle]
+    );
 
     const _onEditTitle = useCallback(() => {
         setEditing(true);
@@ -299,7 +306,10 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
     const _onUpdate = useCallback(async () => {
         try {
             const viewInfo = model.currentView.mutate({
-                columns: columnsInView.map(col => ({ fieldKey: col.index, title: col.caption === col.name ? "" : col.caption })),
+                columns: columnsInView.map(col => ({
+                    fieldKey: col.index,
+                    title: col.caption === col.name ? '' : col.caption,
+                })),
             });
             await saveAsSessionView(schemaQuery, model.containerPath, viewInfo);
             closeModal();
@@ -327,13 +337,16 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
         setEditingColumnTitle(true);
     }, []);
 
-    const updateColumnTitle = useCallback((updatedColumn: QueryColumn, title: string) => {
-        const relabeledColumn = updatedColumn.set('caption', title);
-        const index = columnsInView.findIndex(column => column.index === updatedColumn.index);
-        setColumnsInView([...columnsInView.slice(0, index), relabeledColumn, ...columnsInView.slice(index+1)]);
-        setIsDirty(true);
-        setEditingColumnTitle(false);
-    }, [columnsInView]);
+    const updateColumnTitle = useCallback(
+        (updatedColumn: QueryColumn, title: string) => {
+            const relabeledColumn = updatedColumn.set('caption', title);
+            const index = columnsInView.findIndex(column => column.index === updatedColumn.index);
+            setColumnsInView([...columnsInView.slice(0, index), relabeledColumn, ...columnsInView.slice(index + 1)]);
+            setIsDirty(true);
+            setEditingColumnTitle(false);
+        },
+        [columnsInView]
+    );
 
     const addColumn = useCallback(
         (column: QueryColumn) => {

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -239,13 +239,26 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
                     <div className="right-spacing" {...dragProvided.dragHandleProps}>
                         <DragDropHandle highlighted={snapshot.isDragging} {...dragProvided.dragHandleProps} />
                     </div>
-                    <FieldLabelDisplay column={column} includeFieldKey editing={editing} onEditComplete={_onUpdateTitle}/>
+                    <FieldLabelDisplay
+                        column={column}
+                        includeFieldKey
+                        editing={editing}
+                        onEditComplete={_onUpdateTitle}
+                    />
                     {!editing && (
                         <span className="pull-right">
-                            <span className="edit-inline-field__toggle" onClick={_onEditTitle}>
+                            <span
+                                className="edit-inline-field__toggle"
+                                title="Edit the field's label for this view."
+                                onClick={_onEditTitle}
+                            >
                                 <i id={'select-' + index} className="fa fa-pencil" />
                             </span>
-                            <span className="view-field__action clickable" onClick={_onRemoveColumn}>
+                            <span
+                                className="view-field__action clickable"
+                                title="Remove this field from the view."
+                                onClick={_onRemoveColumn}
+                            >
                                 <i className="fa fa-times" />
                             </span>
                         </span>

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -224,10 +224,11 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
                             )}
                             {canSelectView && (
                                 <ViewMenu
+                                    allowViewCustomization={allowViewCustomization}
                                     model={model}
                                     onViewSelect={onViewSelect}
                                     onSaveView={onSaveView}
-                                    onCustomizeView={allowViewCustomization && onCustomizeView}
+                                    onCustomizeView={onCustomizeView}
                                     onManageViews={onManageViews}
                                     hideEmptyViewMenu={hideEmptyViewMenu}
                                 />

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -367,11 +367,11 @@ interface State {
     errorMsg: React.ReactNode;
     headerClickCount: { [key: string]: number };
     isViewSaved?: boolean;
+    selectedColumn: QueryColumn;
     showCustomizeViewModal: boolean;
     showFilterModalFieldKey: string;
     showManageViewsModal: boolean;
     showSaveViewModal: boolean;
-    selectedColumn: QueryColumn;
 }
 
 /**
@@ -718,14 +718,14 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         this.saveAsSessionView({
             columns: model.displayColumns
                 .filter(column => column.index !== columnToHide.index)
-                .map(col => ({ fieldKey: col.index, title: col.caption === col.name ? "" : col.caption })),
+                .map(col => ({ fieldKey: col.index, title: col.caption === col.name ? '' : col.caption })),
         });
     };
 
     addColumn = (selectedColumn: QueryColumn): void => {
         this.setState({
-            selectedColumn: selectedColumn,
-            showCustomizeViewModal: true
+            selectedColumn,
+            showCustomizeViewModal: true,
         });
     };
 

--- a/packages/components/src/public/QueryModel/ManageViewsModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/ManageViewsModal.spec.tsx
@@ -20,10 +20,19 @@ export const getQueryAPI = (views: ViewInfo[]) => {
 };
 
 describe('ManageViewsModal', () => {
+    const SYSTEM_DEFAULT_VIEW = ViewInfo.create({
+        columns: [],
+        filters: [],
+        default: true,
+        saved: false, // cannot be reverted
+        name: '',
+    });
+
     const DEFAULT_VIEW = ViewInfo.create({
         columns: [],
         filters: [],
         default: true,
+        saved: true, // can be reverted
         name: '',
     });
 
@@ -115,11 +124,37 @@ describe('ManageViewsModal', () => {
         expect(rows.at(3).find('.manage-view-name').text()).toBe('View 3');
         expect(rows.at(3).find('.fa-pencil').length).toBe(1);
         expect(rows.at(3).find('.fa-trash-o').length).toBe(1);
+        expect(rows.at(0).find('.gray-text').length).toBe(0);
         expect(rows.at(3).find('.clickable-text').length).toBe(1);
         expect(rows.at(3).find('.clickable-text').text()).toBe('Set default');
 
         const findButton = wrapper.find('button.btn-default');
         expect(findButton.text()).toEqual('Done editing');
+
+        wrapper.unmount();
+    });
+
+    test('system default view', async () => {
+        const wrapper = mountWithAppServerContext(
+            <ManageViewsModal onDone={jest.fn()} currentView={null} schemaQuery={null} />,
+            {
+                api: getQueryAPI([SYSTEM_DEFAULT_VIEW, VIEW_1, SESSION_VIEW, SHARED_VIEW]),
+            },
+            {
+                user: TEST_USER_PROJECT_ADMIN,
+            }
+        );
+        await waitForLifecycle(wrapper);
+
+        const rows = wrapper.find('.row');
+        expect(rows.length).toBe(4);
+
+        expect(rows.at(0).find('.manage-view-name').text()).toBe('Default View');
+        expect(rows.at(0).find('.fa-pencil').length).toBe(0);
+        expect(rows.at(0).find('.fa-trash-o').length).toBe(0);
+        expect(rows.at(0).find('.clickable-text').length).toBe(0);
+        expect(rows.at(0).find('.gray-text').length).toBe(1);
+        expect(rows.at(0).find('.gray-text').text()).toBe('Revert');
 
         wrapper.unmount();
     });

--- a/packages/components/src/public/QueryModel/ManageViewsModal.tsx
+++ b/packages/components/src/public/QueryModel/ManageViewsModal.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, FC, memo, useCallback, useEffect, useState } from 'react';
-import { Col, Modal, Row } from 'react-bootstrap';
+import { Col, Modal, OverlayTrigger, Popover, Row } from 'react-bootstrap';
 
 import { ViewInfo } from '../../internal/ViewInfo';
 import { SchemaQuery } from '../SchemaQuery';
@@ -153,6 +153,11 @@ export const ManageViewsModal: FC<Props> = memo(props => {
                         let viewLabel = view.isDefault ? 'Default View' : view.label;
                         if (unsavedView) viewLabel += ' (Edited)';
 
+                        let revert = <span className="gray-text">Revert</span>;
+                        if (view.isSaved) {
+                            revert = <span onClick={revertDefaultView} className="clickable-text">Revert</span>;
+                        }
+
                         return (
                             <Row className="small-margin-bottom" key={view.name}>
                                 <Col xs={8}>
@@ -174,9 +179,16 @@ export const ManageViewsModal: FC<Props> = memo(props => {
                                     {user.hasAdminPermission() && (
                                         <>
                                             {isDefault && !isRenaming && (
-                                                <span onClick={revertDefaultView} className="clickable-text">
-                                                    Revert
-                                                </span>
+                                                <OverlayTrigger
+                                                    placement="top"
+                                                    overlay={
+                                                        <Popover id="disabled-button-popover">
+                                                            Revert back to the system default view
+                                                        </Popover>
+                                                    }
+                                                >
+                                                    {revert}
+                                                </OverlayTrigger>
                                             )}
                                             {!isDefault && !isRenaming && (
                                                 <span

--- a/packages/components/src/public/QueryModel/ManageViewsModal.tsx
+++ b/packages/components/src/public/QueryModel/ManageViewsModal.tsx
@@ -155,7 +155,11 @@ export const ManageViewsModal: FC<Props> = memo(props => {
 
                         let revert = <span className="gray-text">Revert</span>;
                         if (view.isSaved) {
-                            revert = <span onClick={revertDefaultView} className="clickable-text">Revert</span>;
+                            revert = (
+                                <span onClick={revertDefaultView} className="clickable-text">
+                                    Revert
+                                </span>
+                            );
                         }
 
                         return (

--- a/packages/components/src/public/QueryModel/ManageViewsModal.tsx
+++ b/packages/components/src/public/QueryModel/ManageViewsModal.tsx
@@ -183,7 +183,7 @@ export const ManageViewsModal: FC<Props> = memo(props => {
                                                     placement="top"
                                                     overlay={
                                                         <Popover id="disabled-button-popover">
-                                                            Revert back to the system default view
+                                                            Revert back to the system default view.
                                                         </Popover>
                                                     }
                                                 >

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -48,6 +48,7 @@ beforeAll(() => {
 });
 
 const DEFAULT_PROPS = {
+    allowViewCustomization: false,
     onViewSelect: jest.fn(),
     onSaveView: jest.fn(),
     onManageViews: jest.fn(),
@@ -104,7 +105,7 @@ describe('ViewMenu', () => {
             isGuest: false,
         };
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu {...DEFAULT_PROPS} hideEmptyViewMenu={false} model={model} />);
+        const wrapper = mount(<ViewMenu {...DEFAULT_PROPS} allowViewCustomization={true} hideEmptyViewMenu={false} model={model} />);
         const items = wrapper.find('MenuItem');
         expect(items).toHaveLength(5);
         expect(items.at(2).text()).toBe('Customize Grid View');
@@ -142,7 +143,7 @@ describe('ViewMenu', () => {
         };
 
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_NO_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu {...DEFAULT_PROPS} hideEmptyViewMenu={false} model={model} />);
+        const wrapper = mount(<ViewMenu {...DEFAULT_PROPS} allowViewCustomization={true} hideEmptyViewMenu={false} model={model} />);
         const items = wrapper.find('MenuItem');
         expect(items).toHaveLength(4); // one separator and three options
         expect(items.at(1).text()).toBe('Customize Grid View');
@@ -161,6 +162,7 @@ describe('ViewMenu', () => {
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_PUBLIC_VIEWS, {}, []);
         const wrapper = mount(
             <ViewMenu
+                allowViewCustomization={false}
                 hideEmptyViewMenu={true}
                 model={model}
                 onViewSelect={onViewSelect}

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -105,7 +105,9 @@ describe('ViewMenu', () => {
             isGuest: false,
         };
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_HIDDEN_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu {...DEFAULT_PROPS} allowViewCustomization={true} hideEmptyViewMenu={false} model={model} />);
+        const wrapper = mount(
+            <ViewMenu {...DEFAULT_PROPS} allowViewCustomization={true} hideEmptyViewMenu={false} model={model} />
+        );
         const items = wrapper.find('MenuItem');
         expect(items).toHaveLength(5);
         expect(items.at(2).text()).toBe('Customize Grid View');
@@ -143,7 +145,9 @@ describe('ViewMenu', () => {
         };
 
         const model = makeTestQueryModel(SCHEMA_QUERY, QUERY_INFO_NO_VIEWS, {}, []);
-        const wrapper = mount(<ViewMenu {...DEFAULT_PROPS} allowViewCustomization={true} hideEmptyViewMenu={false} model={model} />);
+        const wrapper = mount(
+            <ViewMenu {...DEFAULT_PROPS} allowViewCustomization={true} hideEmptyViewMenu={false} model={model} />
+        );
         const items = wrapper.find('MenuItem');
         expect(items).toHaveLength(4); // one separator and three options
         expect(items.at(1).text()).toBe('Customize Grid View');

--- a/packages/components/src/public/QueryModel/ViewMenu.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.tsx
@@ -9,6 +9,7 @@ import { getQueryMetadata } from '../../internal/global';
 import { isCustomizeViewsInAppEnabled } from '../../internal/app/utils';
 
 interface ViewMenuProps {
+    allowViewCustomization: boolean;
     hideEmptyViewMenu: boolean;
     model: QueryModel;
     onCustomizeView?: () => void;
@@ -19,11 +20,21 @@ interface ViewMenuProps {
 
 export class ViewMenu extends PureComponent<ViewMenuProps> {
     render(): ReactNode {
-        const { model, hideEmptyViewMenu, onCustomizeView, onManageViews, onViewSelect, onSaveView } = this.props;
+        const {
+            allowViewCustomization,
+            model,
+            hideEmptyViewMenu,
+            onCustomizeView,
+            onManageViews,
+            onViewSelect,
+            onSaveView,
+        } = this.props;
         const { isLoading, views, viewName, visibleViews } = model;
         const { user } = getServerContext();
         const activeViewName = viewName ?? ViewInfo.DEFAULT_NAME;
         const defaultView = views.find(view => view.isDefault);
+        const hasViewsToManage =
+            defaultView?.isSaved || views.filter(view => !view.hidden && !view.isSystemView).length > 0;
 
         const publicViews = visibleViews.filter(view => view.shared);
         const privateViews = visibleViews.filter(view => !view.shared);
@@ -68,11 +79,13 @@ export class ViewMenu extends PureComponent<ViewMenuProps> {
                     {publicViews.length > 0 && <MenuItem divider />}
                     {publicViews.length > 0 && <MenuItem header>All Saved Views</MenuItem>}
                     {publicViews.length > 0 && publicViews.map(viewMapper)}
-                    {isCustomizeViewsInAppEnabled() && onCustomizeView && !user.isGuest && (
+                    {isCustomizeViewsInAppEnabled() && allowViewCustomization && !user.isGuest && (
                         <>
                             <MenuItem divider />
                             <MenuItem onSelect={onCustomizeView}>Customize Grid View</MenuItem>
-                            <MenuItem onSelect={onManageViews}>Manage Saved Views</MenuItem>
+                            <MenuItem onSelect={onManageViews} disabled={!hasViewsToManage}>
+                                Manage Saved Views
+                            </MenuItem>
                             <MenuItem onSelect={onSaveView}>Save Grid View</MenuItem>
                         </>
                     )}

--- a/packages/components/src/theme/fields.scss
+++ b/packages/components/src/theme/fields.scss
@@ -80,13 +80,13 @@
 .edit-inline-field__toggle {
     cursor: pointer;
 
-    .fa-pencil {
+    .fa {
         color: #D3D3D3;
         padding-left: 5px;
     }
 
     &:hover {
-        .fa-pencil {
+        .fa {
             color: #333333;
         }
     }


### PR DESCRIPTION
#### Rationale
In the LKSM, LKB, and LKFM apps we use app metadata to set properties/info about grid columns. One of those properties is "addToDisplayView" which allows for the app metadata to add in specific fields to the grid views within the app for things that are determined to be used in the app which might not be included in the LKS system default view. This property, however, wasn't playing nicely with the new grid customization work as it was not possible for a user within the app to remove these columns. This PR fixes that by only applying / adding those "addToDisplayView" to the system default view. That is, if the user is viewing a saved view (default or named), we will just show those columns as specified by the view definition.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/870
* https://github.com/LabKey/sampleManagement/pull/1016
* https://github.com/LabKey/provenance/pull/108
* https://github.com/LabKey/biologics/pull/1388
* https://github.com/LabKey/inventory/pull/465
* https://github.com/LabKey/platform/pull/3465

#### Changes
* only add "addToDisplayView" fields to view for unsaved default view (i.e. system default view)
* only allow default view revert in Manage Saved Views modal if it is not the system default
* set allowViewCustomization false for a few more cases
