### PR TITLE
Issues 45509, 45947 and 45866: fixes for saving views, choosing filter values, and one tool tip

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4-miscIssues228sh.1",
+  "version": "2.202.4-miscIssues228sh.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4-miscIssues228sh.0",
+  "version": "2.202.4-miscIssues228sh.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4-miscIssues228sh.3",
+  "version": "2.202.4-miscIssues228sh.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4-miscIssues228sh.4",
+  "version": "2.202.4-miscIssues228sh.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4-miscIssues228sh.2",
+  "version": "2.202.4-miscIssues228sh.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4-miscIssues228sh.5",
+  "version": "2.202.4-miscIssues228sh.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4-miscIssues228sh.6",
+  "version": "2.202.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.3",
+  "version": "2.202.4-miscIssues228sh.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.202.4
+*Released*: 29 July 2022
 * Issue 45509: Remove inaccurate tool tip
 * Issue 45947: Don't allow saving views with reserved names
 * Issue 45866: Improve performance of FilterFacetedSelector by loading only 250 items and not searching with each click.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45509: Remove inaccurate tool tip
+
+
 ### version 2.202.1
 *Released*: 26 July 2022
 * Move `jest` and `enzyme` from devDependencies to dependencies

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 45509: Remove inaccurate tool tip
+* Issue 45947: Don't allow saving views with reserved names
 
 
 ### version 2.202.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Issue 45509: Remove inaccurate tool tip
 * Issue 45947: Don't allow saving views with reserved names
+* Issue 45866: Improve performance of FilterFacetedSelector by loading only 250 items and not searching with each click.
 
 ### version 2.202.3
 *Released*: 28 July 2022

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassPropertiesPanel.spec.tsx.snap
@@ -85,29 +85,6 @@ exports[`DataClassPropertiesPanel custom properties 1`] = `
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>
@@ -286,29 +263,6 @@ exports[`DataClassPropertiesPanel default properties 1`] = `
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>

--- a/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
@@ -69,7 +69,6 @@ export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, a
                         <DomainFieldLabel
                             label="Name"
                             required={true}
-                            helpTipBody={`The name for this ${noun.toLowerCase()}. Note that this can\'t be changed after ${noun.toLowerCase()} creation.`}
                         />
                     </Col>
                     <Col xs={10}>

--- a/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
@@ -14,29 +14,6 @@ exports[`<EntityDetailsForm/> default properties 1`] = `
         className="domain-no-wrap"
       >
         Name
-        <span
-          className="label-help-target"
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-            data-icon="question-circle"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            style={Object {}}
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              fill="currentColor"
-              style={Object {}}
-            />
-          </svg>
-        </span>
          *
       </span>
     </div>
@@ -171,29 +148,6 @@ exports[`<EntityDetailsForm/> initial data 1`] = `
         className="domain-no-wrap"
       >
         Name
-        <span
-          className="label-help-target"
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-            data-icon="question-circle"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            style={Object {}}
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              fill="currentColor"
-              style={Object {}}
-            />
-          </svg>
-        </span>
          *
       </span>
     </div>
@@ -328,29 +282,6 @@ exports[`<EntityDetailsForm/> nameExpression properties 1`] = `
         className="domain-no-wrap"
       >
         Name
-        <span
-          className="label-help-target"
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-            data-icon="question-circle"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            style={Object {}}
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              fill="currentColor"
-              style={Object {}}
-            />
-          </svg>
-        </span>
          *
       </span>
     </div>
@@ -486,29 +417,6 @@ exports[`<EntityDetailsForm/> with formValues 1`] = `
         className="domain-no-wrap"
       >
         Name
-        <span
-          className="label-help-target"
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-            data-icon="question-circle"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            style={Object {}}
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              fill="currentColor"
-              style={Object {}}
-            />
-          </svg>
-        </span>
          *
       </span>
     </div>
@@ -671,7 +579,6 @@ exports[`<EntityDetailsForm/> with previewName 1`] = `
               className="col-xs-2"
             >
               <DomainFieldLabel
-                helpTipBody="The name for this entity. Note that this can't be changed after entity creation."
                 label="Name"
                 required={true}
               >
@@ -679,83 +586,6 @@ exports[`<EntityDetailsForm/> with previewName 1`] = `
                   className="domain-no-wrap"
                 >
                   Name
-                  <Component
-                    customStyle={Object {}}
-                    id="tooltip"
-                    required={true}
-                    size="1x"
-                    title="Name"
-                  >
-                    <span
-                      className="label-help-target"
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <FontAwesomeIcon
-                        border={false}
-                        className="label-help-icon"
-                        fixedWidth={false}
-                        flip={null}
-                        icon={
-                          Object {
-                            "icon": Array [
-                              512,
-                              512,
-                              Array [],
-                              "f059",
-                              "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                            ],
-                            "iconName": "question-circle",
-                            "prefix": "fas",
-                          }
-                        }
-                        inverse={false}
-                        listItem={false}
-                        mask={null}
-                        pull={null}
-                        pulse={false}
-                        rotation={null}
-                        size="1x"
-                        spin={false}
-                        style={Object {}}
-                        swapOpacity={false}
-                        symbol={false}
-                        title=""
-                        transform={null}
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                          data-icon="question-circle"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="img"
-                          style={Object {}}
-                          viewBox="0 0 512 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                            fill="currentColor"
-                            style={Object {}}
-                          />
-                        </svg>
-                      </FontAwesomeIcon>
-                      <Overlay
-                        animation={[Function]}
-                        placement="right"
-                        rootClose={false}
-                        show={false}
-                      >
-                        <Overlay
-                          placement="right"
-                          rootClose={false}
-                          show={false}
-                          transition={[Function]}
-                        />
-                      </Overlay>
-                    </span>
-                  </Component>
                    *
                 </span>
               </DomainFieldLabel>

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -90,29 +90,6 @@ Array [
                 className="domain-no-wrap"
               >
                 Name
-                <span
-                  className="label-help-target"
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                    data-icon="question-circle"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="img"
-                    style={Object {}}
-                    viewBox="0 0 512 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                      fill="currentColor"
-                      style={Object {}}
-                    />
-                  </svg>
-                </span>
                  *
               </span>
             </div>
@@ -529,29 +506,6 @@ Array [
                 className="domain-no-wrap"
               >
                 Name
-                <span
-                  className="label-help-target"
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                    data-icon="question-circle"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="img"
-                    style={Object {}}
-                    viewBox="0 0 512 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                      fill="currentColor"
-                      style={Object {}}
-                    />
-                  </svg>
-                </span>
                  *
               </span>
             </div>
@@ -2312,7 +2266,6 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                               className="col-xs-2"
                                             >
                                               <DomainFieldLabel
-                                                helpTipBody="The name for this sample type. Note that this can't be changed after sample type creation."
                                                 label="Name"
                                                 required={true}
                                               >
@@ -2320,83 +2273,6 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                   className="domain-no-wrap"
                                                 >
                                                   Name
-                                                  <Component
-                                                    customStyle={Object {}}
-                                                    id="tooltip"
-                                                    required={true}
-                                                    size="1x"
-                                                    title="Name"
-                                                  >
-                                                    <span
-                                                      className="label-help-target"
-                                                      onMouseOut={[Function]}
-                                                      onMouseOver={[Function]}
-                                                    >
-                                                      <FontAwesomeIcon
-                                                        border={false}
-                                                        className="label-help-icon"
-                                                        fixedWidth={false}
-                                                        flip={null}
-                                                        icon={
-                                                          Object {
-                                                            "icon": Array [
-                                                              512,
-                                                              512,
-                                                              Array [],
-                                                              "f059",
-                                                              "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                                            ],
-                                                            "iconName": "question-circle",
-                                                            "prefix": "fas",
-                                                          }
-                                                        }
-                                                        inverse={false}
-                                                        listItem={false}
-                                                        mask={null}
-                                                        pull={null}
-                                                        pulse={false}
-                                                        rotation={null}
-                                                        size="1x"
-                                                        spin={false}
-                                                        style={Object {}}
-                                                        swapOpacity={false}
-                                                        symbol={false}
-                                                        title=""
-                                                        transform={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden="true"
-                                                          className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                                          data-icon="question-circle"
-                                                          data-prefix="fas"
-                                                          focusable="false"
-                                                          role="img"
-                                                          style={Object {}}
-                                                          viewBox="0 0 512 512"
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                                            fill="currentColor"
-                                                            style={Object {}}
-                                                          />
-                                                        </svg>
-                                                      </FontAwesomeIcon>
-                                                      <Overlay
-                                                        animation={[Function]}
-                                                        placement="right"
-                                                        rootClose={false}
-                                                        show={false}
-                                                      >
-                                                        <Overlay
-                                                          placement="right"
-                                                          rootClose={false}
-                                                          show={false}
-                                                          transition={[Function]}
-                                                        />
-                                                      </Overlay>
-                                                    </span>
-                                                  </Component>
                                                    *
                                                 </span>
                                               </DomainFieldLabel>

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -60,29 +60,6 @@ exports[`<SampleTypePropertiesPanel/> appPropertiesOnly 1`] = `
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>
@@ -377,29 +354,6 @@ exports[`<SampleTypePropertiesPanel/> default props 1`] = `
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>
@@ -630,29 +584,6 @@ exports[`<SampleTypePropertiesPanel/> include dataclass and use custom labels 1`
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>
@@ -940,29 +871,6 @@ exports[`<SampleTypePropertiesPanel/> includeMetricUnitProperty 1`] = `
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>
@@ -1311,29 +1219,6 @@ exports[`<SampleTypePropertiesPanel/> metricUnitOptions 1`] = `
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>
@@ -1794,29 +1679,6 @@ exports[`<SampleTypePropertiesPanel/> nameExpressionInfoUrl 1`] = `
             className="domain-no-wrap"
           >
             Name
-            <span
-              className="label-help-target"
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                data-icon="question-circle"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
              *
           </span>
         </div>
@@ -2431,7 +2293,6 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                                 className="col-xs-2"
                               >
                                 <DomainFieldLabel
-                                  helpTipBody="The name for this sample type. Note that this can't be changed after sample type creation."
                                   label="Name"
                                   required={true}
                                 >
@@ -2439,83 +2300,6 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                                     className="domain-no-wrap"
                                   >
                                     Name
-                                    <Component
-                                      customStyle={Object {}}
-                                      id="tooltip"
-                                      required={true}
-                                      size="1x"
-                                      title="Name"
-                                    >
-                                      <span
-                                        className="label-help-target"
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                      >
-                                        <FontAwesomeIcon
-                                          border={false}
-                                          className="label-help-icon"
-                                          fixedWidth={false}
-                                          flip={null}
-                                          icon={
-                                            Object {
-                                              "icon": Array [
-                                                512,
-                                                512,
-                                                Array [],
-                                                "f059",
-                                                "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z",
-                                              ],
-                                              "iconName": "question-circle",
-                                              "prefix": "fas",
-                                            }
-                                          }
-                                          inverse={false}
-                                          listItem={false}
-                                          mask={null}
-                                          pull={null}
-                                          pulse={false}
-                                          rotation={null}
-                                          size="1x"
-                                          spin={false}
-                                          style={Object {}}
-                                          swapOpacity={false}
-                                          symbol={false}
-                                          title=""
-                                          transform={null}
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="svg-inline--fa fa-question-circle fa-w-16 fa-1x label-help-icon"
-                                            data-icon="question-circle"
-                                            data-prefix="fas"
-                                            focusable="false"
-                                            role="img"
-                                            style={Object {}}
-                                            viewBox="0 0 512 512"
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                                              fill="currentColor"
-                                              style={Object {}}
-                                            />
-                                          </svg>
-                                        </FontAwesomeIcon>
-                                        <Overlay
-                                          animation={[Function]}
-                                          placement="right"
-                                          rootClose={false}
-                                          show={false}
-                                        >
-                                          <Overlay
-                                            placement="right"
-                                            rootClose={false}
-                                            show={false}
-                                            transition={[Function]}
-                                          />
-                                        </Overlay>
-                                      </span>
-                                    </Component>
                                      *
                                   </span>
                                 </DomainFieldLabel>

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.spec.tsx
@@ -23,6 +23,7 @@ beforeAll(() => {
 
 const valuesListShort = ['ed', 'ned', '', 'ted', 'red', 'bed'];
 const allDisplayValuesShort = ['[All]', '[blank]', 'bed', 'ed', 'ned', 'red', 'ted'];
+const allWithoutBlankDisplayValuesShort = ['[All]', 'bed', 'ed', 'ned', 'red', 'ted'];
 const valuesListLong = [...valuesListShort, 'hop', '1', 'pop', 'all', 'ball', 'fall', 'wall'];
 const allDisplayValuesLong = [
     '[All]',
@@ -63,6 +64,7 @@ const DEFAULT_PROPS = {
     fieldFilters: null,
     selectDistinctOptions: null,
     showSearchLength: 10,
+    canBeBlank: true,
 };
 
 const DEFAULT_PROPS_LONG = {
@@ -75,6 +77,7 @@ const DEFAULT_PROPS_LONG = {
     fieldFilters: null,
     selectDistinctOptions: null,
     showSearchLength: 10,
+    canBeBlank: true,
 };
 
 describe('FilterFacetedSelector', () => {
@@ -98,8 +101,12 @@ describe('FilterFacetedSelector', () => {
                 expect(value).toEqual(allOptions[ind]);
 
                 const checkBox = valuesDiv.find('.form-check-input');
-                if (checkedOptions.indexOf(allOptions[ind]) > -1) expect(checkBox.props().checked).toBeTruthy();
-                else expect(checkBox.props().checked).toBeFalsy();
+                if (checkedOptions.indexOf(allOptions[ind]) > -1) {
+                    expect(checkBox.props().checked).toBeTruthy();
+                }
+                else {
+                    expect(checkBox.props().checked).toBeFalsy();
+                }
             }
         }
 
@@ -121,6 +128,18 @@ describe('FilterFacetedSelector', () => {
         expect(wrapper.find(LoadingSpinner).exists()).toEqual(false);
 
         validate(wrapper, allDisplayValuesShort, [], allDisplayValuesShort, false);
+
+        wrapper.unmount();
+    });
+
+    test('with no initial filter, not blank', async () => {
+        const wrapper = mount(<FilterFacetedSelector {...{...DEFAULT_PROPS, canBeBlank: false}}/>);
+
+        expect(wrapper.find(LoadingSpinner).exists()).toEqual(true);
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(LoadingSpinner).exists()).toEqual(false);
+
+        validate(wrapper, allWithoutBlankDisplayValuesShort, [],  allWithoutBlankDisplayValuesShort, false);
 
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
@@ -17,13 +17,14 @@ interface Props {
     api?: ComponentsAPIWrapper;
     fieldFilters: Filter.IFilter[];
     fieldKey: string;
+    canBeBlank: boolean;
     onFieldFilterUpdate?: (newFilters: Filter.IFilter[], index) => void;
     selectDistinctOptions: Query.SelectDistinctOptions;
     showSearchLength?: number; // show search box if number of unique values > N
 }
 
 export const FilterFacetedSelector: FC<Props> = memo(props => {
-    const { api, selectDistinctOptions, fieldKey, fieldFilters, onFieldFilterUpdate, showSearchLength } = props;
+    const { api, canBeBlank, selectDistinctOptions, fieldKey, fieldFilters, onFieldFilterUpdate, showSearchLength } = props;
 
     const [fieldDistinctValues, setFieldDistinctValues] = useState<string[]>(undefined);
     const [error, setError] = useState<string>(undefined);
@@ -35,7 +36,7 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
     }, [fieldKey]); // on fieldKey change, reload selection values
 
     const setDistinctValues = useCallback((checkAllShown: boolean, searchStr?: string) => {
-        const filterArray = searchStr ? [Filter.create(fieldKey, searchStr, Filter.Types.CONTAINS)].concat(fieldFilters) : fieldFilters;
+        const filterArray = searchStr ? [Filter.create(fieldKey, searchStr, Filter.Types.CONTAINS)].concat(selectDistinctOptions?.filterArray) : fieldFilters;
         api.query
             .selectDistinctRows({...selectDistinctOptions, filterArray, maxRows: MAX_DISTINCT_FILTER_OPTIONS + 1})
             .then(result => {
@@ -51,7 +52,8 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
                 if (distinctValues.indexOf(EMPTY_VALUE_DISPLAY) >= 0) {
                     distinctValues.splice(distinctValues.indexOf(EMPTY_VALUE_DISPLAY), 1);
                 }
-                distinctValues.unshift(EMPTY_VALUE_DISPLAY);
+                if (canBeBlank)
+                    distinctValues.unshift(EMPTY_VALUE_DISPLAY);
 
                 // add [All] to first
                 distinctValues.unshift(ALL_VALUE_DISPLAY);

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
@@ -11,6 +11,8 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 import { ALL_VALUE_DISPLAY, EMPTY_VALUE_DISPLAY, getCheckedFilterValues, getUpdatedChooseValuesFilter } from './utils';
 
+const MAX_DISTINCT_FILTER_OPTIONS = 250;
+
 interface Props {
     api?: ComponentsAPIWrapper;
     fieldFilters: Filter.IFilter[];
@@ -26,21 +28,30 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
     const [fieldDistinctValues, setFieldDistinctValues] = useState<string[]>(undefined);
     const [error, setError] = useState<string>(undefined);
     const [searchStr, setSearchStr] = useState<string>(undefined);
+    const [allShown, setAllShown] = useState<boolean>(true);
 
     useEffect(() => {
+        setDistinctValues(true);
+    }, [fieldKey]); // on fieldKey change, reload selection values
+
+    const setDistinctValues = useCallback((checkAllShown: boolean, searchStr?: string) => {
+        const filterArray = searchStr ? [Filter.create(fieldKey, searchStr, Filter.Types.CONTAINS)].concat(fieldFilters) : fieldFilters;
         api.query
-            .selectDistinctRows(selectDistinctOptions)
+            .selectDistinctRows({...selectDistinctOptions, filterArray, maxRows: MAX_DISTINCT_FILTER_OPTIONS + 1})
             .then(result => {
-                const distinctValues = result.values.sort(naturalSort).map(val => {
+                if (checkAllShown)
+                    setAllShown(result.values.length <= MAX_DISTINCT_FILTER_OPTIONS);
+                const toShow = result.values.slice(0, MAX_DISTINCT_FILTER_OPTIONS);
+                const distinctValues = toShow.sort(naturalSort).map(val => {
                     if (val === '' || val === null || val === undefined) return EMPTY_VALUE_DISPLAY;
                     return val;
                 });
 
                 // move [blank] to first
-                if (distinctValues.indexOf(EMPTY_VALUE_DISPLAY) > 0) {
+                if (distinctValues.indexOf(EMPTY_VALUE_DISPLAY) >= 0) {
                     distinctValues.splice(distinctValues.indexOf(EMPTY_VALUE_DISPLAY), 1);
-                    distinctValues.unshift(EMPTY_VALUE_DISPLAY);
                 }
+                distinctValues.unshift(EMPTY_VALUE_DISPLAY);
 
                 // add [All] to first
                 distinctValues.unshift(ALL_VALUE_DISPLAY);
@@ -51,7 +62,7 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
                 setFieldDistinctValues([]);
                 setError(resolveErrorMessage(error));
             });
-    }, [selectDistinctOptions, fieldKey]); // on fieldKey change, reload selection values
+    }, [selectDistinctOptions]);
 
     const checkedValues = useMemo(() => {
         return getCheckedFilterValues(fieldFilters?.[0], fieldDistinctValues);
@@ -64,6 +75,7 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
 
     const onSearchStrChange = useCallback(e => {
         setSearchStr(e.target.value);
+        setDistinctValues(false, e.target.value);
     }, []);
 
     const onChange = useCallback(
@@ -98,7 +110,7 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
             {error && <Alert>{error}</Alert>}
             {!fieldDistinctValues && <LoadingSpinner />}
             <div className="filter-faceted__panel">
-                {fieldDistinctValues?.length > showSearchLength && (
+                {(fieldDistinctValues?.length > showSearchLength || searchStr) && (
                     <div>
                         <input
                             id="filter-faceted__typeahead-input"
@@ -110,6 +122,15 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
                         />
                     </div>
                 )}
+                {!allShown &&
+                    <Row>
+                        <Col xs={12} className="bottom-spacing">
+                            <div>There are more than {MAX_DISTINCT_FILTER_OPTIONS} distinct values. Use the filter box above
+                                to find additional values.
+                            </div>
+                        </Col>
+                    </Row>
+                }
                 <Row>
                     <Col xs={taggedValues?.length > 0 ? 6 : 12}>
                         <ul className="nav nav-stacked labkey-wizard-pills">

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
@@ -54,7 +54,7 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
                 if (distinctValues.indexOf(EMPTY_VALUE_DISPLAY) >= 0) {
                     distinctValues.splice(distinctValues.indexOf(EMPTY_VALUE_DISPLAY), 1);
                 }
-                if (canBeBlank)
+                if (canBeBlank && toShow.length > 0)
                     distinctValues.unshift(EMPTY_VALUE_DISPLAY);
 
                 // add [All] to first

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
@@ -36,7 +36,9 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
     }, [fieldKey]); // on fieldKey change, reload selection values
 
     const setDistinctValues = useCallback((checkAllShown: boolean, searchStr?: string) => {
-        const filterArray = searchStr ? [Filter.create(fieldKey, searchStr, Filter.Types.CONTAINS)].concat(selectDistinctOptions?.filterArray) : fieldFilters;
+        const filterArray = searchStr
+            ? [Filter.create(fieldKey, searchStr, Filter.Types.CONTAINS)].concat(selectDistinctOptions?.filterArray)
+            : selectDistinctOptions?.filterArray;
         api.query
             .selectDistinctRows({...selectDistinctOptions, filterArray, maxRows: MAX_DISTINCT_FILTER_OPTIONS + 1})
             .then(result => {

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -265,7 +265,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                                 }}
                                                 fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
                                                 fieldKey={activeFieldKey}
-                                                canBeBlank={!activeField?.required}
+                                                canBeBlank={!activeField?.required && !activeField.nameExpression}
                                                 key={activeFieldKey}
                                                 onFieldFilterUpdate={(newFilters, index) =>
                                                     onFilterUpdate(activeField, newFilters, index)

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -265,6 +265,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                                 }}
                                                 fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
                                                 fieldKey={activeFieldKey}
+                                                canBeBlank={!activeField?.required}
                                                 key={activeFieldKey}
                                                 onFieldFilterUpdate={(newFilters, index) =>
                                                     onFilterUpdate(activeField, newFilters, index)

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -94,7 +94,7 @@ export function getFinderViewColumnsConfig(
     };
 }
 
-export const SAMPLE_FINDER_VIEW_NAME = 'Sample Finder';
+export const SAMPLE_FINDER_VIEW_NAME = '~~samplefinder~~';
 
 function getSampleFinderConfigId(finderId: string, suffix: string): string {
     const { uuids } = getServerContext();

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -13,7 +13,7 @@ import { isProductProjectsEnabled } from '../../internal/app/utils';
 import { useServerContext } from '../../internal/components/base/ServerContext';
 
 const MAX_VIEW_NAME_LENGTH = 200;
-const RESERVED_VIEW_NAMES = ['default', 'my default', '~~details~~', '~~insert~~', '~~update~~'];
+const RESERVED_VIEW_NAMES = ['default', 'my default', '~~details~~', '~~insert~~', '~~update~~', '~~samplefinder~~'];
 
 interface ViewNameInputProps {
     autoFocus?: boolean;
@@ -65,7 +65,8 @@ export const ViewNameInput: FC<ViewNameInputProps> = memo(props => {
 
     const onViewNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
         setViewName(evt.target.value);
-        const hasError = evt.target.value.length > maxLength || RESERVED_VIEW_NAMES.indexOf(evt.target.value.toLowerCase()) >= 0;
+        const trimmed = evt.target.value.trim();
+        const hasError = trimmed.length > maxLength || RESERVED_VIEW_NAMES.indexOf(trimmed) >= 0;
         setNameErrorMessage();
         onChange?.(evt.target.value, hasError);
     }, []);

--- a/packages/components/src/public/QueryModel/SaveViewModal.tsx
+++ b/packages/components/src/public/QueryModel/SaveViewModal.tsx
@@ -44,11 +44,12 @@ export const ViewNameInput: FC<ViewNameInputProps> = memo(props => {
     );
 
     const setNameErrorMessage = useCallback(() => {
-        if (viewName.length > maxLength) {
-            setNameError(`Current length: ${viewName.length}; maximum length: ${maxLength}`);
+        const trimmed = viewName.trim();
+        if (trimmed.length > maxLength) {
+            setNameError(`Current length: ${trimmed.length}; maximum length: ${maxLength}`);
         }
-        else if (RESERVED_VIEW_NAMES.indexOf(viewName.toLowerCase()) >= 0)
-            setNameError(`View name '${viewName}' is reserved.`);
+        else if (RESERVED_VIEW_NAMES.indexOf(trimmed.toLowerCase()) >= 0)
+            setNameError(`View name '${trimmed}' is reserved.`);
         else
             setNameError(undefined);
     }, [maxLength, viewName]);


### PR DESCRIPTION
#### Rationale
- [Issue 45947](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45947): In LKSM/LKB, you can save a custom grid view named "Default" but when you try to edit it again, it says that name is not allowed - 0.5h
- [Issue 45509](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45509): Update tooltip for Name field on Sample Types/Source Types/Data Classes since you can now edit them later - 0.5h
- [Issue 45866](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45866): LKSM/LKB: Filter modal should limit items to 250 

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/503
* https://github.com/LabKey/biologics/pull/1481
* https://github.com/LabKey/sampleManagement/pull/1133

#### Changes
* Issue 45509: Remove inaccurate tool tip
* Issue 45947: Don't allow saving views with reserved names
* Issue 45866: Improve performance of FilterFacetedSelector by loading only 250 items and not searching with each click.
