### PR TITLE
Issue 45822: Unit cells in editable grid triggers getQuery calls

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.3",
+  "version": "2.202.4-fb-issue45822Perf",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.4",
+  "version": "2.202.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.XX
+*Released*: XX 2022
+* Issue 45822: incorrect unit types available when adding sample to storage
+    * avoid excessive loading until lookup cell is selected/focused
+
 ### version 2.202.3
 *Released*: 28 July 2022
 * Sample Finder: support containerFilter on expDescendantOfSelectClause

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -89,15 +89,13 @@ export class Cell extends React.PureComponent<Props, State> {
         this.displayEl = React.createRef();
     }
 
-    componentDidUpdate(): void {
+    componentDidUpdate(prevProps: Readonly<Props>): void {
         if (!this.props.focused && this.props.selected) {
             this.displayEl.current.focus();
-            this.loadFilteredLookupKeys();
-        }
-    }
 
-    componentDidMount(): void {
-        this.loadFilteredLookupKeys();
+            if (!prevProps.selected)
+                this.loadFilteredLookupKeys();
+        }
     }
 
     loadFilteredLookupKeys = async (): Promise<void> => {

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -93,8 +93,7 @@ export class Cell extends React.PureComponent<Props, State> {
         if (!this.props.focused && this.props.selected) {
             this.displayEl.current.focus();
 
-            if (!prevProps.selected)
-                this.loadFilteredLookupKeys();
+            if (!prevProps.selected) this.loadFilteredLookupKeys();
         }
     }
 


### PR DESCRIPTION
#### Rationale
Changes made in https://github.com/LabKey/labkey-ui-components/pull/904 to allow cell level lookup value filtering make it so that all Units cells on the grid triggers query loading when the editable grid is rendered. For a box that's 25*25, this would trigger 625 query-getQuery call at once. Change made to only load Unit cell options when the cell is selected/focused. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/904
* https://github.com/LabKey/inventory/pull/506

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
