### PR TITLE
Issue 46148: LKSM: Add multitabbed grid view to Stored Items table

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.211.1-fb-issue46148.1",
+  "version": "2.211.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.211.0",
+  "version": "2.211.1-fb-issue46148.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X August 2022
+* Issue 46148: LKSM: Add multitabbed grid view to Stored Items table
+  * Allow TabbedGridPanel excel handler to be used by getGridPanelDisplay
+
 ### version 2.211.0
 *Relased*: 24 August 2022
 * LKSM Starter edition

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,9 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.X
-*Released*: X August 2022
-* Issue 46148: LKSM: Add multitabbed grid view to Stored Items table
+### version 2.211.1
+*Released*: 25 August 2022
+* Issue 46148: Add multitabbed grid view to Stored Items table
   * Allow TabbedGridPanel excel handler to be used by getGridPanelDisplay
 
 ### version 2.211.0

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -82,7 +82,7 @@ export interface TabbedGridPanelProps<T = {}> extends GridPanelProps<T> {
      * return the custom GridPanel for an active tab
      * @param activeGridId
      */
-    getGridPanelDisplay?: (activeGridId: string) => React.ReactNode;
+    getGridPanelDisplay?: (activeGridId: string, exportHandlers: { [key: string]: (modelId?: string) => any }) => React.ReactNode;
     /**
      * return the showViewMenu value for an active tab
      * @param activeGridId
@@ -217,7 +217,7 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
     const panelTitle = rest.title;
     if (asPanel && hasTabs) delete rest.title;
 
-    const gridDisplay = getGridPanelDisplay?.(activeId) ?? (
+    const gridDisplay = getGridPanelDisplay?.(activeId, exportHandlers) ?? (
         <GridPanel
             allowViewCustomization={allowViewCustomization}
             key={activeId}

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -82,7 +82,10 @@ export interface TabbedGridPanelProps<T = {}> extends GridPanelProps<T> {
      * return the custom GridPanel for an active tab
      * @param activeGridId
      */
-    getGridPanelDisplay?: (activeGridId: string, exportHandlers: { [key: string]: (modelId?: string) => any }) => React.ReactNode;
+    getGridPanelDisplay?: (
+        activeGridId: string,
+        exportHandlers: { [key: string]: (modelId?: string) => any }
+    ) => React.ReactNode;
     /**
      * return the showViewMenu value for an active tab
      * @param activeGridId


### PR DESCRIPTION
#### Rationale
This PR adds sample type tabs to the stored items grid.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/524

#### Changes
* Allow TabbedGridPanel excel handler to be used by getGridPanelDisplay so "All Samples" tab with custom rendering can export all tabs
