### PR TITLE
Issue 45776: adjust BarChartViewer to resolve cross-folder item counts

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.0",
+  "version": "2.192.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.192.1
+*Released*: 30 June 2022
+* Issue 45776: adjust BarChartViewer to resolve cross-folder item counts
+
 ### version 2.192.0
 *Released*: 30 June 2022
 * Grid column drag-n-drop to reorder columns in grid view

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, PureComponent, useCallback } from 'react';
 import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import moment from 'moment';
-import { Filter, PermissionTypes, Query } from '@labkey/api';
+import { Filter, PermissionTypes } from '@labkey/api';
 
 import {
     Alert,
@@ -16,6 +16,7 @@ import {
     SampleTypeEmptyAlert,
     SchemaQuery,
     Section,
+    selectRows,
     selectRowsDeprecated,
     Tip,
     User,
@@ -33,25 +34,19 @@ import { processChartData } from './utils';
 import { BaseBarChart } from './BaseBarChart';
 import { ChartConfig, ChartData, ChartSelector } from './types';
 
-function fetchItemCount(schemaQuery: SchemaQuery, filters?: Filter.IFilter[]): Promise<number> {
-    return new Promise(resolve => {
-        Query.selectRows({
-            filterArray: filters ?? [],
-            includeMetadata: false,
+async function fetchItemCount(schemaQuery: SchemaQuery, filterArray: Filter.IFilter[] = []): Promise<number> {
+    try {
+        const response = await selectRows({
+            filterArray,
             maxRows: 1,
-            method: 'POST',
-            queryName: schemaQuery.getQuery(),
-            requiredVersion: '17.1',
-            schemaName: schemaQuery.getSchema(),
-            success: response => {
-                resolve(response.rowCount);
-            },
-            failure: error => {
-                console.error('Failed to fetch item count for charts', error);
-                resolve(0);
-            },
+            schemaQuery,
         });
-    });
+        return response.rowCount;
+    } catch (error) {
+        console.error('Failed to fetch item count for charts', error);
+    }
+
+    return 0;
 }
 
 interface Props {


### PR DESCRIPTION
#### Rationale
This addresses Issue 45776 by using the `@labkey/components` variant of `selectRows` which automatically configures the container filters necessary for the query to be made cross-folder.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1415

#### Changes
* Use `selectRows` in lieu of `Query.selectRows` in `BarChartViewer.fetchItemCount` to allow for cross-folder data to be resolved.
