### PR TITLE
Add ability to edit field labels when customizing a grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.1-editColumnLabel.2",
+  "version": "2.188.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.189.0-editColumnLabel.0",
+  "version": "2.188.1-editColumnLabel.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.186.0",
+  "version": "2.186.1-editColumnLabel.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.1-editColumnLabel.1",
+  "version": "2.188.1-editColumnLabel.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Enable editing of column titles for fields shown in view
+* Don't show `GridTitle` when grid is not editable in application.
+
 ### version 2.186.0
 *Released*: 20 June 2022
 * Add Picklist menu item in megamenu

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.188.1
+*Released*: 22 June 2022
 * Enable editing of column titles for fields shown in view
 * Don't show `GridTitle` when grid is not editable in application.
 

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -21,6 +21,7 @@ import {
     CustomizeGridViewModal,
     FieldLabelDisplay,
 } from './CustomizeGridViewModal';
+import { Draggable } from 'react-beautiful-dnd';
 
 const QUERY_COL = QueryColumn.create({
     name: 'testColumn',
@@ -123,7 +124,7 @@ describe('ColumnChoice', () => {
 });
 
 describe('ColumnInView', () => {
-    function validate(wrapper: ReactWrapper, column: QueryColumn, canBeRemoved: boolean) {
+    function validate(wrapper: ReactWrapper, column: QueryColumn, canBeRemoved: boolean, dragDisabled: boolean) {
         const fieldName = wrapper.find('.field-name');
         expect(fieldName.text()).toBe(column.caption);
         const removeIcon = wrapper.find('.fa-times');
@@ -133,11 +134,14 @@ describe('ColumnInView', () => {
             expect(iconParent.prop('className')).toContain('clickable');
             expect(iconParent.prop('onClick')).toBeDefined();
         } else {
-            expect(iconParent.prop('className')).toContain('text-muted disabled');
+            expect(iconParent.prop('className')).toContain('view-field__action disabled');
             expect(iconParent.prop('onClick')).toBeNull();
         }
         if (!canBeRemoved) {
             expect(wrapper.find(OverlayTrigger).exists()).toBeTruthy();
+        }
+        if (dragDisabled) {
+            expect(wrapper.find(Draggable).prop("isDragDisabled")).toBe(true);
         }
     }
 
@@ -148,12 +152,15 @@ describe('ColumnInView', () => {
                     column={QUERY_COL}
                     index={1}
                     onRemoveColumn={jest.fn()}
-                    onClick={jest.fn}
+                    onClick={jest.fn()}
                     selected={undefined}
+                    isDragDisabled={false}
+                    onEditTitle={jest.fn()}
+                    onUpdateTitle={jest.fn()}
                 />
             )
         );
-        validate(wrapper, QUERY_COL, true);
+        validate(wrapper, QUERY_COL, true, false);
         wrapper.unmount();
     });
 
@@ -174,10 +181,69 @@ describe('ColumnInView', () => {
                     onRemoveColumn={jest.fn()}
                     onClick={jest.fn}
                     selected={undefined}
+                    isDragDisabled={false}
+                    onEditTitle={jest.fn()}
+                    onUpdateTitle={jest.fn()}
                 />
             )
         );
-        validate(wrapper, column, false);
+        validate(wrapper, column, false, false);
+        wrapper.unmount();
+    });
+
+    test("drag disabled", () => {
+        const column = QueryColumn.create({
+            name: 'testColumn',
+            fieldKey: 'testColumn',
+            fieldKeyArray: ['testColumn'],
+            caption: 'Test Column',
+            addToDisplayView: true,
+        });
+
+        const wrapper = mount(
+            wrapDraggable(
+                <ColumnInView
+                    column={column}
+                    index={1}
+                    onRemoveColumn={jest.fn()}
+                    onClick={jest.fn}
+                    selected={undefined}
+                    isDragDisabled={true}
+                    onEditTitle={jest.fn()}
+                    onUpdateTitle={jest.fn()}
+                />
+            )
+        );
+        validate(wrapper, column, false, false);
+        wrapper.unmount();
+    });
+
+    test("Editing", () => {
+        const column = QueryColumn.create({
+            name: 'testColumn',
+            fieldKey: 'testColumn',
+            fieldKeyArray: ['testColumn'],
+            caption: 'Test Column',
+            addToDisplayView: true,
+        });
+
+        const wrapper = mount(
+            wrapDraggable(
+                <ColumnInView
+                    column={column}
+                    index={1}
+                    onRemoveColumn={jest.fn()}
+                    onClick={jest.fn}
+                    selected={undefined}
+                    isDragDisabled={true}
+                    onEditTitle={jest.fn()}
+                    onUpdateTitle={jest.fn()}
+                />
+            )
+        );
+        wrapper.find(".fa-pencil").simulate("click");
+        expect(wrapper.find(".fa-pencil").exists()).toBeFalsy();
+        expect(wrapper.find("input").exists()).toBe(true);
         wrapper.unmount();
     });
 });
@@ -353,14 +419,17 @@ describe('FieldLabelDisplay', () => {
     test('not lookup', () => {
         const wrapper = mount(<FieldLabelDisplay column={QUERY_COL} includeFieldKey />);
         expect(wrapper.find('.field-name')).toHaveLength(1);
+        expect(wrapper.find('.field-name').text()).toBe(QUERY_COL.caption)
         expect(wrapper.find(OverlayTrigger)).toHaveLength(0);
+        expect(wrapper.find("input")).toHaveLength(0);
         wrapper.unmount();
     });
 
     test('is lookup', () => {
         const wrapper = mount(<FieldLabelDisplay column={QUERY_COL_LOOKUP} includeFieldKey />);
         expect(wrapper.find('.field-name')).toHaveLength(1);
-        expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
+        expect(wrapper.find(OverlayTrigger)).toHaveLength(1)
+        expect(wrapper.find("input")).toHaveLength(0);;
         wrapper.unmount();
     });
 
@@ -368,7 +437,16 @@ describe('FieldLabelDisplay', () => {
         const wrapper = mount(<FieldLabelDisplay column={QUERY_COL_LOOKUP} />);
         expect(wrapper.find('.field-name')).toHaveLength(1);
         expect(wrapper.find(OverlayTrigger)).toHaveLength(0);
+        expect(wrapper.find("input")).toHaveLength(0);
+
         wrapper.unmount();
+    });
+
+    test("is editing", () => {
+       const wrapper = mount(<FieldLabelDisplay column={QUERY_COL} editing />);
+       expect(wrapper.find("input")).toHaveLength(1);
+       expect(wrapper.find("input").prop("defaultValue")).toBe(QUERY_COL.caption);
+       wrapper.unmount();
     });
 });
 

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -288,7 +288,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
     const { schemaQuery, title, queryInfo } = model;
     const [columnsInView, setColumnsInView] = useState<any>(model.displayColumns);
     const [isDirty, setIsDirty] = useState<boolean>(false);
-    const [editingTitle, setEditingTitle] = useState<boolean>(false);
+    const [editingColumnTitle, setEditingColumnTitle] = useState<boolean>(false);
     const [saveError, setSaveError] = useState<string>(undefined);
     const [queryDetailError, setQueryDetailError] = useState<string>(undefined);
     const [showAllColumns, setShowAllColumns] = useState<boolean>(false);
@@ -331,7 +331,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
     );
 
     const onEditColumnTitle = useCallback(() => {
-        setEditingTitle(true);
+        setEditingColumnTitle(true);
     }, []);
 
     const updateColumnTitle = useCallback((updatedColumn: QueryColumn, title: string) => {
@@ -339,7 +339,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
         const index = columnsInView.findIndex(column => column.index === updatedColumn.index);
         setColumnsInView([...columnsInView.slice(0, index), relabeledColumn, ...columnsInView.slice(index+1)]);
         setIsDirty(true);
-        setEditingTitle(false);
+        setEditingColumnTitle(false);
     }, [columnsInView]);
 
     const addColumn = useCallback(
@@ -486,7 +486,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
                                                     key={column.index}
                                                     column={column}
                                                     index={index}
-                                                    isDragDisabled={editingTitle}
+                                                    isDragDisabled={editingColumnTitle}
                                                     onRemoveColumn={removeColumn}
                                                     selected={selectedIndex === index}
                                                     onClick={onSelectField}

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useState } from 'react';
+import React, { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Col, Modal, OverlayTrigger, Popover, Row } from 'react-bootstrap';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 import classNames from 'classnames';
@@ -16,15 +16,53 @@ import { QueryModel } from './QueryModel';
 
 interface FieldLabelDisplayProps {
     column: QueryColumn;
+    editing?: boolean;
     includeFieldKey?: boolean;
+    onEditComplete?: (column?: QueryColumn, title?: string) => void;
 }
 
 // exported for jest testing
 export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
-    const { column, includeFieldKey } = props;
-    const id = column.index + '-fieldlabel-popover';
-    const content = <div className="field-name">{column.caption ?? column.name}</div>;
+    const { column, editing, includeFieldKey, onEditComplete } = props;
 
+    const initialTitle = useMemo(() => {
+        return column.caption ?? column.name;
+    }, [column.caption, column.name]);
+    const [ title, setTitle ] = useState<string>(initialTitle);
+    const id = column.index + '-fieldlabel-popover';
+    const content = useMemo(() => {
+        return <div className="field-name">{initialTitle}</div>;
+    }, [initialTitle]);
+
+    useEffect(() => {
+        setTitle(initialTitle);
+    }, [initialTitle])
+
+    const onTitleChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
+        setTitle(evt.target.value)
+    }, []);
+
+    const onInputBlur = useCallback(() => {
+        if (title !== initialTitle) {
+            onEditComplete(column, title);
+        } else {
+            onEditComplete();
+        }
+    }, [column, initialTitle, title, onEditComplete]);
+
+    if (editing) {
+        return (
+            <input
+                autoFocus
+                placeholder={undefined}
+                className="form-control"
+                defaultValue={title}
+                onBlur={onInputBlur}
+                onChange={onTitleChange}
+                type="text"
+            />
+        )
+    }
     // only show hover tooltip for lookup child fields
     if (!includeFieldKey || column.index.indexOf('/') === -1) return content;
 
@@ -81,12 +119,12 @@ export const ColumnChoice: FC<ColumnChoiceProps> = memo(props => {
             </div>
             <FieldLabelDisplay column={column} />
             {isInView && (
-                <div className="pull-right" title="This field is included in the view.">
+                <div className="pull-right view-field__action disabled" title="This field is included in the view.">
                     <i className="fa fa-check" />
                 </div>
             )}
             {!isInView && column.selectable && (
-                <div className="pull-right clickable" title="Add this field to the view." onClick={_onAddColumn}>
+                <div className="pull-right view-field__action" title="Add this field to the view." onClick={_onAddColumn}>
                     <i className="fa fa-plus" />
                 </div>
             )}
@@ -154,16 +192,20 @@ export const ColumnChoiceGroup: FC<ColumnChoiceLookupProps> = memo(props => {
 
 interface ColumnInViewProps {
     column: QueryColumn;
+    isDragDisabled: boolean;
     index: number;
     onClick: (index: number) => void;
     onRemoveColumn: (column: QueryColumn) => void;
+    onEditTitle: () => void;
+    onUpdateTitle: (column: QueryColumn, title: string) => void;
     selected: boolean;
 }
 
 // exported for jest tests
 export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
-    const { column, onRemoveColumn, onClick, selected, index } = props;
+    const { column, isDragDisabled, onRemoveColumn, onClick, onEditTitle, onUpdateTitle, selected, index } = props;
     const key = column.index;
+    const [ editing, setEditing ] = useState<boolean>(false);
 
     const _onRemoveColumn = useCallback(() => {
         onRemoveColumn(column);
@@ -173,11 +215,23 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
         onClick(index);
     }, [onClick, index]);
 
+    const _onUpdateTitle = useCallback((column: QueryColumn, title: string)  => {
+        setEditing(false);
+        if (column && title) {
+            onUpdateTitle(column, title);
+        }
+    }, [onUpdateTitle]);
+
+    const _onEditTitle = useCallback(() => {
+        setEditing(true);
+        onEditTitle();
+    }, [onEditTitle]);
+
     let overlay;
     const cannotBeRemoved = column.addToDisplayView === true;
-    const content = (
+    const removeIconContent = (
         <span
-            className={'pull-right ' + (cannotBeRemoved ? 'text-muted disabled' : 'clickable')}
+            className={'view-field__action ' + (cannotBeRemoved ? 'disabled' : 'clickable')}
             onClick={cannotBeRemoved ? undefined : _onRemoveColumn}
         >
             <i className="fa fa-times" />
@@ -191,10 +245,10 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
         );
     }
     return (
-        <Draggable key={key} draggableId={key} index={index}>
+        <Draggable key={key} draggableId={key} index={index} isDragDisabled={isDragDisabled}>
             {(dragProvided, snapshot) => (
                 <div
-                    className={classNames('list-group-item flex draggable', { active: selected })}
+                    className={classNames('list-group-item flex draggable', { active: selected && !editing })}
                     onClick={_onClick}
                     ref={dragProvided.innerRef}
                     {...dragProvided.draggableProps}
@@ -202,12 +256,19 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
                     <div className="right-spacing" {...dragProvided.dragHandleProps}>
                         <DragDropHandle highlighted={snapshot.isDragging} {...dragProvided.dragHandleProps} />
                     </div>
-                    <FieldLabelDisplay column={column} includeFieldKey />
-                    {!cannotBeRemoved && content}
-                    {cannotBeRemoved && (
-                        <OverlayTrigger overlay={overlay} placement="left">
-                            {content}
-                        </OverlayTrigger>
+                    <FieldLabelDisplay column={column} includeFieldKey editing={editing} onEditComplete={_onUpdateTitle}/>
+                    {!editing && (
+                        <span className="pull-right">
+                            <span className="edit-inline-field__toggle" onClick={_onEditTitle}>
+                                <i id={'select-' + index} className="fa fa-pencil" />
+                            </span>
+                        {!cannotBeRemoved && removeIconContent}
+                        {cannotBeRemoved && (
+                            <OverlayTrigger overlay={overlay} placement="left">
+                                {removeIconContent}
+                            </OverlayTrigger>
+                        )}
+                        </span>
                     )}
                 </div>
             )}
@@ -227,6 +288,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
     const { schemaQuery, title, queryInfo } = model;
     const [columnsInView, setColumnsInView] = useState<any>(model.displayColumns);
     const [isDirty, setIsDirty] = useState<boolean>(false);
+    const [editingTitle, setEditingTitle] = useState<boolean>(false);
     const [saveError, setSaveError] = useState<string>(undefined);
     const [queryDetailError, setQueryDetailError] = useState<string>(undefined);
     const [showAllColumns, setShowAllColumns] = useState<boolean>(false);
@@ -244,7 +306,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
     const _onUpdate = useCallback(async () => {
         try {
             const viewInfo = model.currentView.mutate({
-                columns: columnsInView.map(col => ({ fieldKey: col.index })),
+                columns: columnsInView.map(col => ({ fieldKey: col.index, title: col.caption === col.name ? "" : col.caption })),
             });
             await saveAsSessionView(schemaQuery, model.containerPath, viewInfo);
             closeModal();
@@ -267,6 +329,18 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
         },
         [columnsInView]
     );
+
+    const onEditColumnTitle = useCallback(() => {
+        setEditingTitle(true);
+    }, []);
+
+    const updateColumnTitle = useCallback((updatedColumn: QueryColumn, title: string) => {
+        const relabeledColumn = updatedColumn.set('caption', title);
+        const index = columnsInView.findIndex(column => column.index === updatedColumn.index);
+        setColumnsInView([...columnsInView.slice(0, index), relabeledColumn, ...columnsInView.slice(index+1)]);
+        setIsDirty(true);
+        setEditingTitle(false);
+    }, [columnsInView]);
 
     const addColumn = useCallback(
         (column: QueryColumn) => {
@@ -412,9 +486,12 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
                                                     key={column.index}
                                                     column={column}
                                                     index={index}
+                                                    isDragDisabled={editingTitle}
                                                     onRemoveColumn={removeColumn}
                                                     selected={selectedIndex === index}
                                                     onClick={onSelectField}
+                                                    onEditTitle={onEditColumnTitle}
+                                                    onUpdateTitle={updateColumnTitle}
                                                 />
                                             );
                                         })}

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -483,7 +483,7 @@ describe('GridTitle', () => {
         isHidden?: boolean
     ): void {
         expect(wrapper.text()).toContain(expectedTitle);
-        if (isEdited) {
+        if (isEdited && allowCustomization) {
             const editedTag = wrapper.find('.view-edit-alert');
             expect(editedTag.exists()).toBe(true);
             expect(editedTag.text()).toBe('Edited');

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -330,7 +330,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
         onSaveView(user?.isAdmin);
     };
 
-    if (!displayTitle && !isEdited && !isUpdated) {
+    if (!displayTitle && (!allowViewCustomization || (!isEdited && !isUpdated))) {
         return null;
     }
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -443,15 +443,10 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         view: ViewAction;
     };
 
-    getModelView = (): ViewInfo => {
-        const { queryInfo, viewName } = this.props.model;
-        return queryInfo?.getView(viewName, true);
-    };
-
     createGridActionValues = (): ActionValue[] => {
         const { model } = this.props;
         const { filterArray, sorts } = model;
-        const view = this.getModelView();
+        const view = model.currentView;
         const actionValues = [];
 
         const _sorts = view ? sorts.concat(view.sorts.toArray()) : sorts;
@@ -543,7 +538,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     handleFilterRemove = (change: Change, column?: QueryColumn): void => {
         const { model, actions, allowSelections } = this.props;
         const { actionValues } = this.state;
-        const view = this.getModelView();
+        const view = model.currentView;
 
         if (change.type === ChangeType.remove) {
             let newFilters = model.filterArray;
@@ -599,7 +594,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     handleSortChange = (change: Change, newQuerySort?: QuerySort): void => {
         const { model, actions } = this.props;
         const { actionValues } = this.state;
-        const view = this.getModelView();
+        const view = model.currentView;
         let newSorts;
 
         if (change.type === ChangeType.remove) {
@@ -720,7 +715,9 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     hideColumn = (columnToHide: QueryColumn): void => {
         const { model } = this.props;
         this.saveAsSessionView({
-            columns: model.displayColumns.filter(column => column.index !== columnToHide.index),
+            columns: model.displayColumns
+                .filter(column => column.index !== columnToHide.index)
+                .map(col => ({ fieldKey: col.index, title: col.caption === col.name ? "" : col.caption })),
         });
     };
 
@@ -732,9 +729,9 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     };
 
     saveAsSessionView = (updates: Record<string, any>): void => {
-        const { schemaQuery, containerPath } = this.props.model;
-        const view = this.getModelView();
-        const viewInfo = view.mutate(updates);
+        const { model } = this.props;
+        const { schemaQuery, containerPath } = model;
+        const viewInfo = model.currentView.mutate(updates);
 
         saveAsSessionView(schemaQuery, containerPath, viewInfo)
             .then(this.afterViewChange)
@@ -794,7 +791,6 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
     onSessionViewUpdate = (): void => {
         const { actions, model, allowSelections } = this.props;
-
         actions.loadModel(model.id, allowSelections);
     };
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -336,8 +336,8 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
 
     return (
         <div className="panel-heading view-header">
-            {isEdited && <span className="alert-info view-edit-alert">Edited</span>}
-            {isUpdated && <span className="alert-success view-edit-alert">Updated</span>}
+            {isEdited && allowViewCustomization && <span className="alert-info view-edit-alert">Edited</span>}
+            {isUpdated && allowViewCustomization && <span className="alert-success view-edit-alert">Updated</span>}
             {displayTitle ?? 'Default View'}
             {showRevert && (
                 <button className="btn btn-default button-left-spacing button-right-spacing" onClick={_revertViewEdit}>

--- a/packages/components/src/theme/fields.scss
+++ b/packages/components/src/theme/fields.scss
@@ -81,13 +81,37 @@
     cursor: pointer;
 
     .fa-pencil {
-        color: #D3D3D3;
+        color: $light-gray;
         padding-left: 5px;
     }
 
     &:hover {
         .fa-pencil {
-            color: #333333;
+            color: $gray-dark;
+        }
+    }
+}
+
+.view-field__action {
+    cursor: pointer;
+
+    .fa {
+        color: $light-gray;
+        padding-left: 8px;
+    }
+
+    &:hover {
+        .fa {
+            color: $gray-dark;
+        }
+    }
+
+    &.disabled {
+        cursor: default;
+        &:hover {
+            .fa {
+                color: $light-gray;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Users often want the labels on fields to be different than the name of the field in the database, so we allow them to update the display title for a field, just as we do for LKS grids.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3470
* https://github.com/LabKey/sampleManagement/pull/1022
* https://github.com/LabKey/biologics/pull/1389
* https://github.com/LabKey/inventory/pull/466

#### Changes
* Enable editing of column titles for fields shown in view
* Don't show `GridTitle` when grid is not editable in application.
