### PR TITLE
Issue 45177: enable ontology filters for Sample Finder

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.3-fb-ontology-lineage-cte.1",
+  "version": "2.192.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.2",
+  "version": "2.192.3-fb-ontology-lineage-cte.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.XX
-*Released*: XX 2022
+### version 2.192.3
+*Released*: 1 July 2022
 * Issue 45177: enable ontology filters for Sample Finder
 
 ### version 2.192.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.XX
+*Released*: XX 2022
+* Issue 45177: enable ontology filters for Sample Finder
+
 ### version 2.192.2
 *Released*: 30 June 2022
 * Issue 45725: MegaMenu truncate and text wrap consistency

--- a/packages/components/src/internal/components/search/EntityFieldFilterModal.tsx
+++ b/packages/components/src/internal/components/search/EntityFieldFilterModal.tsx
@@ -25,7 +25,6 @@ import {
     getFieldFiltersValidationResult,
     getUpdatedDataTypeFilters,
     isValidFilterFieldExcludeLookups,
-    SAMPLE_SEARCH_FILTER_TYPES_TO_EXCLUDE,
 } from './utils';
 import { QueryFilterPanel } from './QueryFilterPanel';
 
@@ -229,7 +228,6 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
                         queryInfo={activeQueryInfo}
                         skipDefaultViewCheck={skipDefaultViewCheck}
                         validFilterField={isValidFilterFieldExcludeLookups}
-                        filterTypesToExclude={SAMPLE_SEARCH_FILTER_TYPES_TO_EXCLUDE}
                     />
                 </Row>
             </Modal.Body>

--- a/packages/components/src/internal/components/search/FilterExpressionView.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.tsx
@@ -24,11 +24,10 @@ interface Props {
     field: QueryColumn;
     fieldFilters: Filter.IFilter[];
     onFieldFilterUpdate?: (newFilters: Filter.IFilter[], index: number) => void;
-    filterTypesToExclude?: string[];
 }
 
 export const FilterExpressionView: FC<Props> = memo(props => {
-    const { field, fieldFilters, onFieldFilterUpdate, filterTypesToExclude } = props;
+    const { field, fieldFilters, onFieldFilterUpdate } = props;
 
     const [fieldFilterOptions, setFieldFilterOptions] = useState<FieldFilterOption[]>(undefined);
     const [activeFilters, setActiveFilters] = useState<FilterSelection[]>([]);
@@ -36,7 +35,7 @@ export const FilterExpressionView: FC<Props> = memo(props => {
     const [expandedOntologyKey, setExpandedOntologyKey] = useState<string>(undefined);
 
     useEffect(() => {
-        const filterOptions = getFilterOptionsForType(field, filterTypesToExclude);
+        const filterOptions = getFilterOptionsForType(field);
         setFieldFilterOptions(filterOptions);
         setActiveFilters(getFilterSelections(fieldFilters, filterOptions));
     }, [field]); // leave fieldFilters out of deps list, fieldFilters is used to init once

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -33,7 +33,6 @@ interface Props {
     emptyMsg?: string;
     entityDataType?: EntityDataType; // used for Sample Finder use case
     fieldKey?: string;
-    filterTypesToExclude?: string[];
     filters: { [key: string]: FieldFilter[] };
     fullWidth?: boolean;
     metricFeatureArea?: string;
@@ -60,7 +59,6 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
         metricFeatureArea,
         fullWidth,
         selectDistinctOptions,
-        filterTypesToExclude,
     } = props;
     const [queryFields, setQueryFields] = useState<List<QueryColumn>>(undefined);
     const [activeField, setActiveField] = useState<QueryColumn>(undefined);
@@ -249,7 +247,6 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                                 onFieldFilterUpdate={(newFilters, index) =>
                                                     onFilterUpdate(activeField, newFilters, index)
                                                 }
-                                                filterTypesToExclude={filterTypesToExclude}
                                             />
                                         )}
                                     </Tab.Pane>

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -237,13 +237,6 @@ export function getSampleFinderColumnNames(cards: FilterProps[]): { [key: string
     return columnNames;
 }
 
-// Issue 45177: Lineage filter "IN EXPDESCENDANTSOF" not working when sub select contains ontology filter
-// Hide ontology tree filter types until issue is fixed
-export const SAMPLE_SEARCH_FILTER_TYPES_TO_EXCLUDE = [
-    Filter.Types.ONTOLOGY_IN_SUBTREE.getURLSuffix(),
-    Filter.Types.ONTOLOGY_NOT_IN_SUBTREE.getURLSuffix(),
-];
-
 export const NEGATE_FILTERS = [
     Filter.Types.NEQ_OR_NULL.getURLSuffix(),
     Filter.Types.DATE_NOT_EQUAL.getURLSuffix(),
@@ -272,7 +265,7 @@ export function isBetweenOperator(urlSuffix: string): boolean {
 
 export const FILTER_URL_SUFFIX_ANY_ALT = 'any';
 
-export function getFilterOptionsForType(field: QueryColumn, filterTypesToExclude?: string[]): FieldFilterOption[] {
+export function getFilterOptionsForType(field: QueryColumn): FieldFilterOption[] {
     if (!field) return null;
 
     const jsonType = field.getDisplayFieldJsonType() as JsonType;
@@ -282,8 +275,7 @@ export function getFilterOptionsForType(field: QueryColumn, filterTypesToExclude
     const filterList = (
         useConceptFilters ? CONCEPT_COLUMN_FILTER_TYPES : Filter.getFilterTypesForType(jsonType)
     ).filter(function (result) {
-        if (Filter.Types.HAS_ANY_VALUE.getURLSuffix() === result.getURLSuffix()) return false;
-        return !filterTypesToExclude || filterTypesToExclude.indexOf(result.getURLSuffix()) === -1;
+        return Filter.Types.HAS_ANY_VALUE.getURLSuffix() !== result.getURLSuffix();
     });
 
     if (jsonType === 'date') {


### PR DESCRIPTION
#### Rationale
Ontology filters were previously hidden from sample finder due to issue with lineage filters that contains ontology subselect. The sql issue is now fixed so we are ready to enable ontology filters for Sample Finder.  

[Issue 45177](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45177): Lineage filter "IN EXPDESCENDANTSOF" not working when sub select contains ontology filter

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3497
* https://github.com/LabKey/ontology/pull/82
* https://github.com/LabKey/labkey-ui-components/pull/885
* https://github.com/LabKey/sampleManagement/pull/1065
* https://github.com/LabKey/biologics/pull/1417

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
