### PR TITLE
Issue 44917: Resolve search icon for uncategorized data classes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.1-fb-fix-44917.0",
+  "version": "2.202.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.1",
+  "version": "2.202.1-fb-fix-44917.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.202.2
+*Released*: 28 July 2022
+* Issue 44917: Resolve search icon for uncategorized data classes
+  * Resolve icons to the data class name value iff the data class is assigned a category (e.g. "registry", "source", etc).
+  * Fallback to default (via undefined) rather than explicitly processing as "default".
+
 ### version 2.202.1
 *Released*: 26 July 2022
 * Move `jest` and `enzyme` from devDependencies to dependencies

--- a/packages/components/src/internal/components/search/actions.spec.ts
+++ b/packages/components/src/internal/components/search/actions.spec.ts
@@ -52,8 +52,23 @@ describe('getSearchResultCardData', () => {
         expect(resultCardData).toStrictEqual({
             title: 'my title',
             iconDir: undefined,
-            iconSrc: 'default',
+            iconSrc: undefined,
             typeName: undefined,
+        });
+
+        const sourceData = {
+            dataClass: {
+                category: 'source',
+                name: 'mice',
+            },
+        };
+
+        const sourceCardData = getSearchResultCardData(sourceData, 'dataClass', 'bruno');
+        expect(sourceCardData).toStrictEqual({
+            title: 'bruno',
+            iconDir: undefined,
+            iconSrc: 'mice',
+            typeName: 'mice',
         });
     });
 

--- a/packages/components/src/internal/components/search/actions.spec.ts
+++ b/packages/components/src/internal/components/search/actions.spec.ts
@@ -178,18 +178,18 @@ describe('getProcessedSearchHits', () => {
 
 describe('resolveTypeName', () => {
     test('data undefined', () => {
-        expect(resolveTypeName(undefined, undefined)).toBe(undefined);
-        expect(resolveTypeName(undefined, null)).toBe(undefined);
-        expect(resolveTypeName(undefined, 'test')).toBe(undefined);
+        expect(resolveTypeName(undefined, undefined)).toBeUndefined();
+        expect(resolveTypeName(undefined, null)).toBeUndefined();
+        expect(resolveTypeName(undefined, 'test')).toBeUndefined();
         expect(resolveTypeName(undefined, 'notebook')).toBe('Notebook');
         expect(resolveTypeName(undefined, 'notebookTemplate')).toBe('Notebook Template');
     });
 
     test('data defined', () => {
-        expect(resolveTypeName({}, undefined)).toBe(undefined);
-        expect(resolveTypeName({ dataClass: { name: undefined } }, undefined)).toBe(undefined);
+        expect(resolveTypeName({}, undefined)).toBeUndefined();
+        expect(resolveTypeName({ dataClass: { name: undefined } }, undefined)).toBeUndefined();
         expect(resolveTypeName({ dataClass: { name: 'testDataClass' } }, undefined)).toBe('testDataClass');
-        expect(resolveTypeName({ sampleSet: { name: undefined } }, undefined)).toBe(undefined);
+        expect(resolveTypeName({ sampleSet: { name: undefined } }, undefined)).toBeUndefined();
         expect(resolveTypeName({ sampleSet: { name: 'testSampleSet' } }, undefined)).toBe('testSampleSet');
         expect(resolveTypeName({ sampleSet: { name: 'testSampleSet' } }, 'notebook')).toBe('testSampleSet');
         expect(resolveTypeName({ sampleSet: { name: undefined } }, 'notebook')).toBe('Notebook');
@@ -198,8 +198,8 @@ describe('resolveTypeName', () => {
 
 describe('resolveIconSrc', () => {
     test('data undefined', () => {
-        expect(resolveIconSrc(undefined, undefined)).toBe('');
-        expect(resolveIconSrc(undefined, 'test')).toBe('');
+        expect(resolveIconSrc(undefined, undefined)).toBeUndefined();
+        expect(resolveIconSrc(undefined, 'test')).toBeUndefined();
         expect(resolveIconSrc(undefined, 'material')).toBe('samples');
         expect(resolveIconSrc(undefined, 'workflowJob')).toBe('workflow');
         expect(resolveIconSrc(undefined, 'notebook')).toBe('notebook_blue');
@@ -207,22 +207,25 @@ describe('resolveIconSrc', () => {
     });
 
     test('data defined', () => {
-        expect(resolveIconSrc({}, undefined)).toBe('');
-        expect(resolveIconSrc({ dataClass: { name: undefined } }, undefined)).toBe('');
-        expect(resolveIconSrc({ dataClass: { name: 'testDataClass' } }, undefined)).toBe('testdataclass');
-        expect(resolveIconSrc({ sampleSet: { name: undefined } }, undefined)).toBe('');
+        expect(resolveIconSrc({}, undefined)).toBeUndefined();
+        expect(resolveIconSrc({ dataClass: { name: undefined } }, undefined)).toBeUndefined();
+        expect(resolveIconSrc({ dataClass: { name: 'testDataClass' } }, undefined)).toBeUndefined();
+        expect(resolveIconSrc({ dataClass: { category: 'test', name: 'testDataClass' } }, undefined)).toBe(
+            'testdataclass'
+        );
+        expect(resolveIconSrc({ sampleSet: { name: undefined } }, undefined)).toBeUndefined();
         expect(resolveIconSrc({ sampleSet: { name: 'testSampleSet' } }, undefined)).toBe('samples');
-        expect(resolveIconSrc({ type: undefined }, undefined)).toBe('');
+        expect(resolveIconSrc({ type: undefined }, undefined)).toBeUndefined();
         expect(resolveIconSrc({ type: 'sampleSet' }, undefined)).toBe('sample_set');
-        expect(resolveIconSrc({ type: 'dataClassTest' }, undefined)).toBe('default');
+        expect(resolveIconSrc({ type: 'dataClassTest' }, undefined)).toBe(undefined);
         expect(resolveIconSrc({ type: 'test' }, undefined)).toBe('test');
     });
 });
 
 describe('resolveIconDir', () => {
     test('category', () => {
-        expect(resolveIconDir(undefined)).toBe(undefined);
-        expect(resolveIconDir('test')).toBe(undefined);
+        expect(resolveIconDir(undefined)).toBeUndefined();
+        expect(resolveIconDir('test')).toBeUndefined();
         expect(resolveIconDir('notebook')).toBe('labbook/images');
         expect(resolveIconDir('notebookTemplate')).toBe('labbook/images');
     });

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -99,21 +99,24 @@ export function resolveTypeName(data: any, category: string) {
 
 // exported for jest testing
 export function resolveIconSrc(data: any, category: string): string {
-    let iconSrc = '';
+    let iconSrc: string;
     if (data) {
         if (data.dataClass?.name) {
-            iconSrc = data.dataClass.name.toLowerCase();
+            // Issue 44917: Resolve search icon for uncategorized data classes
+            if (data.dataClass.category) {
+                iconSrc = data.dataClass.name.toLowerCase();
+            }
+            // else fallback to default
         } else if (data.sampleSet?.name) {
             iconSrc = 'samples';
         } else if (data.type) {
             const lcType = data.type.toLowerCase();
             if (lcType === 'sampleset') {
                 iconSrc = 'sample_set';
-            } else if (lcType.indexOf('dataclass') === 0) {
-                iconSrc = 'default'; // we don't have a generic "data class" icon; default works just fine.
-            } else {
+            } else if (lcType.indexOf('dataclass') !== 0) {
                 iconSrc = lcType;
             }
+            // else fallback to default
         }
     }
     if (!iconSrc && category) {


### PR DESCRIPTION
#### Rationale
This PR addresses [Issue 44917](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44917) by updating the icon resolution method to support resolving uncategorized data classes to the default icon. Previously, the icon resolution would always resolve to the data classes name which does not have a corollary image on the server for user-defined data classes.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1480

#### Changes
* Resolve icons to the data class name value iff the data class is assigned a category (e.g. "registry", "source", etc).
* Always fallback to default rather than explicitly processing as "default".
