### PR TITLE
Issue 45028: Display details view columns in lineage

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.188.2",
+  "version": "2.188.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.188.3
+*Released*: 23 June 2022
+* Issue 45028: Display details view columns in lineage
+
 ### version 2.188.2
 *Released*: 23 June 2022
 * Item 10380: Save Grid Views - Allow removal of addToDisplayView columns


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45028](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45028) by explicitly using `ViewInfo.DETAILS_NAME` when creating the query model for lineage details. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/873
* https://github.com/LabKey/biologics/pull/1392
* https://github.com/LabKey/sampleManagement/pull/1037

#### Changes
* Pass `ViewInfo.DETAILS_NAME` to lineage details query configuration.
