### PR TITLE
Issue 45805: Order projects by title, selectDistinctRows folder scope

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.1",
+  "version": "2.194.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.194.2
+*Released*: 5 July 2022
+* Sort folders by their `title` property.
+* Apply contextual container filter to `selectDistinctRows` requests.
+* Update `getSamplesIdsNotFound` to use the scoped version of `selectDistinctRows`.
+* Export `selectDistinctRows`.
+
 ### version 2.194.1
 *Released*: 5 July 2022
 * Fixes for EntityInsertPanel and EntityInsertGridRequiredFieldAlert to support Biologics registry

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -179,6 +179,7 @@ import {
     InsertRowsResponse,
     invalidateQueryDetailsCache,
     invalidateQueryDetailsCacheKey,
+    selectDistinctRows,
     selectRowsDeprecated,
     updateRows,
 } from './internal/query/api';
@@ -851,6 +852,7 @@ export {
     InsertFormats,
     InsertOptions,
     insertRows,
+    selectDistinctRows,
     selectRows,
     selectRowsDeprecated,
     updateRows,

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -4,6 +4,7 @@ import { Map } from 'immutable';
 import { Container } from '../base/models/Container';
 import { fetchContainerSecurityPolicy, UserLimitSettings, getUserLimitSettings } from '../permissions/actions';
 import { Principal, SecurityPolicy } from '../permissions/models';
+import { naturalSortByProperty } from '../../..';
 
 export type FetchContainerOptions = Omit<Security.GetContainersOptions, 'success' | 'failure' | 'scope'>;
 
@@ -37,9 +38,11 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
 }
 
 function recurseContainerHierarchy(data: Security.ContainerHierarchy, container: Container): Container[] {
-    return data.children.reduce(
-        (containers, c) => containers.concat(recurseContainerHierarchy(c, new Container(c))),
-        [container]
+    return (
+        data.children
+            .reduce((containers, c) => containers.concat(recurseContainerHierarchy(c, new Container(c))), [container])
+            // Issue 45805: sort folders by title as server-side sorting is insufficient
+            .sort(naturalSortByProperty('title'))
     );
 }
 

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -11,7 +11,7 @@ import { SchemaQuery } from '../../public/SchemaQuery';
 
 import { ViewInfo } from '../ViewInfo';
 
-import { getQueryDetails, GetQueryDetailsOptions, SelectDistinctResponse, selectDistinctRows } from './api';
+import { getQueryDetails, GetQueryDetailsOptions, selectDistinctRows } from './api';
 import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows';
 
 export interface QueryAPIWrapper {
@@ -28,7 +28,7 @@ export interface QueryAPIWrapper {
     ) => Promise<ViewInfo[]>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
-    selectDistinctRows: (selectDistinctOptions: Query.SelectDistinctOptions) => Promise<SelectDistinctResponse>;
+    selectDistinctRows: (selectDistinctOptions: Query.SelectDistinctOptions) => Promise<Query.SelectDistinctResponse>;
     selectRows: (options: SelectRowsOptions) => Promise<SelectRowsResponse>;
 }
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1010,24 +1010,13 @@ export function getContainerFilterForLookups(): Query.ContainerFilter {
     return Query.ContainerFilter.currentPlusProjectAndShared;
 }
 
-export interface SelectDistinctResponse {
-    queryName: string;
-    schemaName: string;
-    values: any[];
-}
-
-export function selectDistinctRows(
-    selectDistinctOptions: Query.SelectDistinctOptions
-): Promise<SelectDistinctResponse> {
+export function selectDistinctRows(options: Query.SelectDistinctOptions): Promise<Query.SelectDistinctResponse> {
     return new Promise((resolve, reject) => {
         Query.selectDistinctRows({
-            ...selectDistinctOptions,
+            ...options,
+            containerFilter: options.containerFilter ?? getContainerFilter(options.containerPath),
             success: response => {
-                resolve({
-                    values: response['values'],
-                    schemaName: response['schemaName'],
-                    queryName: response['queryName'],
-                });
+                resolve(response);
             },
             failure: error => {
                 console.error(error);

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -213,12 +213,7 @@ function applyColumnMetadata(schemaQuery: SchemaQuery, rawColumn: any): QueryCol
             allMeta = allMeta.toJS();
         }
 
-        let schemaMeta = metadata.getIn([
-            'schema',
-            schemaQuery.schemaName.toLowerCase(),
-            'columnDefaults',
-            lcFieldKey,
-        ]);
+        let schemaMeta = metadata.getIn(['schema', schemaQuery.schemaName.toLowerCase(), 'columnDefaults', lcFieldKey]);
 
         if (schemaMeta) {
             schemaMeta = schemaMeta.toJS();

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1013,6 +1013,7 @@ export function getContainerFilterForLookups(): Query.ContainerFilter {
 export function selectDistinctRows(options: Query.SelectDistinctOptions): Promise<Query.SelectDistinctResponse> {
     return new Promise((resolve, reject) => {
         Query.selectDistinctRows({
+            method: 'POST',
             ...options,
             containerFilter: options.containerFilter ?? getContainerFilter(options.containerPath),
             success: response => {


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45805](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45805) by recursively sorting all folder request results by "title". The server does a sort by "name", however, this is not the property used to label folders/projects.

Additionally, this updates all `selectDistinctRows` requests to apply the container filter scope based on the folder/project context. This is most noticeable in the faceted filter panel where the results previously did not include cross-folder results.  I went a step further and searched for all usages of `Query.selectDistinctRows` in the `@labkey/components` package to make sure they're using the package-specific variant instead.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1422
* https://github.com/LabKey/sampleManagement/pull/1074

#### Changes
* Sort folders by their `title` property.
* Apply contextual container filter to `selectDistinctRows` requests.
* Update `getSamplesIdsNotFound` to use the scoped version of `selectDistinctRows`.
* Export `selectDistinctRows`. Remove duplicative `SelectDistinctResponse` interface and reuse the interface provided by `@labkey/api`.
