### PR TITLE
Misc dataset domain designer issue fixes (45942, 45704)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.9",
+  "version": "2.194.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.8",
+  "version": "2.194.8-fb-datasetDesignerIssues.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.194.8-fb-datasetDesignerIssues.0",
+  "version": "2.194.8-fb-datasetDesignerIssues.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.194.TBD
-*Released*: TBD August 2022
+### version 2.194.10
+*Released*: 2 August 2022
 * Misc dataset domain designer issue fixes
   * Issue 45942: While creating a new dataset via infer from fields, clicking Add Field results in JS error
   * Issue 45704: Multiple error messages provide less detail than a single error message during dataset creation

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.194.TBD
+*Released*: TBD August 2022
+* Misc dataset domain designer issue fixes
+  * Issue 45942: While creating a new dataset via infer from fields, clicking Add Field results in JS error
+  * Issue 45704: Multiple error messages provide less detail than a single error message during dataset creation
+
 ### version 2.194.8
 *Released*: 29 July 2022
 * Issue 45975: useContainerUser resolving incorrect container

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -333,7 +333,8 @@ export function getMaxPhiLevel(containerPath?: string): Promise<string> {
  * @param options: Options for creating new Domain
  * @param name: Name of new Domain
  * @param includeWarnings: Set this to true if warnings are desired
- * @param originalDomain: Original DomainDesign (before filtering out of locked/mapped fields), to be used for error message rowIndices
+ * @param addRowIndexes: Boolean indicating if rowIndices should be added to the error message objects
+ * @param originalDomain: Original DomainDesign (before filtering out of locked/mapped fields), to be used for addRowIndexes = true
  * @return Promise wrapped Domain API call.
  */
 export function saveDomain(
@@ -342,6 +343,7 @@ export function saveDomain(
     options?: any,
     name?: string,
     includeWarnings?: boolean,
+    addRowIndexes?: boolean,
     originalDomain?: DomainDesign
 ): Promise<DomainDesign> {
     return new Promise((resolve, reject) => {
@@ -361,7 +363,7 @@ export function saveDomain(
             }
 
             const exception = DomainException.create(response, SEVERITY_LEVEL_ERROR);
-            const badDomain = setDomainException(domain, exception, originalDomain);
+            const badDomain = setDomainException(domain, exception, addRowIndexes, originalDomain);
             reject(badDomain);
         }
 
@@ -881,10 +883,11 @@ export function setDomainFields(domain: DomainDesign, fields: List<QueryColumn>)
 export function setDomainException(
     domain: DomainDesign,
     exception: DomainException,
+    addRowIndexes = true,
     originalDomain?: DomainDesign
 ): DomainDesign {
-    const exceptionWithRowIndexes = originalDomain
-        ? DomainException.addRowIndexesToErrors(originalDomain, exception)
+    const exceptionWithRowIndexes = addRowIndexes
+        ? DomainException.addRowIndexesToErrors(originalDomain ?? domain, exception)
         : exception;
     const exceptionWithAllErrors = DomainException.mergeWarnings(domain, exceptionWithRowIndexes);
     return domain.set('domainException', exceptionWithAllErrors ? exceptionWithAllErrors : exception) as DomainDesign;

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -333,6 +333,7 @@ export function getMaxPhiLevel(containerPath?: string): Promise<string> {
  * @param options: Options for creating new Domain
  * @param name: Name of new Domain
  * @param includeWarnings: Set this to true if warnings are desired
+ * @param originalDomain: Original DomainDesign (before filtering out of locked/mapped fields), to be used for error message rowIndices
  * @return Promise wrapped Domain API call.
  */
 export function saveDomain(
@@ -341,7 +342,7 @@ export function saveDomain(
     options?: any,
     name?: string,
     includeWarnings?: boolean,
-    addRowIndexes?: boolean
+    originalDomain?: DomainDesign
 ): Promise<DomainDesign> {
     return new Promise((resolve, reject) => {
         function successHandler(response) {
@@ -360,7 +361,7 @@ export function saveDomain(
             }
 
             const exception = DomainException.create(response, SEVERITY_LEVEL_ERROR);
-            const badDomain = setDomainException(domain, exception, addRowIndexes);
+            const badDomain = setDomainException(domain, exception, originalDomain);
             reject(badDomain);
         }
 
@@ -880,10 +881,10 @@ export function setDomainFields(domain: DomainDesign, fields: List<QueryColumn>)
 export function setDomainException(
     domain: DomainDesign,
     exception: DomainException,
-    addRowIndexes = true
+    originalDomain?: DomainDesign
 ): DomainDesign {
-    const exceptionWithRowIndexes = addRowIndexes
-        ? DomainException.addRowIndexesToErrors(domain, exception)
+    const exceptionWithRowIndexes = originalDomain
+        ? DomainException.addRowIndexesToErrors(originalDomain, exception)
         : exception;
     const exceptionWithAllErrors = DomainException.mergeWarnings(domain, exceptionWithRowIndexes);
     return domain.set('domainException', exceptionWithAllErrors ? exceptionWithAllErrors : exception) as DomainDesign;

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetColumnMappingPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetColumnMappingPanel.tsx
@@ -117,7 +117,7 @@ export class DatasetColumnMappingPanel extends React.PureComponent<Props, State>
             // DATE or CONTINUOUS
             return model.domain.fields
                 .filter(
-                    field => field.rangeURI.toLowerCase() === 'xsd:datetime' || field.rangeURI === DATETIME_RANGE_URI
+                    field => field.rangeURI?.toLowerCase() === 'xsd:datetime' || field.rangeURI === DATETIME_RANGE_URI
                 )
                 .toList();
         }

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
@@ -392,9 +392,6 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         const participantIdMapCol = this._participantId;
         const sequenceNumMapCol = this._sequenceNum;
 
-        // if there is a domain error and we are mapping columns, the row indices will be incorrect so don't include them
-        const addRowIndexes = !(participantIdMapCol || sequenceNumMapCol);
-
         // filter out the selected column mapping files as those will be created in the base domain fields
         const updatedDomain = model.domain.merge({
             fields: model.domain.fields
@@ -415,7 +412,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
             }
         });
 
-        saveDomain(updatedDomain, model.getDomainKind(), model.getOptions(), model.name, false, addRowIndexes)
+        saveDomain(updatedDomain, model.getDomainKind(), model.getOptions(), model.name, false, model.domain)
             .then(response => {
                 this.setState(
                     produce((draftState: Draft<State>) => {

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
@@ -412,7 +412,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
             }
         });
 
-        saveDomain(updatedDomain, model.getDomainKind(), model.getOptions(), model.name, false, model.domain)
+        saveDomain(updatedDomain, model.getDomainKind(), model.getOptions(), model.name, false, true, model.domain)
             .then(response => {
                 this.setState(
                     produce((draftState: Draft<State>) => {


### PR DESCRIPTION
#### Rationale
* Issue [45942](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45942): While creating a new dataset via infer from fields, clicking Add Field results in JS error
* Issue [45704](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45704): Multiple error messages provide less detail than a single error message during dataset creation

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3575

#### Changes
* add null check to DatasetColumnMappingPanel rangURI check
* pass original domain fields to helper for DomainException.addRowIndexesToErrors
