### PR TITLE
Adjust placement of checkbox in grid header row

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.3-checkboxPlacement.0",
+  "version": "2.194.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.2",
+  "version": "2.194.3-checkboxPlacement.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.194.X
-*Released*: TBD
+### version 2.194.3
+*Released*: 7 July 2022
 * Update styling for checkbox that appears in grid header input fields
 
 ### version 2.194.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.194.X
+*Released*: TBD
+* Update styling for checkbox that appears in grid header input fields
+
 ### version 2.194.2
 *Released*: 5 July 2022
 * Sort folders by their `title` property.

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -66,7 +66,7 @@
   padding: 0 9px;
   font-weight: bold;
 
-    input {
+    input:not([type=checkbox]) {
         width: 100%
     }
 }


### PR DESCRIPTION
#### Rationale
Styling for allowing inline editing of field labels inadvertently messed up styling for the checkbox in the header

#### Related Pull Requests
* #886 

#### Changes
* Adjust css for input width in header
