### PR TITLE
Issue 43943: App grid column header locking on scroll

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.193.0",
+  "version": "2.193.0-fb-gridStickyHeader.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.3-fb-gridStickyHeader.3",
+  "version": "2.192.3-fb-gridStickyHeader.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.3",
+  "version": "2.192.3-fb-gridStickyHeader.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.3-fb-gridStickyHeader.2",
+  "version": "2.192.3-fb-gridStickyHeader.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.3-fb-gridStickyHeader.1",
+  "version": "2.192.3-fb-gridStickyHeader.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.193.0-fb-gridStickyHeader.1",
+  "version": "2.194.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.192.3-fb-gridStickyHeader.0",
+  "version": "2.192.3-fb-gridStickyHeader.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.193.0-fb-gridStickyHeader.0",
+  "version": "2.193.0-fb-gridStickyHeader.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 43943: App grid column header locking on scroll
   * set fixed height for GridPanel usage of <Grid>
   * add SCSS for `position: sticky;` on GridPanel `thead`
+  * experimental feature: lock left column in app grid on horizontal scroll
   * note: not currently applied to the editable grid case
 
 ### version 2.192.3

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 43943: App grid column header locking on scroll
   * set fixed height for GridPanel usage of <Grid>
   * add SCSS for `position: sticky;` on GridPanel `thead`
+  * fix to disable column dnd when editing column label
   * experimental feature: lock left column in app grid on horizontal scroll
   * note: not currently applied to the editable grid case
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 43943: App grid column header locking on scroll
+  * set fixed height for GridPanel usage of <Grid>
+  * add SCSS for `position: sticky;` on GridPanel `thead`
+
 ### version 2.192.3
 *Released*: 1 July 2022
 * Issue 45177: enable ontology filters for Sample Finder

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.194.0
+*Released*: 5 July 2022
 * Issue 43943: App grid column header locking on scroll
   * set fixed height for GridPanel usage of <Grid>
   * add SCSS for `position: sticky;` on GridPanel `thead`

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 43943: App grid column header locking on scroll
   * set fixed height for GridPanel usage of <Grid>
   * add SCSS for `position: sticky;` on GridPanel `thead`
+  * note: not currently applied to the editable grid case
 
 ### version 2.192.3
 *Released*: 1 July 2022

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -89,6 +89,7 @@ export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';
 export const EXPERIMENTAL_SAMPLE_FINDER = 'experimental-biologics-sample-finder';
 export const EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR = 'experimental-sample-aliquot-selector';
+export const EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN = 'experimental-grid-lock-left-column';
 
 export const BIOLOGICS_APP_PROPERTIES: AppProperties = {
     productId: BIOLOGICS_PRODUCT_ID,

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -21,6 +21,7 @@ import {
     BIOLOGICS_APP_PROPERTIES,
     EXPERIMENTAL_REQUESTS_MENU,
     EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR,
+    EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN,
     EXPERIMENTAL_SAMPLE_FINDER,
     FREEZER_MANAGER_APP_PROPERTIES,
     FREEZERS_KEY,
@@ -227,6 +228,13 @@ export function isSampleAliquotSelectorEnabled(moduleContext?: any): boolean {
         (moduleContext ?? getServerContext().moduleContext)?.samplemanagement?.[
             EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR
         ] === true
+    );
+}
+
+export function isGridLockLeftColumnEnabled(moduleContext?: any): boolean {
+    return (
+        (moduleContext ?? getServerContext().moduleContext)?.samplemanagement?.[EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN] ===
+        true
     );
 }
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -378,7 +378,7 @@ function getPicklistsSectionConfig(appBase: string): MenuSectionConfig {
     return new MenuSectionConfig({
         headerURL: appBase + PICKLIST_HOME_HREF.toHref(),
         iconURL: imageURL('_images', 'picklist.svg'),
-    })
+    });
 }
 
 function getNotebooksSectionConfig(appBase: string): MenuSectionConfig {
@@ -418,12 +418,11 @@ const REQUESTS_SECTION_CONFIG = new MenuSectionConfig({
 function getBioWorkflowNotebookMediaConfigs(appBase: string, user: User) {
     let configs = Map({
         [WORKFLOW_KEY]: getWorkflowSectionConfig(appBase),
-
     });
     if (userCanReadMedia(user)) {
         configs = configs.set(MEDIA_KEY, getMediaSectionConfig(appBase));
     }
-    configs = configs.set(PICKLIST_KEY, getPicklistsSectionConfig(appBase),)
+    configs = configs.set(PICKLIST_KEY, getPicklistsSectionConfig(appBase));
     if (userCanReadNotebooks(user)) {
         configs = configs.set(NOTEBOOKS_KEY, getNotebooksSectionConfig(appBase));
     }
@@ -475,7 +474,7 @@ export function getMenuSectionConfigs(
 
         let configs = Map({
             [WORKFLOW_KEY]: workflowConfig,
-            [PICKLIST_KEY]: getPicklistsSectionConfig(appBase)
+            [PICKLIST_KEY]: getPicklistsSectionConfig(appBase),
         });
 
         if (userCanReadNotebooks(user) && isELNEnabledInLKSM(moduleContext)) {

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -386,7 +386,7 @@ export const Grid: FC<GridProps> = memo(props => {
         const maxHeight = window.innerHeight * 0.7;
         divRef.current.style.height =
             divRef.current.lastElementChild?.clientHeight < maxHeight ? 'unset' : maxHeight + 'px';
-    }, [fixedHeight, gridData.size]);
+    }, [fixedHeight, gridData.size]); // dep on gridData.size to recalculate div height on each grid row count change
 
     const headerProps: GridHeaderProps = {
         calcWidths,

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, memo, PureComponent, ReactNode, RefObject } from 'react';
+import React, { FC, memo, PureComponent, ReactNode, RefObject, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { fromJS, List, Map } from 'immutable';
 
@@ -339,7 +339,6 @@ export interface GridProps {
     onColumnDrop?: (sourceIndex: string, targetIndex: string) => void;
     onHeaderCellClick?: (column: GridColumn) => void;
     responsive?: boolean;
-
     /**
      * If a rowKey is specified the <Grid> will use it as a lookup key into each row. The associated value
      * will be used as the Key for the row.
@@ -349,6 +348,7 @@ export interface GridProps {
     striped?: boolean;
     tableRef?: RefObject<HTMLTableElement>;
     transpose?: boolean;
+    fixedHeight?: boolean;
 }
 
 export const Grid: FC<GridProps> = memo(props => {
@@ -367,6 +367,7 @@ export const Grid: FC<GridProps> = memo(props => {
         striped = true,
         tableRef = undefined,
         transpose = false,
+        fixedHeight = false,
         columns,
         headerCell,
         onHeaderCellClick,
@@ -378,6 +379,14 @@ export const Grid: FC<GridProps> = memo(props => {
     } = props;
     const gridData = processData(data);
     const gridColumns = columns !== undefined ? processColumns(columns) : resolveColumns(gridData);
+
+    const divRef = useRef<HTMLDivElement>();
+    useEffect(() => {
+        if (!fixedHeight) return;
+        const maxHeight = window.innerHeight * 0.7;
+        divRef.current.style.height =
+            divRef.current.lastElementChild?.clientHeight < maxHeight ? 'unset' : maxHeight + 'px';
+    }, [fixedHeight, gridData.size]);
 
     const headerProps: GridHeaderProps = {
         calcWidths,
@@ -414,7 +423,7 @@ export const Grid: FC<GridProps> = memo(props => {
     });
 
     return (
-        <div className={wrapperClasses} data-gridid={gridId}>
+        <div className={wrapperClasses} data-gridid={gridId} ref={divRef}>
             <GridMessages messages={messages} />
 
             <table className={tableClasses} ref={tableRef}>

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -329,6 +329,7 @@ export interface GridProps {
     condensed?: boolean;
     data?: GridData;
     emptyText?: string;
+    fixedHeight?: boolean;
     gridId?: string;
     headerCell?: any;
     highlightRowIndexes?: List<number>;
@@ -348,7 +349,6 @@ export interface GridProps {
     striped?: boolean;
     tableRef?: RefObject<HTMLTableElement>;
     transpose?: boolean;
-    fixedHeight?: boolean;
 }
 
 export const Grid: FC<GridProps> = memo(props => {

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -169,6 +169,28 @@ describe('HeaderCellDropdown', () => {
         wrapper.unmount();
     });
 
+    test('column not sortable or filterable, can add but not hide', () => {
+        const wrapper = mount(
+            <HeaderCellDropdown
+                {...DEFAULT_PROPS}
+                column={
+                    new GridColumn({
+                        index: 'column',
+                        title: 'Column',
+                        raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: false }),
+                    })
+                }
+                handleAddColumn={jest.fn}
+                handleHideColumn={undefined}
+            />
+        );
+        validate(wrapper, 0, 2);
+        expect(wrapper.find(DisableableMenuItem)).toHaveLength(1);
+        expect(wrapper.find(DisableableMenuItem).text()).toContain('Hide Column');
+        expect(wrapper.find(DisableableMenuItem).prop('operationPermitted')).toBe(undefined);
+        wrapper.unmount();
+    });
+
     test('column sortable, not filterable', () => {
         const wrapper = mount(
             <HeaderCellDropdown

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -184,7 +184,7 @@ describe('HeaderCellDropdown', () => {
                 handleHideColumn={undefined}
             />
         );
-        validate(wrapper, 0, 2);
+        validate(wrapper, 0, 3);
         expect(wrapper.find(DisableableMenuItem)).toHaveLength(1);
         expect(wrapper.find(DisableableMenuItem).text()).toContain('Hide Column');
         expect(wrapper.find(DisableableMenuItem).prop('operationPermitted')).toBe(undefined);

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -111,6 +111,7 @@ interface HeaderCellDropdownProps {
     i: number;
     model?: QueryModel;
     onColumnTitleChange?: (column: QueryColumn) => void;
+    onColumnTitleEdit?: (column: QueryColumn) => void;
     selectable?: boolean;
 }
 
@@ -126,6 +127,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
         headerClickCount,
         model,
         onColumnTitleChange,
+        onColumnTitleEdit,
     } = props;
     const col: QueryColumn = column.raw;
     const [open, setOpen] = useState<boolean>();
@@ -185,7 +187,8 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
     const editColumnTitle = useCallback(() => {
         setOpen(false);
         setEditingTitle(true);
-    }, []);
+        onColumnTitleEdit?.(col);
+    }, [col, onColumnTitleEdit]);
 
     const onColumnTitleUpdate = useCallback(
         (newTitle: string) => {
@@ -196,7 +199,8 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
 
     const onEditTitleToggle = useCallback((value: boolean) => {
         setEditingTitle(value);
-    }, []);
+        onColumnTitleEdit?.(col);
+    }, [col, onColumnTitleEdit]);
 
     // headerClickCount is tracked by the GridPanel, if it changes we will open the dropdown menu
     useEffect(() => {
@@ -378,6 +382,7 @@ export function headerCell(
     handleFilter?: (column: QueryColumn, remove?: boolean) => void,
     handleAddColumn?: (column: QueryColumn) => void,
     handleHideColumn?: (column: QueryColumn) => void,
+    onColumnTitleEdit?: (column: QueryColumn) => void,
     onColumnTitleChange?: (column: QueryColumn) => void,
     model?: QueryModel,
     headerClickCount?: number
@@ -395,6 +400,7 @@ export function headerCell(
             headerClickCount={headerClickCount}
             model={model}
             onColumnTitleChange={onColumnTitleChange}
+            onColumnTitleEdit={onColumnTitleEdit}
         />
     );
 }

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -239,7 +239,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
                                         </MenuItem>
                                     )}
                                     <DisableableMenuItem
-                                        operationPermitted={allowColumnViewChange}
+                                        operationPermitted={handleHideColumn && !!model}
                                         onClick={() => _handleHideColumn()}
                                         disabledMessage={APP_FIELD_CANNOT_BE_REMOVED_MESSAGE}
                                     >

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -197,10 +197,13 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
         [col, onColumnTitleChange]
     );
 
-    const onEditTitleToggle = useCallback((value: boolean) => {
-        setEditingTitle(value);
-        onColumnTitleEdit?.(col);
-    }, [col, onColumnTitleEdit]);
+    const onEditTitleToggle = useCallback(
+        (value: boolean) => {
+            setEditingTitle(value);
+            onColumnTitleEdit?.(col);
+        },
+        [col, onColumnTitleEdit]
+    );
 
     // headerClickCount is tracked by the GridPanel, if it changes we will open the dropdown menu
     useEffect(() => {

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -55,6 +55,7 @@ import { FilterStatus } from './FilterStatus';
 import { SaveViewModal } from './SaveViewModal';
 import { CustomizeGridViewModal } from './CustomizeGridViewModal';
 import { ManageViewsModal } from './ManageViewsModal';
+import { isGridLockLeftColumnEnabled } from '../../internal/app/utils';
 
 export interface GridPanelProps<ButtonsComponentProps> {
     ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
@@ -1046,6 +1047,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         let loadingMessage;
         const gridIsLoading = !hasGridError && isLoading;
         const selectionsAreLoading = !hasError && allowSelections && isLoadingSelections;
+        const lockLeftCol = isGridLockLeftColumnEnabled();
 
         if (gridIsLoading) {
             loadingMessage = 'Loading data...';
@@ -1108,7 +1110,13 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                             </div>
                         )}
 
-                        <div className="grid-panel__grid">
+                        <div
+                            className={classNames('grid-panel__grid', {
+                                'grid-panel__lock-left': lockLeftCol,
+                                'grid-panel__lock-left-with-checkboxes': lockLeftCol && allowSelections,
+                                'grid-panel__lock-left-without-checkboxes': lockLeftCol && !allowSelections,
+                            })}
+                        >
                             {hasError && <Alert>{errorMsg || queryInfoError || rowsError || selectionsError}</Alert>}
 
                             {!hasGridError && hasData && (

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -975,6 +975,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         const { allowSelections, allowSorting, allowFiltering, allowViewCustomization, model } = this.props;
         const { isLoading, isLoadingSelections, hasRows, rowCount } = model;
         const disabled = isLoadingSelections || isLoading || (hasRows && rowCount === 0);
+        const nonSelectableColumnCount = allowSelections ? columnCount - 1 : columnCount;
 
         if (column.index === GRID_SELECTION_INDEX) {
             return headerSelectionCell(this.selectPage, model.selectedState, disabled, 'grid-panel__page-checkbox');
@@ -988,7 +989,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             allowSorting ? this.sortColumn : undefined,
             allowFiltering ? this.filterColumn : undefined,
             allowViewCustomization ? this.addColumn : undefined,
-            allowViewCustomization ? this.hideColumn : undefined,
+            allowViewCustomization && nonSelectableColumnCount > 1 ? this.hideColumn : undefined,
             model,
             headerClickCount[column.index]
         );

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -31,6 +31,8 @@ import { getGridView, revertViewEdit, saveGridView, saveAsSessionView, saveSessi
 
 import { hasServerContext } from '../../internal/components/base/ServerContext';
 
+import { isGridLockLeftColumnEnabled } from '../../internal/app/utils';
+
 import { ActionValue } from './grid/actions/Action';
 import { FilterAction } from './grid/actions/Filter';
 import { SearchAction } from './grid/actions/Search';
@@ -55,7 +57,6 @@ import { FilterStatus } from './FilterStatus';
 import { SaveViewModal } from './SaveViewModal';
 import { CustomizeGridViewModal } from './CustomizeGridViewModal';
 import { ManageViewsModal } from './ManageViewsModal';
-import { isGridLockLeftColumnEnabled } from '../../internal/app/utils';
 
 export interface GridPanelProps<ButtonsComponentProps> {
     ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -1120,6 +1120,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                                     calcWidths
                                     condensed
                                     emptyText={gridEmptyText}
+                                    fixedHeight
                                     gridId={id}
                                     messages={fromJS(messages)}
                                     columns={this.getGridColumns()}

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -364,9 +364,10 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
 
 interface State {
     actionValues: ActionValue[];
+    disableColumnDrag: boolean;
     errorMsg: React.ReactNode;
     headerClickCount: { [key: string]: number };
-    isViewSaved?: boolean;
+    isViewSaved: boolean;
     selectedColumn: QueryColumn;
     showCustomizeViewModal: boolean;
     showFilterModalFieldKey: string;
@@ -413,6 +414,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
         this.state = {
             actionValues: [],
+            disableColumnDrag: false,
             showFilterModalFieldKey: undefined,
             showSaveViewModal: false,
             showCustomizeViewModal: false,
@@ -729,6 +731,10 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         });
     };
 
+    onColumnTitleEdit = (): void => {
+        this.setState(state => ({ disableColumnDrag: !state.disableColumnDrag }));
+    };
+
     updateColumnTitle = (updatedCol: QueryColumn): void => {
         const { model } = this.props;
         this.saveAsSessionView({
@@ -743,6 +749,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 }
             }),
         });
+        this.setState({ disableColumnDrag: false });
     };
 
     saveAsSessionView = (updates: Record<string, any>): void => {
@@ -1007,6 +1014,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             allowFiltering ? this.filterColumn : undefined,
             allowViewCustomization ? this.addColumn : undefined,
             allowViewCustomization && nonSelectableColumnCount > 1 ? this.hideColumn : undefined,
+            allowViewCustomization ? this.onColumnTitleEdit : undefined,
             allowViewCustomization ? this.updateColumnTitle : undefined,
             model,
             headerClickCount[column.index]
@@ -1046,6 +1054,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
             actionValues,
             errorMsg,
             isViewSaved,
+            disableColumnDrag,
         } = this.state;
         const {
             hasData,
@@ -1141,7 +1150,9 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                                     headerCell={this.headerCell}
                                     onHeaderCellClick={this.onHeaderCellClick}
                                     onColumnDrag={this.onColumnDrag}
-                                    onColumnDrop={allowViewCustomization ? this.onColumnDrop : undefined}
+                                    onColumnDrop={
+                                        allowViewCustomization && !disableColumnDrag ? this.onColumnDrop : undefined
+                                    }
                                     showHeader={showHeader}
                                     calcWidths
                                     condensed

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -449,6 +449,17 @@ $table-cell-selection-bg-color: #EDF3FF;
     padding: 10px 15px;
 }
 
+.view-menu .dropdown-menu {
+    max-width: 600px;
+    width: max-content;
+
+    li {
+        a {
+            white-space: normal;
+        }
+    }
+}
+
 .view-edit-alert {
     padding: 4px 10px;
     margin-right: 10px;

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -178,12 +178,16 @@
 
     thead {
         position: sticky;
-        top: 0;
+        top: -1px;
         z-index: 2;
 
         th {
             background-color: $white;
-            border-color: $border-color;
         }
+    }
+
+    /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
+    table thead th {
+        background-clip: padding-box
     }
 }

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -172,3 +172,18 @@
         }
     }
 }
+
+.grid-panel__grid .table-responsive {
+    overflow-y: auto;
+
+    thead {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+
+        th {
+            background-color: $white;
+            border-color: $border-color;
+        }
+    }
+}

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -173,6 +173,7 @@
     }
 }
 
+/* Grid sticky/locked column headers on vertical scroll */
 .grid-panel__grid .table-responsive {
     overflow-y: auto;
 
@@ -189,5 +190,35 @@
     /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
     table thead th {
         background-clip: padding-box
+    }
+}
+
+/* Grid sticky/locked left most column on horizontal scroll */
+.grid-panel__grid.grid-panel__lock-left .table-responsive {
+    thead th:nth-child(1), tr td:nth-child(1) {
+        position: sticky;
+        left: -1px;
+        z-index: 1;
+    }
+}
+.grid-panel__grid.grid-panel__lock-left-with-checkboxes .table-responsive {
+    thead th:nth-child(2), tr td:nth-child(2) {
+        position: sticky;
+        left: 22px;
+        z-index: 1;
+    }
+    thead th:nth-child(1), thead th:nth-child(2) {
+        background-color: $white;
+    }
+    tr td:nth-child(1), tr td:nth-child(2) {
+        background-color: $table-bg-accent;
+    }
+}
+.grid-panel__grid.grid-panel__lock-left-without-checkboxes .table-responsive {
+    thead th:nth-child(1) {
+        background-color: $white;
+    }
+    tr td:nth-child(1) {
+        background-color: $table-bg-accent;
     }
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43943

For app grids will too many rows to fit on view or grid rows that have a lot of wrapped content in a cell, scrolling down the page can result in the column headers going out of view and making it hard for the user to: a) know what row cells go with which column header, b) make a row selection and use the grid header buttons when the row is at the end of the list. This PR addresses that by setting a max / fixed height to the grid and scrolling the grid contents within that height. This then allows for the column headers to be sticky at the top of the grid content area.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/887
* https://github.com/LabKey/inventory/pull/475
* https://github.com/LabKey/biologics/pull/1421
* https://github.com/LabKey/sampleManagement/pull/1070

#### Changes
* set fixed height for GridPanel usage of <Grid>
* add SCSS for `position: sticky;` on GridPanel `thead`
