### PR TITLE
Projects - Cross-Folder Storage Actions

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.204.0",
+  "version": "2.204.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.203.1-fb-crossFolderFMActions.1",
+  "version": "2.203.1-fb-crossFolderFMActions.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.203.0",
+  "version": "2.203.1-fb-crossFolderFMActions.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.XX
+*Released*: XX 2022
+* Projects - Cross-Folder Storage Actions
+    * Added ValueList component
+
 ### version 2.203.0
 *Released*: 2 August 2022
 * Workflow job template custom fields

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -153,6 +153,7 @@ import { getMenuItemForSectionKey, getMenuItemsForSection } from './internal/com
 import { Cards } from './internal/components/base/Cards';
 import { Footer } from './internal/components/base/Footer';
 import { Setting } from './internal/components/base/Setting';
+import { ValueList } from './internal/components/base/ValueList';
 
 import { EditorModel, createGridModelId } from './internal/models';
 import {
@@ -1366,6 +1367,7 @@ export {
     SelectView,
     SelectViewInput,
     Setting,
+    ValueList,
     // base models, enums, constants
     Container,
     User,

--- a/packages/components/src/internal/components/base/ValueList.spec.tsx
+++ b/packages/components/src/internal/components/base/ValueList.spec.tsx
@@ -5,9 +5,7 @@ import { ValueList } from './ValueList';
 
 describe('<ValueList />', () => {
     test('values.length = 2, maxCount = 3', () => {
-        const wrapper = mount(
-            <ValueList values={['a', 'b']} maxCount={3}/>
-        );
+        const wrapper = mount(<ValueList values={['a', 'b']} maxCount={3} />);
         expect(wrapper.find('li')).toHaveLength(2);
         expect(wrapper.find('li').at(0).text()).toBe('a');
         expect(wrapper.find('li').at(1).text()).toBe('b');
@@ -15,9 +13,7 @@ describe('<ValueList />', () => {
     });
 
     test('values.length > 3, maxCount = 3', () => {
-        const wrapper = mount(
-            <ValueList values={['a', 'b', 'c', 'd', 'e']} maxCount={3}/>
-        );
+        const wrapper = mount(<ValueList values={['a', 'b', 'c', 'd', 'e']} maxCount={3} />);
         expect(wrapper.find('li')).toHaveLength(3);
         expect(wrapper.find('li').at(2).text()).toBe('c');
         expect(wrapper.text()).toBe('abc...');

--- a/packages/components/src/internal/components/base/ValueList.spec.tsx
+++ b/packages/components/src/internal/components/base/ValueList.spec.tsx
@@ -6,6 +6,12 @@ import { ValueList } from './ValueList';
 describe('<ValueList />', () => {
     test('values.length = 2, maxCount = 3', () => {
         const wrapper = mount(<ValueList values={['a', 'b']} maxCount={3} />);
+        expect(wrapper.text()).toBe('a, b');
+        wrapper.unmount();
+    });
+
+    test('values.length = 2, maxCount = 3, vertical', () => {
+        const wrapper = mount(<ValueList values={['a', 'b']} maxCount={3} vertical={true}/>);
         expect(wrapper.find('li')).toHaveLength(2);
         expect(wrapper.find('li').at(0).text()).toBe('a');
         expect(wrapper.find('li').at(1).text()).toBe('b');
@@ -14,6 +20,12 @@ describe('<ValueList />', () => {
 
     test('values.length > 3, maxCount = 3', () => {
         const wrapper = mount(<ValueList values={['a', 'b', 'c', 'd', 'e']} maxCount={3} />);
+        expect(wrapper.text()).toBe('a, b, c and 2 more');
+        wrapper.unmount();
+    });
+
+    test('values.length > 3, maxCount = 3, vertical', () => {
+        const wrapper = mount(<ValueList values={['a', 'b', 'c', 'd', 'e']} maxCount={3} vertical={true}/>);
         expect(wrapper.find('li')).toHaveLength(3);
         expect(wrapper.find('li').at(2).text()).toBe('c');
         expect(wrapper.text()).toBe('abc...');

--- a/packages/components/src/internal/components/base/ValueList.spec.tsx
+++ b/packages/components/src/internal/components/base/ValueList.spec.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { ValueList } from './ValueList';
+
+describe('<ValueList />', () => {
+    test('values.length = 2, maxCount = 3', () => {
+        const wrapper = mount(
+            <ValueList values={['a', 'b']} maxCount={3}/>
+        );
+        expect(wrapper.find('li')).toHaveLength(2);
+        expect(wrapper.find('li').at(0).text()).toBe('a');
+        expect(wrapper.find('li').at(1).text()).toBe('b');
+        wrapper.unmount();
+    });
+
+    test('values.length > 3, maxCount = 3', () => {
+        const wrapper = mount(
+            <ValueList values={['a', 'b', 'c', 'd', 'e']} maxCount={3}/>
+        );
+        expect(wrapper.find('li')).toHaveLength(3);
+        expect(wrapper.find('li').at(2).text()).toBe('c');
+        expect(wrapper.text()).toBe('abc...');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/base/ValueList.tsx
+++ b/packages/components/src/internal/components/base/ValueList.tsx
@@ -1,18 +1,16 @@
 import React, { FC } from 'react';
 
 export interface Props {
-    values: string[];
     maxCount: number;
+    values: string[];
 }
 
-export const ValueList: FC<Props> = ({ values, maxCount= 5 }) => (
+export const ValueList: FC<Props> = ({ values, maxCount = 5 }) => (
     <ul>
         {values.map((value, ind) => {
-            if (ind > maxCount)
-                return null;
+            if (ind > maxCount) return null;
 
-            if (ind === maxCount)
-                return '...';
+            if (ind === maxCount) return '...';
 
             return <li key={ind}>{value}</li>;
         })}

--- a/packages/components/src/internal/components/base/ValueList.tsx
+++ b/packages/components/src/internal/components/base/ValueList.tsx
@@ -3,16 +3,30 @@ import React, { FC } from 'react';
 export interface Props {
     maxCount: number;
     values: string[];
+    vertical?: boolean;
 }
 
-export const ValueList: FC<Props> = ({ values, maxCount = 5 }) => (
-    <ul>
-        {values.map((value, ind) => {
-            if (ind > maxCount) return null;
+export const ValueList: FC<Props> = ({ values, maxCount = 5 , vertical = false}) => {
+    if (vertical) {
+        return (
+            <ul>
+                {values.map((value, ind) => {
+                    if (ind > maxCount) return null;
 
-            if (ind === maxCount) return '...';
+                    if (ind === maxCount) return '...';
 
-            return <li key={ind}>{value}</li>;
-        })}
-    </ul>
-);
+                    return <li key={ind}>{value}</li>;
+                })}
+            </ul>
+        );
+    }
+
+    let valueDisplay;
+    if (values.length <= maxCount)
+        valueDisplay = values.join(", ");
+    else
+        valueDisplay = values.slice(0, maxCount).join(", ") + ` and ${values.length - maxCount} more`;
+
+    return <ul><li>{valueDisplay}</li></ul>;
+};
+

--- a/packages/components/src/internal/components/base/ValueList.tsx
+++ b/packages/components/src/internal/components/base/ValueList.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+
+export interface Props {
+    values: string[];
+    maxCount: number;
+}
+
+export const ValueList: FC<Props> = ({ values, maxCount= 5 }) => (
+    <ul>
+        {values.map((value, ind) => {
+            if (ind > maxCount)
+                return null;
+
+            if (ind === maxCount)
+                return '...';
+
+            return <li key={ind}>{value}</li>;
+        })}
+    </ul>
+);

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -730,6 +730,7 @@ export interface IDomainField {
     importAliases?: string;
     isPrimaryKey: boolean;
     label?: string;
+    lockExistingField?: boolean;
     lockType: string;
     lookupContainer?: string;
     lookupQuery?: string;
@@ -739,7 +740,6 @@ export interface IDomainField {
     lookupValidator?: PropertyValidator;
     measure?: boolean;
     mvEnabled?: boolean;
-    name: string;
     original: Partial<IDomainField>;
     primaryKey?: boolean;
     principalConceptCode?: string;
@@ -760,7 +760,7 @@ export interface IDomainField {
     textChoiceValidator?: PropertyValidator;
     updatedField: boolean;
     visible: boolean;
-    lockExistingField?: boolean;
+    name: string;
 }
 
 export class DomainField


### PR DESCRIPTION
#### Rationale
The StorageButton in freezermanager package is used by LKSM and LKB to support storage actions from samples grid. In a projects setup, the storage button needs to check folder context as well as storage permission for the selected samples and show appropriate warnings or errors. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/925
* https://github.com/LabKey/inventory/pull/511
* https://github.com/LabKey/sampleManagement/pull/1141
* https://github.com/LabKey/biologics/pull/1493

#### Changes
* Added ValueList component, which is used to list samples that the user lack permissions to or is of invalid folder context at various places
