### PR TITLE
Cross-Folder lookup scope

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.189.1",
+  "version": "2.190.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.190.0
+*Released*: 27 June 2022
+* Rename `getContainerFilterForInsert` to `getContainerFilterForLookups`.
+* Add optional `containerFilter?: Query.ContainerFilter` prop to `BulkUpdateForm`, `EditableGrid`, `EntityInsertPanel`, and `QueryInfoForm`.
+* Restructure prop declarations for `QueryInfoForm` to extend `QueryFormInputsProps`.
+* Convert `BulkUpdateForm` to accept a `Set<string>` for `selectedIds` to align with `QueryModel.selection`.
+
 ### version 2.189.1
 *Released*: 24 June 2022
 * Issue 45385: don't export empty tabs by default

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -170,7 +170,7 @@ import { initQueryGridState } from './internal/global';
 import {
     deleteRows,
     getContainerFilter,
-    getContainerFilterForInsert,
+    getContainerFilterForLookups,
     getQueryDetails,
     importData,
     InsertFormats,
@@ -834,7 +834,7 @@ export {
     initQueryGridState,
     initNotificationsState,
     getContainerFilter,
-    getContainerFilterForInsert,
+    getContainerFilterForLookups,
     createGridModelId,
     clearSelected,
     // grid functions

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1545,3 +1545,4 @@ export type { PageDetailHeaderProps } from './internal/components/forms/PageDeta
 export type { HorizontalBarData } from './internal/components/chart/HorizontalBarSection';
 export type { HorizontalBarLegendData } from './internal/components/chart/utils';
 export type { InjectedLineage } from './internal/components/lineage/withLineage';
+export type { EditableGridPanelForUpdateWithLineageProps } from './internal/components/editable/EditableGridPanelForUpdateWithLineage';

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -236,6 +236,7 @@ export class Cell extends React.PureComponent<Props> {
             cellActions,
             col,
             colIdx,
+            containerFilter,
             focused,
             message,
             placeholder,
@@ -310,6 +311,7 @@ export class Cell extends React.PureComponent<Props> {
             const lookupProps: LookupCellProps = {
                 col,
                 colIdx,
+                containerFilter,
                 disabled: this.isReadOnly(),
                 modifyCell: cellActions.modifyCell,
                 rowIdx,

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { List } from 'immutable';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { Query } from '@labkey/api';
 
 import { cancelEvent, isCopy, isPaste, isSelectAll } from '../../events';
 import { CellMessage, ValueDescriptor } from '../../models';
@@ -40,6 +41,7 @@ interface Props {
     cellActions: CellActions;
     col: QueryColumn;
     colIdx: number;
+    containerFilter?: Query.ContainerFilter;
     name?: string;
     placeholder?: string;
     readOnly?: boolean;
@@ -73,7 +75,7 @@ export class Cell extends React.PureComponent<Props> {
         this.displayEl = React.createRef();
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(): void {
         if (!this.props.focused && this.props.selected) {
             this.displayEl.current.focus();
         }

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -42,18 +42,18 @@ interface Props {
     col: QueryColumn;
     colIdx: number;
     containerFilter?: Query.ContainerFilter;
+    filteredLookupKeys?: List<any>;
+    filteredLookupValues?: List<string>;
+    focused?: boolean;
+    locked?: boolean;
+    message?: CellMessage;
     name?: string;
     placeholder?: string;
     readOnly?: boolean;
-    locked?: boolean;
     rowIdx: number;
-    focused?: boolean;
-    message?: CellMessage;
     selected?: boolean;
     selection?: boolean;
     values?: List<ValueDescriptor>;
-    filteredLookupValues?: List<string>;
-    filteredLookupKeys?: List<any>;
 }
 
 export class Cell extends React.PureComponent<Props> {

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -49,10 +49,11 @@ import { CellMessage, EditorModel, EditorModelProps, ValueDescriptor } from '../
 
 import { BulkAddUpdateForm } from '../forms/BulkAddUpdateForm';
 
+import { EditableGridExportMenu, ExportOption } from '../../../public/QueryModel/ExportMenu';
+
 import { AddRowsControl, AddRowsControlProps, PlacementType } from './Controls';
 import { Cell, CellActions } from './Cell';
 import { EDITABLE_GRID_CONTAINER_CLS } from './constants';
-import { EditableGridExportMenu, ExportOption } from '../../../public/QueryModel/ExportMenu';
 
 function isCellEmpty(values: List<ValueDescriptor>): boolean {
     return !values || values.isEmpty() || values.some(v => v.raw === undefined || v.raw === null || v.raw === '');
@@ -207,12 +208,12 @@ export interface SharedEditableGridProps {
     hideCountCol?: boolean;
     insertColumns?: List<QueryColumn>;
     isSubmitting?: boolean;
-    lockedRows?: List<any>;   // list of key values for rows that are locked. locked rows are readonly but might have a different display from readonly rows
+    lockedRows?: List<any>; // list of key values for rows that are locked. locked rows are readonly but might have a different display from readonly rows
     maxRows?: number;
-    notDeletable?: List<any>;   // list of key values that cannot be deleted.
+    notDeletable?: List<any>; // list of key values that cannot be deleted.
     processBulkData?: (data: OrderedMap<string, any>) => BulkAddData;
     readOnlyColumns?: List<string>;
-    readonlyRows?: List<any>;   // list of key values for rows that are readonly.
+    readonlyRows?: List<any>; // list of key values for rows that are readonly.
     removeColumnTitle?: string;
     rowNumColumn?: GridColumn;
     striped?: boolean;

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -183,18 +183,6 @@ export interface BulkAddData {
     validationMsg?: ReactNode;
 }
 
-export interface SharedEditableGridPanelProps extends SharedEditableGridProps {
-    activeTab?: number;
-    bsStyle?: any;
-    className?: string;
-    getColumnMetadata?: (tabId?: number) => Map<string, EditableColumnMetadata>;
-    getReadOnlyRows?: (tabId?: number) => List<any>;
-    getTabHeader?: (tabId?: number) => ReactNode;
-    getTabTitle?: (tabId?: number) => string;
-    getUpdateColumns?: (tabId?: number) => List<QueryColumn>;
-    title?: string;
-}
-
 export interface SharedEditableGridProps {
     addControlProps?: Partial<AddRowsControlProps>;
     allowAdd?: boolean;
@@ -231,18 +219,30 @@ export interface SharedEditableGridProps {
     updateColumns?: List<QueryColumn>;
 }
 
+export interface SharedEditableGridPanelProps extends SharedEditableGridProps {
+    activeTab?: number;
+    bsStyle?: any;
+    className?: string;
+    getColumnMetadata?: (tabId?: number) => Map<string, EditableColumnMetadata>;
+    getReadOnlyRows?: (tabId?: number) => List<any>;
+    getTabHeader?: (tabId?: number) => ReactNode;
+    getTabTitle?: (tabId?: number) => string;
+    getUpdateColumns?: (tabId?: number) => List<QueryColumn>;
+    title?: string;
+}
+
 export interface EditableGridProps extends SharedEditableGridProps {
     data?: Map<any, Map<string, any>>;
     dataKeys?: List<any>;
     editorModel: EditorModel;
     error: string;
+    exportHandler?: (option: ExportOption) => void;
     onChange: (
         editorModelChanges: Partial<EditorModelProps>,
         dataKeys?: List<any>,
         data?: Map<any, Map<string, any>>
     ) => void;
     queryInfo: QueryInfo;
-    exportHandler?: (option: ExportOption) => void;
 }
 
 export interface EditableGridState {
@@ -302,12 +302,12 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.addEventListener('copy', this.onCopy);
         document.addEventListener('paste', this.onPaste);
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener('copy', this.onCopy);
         document.removeEventListener('paste', this.onPaste);
     }

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -17,6 +17,7 @@ import classNames from 'classnames';
 import React, { ChangeEvent, MouseEvent, PureComponent, ReactNode } from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { List, Map, OrderedMap, Set } from 'immutable';
+import { Query } from '@labkey/api';
 
 import {
     addRows,
@@ -97,7 +98,8 @@ function inputCellFactory(
     columnMetadata: EditableColumnMetadata,
     readonlyRows: List<any>,
     lockedRows: List<any>,
-    cellActions: CellActions
+    cellActions: CellActions,
+    containerFilter: Query.ContainerFilter
 ) {
     return (value: any, row: any, c: GridColumn, rn: number, cn: number) => {
         let colOffset = 0;
@@ -134,6 +136,7 @@ function inputCellFactory(
                 cellActions={cellActions}
                 col={c.raw}
                 colIdx={colIdx}
+                containerFilter={containerFilter}
                 key={inputCellKey(c.raw, row)}
                 placeholder={columnMetadata ? columnMetadata.placeholder : undefined}
                 readOnly={isReadonlyCol || isReadonlyRow || isReadonlyCell}
@@ -208,6 +211,7 @@ export interface SharedEditableGridProps {
     bulkUpdateText?: string;
     columnMetadata?: Map<string, EditableColumnMetadata>;
     condensed?: boolean;
+    containerFilter?: Query.ContainerFilter;
     disabled?: boolean;
     emptyGridMsg?: string;
     extraExportColumns?: Array<Partial<QueryColumn>>;
@@ -222,9 +226,9 @@ export interface SharedEditableGridProps {
     readOnlyColumns?: List<string>;
     readonlyRows?: List<any>;   // list of key values for rows that are readonly.
     removeColumnTitle?: string;
+    rowNumColumn?: GridColumn;
     striped?: boolean;
     updateColumns?: List<QueryColumn>;
-    rowNumColumn?: GridColumn;
 }
 
 export interface EditableGridProps extends SharedEditableGridProps {
@@ -566,6 +570,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             allowBulkRemove,
             allowBulkUpdate,
             allowRemove,
+            containerFilter,
             editorModel,
             hideCountCol,
             queryInfo,
@@ -608,7 +613,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                         metadata,
                         readonlyRows,
                         lockedRows,
-                        this.cellActions
+                        this.cellActions,
+                        containerFilter
                     ),
                     index: qCol.fieldKey,
                     raw: qCol,

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
@@ -20,21 +20,21 @@ import { applyEditableGridChangesToModels, getUpdatedDataFromEditableGrid, initE
 
 interface Props {
     containerFilter?: Query.ContainerFilter;
-    queryModel: QueryModel;
+    idField: string;
     loader: EditableGridLoaderFromSelection;
-    selectionData: Map<string, any>;
-    updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise<any>;
     onCancel: () => any;
     onComplete: () => any;
-    idField: string;
-    singularNoun?: string;
     pluralNoun?: string;
+    queryModel: QueryModel;
+    selectionData: Map<string, any>;
+    singularNoun?: string;
+    updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise<any>;
 }
 
 interface State {
-    isSubmitting: boolean;
     dataModels: QueryModel[];
     editorModels: EditorModel[];
+    isSubmitting: boolean;
 }
 
 export class EditableGridPanelForUpdate extends React.Component<Props, State> {

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { List, Map } from 'immutable';
+import { Query } from '@labkey/api';
 
 import {
     EditableGridLoaderFromSelection,
@@ -18,6 +19,7 @@ import { getUniqueIdColumnMetadata } from '../entities/utils';
 import { applyEditableGridChangesToModels, getUpdatedDataFromEditableGrid, initEditableGridModels } from './utils';
 
 interface Props {
+    containerFilter?: Query.ContainerFilter;
     queryModel: QueryModel;
     loader: EditableGridLoaderFromSelection;
     selectionData: Map<string, any>;
@@ -55,7 +57,7 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.initEditorModel();
     }
 
@@ -122,7 +124,7 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
     };
 
     render() {
-        const { onCancel, singularNoun, pluralNoun, ...editableGridProps } = this.props;
+        const { containerFilter, onCancel, singularNoun, pluralNoun, ...editableGridProps } = this.props;
         const { isSubmitting, dataModels, editorModels } = this.state;
         const firstModel = dataModels[0];
         const columnMetadata = getUniqueIdColumnMetadata(firstModel.queryInfo);
@@ -139,8 +141,9 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
                     allowRemove={false}
                     bordered
                     bsStyle="info"
-                    editorModel={editorModels}
                     columnMetadata={columnMetadata}
+                    containerFilter={containerFilter}
+                    editorModel={editorModels}
                     forUpdate
                     model={dataModels}
                     onChange={this.onGridChange}

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
@@ -3,7 +3,6 @@ import { fromJS, List, Map } from 'immutable';
 
 import {
     createNotification,
-    EditableColumnMetadata,
     EditableGridLoaderFromSelection,
     EditableGridPanel,
     EditorModel,
@@ -137,7 +136,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
                     });
                 });
         }
-    }, [loaders, queryModel, editableGridModels]);
+    }, [loaders, queryModel, editableGridModels, extraExportColumns]);
 
     const onGridChange = useCallback(
         (

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
@@ -56,11 +56,11 @@ export interface EditableGridPanelForUpdateWithLineageProps
     parentDataTypes: List<EntityDataType>;
     parentTypeOptions: Map<string, List<IEntityTypeOption>>;
     pluralNoun?: string;
+    queryModel: QueryModel;
     selectionData?: Map<string, any>;
     singularNoun?: string;
     targetEntityDataType: EntityDataType;
     updateAllTabRows: (updateData: any[]) => Promise<boolean>;
-    queryModel: QueryModel;
 }
 
 export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdateWithLineageProps> = memo(props => {

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -14,31 +14,31 @@
  * limitations under the License.
  */
 import React, { PureComponent, ReactNode } from 'react';
-import { List, Map } from 'immutable';
+import { List } from 'immutable';
 
-import { Filter } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { ValueDescriptor } from '../../models';
 import { LOOKUP_DEFAULT_SIZE, MODIFICATION_TYPES, SELECTION_TYPES } from '../../constants';
-import { QueryColumn, QuerySelect, SchemaQuery } from '../../..';
+import { QueryColumn, QuerySelect } from '../../..';
 import { TextChoiceInput } from '../forms/input/TextChoiceInput';
 
 const customStyles = {
-    control: (provided, state) => ({
+    control: provided => ({
         ...provided,
         minHeight: 24,
         borderRadius: 0,
     }),
-    valueContainer: (provided, state) => ({
+    valueContainer: provided => ({
         ...provided,
         minHeight: 24,
         padding: '0 4px',
     }),
-    input: (provided, state) => ({
+    input: provided => ({
         ...provided,
         margin: '0px',
     }),
-    indicatorsContainer: (provided, state) => ({
+    indicatorsContainer: provided => ({
         ...provided,
         minHeight: 24,
     }),
@@ -63,6 +63,7 @@ const customTheme = theme => ({
 export interface LookupCellProps {
     col: QueryColumn;
     colIdx: number;
+    containerFilter?: Query.ContainerFilter;
     disabled?: boolean;
     modifyCell: (colIdx: number, rowIdx: number, newValues: ValueDescriptor[], mod: MODIFICATION_TYPES) => void;
     rowIdx: number;
@@ -96,7 +97,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
     };
 
     render(): ReactNode {
-        const { col, values, filteredLookupKeys, filteredLookupValues } = this.props;
+        const { col, containerFilter, disabled, values, filteredLookupKeys, filteredLookupValues } = this.props;
 
         const rawValues = values
             .filter(vd => vd.raw !== undefined)
@@ -108,12 +109,12 @@ export class LookupCell extends PureComponent<LookupCellProps> {
                 <TextChoiceInput
                     autoFocus
                     queryColumn={col}
-                    disabled={this.props.disabled}
+                    disabled={disabled}
                     containerClass="select-input-cell-container"
                     customTheme={customTheme}
                     customStyles={customStyles}
                     menuPosition="fixed" // note that there is an open issue related to scrolling when the menu is open: https://github.com/JedWatson/react-select/issues/4088
-                    openMenuOnFocus={true}
+                    openMenuOnFocus
                     inputClass="select-input-cell"
                     placeholder=""
                     onChange={this.onInputChange}
@@ -137,8 +138,8 @@ export class LookupCell extends PureComponent<LookupCellProps> {
         return (
             <QuerySelect
                 autoFocus
-                containerFilter={lookup.containerFilter}
-                disabled={this.props.disabled}
+                containerFilter={lookup.containerFilter ?? containerFilter}
+                disabled={disabled}
                 queryFilters={queryFilters}
                 multiple={isMultiple}
                 schemaQuery={lookup.schemaQuery}
@@ -153,8 +154,8 @@ export class LookupCell extends PureComponent<LookupCellProps> {
                 inputClass="select-input-cell"
                 placeholder=""
                 onQSChange={this.onInputChange}
-                label={null}
-                preLoad={true}
+                preLoad
+                showLabel={false}
                 value={isMultiple ? rawValues : rawValues[0]}
             />
         );

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -65,12 +65,12 @@ export interface LookupCellProps {
     colIdx: number;
     containerFilter?: Query.ContainerFilter;
     disabled?: boolean;
+    filteredLookupKeys?: List<any>;
+    filteredLookupValues?: List<string>;
     modifyCell: (colIdx: number, rowIdx: number, newValues: ValueDescriptor[], mod: MODIFICATION_TYPES) => void;
     rowIdx: number;
     select: (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES, resetValue?: boolean) => void;
     values: List<ValueDescriptor>;
-    filteredLookupValues?: List<string>;
-    filteredLookupKeys?: List<any>;
 }
 
 export class LookupCell extends PureComponent<LookupCellProps> {

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -222,9 +222,9 @@ interface StateProps {
     insertModel: EntityIdCreationModel;
     isMerge: boolean;
     isSubmitting: boolean;
-    previewName: string;
-    previewAliquotName: string;
     originalQueryInfo: QueryInfo;
+    previewAliquotName: string;
+    previewName: string;
     useAsync: boolean;
 }
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -16,7 +16,7 @@
 import React, { Component, FC, memo, ReactNode, useMemo } from 'react';
 import { Button } from 'react-bootstrap';
 import { List, Map, OrderedMap, fromJS } from 'immutable';
-import { AuditBehaviorTypes, Utils } from '@labkey/api';
+import { AuditBehaviorTypes, Query, Utils } from '@labkey/api';
 
 import { Link } from 'react-router';
 
@@ -166,6 +166,7 @@ interface OwnProps {
     auditBehavior?: AuditBehaviorTypes;
     canEditEntityTypeDetails?: boolean;
     combineParentTypes?: boolean; // Puts all parent types in one parent button. Name on the button will be the first parent type listed
+    containerFilter?: Query.ContainerFilter;
     creationTypeOptions?: SampleCreationTypeModel[];
     disableMerge?: boolean;
     entityDataType: EntityDataType;
@@ -953,7 +954,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
     renderCreateFromGrid = (): ReactNode => {
         const { insertModel, creationType, dataModel, editorModel } = this.state;
-        const { creationTypeOptions, nounPlural, onBulkAdd } = this.props;
+        const { containerFilter, creationTypeOptions, maxEntities, nounPlural, onBulkAdd } = this.props;
         const columnMetadata = this.getColumnMetadata();
         const isLoaded = (dataModel && !dataModel?.isLoading) ?? false;
 
@@ -1007,16 +1008,17 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                                     creationTypeOptions: bulkCreationTypeOptions,
                                     countText: `New ${gridNounPlural}`,
                                 }}
-                                processBulkData={onBulkAdd}
                                 bulkUpdateProps={{ columnFilter: this.columnFilter }}
                                 bulkRemoveText={'Remove ' + gridNounPluralCap}
                                 columnMetadata={columnMetadata}
+                                containerFilter={containerFilter}
+                                editorModel={editorModel}
                                 emptyGridMsg={`Start by adding the quantity of ${gridNounPlural} you want to create.`}
                                 insertColumns={this.getInsertColumns()}
+                                maxRows={maxEntities}
                                 model={dataModel}
-                                editorModel={editorModel}
-                                maxRows={this.props.maxEntities}
                                 onChange={this.onGridChange}
+                                processBulkData={onBulkAdd}
                             />
                         </>
                     )}

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
@@ -44,7 +44,7 @@ const DEFAULT_PROPS = {
     onCancel: jest.fn,
     onSubmitForEdit: jest.fn,
     queryInfo: QUERY_INFO,
-    selectedIds: [],
+    selectedIds: new Set<string>(),
     updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise.resolve(),
 };
 

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -72,7 +72,13 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
         const { schemaName, name } = queryInfo;
 
         try {
-            const { data, dataIds } = await getSelectedData(schemaName, name, Array.from(selectedIds), columnString, sortString);
+            const { data, dataIds } = await getSelectedData(
+                schemaName,
+                name,
+                Array.from(selectedIds),
+                columnString,
+                sortString
+            );
             this.setState({
                 dataForSelection: data,
                 dataIdsForSelection: dataIds,

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -45,8 +45,10 @@ export const getFieldEnabledFieldName = function (column: QueryColumn, fieldName
     return name + '::enabled';
 };
 
-interface QueryFormInputsProps {
+export interface QueryFormInputsProps {
     allowFieldDisable?: boolean;
+    // this can be used when you want a form to supply a set of values to populate a grid, which will be filled in with additional data
+    // (e.g., if you want to generate a set of samples with common properties but need to provide the individual, unique ids)
     checkRequiredFields?: boolean;
     columnFilter?: (col?: QueryColumn) => boolean;
     componentKey?: string; // unique key to add to QuerySelect to avoid duplication w/ transpose
@@ -58,16 +60,16 @@ interface QueryFormInputsProps {
     includeLabelField?: boolean;
     initiallyDisableFields?: boolean;
     lookups?: Map<string, number>;
+    onAdditionalFormDataChange?: (name: string, value: any) => void;
     onFieldsEnabledChange?: (numEnabled: number) => void;
-    onQSChange?: (name: string, value: string | any[], items: any) => any;
+    onQSChange?: (name: string, value: string | any[], items: any) => void;
     queryColumns?: OrderedMap<string, QueryColumn>;
     queryInfo?: QueryInfo;
-    renderFileInputs?: boolean;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
+    renderFileInputs?: boolean;
     showLabelAsterisk?: boolean; // only used if checkRequiredFields is false, to show * for fields that are originally required
     showQuerySelectPreviewOptions?: boolean;
     useDatePicker?: boolean;
-    onAdditionalFormDataChange?: (name: string, value: any) => any;
 }
 
 interface State {

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, ReactNode } from 'react';
 import { List, Map, OrderedMap } from 'immutable';
 
-import { AuditBehaviorTypes } from '@labkey/api';
+import { AuditBehaviorTypes, Query } from '@labkey/api';
 
 import {
     Alert,
@@ -28,6 +28,7 @@ import { SamplesSelectionProvider } from './SamplesSelectionContextProvider';
 import { DISCARD_CONSUMED_CHECKBOX_FIELD, DISCARD_CONSUMED_COMMENT_FIELD } from './DiscardConsumedSamplesPanel';
 
 interface OwnProps {
+    containerFilter?: Query.ContainerFilter;
     queryModel: QueryModel;
     updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise<void>;
     hasValidMaxSelection: boolean;
@@ -189,6 +190,7 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
     render(): ReactNode {
         const {
             aliquots,
+            containerFilter,
             updateRows,
             queryModel,
             hasValidMaxSelection,
@@ -202,11 +204,12 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
 
         return (
             <BulkUpdateForm
+                containerFilter={containerFilter}
                 singularNoun={selectedNoun}
                 pluralNoun={`${selectedNoun}s`}
                 itemLabel={sampleSetLabel}
                 queryInfo={this.getQueryInfo()}
-                selectedIds={[...queryModel.selections]}
+                selectedIds={queryModel.selections}
                 canSubmitForEdit={hasValidMaxSelection}
                 onCancel={onCancel}
                 onError={onBulkUpdateError}

--- a/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/samples/SamplesBulkUpdateForm.tsx
@@ -29,14 +29,14 @@ import { DISCARD_CONSUMED_CHECKBOX_FIELD, DISCARD_CONSUMED_COMMENT_FIELD } from 
 
 interface OwnProps {
     containerFilter?: Query.ContainerFilter;
-    queryModel: QueryModel;
-    updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise<void>;
-    hasValidMaxSelection: boolean;
-    sampleSetLabel: string;
-    onCancel: () => void;
-    onBulkUpdateError: (message: string) => void;
-    onBulkUpdateComplete: (data: any, submitForEdit) => void;
     editSelectionInGrid: (updateData: any, dataForSelection: Map<string, any>, dataIdsForSelection: List<any>) => any;
+    hasValidMaxSelection: boolean;
+    onBulkUpdateComplete: (data: any, submitForEdit) => void;
+    onBulkUpdateError: (message: string) => void;
+    onCancel: () => void;
+    queryModel: QueryModel;
+    sampleSetLabel: string;
+    updateRows: (schemaQuery: SchemaQuery, rows: any[]) => Promise<void>;
     user: User;
 }
 
@@ -44,8 +44,8 @@ type Props = OwnProps & SamplesSelectionProviderProps & SamplesSelectionResultPr
 
 interface UpdateAlertProps {
     aliquots: any[];
-    numSelections: number;
     editStatusData: OperationConfirmationData;
+    numSelections: number;
 }
 
 // exported for jest testing
@@ -73,8 +73,8 @@ export const SamplesBulkUpdateAlert: FC<UpdateAlertProps> = memo(props => {
 });
 
 interface State {
-    shouldDiscard: boolean;
     discardComment: string;
+    shouldDiscard: boolean;
 }
 
 // exported for jest testing

--- a/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/internal/components/samples/SamplesTabbedGridPanel.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType, FC, memo, useCallback, useMemo, useState } from 'react';
 import { Set, List, Map, OrderedMap } from 'immutable';
-import { AuditBehaviorTypes, Filter } from '@labkey/api';
+import { AuditBehaviorTypes, Filter, Query } from '@labkey/api';
 
 import {
     App,
@@ -38,6 +38,7 @@ interface Props extends InjectedQueryModels {
     afterSampleActionComplete?: (hasDelete?: boolean) => void;
     asPanel?: boolean;
     canPrintLabels?: boolean;
+    containerFilter?: Query.ContainerFilter;
     createBtnParentKey?: string;
     createBtnParentType?: string;
     getSampleAuditBehaviorType: () => AuditBehaviorTypes;
@@ -56,6 +57,7 @@ interface Props extends InjectedQueryModels {
 export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
     const {
         actions,
+        containerFilter,
         queryModels,
         modelId,
         user,
@@ -98,10 +100,10 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
 
     const onEditSelectionInGrid = useCallback(
         (
-            editableGridUpdateData: OrderedMap<string, any>,
+            editableGridUpdateData_: OrderedMap<string, any>,
             editableGridDataForSelection: Map<string, any>
         ): Promise<Map<string, any>> => {
-            setEditableGridUpdateData(editableGridUpdateData);
+            setEditableGridUpdateData(editableGridUpdateData_);
             return Promise.resolve(editableGridDataForSelection);
         },
         []
@@ -302,6 +304,7 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             )}
             {showBulkUpdate && (
                 <SamplesBulkUpdateForm
+                    containerFilter={containerFilter}
                     determineSampleData
                     selection={selection}
                     sampleSet={activeModel.schemaQuery.queryName}

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -992,7 +992,7 @@ export function getContainerFilter(containerPath?: string): Query.ContainerFilte
  * This ContainerFilter must be explicitly applied to be respected.
  * @private
  */
-export function getContainerFilterForInsert(): Query.ContainerFilter {
+export function getContainerFilterForLookups(): Query.ContainerFilter {
     // Check to see if product projects support is enabled.
     if (!isProductProjectsEnabled()) {
         return undefined;


### PR DESCRIPTION
#### Rationale
For Product Projects the intent for lookups is to always source the data from the current folder or above in the hierarchy. This is manifested in our applications in several different places but can be mainly thought of as anywhere users are inserting/updating data. This PR updates additional shared components, namely `BulkUpdateForm`, `EditableGrid`, `EntityInsertPanel`, and `QueryInfoForm` to accept an optional `ContainerFilter`. The application usages of these components responsible for supplying the desired container filter.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/876
* https://github.com/LabKey/biologics/pull/1400
* https://github.com/LabKey/sampleManagement/pull/1050

#### Changes
* Rename `getContainerFilterForInsert` to `getContainerFilterForLookups`.
* Add optional `containerFilter?: Query.ContainerFilter` prop to `BulkUpdateForm`, `EditableGrid`, `EntityInsertPanel`, and `QueryInfoForm`.
* Restructure prop declarations for `QueryInfoForm` to extend `QueryFormInputsProps`.
* Convert `BulkUpdateForm` to accept a `Set<string>` for `selectedIds` to align with `QueryModel.selection`.
