### PR TITLE
Issue 45836: Export for editable grid should export display values instead of ids for lookups

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.5-fb-22.7-fb-issue45836.1",
+  "version": "2.194.5-fb-issue45836.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.4",
+  "version": "2.194.5-fb-22.7-fb-issue45836.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.5-fb-issue45836.1",
+  "version": "2.194.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.194.5
+*Released*: XX July 2022
+* Issue 45836: Export for editable grid should export display values instead of ids for lookups
+
 ### version 2.194.4
 *Released*: 7 July 2022
 * Add and export Row, RowValue types

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.194.5
-*Released*: XX July 2022
+*Released*: 12 July 2022
 * Issue 45836: Export for editable grid should export display values instead of ids for lookups
 
 ### version 2.194.4

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -43,7 +43,8 @@ const exportHandler = (
             readOnlyColumns,
             headings,
             editorData,
-            extraColumns
+            extraColumns,
+            true
         );
         headings = modelHeadings;
         editorData = modelEditorData;

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -277,7 +277,8 @@ export const getEditorTableData = (
     readOnlyColumns: List<string>,
     headings: OrderedMap<string, string>,
     editorData: OrderedMap<string, OrderedMap<string, any>>,
-    extraColumns?: Array<Partial<QueryColumn>>
+    extraColumns?: Array<Partial<QueryColumn>>,
+    forExport?: boolean,
 ): [Map<string, string>, Map<string, Map<string, any>>] => {
     const tabData = editorModel
         .getRawDataFromGridData(
@@ -287,7 +288,8 @@ export const getEditorTableData = (
             true,
             true,
             readOnlyColumns,
-            extraColumns
+            extraColumns,
+            forExport
         )
         .toArray();
 

--- a/packages/components/src/internal/models.ts
+++ b/packages/components/src/internal/models.ts
@@ -351,7 +351,8 @@ export class EditorModel
         displayValues = true,
         forUpdate = false,
         readOnlyColumns?: List<string>,
-        extraColumns?: Array<Partial<QueryColumn>>
+        extraColumns?: Array<Partial<QueryColumn>>,
+        forExport?: boolean,
     ): List<Map<string, any>> {
         let rawData = List<Map<string, any>>();
         const columns = this.getColumns(queryInfo, forUpdate, readOnlyColumns);
@@ -394,8 +395,9 @@ export class EditorModel
                         row = row.set(
                             col.name,
                             values.reduce((arr, vd) => {
-                                if (vd.raw !== undefined && vd.raw !== null) {
-                                    arr.push(vd.raw);
+                                const val = forExport ? vd.display : vd.raw;
+                                if (val !== undefined && val !== null) {
+                                    arr.push(val);
                                 }
                                 return arr;
                             }, [])
@@ -406,7 +408,10 @@ export class EditorModel
                             values.size === 1 ? quoteValueWithDelimiters(values.first().display, ',') : undefined
                         );
                     } else {
-                        row = row.set(col.name, values.size === 1 ? values.first()?.raw : undefined);
+                        let val = undefined;
+                        if (values.size === 1)
+                            val = forExport ? values.first()?.display : values.first()?.raw;
+                        row = row.set(col.name, val);
                     }
                 } else if (col.jsonType === 'date' && !displayValues) {
                     let dateVal;


### PR DESCRIPTION
#### Rationale
For editable grid export, we want to export display value instead of raw value for lookups

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/896
* https://github.com/LabKey/inventory/pull/480
* https://github.com/LabKey/sampleManagement/pull/1092
* https://github.com/LabKey/biologics/pull/1436

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
