### PR TITLE
Issues 45815 and 45686: Update dashboard button and tabbed-grid export modal

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.198.1-exportModalViewNames.0",
+  "version": "2.198.1-exportModalViewNames.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.198.0",
+  "version": "2.198.1-exportModalViewNames.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.198.2-exportModalViewNames.2",
+  "version": "2.199.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.198.2-exportModalViewNames.1",
+  "version": "2.198.2-exportModalViewNames.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 12 July 2022
 Added SearchScope enum and ContainerFilter mapping utility method
 
+### version TBD
+*Released*: TBD
+* Issue 45815: Show view name in tabbed export modal
+* Issue 45686: Change "Create Samples" to "Add Samples" on dashboard button
+
 ### version 2.197.0
 *Released*: 12 July 2022
 * Issue 45479: Add getIsDirty and setIsDirty callback in editable grids so we warn on page leave but not on export

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.199.0
+*Released*: 14 July 2022
 * Issue 45815: Show view name in tabbed export modal
 * Issue 45686: Change "Create Samples" to "Add Samples" on dashboard button
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45815: Show view name in tabbed export modal
+* Issue 45686: Change "Create Samples" to "Add Samples" on dashboard button
+
 ### version 2.198.1
 *Released*: 13 July 2022
 * Merge release22.7-SNAPSHOT to develop
@@ -9,11 +14,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.198.0
 *Released*: 12 July 2022
 Added SearchScope enum and ContainerFilter mapping utility method
-
-### version TBD
-*Released*: TBD
-* Issue 45815: Show view name in tabbed export modal
-* Issue 45686: Change "Create Samples" to "Add Samples" on dashboard button
 
 ### version 2.197.0
 *Released*: 12 July 2022

--- a/packages/components/src/internal/components/chart/BarChartViewer.spec.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.spec.tsx
@@ -12,7 +12,7 @@ describe('SampleButtons', () => {
         const wrapper = mountWithServerContext(<SampleButtons />, { user: TEST_USER_AUTHOR });
         expect(wrapper.find(Button)).toHaveLength(2);
         expect(wrapper.find(Button).first().text()).toBe('Go to Sample Finder');
-        expect(wrapper.find(Button).last().text()).toBe('Create Samples');
+        expect(wrapper.find(Button).last().text()).toBe('Add Samples');
         wrapper.unmount();
     });
 
@@ -28,7 +28,7 @@ describe('SampleButtons', () => {
         LABKEY.moduleContext = { biologics: {} };
         const wrapper = mountWithServerContext(<SampleButtons />, { user: TEST_USER_AUTHOR });
         expect(wrapper.find(Button)).toHaveLength(1);
-        expect(wrapper.find(Button).first().text()).toBe('Create Samples');
+        expect(wrapper.find(Button).first().text()).toBe('Add Samples');
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -278,7 +278,7 @@ export const SampleButtons: FC<SampleButtonProps> = memo(props => {
             )}
             <RequiresPermission perms={PermissionTypes.Insert}>
                 <Button bsStyle="success" className="button-left-spacing" href={App.NEW_SAMPLES_HREF.toHref()}>
-                    Create Samples
+                    Add Samples
                 </Button>
             </RequiresPermission>
         </div>

--- a/packages/components/src/internal/components/gridbar/ExportModal.tsx
+++ b/packages/components/src/internal/components/gridbar/ExportModal.tsx
@@ -53,24 +53,35 @@ export const ExportModal: FC<ExportModalProperties> = memo(props => {
                 <Modal.Title>{title}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                <div className="export-modal-body">
-                    <ul>
+                    <table className="export-modal-body">
+                        <tr>
+                            <th></th>
+                            <th className="pull-right">Count</th>
+                            <th className="view-name">View</th>
+                        </tr>
+
                         {tabOrder.map(modelId => {
                             const model = queryModels[modelId];
                             return (
-                                <Checkbox
-                                    checked={selected.has(modelId)}
-                                    className="export-modal-checkbox"
-                                    key={modelId}
-                                    value={modelId}
-                                    onChange={onChecked}
-                                >
-                                    {`${model.title} (${model.rowCount})`}
-                                </Checkbox>
+                                <tr>
+                                    <td>
+                                        <Checkbox
+                                            checked={selected.has(modelId)}
+                                            key={modelId}
+                                            value={modelId}
+                                            onChange={onChecked}
+                                        >
+                                            {model.title}
+                                        </Checkbox>
+                                    </td>
+                                    <td className="pull-right">{model.rowCount}</td>
+                                    <td className="view-name">
+                                        {model.viewName || 'Default'} {model.currentView.session && <span className="text-muted">(edited)</span>}
+                                    </td>
+                                </tr>
                             );
                         })}
-                    </ul>
-                </div>
+                    </table>
             </Modal.Body>
             <Modal.Footer>
                 <div className="pull-left">

--- a/packages/components/src/internal/components/samples/SamplesAddButton.tsx
+++ b/packages/components/src/internal/components/samples/SamplesAddButton.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export const SamplesAddButton: FC<Props> = memo(props => {
-    const { model, hideImport, asSubMenu, text = 'Create Samples', bsStyle = 'default' } = props;
+    const { model, hideImport, asSubMenu, text = 'Add', bsStyle = 'default' } = props;
     const { showInsertNewButton, showImportDataButton, queryInfo } = model;
     const cls = bsStyle === 'default' ? 'responsive-menu' : '';
     const createSampleHref = App.NEW_SAMPLES_HREF.addParams({

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -484,3 +484,22 @@ $table-cell-selection-bg-color: #EDF3FF;
 .grid-view-name-error {
     border-color: $red-border;
 }
+
+.export-modal-body {
+    margin: 0 15px 8px 15px;
+
+    & .checkbox {
+        margin: 0;
+    }
+    & td, & th {
+        padding: 8px 8px 0 0;
+    }
+
+    & td.count {
+        float: right;
+    }
+
+    & td.view-name, & th.view-name {
+        padding-left: 15px;
+    }
+}


### PR DESCRIPTION
#### Rationale
* [Issue 45815](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45815)
* [Issue 45686](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45686)

#### Related Pull Requests
https://github.com/LabKey/sampleManagement/pull/1101
https://github.com/LabKey/biologics/pull/1444
https://github.com/LabKey/inventory/pull/484

#### Changes
* Issue 45815: Show view name in tabbed export modal
* Issue 45686: Change "Create Samples" to "Add Samples" on dashboard button