### PR TITLE
Issue 45793: Biologics Registry import from file/grid issues when selecting target type

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.2-fb-biologics-reg-fixes.0",
+  "version": "2.192.2-fb-biologics-reg-fixes.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.0-fb-biologics-reg-fixes.0",
+  "version": "2.194.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.1",
+  "version": "2.192.1-fb-biologics-reg-fixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.194.1
+*Released*: 5 July 2022
+* Fixes for EntityInsertPanel and EntityInsertGridRequiredFieldAlert to support Biologics registry
+
 ### version 2.194.0
 *Released*: 5 July 2022
 * Issue 43943: App grid column header locking on scroll

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
@@ -12,15 +12,20 @@ interface Props {
 
 export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
     const { type, queryInfo } = props;
-    if (!queryInfo || queryInfo.isLoading) {
-        return null;
-    }
 
-    const allRequiredCols = useMemo(() => getFieldKeysOfRequiredCols(queryInfo.getAllColumns()), [queryInfo]);
-    const insertRequiredCols = useMemo(() => getFieldKeysOfRequiredCols(queryInfo.getInsertColumns()), [queryInfo]);
-    if (allRequiredCols.length === insertRequiredCols.length) {
-        return null;
-    }
+    const allRequiredCols = useMemo(() => {
+        if (!queryInfo || queryInfo.isLoading)
+            return [];
+
+        return getFieldKeysOfRequiredCols(queryInfo.getAllColumns())
+    }, [queryInfo]);
+
+    const insertRequiredCols = useMemo(() => {
+        if (!queryInfo || queryInfo.isLoading)
+            return [];
+
+        return getFieldKeysOfRequiredCols(queryInfo.getInsertColumns())
+    }, [queryInfo]);
 
     const missingReqColLabels = useMemo(() => {
         return allRequiredCols
@@ -29,10 +34,15 @@ export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
     }, [queryInfo]);
 
     return (
-        <Alert bsStyle="warning">
-            <b>Warning: </b> the selected {type} has required fields that are not included in the grid below:{' '}
-            {missingReqColLabels.join(', ')}.
-        </Alert>
+        <>
+            { missingReqColLabels.length > 0 &&
+                <Alert bsStyle="warning">
+                    <b>Warning: </b> the selected {type} has required fields that are not included in the grid
+                    below:{' '}
+                    {missingReqColLabels.join(', ')}.
+                </Alert>
+            }
+        </>
     );
 });
 

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
@@ -6,25 +6,23 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { Alert } from '../base/Alert';
 
 interface Props {
-    type: string;
     queryInfo: QueryInfo;
+    type: string;
 }
 
 export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
     const { type, queryInfo } = props;
 
     const allRequiredCols = useMemo(() => {
-        if (!queryInfo || queryInfo.isLoading)
-            return [];
+        if (!queryInfo || queryInfo.isLoading) return [];
 
-        return getFieldKeysOfRequiredCols(queryInfo.getAllColumns())
+        return getFieldKeysOfRequiredCols(queryInfo.getAllColumns());
     }, [queryInfo]);
 
     const insertRequiredCols = useMemo(() => {
-        if (!queryInfo || queryInfo.isLoading)
-            return [];
+        if (!queryInfo || queryInfo.isLoading) return [];
 
-        return getFieldKeysOfRequiredCols(queryInfo.getInsertColumns())
+        return getFieldKeysOfRequiredCols(queryInfo.getInsertColumns());
     }, [queryInfo]);
 
     const missingReqColLabels = useMemo(() => {
@@ -35,13 +33,12 @@ export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
 
     return (
         <>
-            { missingReqColLabels.length > 0 &&
+            {missingReqColLabels.length > 0 && (
                 <Alert bsStyle="warning">
-                    <b>Warning: </b> the selected {type} has required fields that are not included in the grid
-                    below:{' '}
+                    <b>Warning: </b> the selected {type} has required fields that are not included in the grid below:{' '}
                     {missingReqColLabels.join(', ')}.
                 </Alert>
-            }
+            )}
         </>
     );
 });

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.tsx
@@ -29,17 +29,17 @@ export const EntityInsertGridRequiredFieldAlert: FC<Props> = memo(props => {
         return allRequiredCols
             .filter(fieldKey => insertRequiredCols.indexOf(fieldKey) === -1)
             .map(fieldKey => queryInfo.getColumn(fieldKey).caption);
-    }, [queryInfo]);
+    }, [queryInfo, allRequiredCols, insertRequiredCols]);
+
+    if (missingReqColLabels.length === 0) {
+        return null;
+    }
 
     return (
-        <>
-            {missingReqColLabels.length > 0 && (
-                <Alert bsStyle="warning">
-                    <b>Warning: </b> the selected {type} has required fields that are not included in the grid below:{' '}
-                    {missingReqColLabels.join(', ')}.
-                </Alert>
-            )}
-        </>
+        <Alert bsStyle="warning">
+            <b>Warning: </b> the selected {type} has required fields that are not included in the grid below:{' '}
+            {missingReqColLabels.join(', ')}.
+        </Alert>
     );
 });
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -749,7 +749,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         const { originalQueryInfo } = this.state;
 
         const requiredProperties = [];
-        originalQueryInfo.columns.forEach((column, key) => {
+        originalQueryInfo.columns.forEach((column) => {
             if (
                 column.required &&
                 column.shownInInsertView &&
@@ -1030,7 +1030,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         );
     };
 
-    renderUpdateTooltipText = () => {
+    renderUpdateTooltipText = (): ReactNode => {
         const { nounPlural } = this.props;
         const { allowUserSpecifiedNames } = this.state;
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -294,6 +294,9 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         ) {
             this.init();
         }
+
+        if (this.props.importOnly && this.props.tab !== EntityInsertPanelTabs.First)
+            this.props.selectStep(EntityInsertPanelTabs.First);
     }
 
     allowParents = (): boolean => {


### PR DESCRIPTION
#### Rationale
A couple issues in Biologics registry import were exposed by recent updates to EntityInsertPanel

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1419

#### Changes
* Refactor EntityInsertGridRequiredFieldAlert to not have returns before hooks
* Ensure if EntityInsertPanel prop importOnly is true, then tab selected in state is first tab
