### PR TITLE
Issue 44599: Field editor PHI Level doesn't show correct value for a field if the admin user does not have that level of PHI access

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.195.0",
+  "version": "2.195.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.0",
+  "version": "2.194.0-fb-fieldEditorPHI44599.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD July 2022
+* Issue 44599: Field editor PHI Level doesn't show correct value for a field if the admin user does not have that level of PHI access
+  * AdvancedSettings.tsx update to show current PHI level as select option and disable the input if current value is above max for user
+
 ### version 2.194.0
 *Released*: 5 July 2022
 * Issue 43943: App grid column header locking on scroll

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD July 2022
+### version 2.195.1
+*Released*: 7 July 2022
 * Issue 44599: Field editor PHI Level doesn't show correct value for a field if the admin user does not have that level of PHI access
   * AdvancedSettings.tsx update to show current PHI level as select option and disable the input if current value is above max for user
 

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.spec.tsx
@@ -144,7 +144,7 @@ describe('AdvancedSettings', () => {
             bsClass: 'form-control',
         });
         expect(phi.length).toEqual(1);
-        expect(phi.props().children.size).toEqual(3);
+        expect(phi.find('option')).toHaveLength(3);
         expect(phi.props().value).toEqual(PHILEVEL_LIMITED_PHI);
 
         // Verify default type

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -37,37 +37,37 @@ import {
 import { DomainFieldLabel } from './DomainFieldLabel';
 
 interface AdvancedSettingsProps {
-    domainId?: number;
-    helpNoun: string;
     defaultDefaultValueType: string;
     defaultValueOptions: List<string>;
-    label: string;
-    index: number;
-    show: boolean;
-    maxPhiLevel: string;
-    field: DomainField;
-    onHide: () => any;
-    onApply: (any) => any;
-    showDefaultValueSettings: boolean;
-    domainIndex: number;
-    successBsStyle?: string;
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
+    domainId?: number;
+    domainIndex: number;
+    field: DomainField;
+    helpNoun: string;
+    index: number;
+    label: string;
+    maxPhiLevel: string;
+    onApply: (any) => any;
+    onHide: () => any;
+    show: boolean;
+    showDefaultValueSettings: boolean;
+    successBsStyle?: string;
 }
 
 interface AdvancedSettingsState {
+    PHI?: string;
+    defaultDisplayValue?: string;
+    defaultValueType?: string;
+    dimension?: boolean;
+    excludeFromShifting?: boolean;
     hidden?: boolean;
+    measure?: boolean;
+    mvEnabled?: boolean;
+    phiLevels?: List<any>;
+    recommendedVariable?: boolean;
     shownInDetailsView?: boolean;
     shownInInsertView?: boolean;
     shownInUpdateView?: boolean;
-    defaultValueType?: string;
-    defaultDisplayValue?: string;
-    dimension?: boolean;
-    measure?: boolean;
-    mvEnabled?: boolean;
-    recommendedVariable?: boolean;
-    PHI?: string;
-    phiLevels?: List<any>;
-    excludeFromShifting?: boolean;
 }
 
 export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps, AdvancedSettingsState> {

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -334,6 +334,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
     renderMiscOptions = () => {
         const { index, field, domainIndex, domainFormDisplayOptions } = this.props;
         const { measure, dimension, mvEnabled, recommendedVariable, PHI, excludeFromShifting, phiLevels } = this.state;
+        const currentValueExists = phiLevels?.find(level => level.value === PHI) !== undefined;
+        const disablePhiSelect =
+            domainFormDisplayOptions.phiLevelDisabled || field.disablePhiLevel || !currentValueExists;
 
         return (
             <>
@@ -349,10 +352,15 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                             id={createFormInputId(DOMAIN_FIELD_PHI, domainIndex, index)}
                             onChange={this.handleChange}
                             value={PHI}
-                            disabled={domainFormDisplayOptions.phiLevelDisabled || field.disablePhiLevel}
+                            disabled={disablePhiSelect}
                         >
-                            {phiLevels.map((level, i) => (
-                                <option key={i} value={level.value}>
+                            {!currentValueExists && (
+                                <option key={PHI} value={PHI}>
+                                    {DOMAIN_PHI_LEVELS.find(level => level.value === PHI)?.label ?? PHI}
+                                </option>
+                            )}
+                            {phiLevels.map(level => (
+                                <option key={level.value} value={level.value}>
                                     {level.label}
                                 </option>
                             ))}


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=44599

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/889
* https://github.com/LabKey/sampleManagement/pull/1075
* https://github.com/LabKey/biologics/pull/1423
* https://github.com/LabKey/platform/pull/3506

#### Changes
* AdvancedSettings.tsx update to show current PHI level as select option and disable the input if current value is above max for user
