### PR TITLE
Allow in-line editing of column titles for grid customization

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.4-editColumnTitle.4",
+  "version": "2.193.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.4-editColumnTitle.2",
+  "version": "2.192.4-editColumnTitle.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.4-editColumnTitle.1",
+  "version": "2.192.4-editColumnTitle.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.4-editColumnTitle.3",
+  "version": "2.192.4-editColumnTitle.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.3",
+  "version": "2.192.4-editColumnTitle.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.4-editColumnTitle.0",
+  "version": "2.192.4-editColumnTitle.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.193.0
+*Released*: 4 July 2022
 * Add ability to edit the column title (caption) from the column header
 
 ### version 2.192.3

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add ability to edit the column title (caption) from the column header
+
 ### version 2.192.3
 *Released*: 1 July 2022
 * Issue 45177: enable ontology filters for Sample Finder

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -38,10 +38,10 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
                 <DropdownButton id="responsive-menu-button-group" title="More" className="responsive-menu">
                     {buttons.map((item, index) => {
                         return (
-                            <>
+                            <React.Fragment key={index}>
                                 {React.cloneElement(item, { asSubMenu: true })}
                                 {index < buttons.length - 1 && <MenuItem divider />}
-                            </>
+                            </React.Fragment>
                         );
                     })}
                 </DropdownButton>

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -14,7 +14,7 @@ import { QuerySort } from '../public/QuerySort';
 
 import { QueryInfo } from '../public/QueryInfo';
 
-import { HeaderCellDropdown, isFilterColumnNameMatch } from './renderers';
+import { EditableColumnTitle, HeaderCellDropdown, isFilterColumnNameMatch } from './renderers';
 import { GridColumn } from './components/base/models/GridColumn';
 import { LabelHelpTip } from './components/base/LabelHelpTip';
 import { CustomToggle } from './components/base/CustomToggle';
@@ -143,7 +143,7 @@ describe('HeaderCellDropdown', () => {
                 handleHideColumn={jest.fn}
             />
         );
-        validate(wrapper, 0, 2);
+        validate(wrapper, 0, 3);
         wrapper.unmount();
     });
 
@@ -162,7 +162,7 @@ describe('HeaderCellDropdown', () => {
                 handleHideColumn={jest.fn}
             />
         );
-        validate(wrapper, 0, 2);
+        validate(wrapper, 0, 3);
         expect(wrapper.find(DisableableMenuItem)).toHaveLength(1);
         expect(wrapper.find(DisableableMenuItem).text()).toContain('Hide Column');
         expect(wrapper.find(DisableableMenuItem).prop('operationPermitted')).toBe(true);
@@ -200,7 +200,7 @@ describe('HeaderCellDropdown', () => {
                 handleHideColumn={jest.fn}
             />
         );
-        validate(wrapper, 0, 5);
+        validate(wrapper, 0, 6);
         wrapper.unmount();
     });
 
@@ -235,7 +235,7 @@ describe('HeaderCellDropdown', () => {
                 handleHideColumn={jest.fn}
             />
         );
-        validate(wrapper, 0, 4);
+        validate(wrapper, 0, 5);
         wrapper.unmount();
     });
 
@@ -389,6 +389,87 @@ describe('HeaderCellDropdown', () => {
         const removeFilterItem = wrapper.find(MenuItem).at(1);
         expect(removeFilterItem.text()).toBe('  Remove filters');
         expect(removeFilterItem.prop('disabled')).toBe(false);
+        wrapper.unmount();
+    });
+});
+
+describe("EditableColumnTitle", () => {
+
+    test("Not editing, with caption", () => {
+        const column = QueryColumn.create({
+            caption: "Test Column",
+            name: "Testing"
+        });
+        const wrapper = mount(
+            <EditableColumnTitle
+                column={column}
+                onChange={jest.fn()}
+                onEditToggle={jest.fn()}
+            />
+        );
+        expect(wrapper.find("input").exists()).toBe(false);
+        expect(wrapper.text()).toBe(column.caption);
+        wrapper.unmount();
+    });
+
+    test("Not editing, no caption", () => {
+        const wrapper = mount(
+            <EditableColumnTitle
+                column={QueryColumn.create({name: "TestName"})}
+                onChange={jest.fn()}
+                onEditToggle={jest.fn()}
+            />
+        );
+        expect(wrapper.find("input").exists()).toBe(false);
+        expect(wrapper.text()).toBe("TestName");
+        wrapper.unmount();
+    });
+
+    test("Not editing with nbsp", () => {
+        const wrapper = mount(
+            <EditableColumnTitle
+                column={QueryColumn.create({name: "TestName", caption: '&nbsp;'})}
+                onChange={jest.fn()}
+                onEditToggle={jest.fn()}
+            />
+        );
+        expect(wrapper.find("input").exists()).toBe(false);
+        expect(wrapper.text()).toBe("");
+        wrapper.unmount();
+    });
+
+    test("Editing with nbsp", () => {
+        const wrapper = mount(
+            <EditableColumnTitle
+                column={QueryColumn.create({name: "TestName", caption: '&nbsp;'})}
+                onChange={jest.fn()}
+                onEditToggle={jest.fn()}
+                editing
+            />
+        );
+        expect(wrapper.find("input").exists()).toBe(false);
+        expect(wrapper.text()).toBe("");
+        wrapper.unmount();
+    });
+
+    test("Editing", async () => {
+        const column = QueryColumn.create({
+            caption: "Test Column",
+            name: "Testing"
+        });
+        const changeFn = jest.fn();
+        const editToggleFn = jest.fn();
+        const wrapper = mount(
+            <EditableColumnTitle
+                column={column}
+                onChange={changeFn}
+                onEditToggle={editToggleFn}
+                editing
+            />
+        );
+        const inputField = wrapper.find("input");
+        expect(inputField.exists()).toBe(true);
+        expect(inputField.prop("defaultValue")).toBe(column.caption);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -393,83 +393,71 @@ describe('HeaderCellDropdown', () => {
     });
 });
 
-describe("EditableColumnTitle", () => {
-
-    test("Not editing, with caption", () => {
+describe('EditableColumnTitle', () => {
+    test('Not editing, with caption', () => {
         const column = QueryColumn.create({
-            caption: "Test Column",
-            name: "Testing"
+            caption: 'Test Column',
+            name: 'Testing',
         });
-        const wrapper = mount(
-            <EditableColumnTitle
-                column={column}
-                onChange={jest.fn()}
-                onEditToggle={jest.fn()}
-            />
-        );
-        expect(wrapper.find("input").exists()).toBe(false);
+        const wrapper = mount(<EditableColumnTitle column={column} onChange={jest.fn()} onEditToggle={jest.fn()} />);
+        expect(wrapper.find('input').exists()).toBe(false);
         expect(wrapper.text()).toBe(column.caption);
         wrapper.unmount();
     });
 
-    test("Not editing, no caption", () => {
+    test('Not editing, no caption', () => {
         const wrapper = mount(
             <EditableColumnTitle
-                column={QueryColumn.create({name: "TestName"})}
+                column={QueryColumn.create({ name: 'TestName' })}
                 onChange={jest.fn()}
                 onEditToggle={jest.fn()}
             />
         );
-        expect(wrapper.find("input").exists()).toBe(false);
-        expect(wrapper.text()).toBe("TestName");
+        expect(wrapper.find('input').exists()).toBe(false);
+        expect(wrapper.text()).toBe('TestName');
         wrapper.unmount();
     });
 
-    test("Not editing with nbsp", () => {
+    test('Not editing with nbsp', () => {
         const wrapper = mount(
             <EditableColumnTitle
-                column={QueryColumn.create({name: "TestName", caption: '&nbsp;'})}
+                column={QueryColumn.create({ name: 'TestName', caption: '&nbsp;' })}
                 onChange={jest.fn()}
                 onEditToggle={jest.fn()}
             />
         );
-        expect(wrapper.find("input").exists()).toBe(false);
-        expect(wrapper.text()).toBe("");
+        expect(wrapper.find('input').exists()).toBe(false);
+        expect(wrapper.text()).toBe('');
         wrapper.unmount();
     });
 
-    test("Editing with nbsp", () => {
+    test('Editing with nbsp', () => {
         const wrapper = mount(
             <EditableColumnTitle
-                column={QueryColumn.create({name: "TestName", caption: '&nbsp;'})}
+                column={QueryColumn.create({ name: 'TestName', caption: '&nbsp;' })}
                 onChange={jest.fn()}
                 onEditToggle={jest.fn()}
                 editing
             />
         );
-        expect(wrapper.find("input").exists()).toBe(false);
-        expect(wrapper.text()).toBe("");
+        expect(wrapper.find('input').exists()).toBe(false);
+        expect(wrapper.text()).toBe('');
         wrapper.unmount();
     });
 
-    test("Editing", async () => {
+    test('Editing', async () => {
         const column = QueryColumn.create({
-            caption: "Test Column",
-            name: "Testing"
+            caption: 'Test Column',
+            name: 'Testing',
         });
         const changeFn = jest.fn();
         const editToggleFn = jest.fn();
         const wrapper = mount(
-            <EditableColumnTitle
-                column={column}
-                onChange={changeFn}
-                onEditToggle={editToggleFn}
-                editing
-            />
+            <EditableColumnTitle column={column} onChange={changeFn} onEditToggle={editToggleFn} editing />
         );
-        const inputField = wrapper.find("input");
+        const inputField = wrapper.find('input');
         expect(inputField.exists()).toBe(true);
-        expect(inputField.prop("defaultValue")).toBe(column.caption);
+        expect(inputField.prop('defaultValue')).toBe(column.caption);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -128,7 +128,6 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
 
     useEffect(() => {
         return () => {
-            setEditingTitle(false);
             setOpen(false);
         }
     }, []);

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -71,7 +71,9 @@ export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
     const onEditFinish = useCallback(() => {
         onEditToggle(false);
         const trimmedTitle = title?.trim();
-        if (trimmedTitle !== initialTitle) {
+        if (!trimmedTitle) {
+            setTitle(initialTitle);
+        } else if (trimmedTitle !== initialTitle) {
             onChange(trimmedTitle);
         }
     }, [initialTitle, onChange, onEditToggle, title]);
@@ -90,7 +92,8 @@ export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
                 defaultValue={title}
                 onKeyDown={onKeyDown}
                 onChange={onTitleChange}
-                onBlur={onEditFinish} />
+                onBlur={onEditFinish}
+            />
         );
     }
 
@@ -176,7 +179,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
 
     const onColumnTitleUpdate = useCallback((newTitle: string) => {
         onColumnTitleChange(col.set('caption', newTitle) as QueryColumn);
-    }, []);
+    }, [col, onColumnTitleChange]);
 
     const onEditTitleToggle = useCallback((value: boolean) => {
         setEditingTitle(value);
@@ -231,16 +234,16 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
                     onEditToggle={onEditTitleToggle}
                 />
 
-                {colFilters?.length > 0 && (
+                {!editingTitle && colFilters?.length > 0 && (
                     <span
                         className="fa fa-filter grid-panel__col-header-icon"
                         title={colFilters?.length + ' filter' + (colFilters?.length > 1 ? 's' : '') + ' applied'}
                     />
                 )}
-                {isSortAsc && (
+                {!editingTitle && isSortAsc && (
                     <span className="fa fa-sort-amount-asc grid-panel__col-header-icon" title="Sorted ascending" />
                 )}
-                {isSortDesc && (
+                {!editingTitle && isSortDesc && (
                     <span className="fa fa-sort-amount-desc grid-panel__col-header-icon" title="Sorted descending" />
                 )}
                 {!editingTitle && column.helpTipRenderer && (

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -189,7 +189,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
             <span onClick={evt => onToggleClick(!open, evt)}>
                 {col.caption === '&nbsp;' ? '' :
                     (editingTitle ?
-                        <input ref={titleInput} value={title} onKeyDown={onKeyDown} onChange={onTitleChange} onBlur={onEditFinish} />
+                        <input autoFocus ref={titleInput} defaultValue={title} onKeyDown={onKeyDown} onChange={onTitleChange} onBlur={onEditFinish} />
                         : col.caption)
                 }
                 {colFilters?.length > 0 && (

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -40,7 +40,7 @@ export function isFilterColumnNameMatch(filter: Filter.IFilter, col: QueryColumn
 
 interface EditableColumnTitleProps {
     column: QueryColumn;
-    editing: boolean;
+    editing?: boolean;
     onEditToggle: (editing: boolean) => void;
     onChange: (newValue: string) => void;
 }
@@ -51,7 +51,7 @@ export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
     const initialTitle = useMemo(() => {
         return column.caption ?? column.name;
     }, [column.caption, column.name]);
-    const [title, setTitle] = useState<string>(column.caption);
+    const [title, setTitle] = useState<string>(initialTitle);
 
     const titleInput: React.RefObject<HTMLInputElement> = React.createRef();
 
@@ -62,7 +62,6 @@ export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
     const onTitleChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
         setTitle(evt.target.value)
     }, []);
-
 
     const onCancelEdit = useCallback(() => {
         onEditToggle(false);
@@ -75,12 +74,12 @@ export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
         if (trimmedTitle !== initialTitle) {
             onChange(trimmedTitle);
         }
-    }, [initialTitle, onChange, title]);
+    }, [initialTitle, onChange, onEditToggle, title]);
 
     const onKeyDown = useEnterEscape(onEditFinish, onCancelEdit);
 
     if (initialTitle === '&nbsp;')  {
-        return <>''</>;
+        return <></>;
     }
 
     if (editing) {

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -25,7 +25,7 @@ import {
     LabelHelpTip,
     QueryColumn,
     QueryModel,
-    useEnterEscape
+    useEnterEscape,
 } from '..';
 
 import { DefaultRenderer } from './renderers/DefaultRenderer';
@@ -41,13 +41,13 @@ export function isFilterColumnNameMatch(filter: Filter.IFilter, col: QueryColumn
 interface EditableColumnTitleProps {
     column: QueryColumn;
     editing?: boolean;
-    onEditToggle: (editing: boolean) => void;
     onChange: (newValue: string) => void;
+    onEditToggle: (editing: boolean) => void;
 }
 
 // exported for jest tests
 export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
-    const {column, editing, onChange, onEditToggle} = props;
+    const { column, editing, onChange, onEditToggle } = props;
     const initialTitle = useMemo(() => {
         return column.caption ?? column.name;
     }, [column.caption, column.name]);
@@ -60,7 +60,7 @@ export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
     }, [initialTitle]);
 
     const onTitleChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
-        setTitle(evt.target.value)
+        setTitle(evt.target.value);
     }, []);
 
     const onCancelEdit = useCallback(() => {
@@ -80,7 +80,7 @@ export const EditableColumnTitle: FC<EditableColumnTitleProps> = memo(props => {
 
     const onKeyDown = useEnterEscape(onEditFinish, onCancelEdit);
 
-    if (initialTitle === '&nbsp;')  {
+    if (initialTitle === '&nbsp;') {
         return <></>;
     }
 
@@ -108,15 +108,25 @@ interface HeaderCellDropdownProps {
     handleHideColumn?: (column: QueryColumn) => void;
     handleSort?: (column: QueryColumn, dir?: string) => void;
     headerClickCount?: number;
-    onColumnTitleChange?: (column: QueryColumn) => void;
     i: number;
     model?: QueryModel;
+    onColumnTitleChange?: (column: QueryColumn) => void;
     selectable?: boolean;
 }
 
 // exported for jest testing
 export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
-    const { i, column, handleSort, handleFilter, handleAddColumn, handleHideColumn, headerClickCount, model, onColumnTitleChange } = props;
+    const {
+        i,
+        column,
+        handleSort,
+        handleFilter,
+        handleAddColumn,
+        handleHideColumn,
+        headerClickCount,
+        model,
+        onColumnTitleChange,
+    } = props;
     const col: QueryColumn = column.raw;
     const [open, setOpen] = useState<boolean>();
     const [editingTitle, setEditingTitle] = useState<boolean>(false);
@@ -131,7 +141,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
     useEffect(() => {
         return () => {
             setOpen(false);
-        }
+        };
     }, []);
 
     const onToggleClick = useCallback(
@@ -177,9 +187,12 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
         setEditingTitle(true);
     }, []);
 
-    const onColumnTitleUpdate = useCallback((newTitle: string) => {
-        onColumnTitleChange(col.set('caption', newTitle) as QueryColumn);
-    }, [col, onColumnTitleChange]);
+    const onColumnTitleUpdate = useCallback(
+        (newTitle: string) => {
+            onColumnTitleChange(col.set('caption', newTitle) as QueryColumn);
+        },
+        [col, onColumnTitleChange]
+    );
 
     const onEditTitleToggle = useCallback((value: boolean) => {
         setEditingTitle(value);
@@ -331,7 +344,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
                                 <>
                                     {(allowColSort || allowColFilter) && <MenuItem divider />}
                                     <MenuItem onClick={editColumnTitle}>
-                                        <span className="fa fa-pencil grid-panel__menu-icon"/> Edit Label
+                                        <span className="fa fa-pencil grid-panel__menu-icon" /> Edit Label
                                     </MenuItem>
                                     {handleAddColumn && (
                                         <MenuItem onClick={_handleAddColumn}>

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ChangeEvent, FC, memo, ReactNode, useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import React, { ChangeEvent, FC, memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Map, OrderedMap } from 'immutable';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import { Filter } from '@labkey/api';
@@ -131,6 +131,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
         setTitle(evt.target.value)
     }, []);
 
+
     const onCancelEdit = useCallback(() => {
         setEditingTitle(false);
         setTitle(col.caption);
@@ -138,8 +139,9 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
 
     const onEditFinish = useCallback(() => {
         setEditingTitle(false);
-        if (title !== col.caption) {
-            onColumnTitleChange(col.set('caption', title) as QueryColumn);
+        const trimmedTitle = title?.trim();
+        if (trimmedTitle !== col.caption) {
+            onColumnTitleChange(col.set('caption', trimmedTitle) as QueryColumn);
         }
     }, [col, onColumnTitleChange, title]);
 
@@ -190,7 +192,8 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
                 {col.caption === '&nbsp;' ? '' :
                     (editingTitle ?
                         <input autoFocus ref={titleInput} defaultValue={title} onKeyDown={onKeyDown} onChange={onTitleChange} onBlur={onEditFinish} />
-                        : col.caption)
+                        : col.caption
+                    )
                 }
                 {colFilters?.length > 0 && (
                     <span
@@ -204,7 +207,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
                 {isSortDesc && (
                     <span className="fa fa-sort-amount-desc grid-panel__col-header-icon" title="Sorted descending" />
                 )}
-                {column.helpTipRenderer && (
+                {!editingTitle && column.helpTipRenderer && (
                     <LabelHelpTip id={column.index} title={column.title} popoverClassName="label-help-arrow-top">
                         <HelpTipRenderer type={column.helpTipRenderer} />
                     </LabelHelpTip>

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -396,7 +396,7 @@ export class QueryColumn extends Record({
     }
 
     get customViewTitle(): string {
-        return this.caption === this.name ? '' : this.caption
+        return this.caption === this.name ? '' : this.caption;
     }
 }
 

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -394,6 +394,10 @@ export class QueryColumn extends Record({
     getDisplayFieldJsonType(): string {
         return (this.displayFieldJsonType ? this.displayFieldJsonType : this.jsonType) ?? 'string';
     }
+
+    get customViewTitle(): string {
+        return this.caption === this.name ? '' : this.caption
+    }
 }
 
 export function insertColumnFilter(col: QueryColumn, includeFileInputs = true): boolean {

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -317,7 +317,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
             const viewInfo = model.currentView.mutate({
                 columns: columnsInView.map(col => ({
                     fieldKey: col.index,
-                    title: col.caption === col.name ? '' : col.caption,
+                    title: col.customViewTitle,
                 })),
             });
             await saveAsSessionView(schemaQuery, model.containerPath, viewInfo);

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -728,6 +728,24 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         });
     };
 
+    updateColumnTitle = (updatedCol: QueryColumn): void => {
+        const { model } = this.props;
+        this.saveAsSessionView({
+            columns: model.displayColumns
+                .map(col => {
+                    if (col.index === updatedCol.index) {
+                        return {
+                            fieldKey: updatedCol.index,
+                            title: updatedCol.caption === updatedCol.name ? '' : updatedCol.caption,
+                        }
+                    } else {
+                        return {fieldKey: col.index, title: col.caption === col.name ? '' : col.caption}
+                    }
+
+                })
+        });
+    }
+
     saveAsSessionView = (updates: Record<string, any>): void => {
         const { model } = this.props;
         const { schemaQuery, containerPath } = model;
@@ -989,6 +1007,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             allowFiltering ? this.filterColumn : undefined,
             allowViewCustomization ? this.addColumn : undefined,
             allowViewCustomization ? this.hideColumn : undefined,
+            allowViewCustomization? this.updateColumnTitle: undefined,
             model,
             headerClickCount[column.index]
         );

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -717,7 +717,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         this.saveAsSessionView({
             columns: model.displayColumns
                 .filter(column => column.index !== columnToHide.index)
-                .map(col => ({ fieldKey: col.index, title: col.caption === col.name ? '' : col.caption })),
+                .map(col => ({ fieldKey: col.index, title: col.customViewTitle })),
         });
     };
 
@@ -736,10 +736,10 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                     if (col.index === updatedCol.index) {
                         return {
                             fieldKey: updatedCol.index,
-                            title: updatedCol.caption === updatedCol.name ? '' : updatedCol.caption,
+                            title: updatedCol.customViewTitle,
                         }
                     } else {
-                        return {fieldKey: col.index, title: col.caption === col.name ? '' : col.caption}
+                        return {fieldKey: col.index, title: col.customViewTitle}
                     }
 
                 })
@@ -979,7 +979,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 this.saveAsSessionView({
                     columns: updatedColumns.map(col => ({
                         fieldKey: col.index,
-                        title: col.caption === col.name ? '' : col.caption,
+                        title: col.customViewTitle,
                     })),
                 });
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -731,20 +731,18 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     updateColumnTitle = (updatedCol: QueryColumn): void => {
         const { model } = this.props;
         this.saveAsSessionView({
-            columns: model.displayColumns
-                .map(col => {
-                    if (col.index === updatedCol.index) {
-                        return {
-                            fieldKey: updatedCol.index,
-                            title: updatedCol.customViewTitle,
-                        }
-                    } else {
-                        return {fieldKey: col.index, title: col.customViewTitle}
-                    }
-
-                })
+            columns: model.displayColumns.map(col => {
+                if (col.index === updatedCol.index) {
+                    return {
+                        fieldKey: updatedCol.index,
+                        title: updatedCol.customViewTitle,
+                    };
+                } else {
+                    return { fieldKey: col.index, title: col.customViewTitle };
+                }
+            }),
         });
-    }
+    };
 
     saveAsSessionView = (updates: Record<string, any>): void => {
         const { model } = this.props;
@@ -1007,7 +1005,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             allowFiltering ? this.filterColumn : undefined,
             allowViewCustomization ? this.addColumn : undefined,
             allowViewCustomization ? this.hideColumn : undefined,
-            allowViewCustomization? this.updateColumnTitle: undefined,
+            allowViewCustomization ? this.updateColumnTitle : undefined,
             model,
             headerClickCount[column.index]
         );

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -65,6 +65,10 @@
   position: relative;
   padding: 0 9px;
   font-weight: bold;
+
+    input {
+        width: 100%
+    }
 }
 
 .grid-header-draggable {


### PR DESCRIPTION
#### Rationale
Users can currently edit the titles (captions) for columns within the `CustomzieGridViewModal`. Here we allow users to do this customization for individual fields from an "Edit Label" option in the header menu that changes the title cell to an input box.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/474
* https://github.com/LabKey/sampleManagement/pull/1067
* https://github.com/LabKey/biologics/pull/1420

#### Changes
* Add `EditableColumnTitle` component for displaying titles in `HeaderCellDropdown`
