### PR TITLE
Issue 45975: useContainerUser resolving incorrect container

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.7",
+  "version": "2.194.7-fb-fix-45975.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.7-fb-fix-45975.0",
+  "version": "2.194.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.194.8
+*Released*: 29 July 2022
+* Issue 45975: useContainerUser resolving incorrect container
+
 ### version 2.194.7
 *Released*: 22 July 2022
 * Issue 45852: External links should include 'noopener' in 'ref' attribute

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -4,7 +4,6 @@ import { Map } from 'immutable';
 import { Container } from '../base/models/Container';
 import { fetchContainerSecurityPolicy, UserLimitSettings, getUserLimitSettings } from '../permissions/actions';
 import { Principal, SecurityPolicy } from '../permissions/models';
-import { naturalSortByProperty } from '../../..';
 
 export type FetchContainerOptions = Omit<Security.GetContainersOptions, 'success' | 'failure' | 'scope'>;
 
@@ -38,11 +37,9 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
 }
 
 function recurseContainerHierarchy(data: Security.ContainerHierarchy, container: Container): Container[] {
-    return (
-        data.children
-            .reduce((containers, c) => containers.concat(recurseContainerHierarchy(c, new Container(c))), [container])
-            // Issue 45805: sort folders by title as server-side sorting is insufficient
-            .sort(naturalSortByProperty('title'))
+    return data.children.reduce(
+        (containers, c) => containers.concat(recurseContainerHierarchy(c, new Container(c))),
+        [container]
     );
 }
 


### PR DESCRIPTION
#### Rationale
This addresses 45975 by fixing a client-side issue that was introduced with https://github.com/LabKey/labkey-ui-components/pull/888 where sorting of containers received from `api.security.fetchContainers()` was being done prior to resolving the results. This [broke an implicit contract](https://github.com/LabKey/labkey-ui-components/blob/5bc7d3/packages/components/src/internal/components/container/actions.ts#L104) with `useContainerUser` where that hook expects the first container returned to be the one that matches the one requested (a holdover from how the `project-getContainers.api` response is shaped). As a result, the wrong container ends up being processed by `useContainerUser` as the one requested which can result in improper request generation from the client (e.g. calls to `query-updateRows.api` at the wrong container path).

I've elected to move the sorting to be done within the `FolderMenu` component itself so that [Issue 45805](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45805) remains addressed. Additionally, I've fixed a break from our expected behavior which is that the top-level folder should always be the first result given in the `FolderMenu` dropdown.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1482

#### Changes
* Sort folders for project menu in `FolderMenu` component. Extracted out of `api.security.fetchContainers()` wrapper.
* Update `FolderMenu` to always display top-level folder at the top.
