### PR TITLE
Sample Finder: support containerFilter on expDescendantOfSelectClause

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.2",
+  "version": "2.202.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.202.3
+*Released*: 28 July 2022
+* Sample Finder: support containerFilter on expDescendantOfSelectClause
+
 ### version 2.202.2
 *Released*: 28 July 2022
 * Issue 44917: Resolve search icon for uncategorized data classes

--- a/packages/components/src/internal/components/search/SampleFinderSavedViewsMenu.tsx
+++ b/packages/components/src/internal/components/search/SampleFinderSavedViewsMenu.tsx
@@ -57,34 +57,26 @@ export const SampleFinderSavedViewsMenu: FC<Props> = memo(props => {
             const view = savedSearches.find(search => search.reportId === e.target.name);
             loadSearch(view);
         },
-        [savedSearches]
+        [loadSearch, savedSearches]
     );
 
     const onLoadSessionSearch = useCallback(() => {
         loadSearch({ isSession: true, reportName: sessionViewName });
-    }, [sessionViewName]);
+    }, [loadSearch, sessionViewName]);
 
-    const onSaveCurrentView = useCallback(e => {
+    const onSaveCurrentView = useCallback(() => {
         saveSearch(true);
-    }, []);
+    }, [saveSearch]);
 
-    const onSaveNewView = useCallback(
-        e => {
-            if (!currentView && !hasUnsavedChanges) return;
+    const onSaveNewView = useCallback(() => {
+        if (!currentView && !hasUnsavedChanges) return;
+        saveSearch(false);
+    }, [currentView, hasUnsavedChanges, saveSearch]);
 
-            saveSearch(false);
-        },
-        [currentView, currentView]
-    );
-
-    const onManageView = useCallback(
-        e => {
-            if (!hasSavedView) return;
-
-            manageSearches();
-        },
-        [hasSavedView]
-    );
+    const onManageView = useCallback(() => {
+        if (!hasSavedView) return;
+        manageSearches();
+    }, [hasSavedView, manageSearches]);
 
     return (
         <>

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -325,7 +325,7 @@ describe('getSampleFinderCommonConfigs', () => {
                 Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK),
                 Filter.create(
                     '*',
-                    `SELECT "TestQuery2".expObject() FROM Samples."TestQuery2"[ContainerFilter='CurrentAndFirstChildren'] WHERE "TestColumn" = 'value'`,
+                    'SELECT "TestQuery2".expObject() FROM Samples."TestQuery2"[ContainerFilter=\'CurrentAndFirstChildren\'] WHERE "TestColumn" = \'value\'',
                     IN_EXP_DESCENDANTS_OF_FILTER_TYPE
                 ),
             ],
@@ -1173,7 +1173,7 @@ describe('getExpDescendantOfSelectClause', () => {
     test('respects container filter', () => {
         const cf = Query.ContainerFilter.currentAndSubfoldersPlusShared;
         expect(getExpDescendantOfSelectClause(schemaQuery, [intEqFilter], cf)).toEqual(
-            `SELECT "SampleA".expObject() FROM Test."SampleA"[ContainerFilter='CurrentAndSubfoldersPlusShared'] WHERE "intField" = 1`
+            'SELECT "SampleA".expObject() FROM Test."SampleA"[ContainerFilter=\'CurrentAndSubfoldersPlusShared\'] WHERE "intField" = 1'
         );
     });
 });

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { fromJS, List, Map } from 'immutable';
 
@@ -317,14 +317,15 @@ describe('getSampleFinderCommonConfigs', () => {
                         filterArray: [cardFilter],
                     },
                 ],
-                false
+                false,
+                Query.ContainerFilter.currentAndFirstChildren
             )
         ).toStrictEqual({
             baseFilters: [
                 Filter.create('Inputs/Materials/TestQuery/Name', null, Filter.Types.NONBLANK),
                 Filter.create(
                     '*',
-                    'SELECT "TestQuery2".expObject() FROM Samples."TestQuery2" WHERE "TestColumn" = \'value\'',
+                    `SELECT "TestQuery2".expObject() FROM Samples."TestQuery2"[ContainerFilter='CurrentAndFirstChildren'] WHERE "TestColumn" = 'value'`,
                     IN_EXP_DESCENDANTS_OF_FILTER_TYPE
                 ),
             ],
@@ -1166,6 +1167,13 @@ describe('getExpDescendantOfSelectClause', () => {
         );
         expect(getExpDescendantOfSelectClause(schemaQueryWithSpace, [intEqFilter, booleanEqFilter])).toEqual(
             'SELECT "Sample Type A".expObject() FROM Test."Sample Type A" WHERE "intField" = 1 AND "Boolean Field" = TRUE'
+        );
+    });
+
+    test('respects container filter', () => {
+        const cf = Query.ContainerFilter.currentAndSubfoldersPlusShared;
+        expect(getExpDescendantOfSelectClause(schemaQuery, [intEqFilter], cf)).toEqual(
+            `SELECT "SampleA".expObject() FROM Test."SampleA"[ContainerFilter='CurrentAndSubfoldersPlusShared'] WHERE "intField" = 1`
         );
     });
 });

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -4,6 +4,7 @@ import { EntityDataType } from '../entities/models';
 import { JsonType } from '../domainproperties/PropDescType';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { QueryConfig, QueryModel } from '../../../public/QueryModel/QueryModel';
+import { QueryConfigMap } from '../../../public/QueryModel/withQueryModels';
 import { SAMPLE_STATUS_REQUIRED_COLUMNS } from '../samples/constants';
 import { User } from '../base/models/User';
 
@@ -23,6 +24,8 @@ import { QueryInfo } from '../../../public/QueryInfo';
 import { getPrimaryAppProperties, isOntologyEnabled } from '../../app/utils';
 
 import { formatDateTime } from '../../util/Date';
+
+import { getContainerFilter } from '../../query/api';
 
 import { FieldFilter, FieldFilterOption, FilterProps, FilterSelection, SearchSessionStorageProps } from './models';
 import { SearchScope } from './constants';
@@ -118,32 +121,37 @@ export function getLabKeySqlWhere(fieldFilters: FieldFilter[]): string {
     return 'WHERE ' + clauses.join(' AND ');
 }
 
-export function getExpDescendantOfSelectClause(schemaQuery: SchemaQuery, fieldFilters: FieldFilter[]): string {
+export function getExpDescendantOfSelectClause(
+    schemaQuery: SchemaQuery,
+    fieldFilters: FieldFilter[],
+    cf?: Query.ContainerFilter
+): string {
     const selectClauseWhere = getLabKeySqlWhere(fieldFilters);
     if (!selectClauseWhere) return null;
 
-    return (
-        'SELECT "' +
-        schemaQuery.queryName +
-        '".expObject() FROM ' +
-        schemaQuery.schemaName +
-        '."' +
-        schemaQuery.queryName +
-        '" ' +
-        selectClauseWhere
-    );
+    const { queryName, schemaName } = schemaQuery;
+    const cfClause = cf ? `[ContainerFilter='${cf}']` : '';
+
+    return `SELECT "${queryName}".expObject() FROM ${schemaName}."${queryName}"${cfClause} ${selectClauseWhere}`;
 }
 
-export function getExpDescendantOfFilter(schemaQuery: SchemaQuery, fieldFilters: FieldFilter[]): Filter.IFilter {
-    const selectClause = getExpDescendantOfSelectClause(schemaQuery, fieldFilters);
+export function getExpDescendantOfFilter(
+    schemaQuery: SchemaQuery,
+    fieldFilters: FieldFilter[],
+    cf?: Query.ContainerFilter
+): Filter.IFilter {
+    const selectClause = getExpDescendantOfSelectClause(schemaQuery, fieldFilters, cf);
+    if (!selectClause) return null;
 
-    if (selectClause) return Filter.create('*', selectClause, IN_EXP_DESCENDANTS_OF_FILTER_TYPE);
-
-    return null;
+    return Filter.create('*', selectClause, IN_EXP_DESCENDANTS_OF_FILTER_TYPE);
 }
 
 // exported for jest testing
-export function getSampleFinderCommonConfigs(cards: FilterProps[], useAncestors: boolean): Partial<QueryConfig> {
+export function getSampleFinderCommonConfigs(
+    cards: FilterProps[],
+    useAncestors: boolean,
+    cf?: Query.ContainerFilter
+): Partial<QueryConfig> {
     const baseFilters = [];
     const requiredColumns = [...SAMPLE_STATUS_REQUIRED_COLUMNS];
     cards.forEach(card => {
@@ -165,7 +173,7 @@ export function getSampleFinderCommonConfigs(cards: FilterProps[], useAncestors:
                 }
             });
 
-            const filter = getExpDescendantOfFilter(schemaQuery, card.filterArray);
+            const filter = getExpDescendantOfFilter(schemaQuery, card.filterArray, cf);
             if (filter) {
                 baseFilters.push(filter);
             }
@@ -184,10 +192,11 @@ export function getSampleFinderQueryConfigs(
     sampleTypeNames: string[],
     cards: FilterProps[],
     finderId: string
-): { [key: string]: QueryConfig } {
+): QueryConfigMap {
     const omittedColumns = getOmittedSampleTypeColumns(user);
     const allSamplesKey = getSampleFinderConfigId(finderId, 'exp/materials');
-    const configs: { [key: string]: QueryConfig } = {
+    const cf = getContainerFilter();
+    const configs: QueryConfigMap = {
         [allSamplesKey]: {
             id: allSamplesKey,
             title: 'All Samples',
@@ -197,12 +206,13 @@ export function getSampleFinderQueryConfigs(
                 SAMPLE_FINDER_VIEW_NAME
             ),
             omittedColumns: [...omittedColumns, 'Run'],
-            ...getSampleFinderCommonConfigs(cards, false),
+            ...getSampleFinderCommonConfigs(cards, false, cf),
         },
     };
 
-    const commonConfig = getSampleFinderCommonConfigs(cards, true);
     if (sampleTypeNames) {
+        const commonConfig = getSampleFinderCommonConfigs(cards, true, cf);
+
         for (const name of sampleTypeNames) {
             const id = getSampleFinderConfigId(finderId, 'samples/' + name);
             const schemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, name, SAMPLE_FINDER_VIEW_NAME);
@@ -216,6 +226,7 @@ export function getSampleFinderQueryConfigs(
             };
         }
     }
+
     return configs;
 }
 


### PR DESCRIPTION
#### Rationale
This allows for items that are filtered on in the sample finder to be found with the applicable container context-driven container filter.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1476
* https://github.com/LabKey/sampleManagement/pull/1129

#### Changes
* Support `containerFilter` on `expDescendantOfSelectClause` generation.
* Revise some hook dependencies in sample finder.
