### PR TITLE
Remove ability to conditionalize the display of Sample Finder

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.6-fb-experimental-sample-finder.0",
+  "version": "2.202.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.202.5",
+  "version": "2.202.6-fb-experimental-sample-finder.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.202.X
-*Released*: TBD
+### version 2.202.6
+*Released*: 4 August 2022
 * Remove conditional code to expose Sample Finder
 
 ### version 2.202.5

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.202.X
+*Released*: TBD
+* Remove conditional code to expose Sample Finder
+
 ### version 2.202.5
 *Released*: 29 July 2022
 * Issue 45822: incorrect unit types available when adding sample to storage

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -87,7 +87,6 @@ export const NOTIFICATION_TIMEOUT = 500;
 export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';
-export const EXPERIMENTAL_SAMPLE_FINDER = 'experimental-biologics-sample-finder';
 export const EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR = 'experimental-sample-aliquot-selector';
 export const EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN = 'experimental-grid-lock-left-column';
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -22,7 +22,6 @@ import {
     EXPERIMENTAL_REQUESTS_MENU,
     EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR,
     EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN,
-    EXPERIMENTAL_SAMPLE_FINDER,
     FREEZER_MANAGER_APP_PROPERTIES,
     FREEZERS_KEY,
     HOME_KEY,
@@ -183,13 +182,6 @@ export function biologicsIsPrimaryApp(moduleContext?: any): boolean {
 
 export function isSampleStatusEnabled(): boolean {
     return hasModule('SampleManagement');
-}
-
-export function isSampleFinderEnabled(moduleContext?: any): boolean {
-    return (
-        !biologicsIsPrimaryApp(moduleContext) ||
-        (moduleContext ?? getServerContext().moduleContext)?.biologics?.[EXPERIMENTAL_SAMPLE_FINDER] === true
-    );
 }
 
 export function getCurrentAppProperties(): AppProperties {

--- a/packages/components/src/internal/components/chart/BarChartViewer.spec.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.spec.tsx
@@ -8,7 +8,7 @@ import { SampleButtons } from './BarChartViewer';
 
 describe('SampleButtons', () => {
     test('with insert and sample finder enabled', () => {
-        LABKEY.moduleContext = { samplemanagement: {  } };
+        LABKEY.moduleContext = { samplemanagement: {} };
         const wrapper = mountWithServerContext(<SampleButtons />, { user: TEST_USER_AUTHOR });
         expect(wrapper.find(Button)).toHaveLength(2);
         expect(wrapper.find(Button).first().text()).toBe('Go to Sample Finder');
@@ -17,7 +17,7 @@ describe('SampleButtons', () => {
     });
 
     test('without insert and sample finder enabled', () => {
-        LABKEY.moduleContext = { samplemanagement: {  } };
+        LABKEY.moduleContext = { samplemanagement: {} };
         const wrapper = mountWithServerContext(<SampleButtons />, { user: TEST_USER_READER });
         expect(wrapper.find(Button)).toHaveLength(1);
         expect(wrapper.find(Button).first().text()).toBe('Go to Sample Finder');

--- a/packages/components/src/internal/components/chart/BarChartViewer.spec.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.spec.tsx
@@ -23,19 +23,4 @@ describe('SampleButtons', () => {
         expect(wrapper.find(Button).first().text()).toBe('Go to Sample Finder');
         wrapper.unmount();
     });
-
-    test('with insert and sample finder not enabled', () => {
-        LABKEY.moduleContext = { biologics: {} };
-        const wrapper = mountWithServerContext(<SampleButtons />, { user: TEST_USER_AUTHOR });
-        expect(wrapper.find(Button)).toHaveLength(1);
-        expect(wrapper.find(Button).first().text()).toBe('Add Samples');
-        wrapper.unmount();
-    });
-
-    test('without insert and sample finder not enabled', () => {
-        LABKEY.moduleContext = { biologics: {} };
-        const wrapper = mountWithServerContext(<SampleButtons />, { user: TEST_USER_READER });
-        expect(wrapper.find(Button)).toHaveLength(0);
-        wrapper.unmount();
-    });
 });

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -21,7 +21,7 @@ import {
     User,
 } from '../../..';
 
-import { getDateFormat, isSampleFinderEnabled } from '../../app/utils';
+import { getDateFormat } from '../../app/utils';
 
 import { ASSAYS_KEY, FIND_SAMPLES_BY_FILTER_HREF, NEW_SAMPLES_HREF, SAMPLES_KEY } from '../../app/constants';
 
@@ -270,11 +270,9 @@ export const SampleButtons: FC<SampleButtonProps> = memo(props => {
 
     return (
         <div className="pull-right bar-chart-viewer-sample-buttons">
-            {isSampleFinderEnabled() && (
-                <Button bsStyle="primary" onClick={onSampleFinder} href={FIND_SAMPLES_BY_FILTER_HREF.toHref()}>
-                    Go to Sample Finder
-                </Button>
-            )}
+            <Button bsStyle="primary" onClick={onSampleFinder} href={FIND_SAMPLES_BY_FILTER_HREF.toHref()}>
+                Go to Sample Finder
+            </Button>
             <RequiresPermission perms={PermissionTypes.Insert}>
                 <Button bsStyle="success" className="button-left-spacing" href={NEW_SAMPLES_HREF.toHref()}>
                     Add Samples

--- a/packages/components/src/internal/components/search/FindAndSearchDropdown.spec.tsx
+++ b/packages/components/src/internal/components/search/FindAndSearchDropdown.spec.tsx
@@ -64,26 +64,4 @@ describe('FindAndSearchDropdown', () => {
         expect(items.at(1).text().trim()).toBe('Find Tests by ID');
         expect(items.at(2).text().trim()).toBe('Sample Finder');
     });
-
-    test('without sample finder', () => {
-        window.location = Object.assign(
-            { ...location },
-            {
-                pathname: 'labkey/Bio/biologics-app.view#',
-            }
-        );
-        LABKEY.moduleContext = {
-            api: {
-                moduleNames: ['biologics', 'study', 'premium'],
-            },
-            biologics: {}
-        };
-        const wrapper = mount(
-            <FindAndSearchDropdown title="Test title" findNounPlural="tests" onFindByIds={jest.fn} />
-        );
-        const items = wrapper.find(MenuItem);
-        expect(items).toHaveLength(2);
-        expect(items.at(0).text().trim()).toBe('Find Tests by Barcode');
-        expect(items.at(1).text().trim()).toBe('Find Tests by ID');
-    });
 });

--- a/packages/components/src/internal/components/search/FindAndSearchDropdown.tsx
+++ b/packages/components/src/internal/components/search/FindAndSearchDropdown.tsx
@@ -15,11 +15,11 @@ import { SAMPLE_FILTER_METRIC_AREA } from './utils';
 
 interface Props {
     api?: ComponentsAPIWrapper;
-    title: ReactNode;
-    findNounPlural?: string;
-    onSearch?: (form: any) => void;
-    onFindByIds?: (sessionKey: string) => void;
     className?: string;
+    findNounPlural?: string;
+    onFindByIds?: (sessionKey: string) => void;
+    onSearch?: (form: any) => void;
+    title: ReactNode;
 }
 
 export const FindAndSearchDropdown: FC<Props> = memo(props => {

--- a/packages/components/src/internal/components/search/FindAndSearchDropdown.tsx
+++ b/packages/components/src/internal/components/search/FindAndSearchDropdown.tsx
@@ -3,7 +3,7 @@ import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { capitalizeFirstChar } from '../../util/utils';
 
-import { getCurrentAppProperties, getPrimaryAppProperties, isSampleFinderEnabled } from '../../app/utils';
+import { getCurrentAppProperties, getPrimaryAppProperties } from '../../app/utils';
 import { SAMPLE_ID_FIND_FIELD, UNIQUE_ID_FIND_FIELD } from '../samples/constants';
 import { FindField } from '../samples/models';
 import { createProductUrl } from '../../url/AppURL';
@@ -72,21 +72,19 @@ export const FindAndSearchDropdown: FC<Props> = memo(props => {
                         </MenuItem>
                     </>
                 )}
-                {isSampleFinderEnabled() && (
-                    <MenuItem
-                        key="sampleFinder"
-                        onClick={onSampleFinder}
-                        href={
-                            createProductUrl(
-                                getPrimaryAppProperties()?.productId,
-                                getCurrentAppProperties()?.productId,
-                                FIND_SAMPLES_BY_FILTER_HREF.toHref()
-                            ) as string
-                        }
-                    >
-                        <i className="fa fa-sitemap" /> Sample Finder
-                    </MenuItem>
-                )}
+                <MenuItem
+                    key="sampleFinder"
+                    onClick={onSampleFinder}
+                    href={
+                        createProductUrl(
+                            getPrimaryAppProperties()?.productId,
+                            getCurrentAppProperties()?.productId,
+                            FIND_SAMPLES_BY_FILTER_HREF.toHref()
+                        ) as string
+                    }
+                >
+                    <i className="fa fa-sitemap" /> Sample Finder
+                </MenuItem>
                 {!!onSearch && (
                     <MenuItem key="search" onClick={onSearch}>
                         <i className="fa fa-search" /> Search


### PR DESCRIPTION
#### Rationale
We are removing the experimental flag to make Sample Finder available in Biologics.. Since there will be no need to conditionalize Sample Finder, this PR removes that code including those related tests.

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/1495
