### PR TITLE
Issue 45857: Table/grid left column locking styling

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.211.2",
+  "version": "2.211.2-fb-tableLeftColLock.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.211.2-fb-tableLeftColLock.0",
+  "version": "2.211.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 45857: Improve styling for left column locking in app grids (experimental feature)
+
 ### version 2.211.2
 *Released*: 25 August 2022
 * Misc grid menu and button fixes for 22.9

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.211.3
+*Released*: 26 August 2022
 * Issue 45857: Improve styling for left column locking in app grids (experimental feature)
 
 ### version 2.211.2

--- a/packages/components/src/internal/components/__snapshots__/PreviewGrid.spec.tsx.snap
+++ b/packages/components/src/internal/components/__snapshots__/PreviewGrid.spec.tsx.snap
@@ -116,7 +116,7 @@ null"
       </thead>
       <tbody>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -162,7 +162,7 @@ null"
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row"
         >
           <td
             style={
@@ -208,7 +208,7 @@ null"
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -321,7 +321,7 @@ null"
       </thead>
       <tbody>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -345,7 +345,7 @@ null"
           />
         </tr>
         <tr
-          className=""
+          className="grid-row"
         >
           <td
             style={

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -272,7 +272,14 @@ class GridBody extends PureComponent<GridBodyProps> {
         // style cast to "any" type due to @types/react@16.3.14 switch to csstype package usage which does not declare
         // "textAlign" property correctly for <td> elements.
         return (
-            <tr key={key} className={classNames({ 'grid-row-highlight': highlight })}>
+            <tr
+                key={key}
+                className={classNames({
+                    'grid-row-highlight': highlight,
+                    'grid-row-alternate': r % 2 === 0,
+                    'grid-row': r % 2 === 1,
+                })}
+            >
                 {columns.map((column: GridColumn, c: number) =>
                     column.tableCell ? (
                         column.cell(row.get(column.index), row, column, r, c)

--- a/packages/components/src/internal/components/base/__snapshots__/Grid.spec.tsx.snap
+++ b/packages/components/src/internal/components/base/__snapshots__/Grid.spec.tsx.snap
@@ -88,7 +88,7 @@ exports[`Grid component hide tooltip 1`] = `
     </thead>
     <tbody>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -126,7 +126,7 @@ exports[`Grid component hide tooltip 1`] = `
         />
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -164,7 +164,7 @@ exports[`Grid component hide tooltip 1`] = `
         />
       </tr>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -202,7 +202,7 @@ exports[`Grid component hide tooltip 1`] = `
         />
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -403,7 +403,7 @@ exports[`Grid component render with messages 1`] = `
     </thead>
     <tbody>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -434,7 +434,7 @@ exports[`Grid component render with messages 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -465,7 +465,7 @@ exports[`Grid component render with messages 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -496,7 +496,7 @@ exports[`Grid component render with messages 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -601,7 +601,7 @@ exports[`Grid component render with non-default properties 1`] = `
     </thead>
     <tbody>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -632,7 +632,7 @@ exports[`Grid component render with non-default properties 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -663,7 +663,7 @@ exports[`Grid component render with non-default properties 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -694,7 +694,7 @@ exports[`Grid component render with non-default properties 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -799,7 +799,7 @@ exports[`Grid component rendering with data 1`] = `
     </thead>
     <tbody>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -830,7 +830,7 @@ exports[`Grid component rendering with data 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -861,7 +861,7 @@ exports[`Grid component rendering with data 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -892,7 +892,7 @@ exports[`Grid component rendering with data 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -997,7 +997,7 @@ exports[`Grid component rendering with data and columns 1`] = `
     </thead>
     <tbody>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -1028,7 +1028,7 @@ exports[`Grid component rendering with data and columns 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -1059,7 +1059,7 @@ exports[`Grid component rendering with data and columns 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -1090,7 +1090,7 @@ exports[`Grid component rendering with data and columns 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -1354,7 +1354,7 @@ exports[`Grid component with phi data 1`] = `
     </thead>
     <tbody>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -1413,7 +1413,7 @@ exports[`Grid component with phi data 1`] = `
         />
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={
@@ -1472,7 +1472,7 @@ exports[`Grid component with phi data 1`] = `
         />
       </tr>
       <tr
-        className=""
+        className="grid-row-alternate"
       >
         <td
           style={
@@ -1531,7 +1531,7 @@ exports[`Grid component with phi data 1`] = `
         />
       </tr>
       <tr
-        className=""
+        className="grid-row"
       >
         <td
           style={

--- a/packages/components/src/internal/components/files/__snapshots__/FilePreviewGrid.spec.tsx.snap
+++ b/packages/components/src/internal/components/files/__snapshots__/FilePreviewGrid.spec.tsx.snap
@@ -87,7 +87,7 @@ Array [
       </thead>
       <tbody>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -118,7 +118,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row"
         >
           <td
             style={
@@ -149,7 +149,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -273,7 +273,7 @@ Array [
       </thead>
       <tbody>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -304,7 +304,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row"
         >
           <td
             style={
@@ -335,7 +335,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -486,7 +486,7 @@ Array [
       </thead>
       <tbody>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -591,7 +591,7 @@ Array [
       </thead>
       <tbody>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -622,7 +622,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row"
         >
           <td
             style={
@@ -653,7 +653,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -782,7 +782,7 @@ Array [
       </thead>
       <tbody>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={
@@ -813,7 +813,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row"
         >
           <td
             style={
@@ -844,7 +844,7 @@ Array [
           </td>
         </tr>
         <tr
-          className=""
+          className="grid-row-alternate"
         >
           <td
             style={

--- a/packages/components/src/internal/components/lineage/grid/__snapshots__/LineageGrid.spec.tsx.snap
+++ b/packages/components/src/internal/components/lineage/grid/__snapshots__/LineageGrid.spec.tsx.snap
@@ -408,7 +408,7 @@ exports[`<LineageGrid/> with data 1`] = `
           </thead>
           <tbody>
             <tr
-              className=""
+              className="grid-row-alternate"
             >
               <td
                 style={
@@ -526,7 +526,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row"
             >
               <td
                 style={
@@ -651,7 +651,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row-alternate"
             >
               <td
                 style={
@@ -774,7 +774,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row"
             >
               <td
                 style={
@@ -897,7 +897,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row-alternate"
             >
               <td
                 style={
@@ -1020,7 +1020,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row"
             >
               <td
                 style={
@@ -1143,7 +1143,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row-alternate"
             >
               <td
                 style={
@@ -1266,7 +1266,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row"
             >
               <td
                 style={
@@ -1389,7 +1389,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row-alternate"
             >
               <td
                 style={
@@ -1512,7 +1512,7 @@ exports[`<LineageGrid/> with data 1`] = `
               />
             </tr>
             <tr
-              className=""
+              className="grid-row"
             >
               <td
                 style={

--- a/packages/components/src/internal/components/timeline/__snapshots__/SampleTimelinePageBase.spec.tsx.snap
+++ b/packages/components/src/internal/components/timeline/__snapshots__/SampleTimelinePageBase.spec.tsx.snap
@@ -845,7 +845,7 @@ exports[`<SampleTimelinePageBase/> With selected assay re-import event 1`] = `
             />
             <tbody>
               <tr
-                className=""
+                className="grid-row-alternate"
               >
                 <td
                   style={
@@ -871,7 +871,7 @@ exports[`<SampleTimelinePageBase/> With selected assay re-import event 1`] = `
                 </td>
               </tr>
               <tr
-                className=""
+                className="grid-row"
               >
                 <td
                   style={
@@ -897,7 +897,7 @@ exports[`<SampleTimelinePageBase/> With selected assay re-import event 1`] = `
                 </td>
               </tr>
               <tr
-                className=""
+                className="grid-row-alternate"
               >
                 <td
                   style={
@@ -923,7 +923,7 @@ exports[`<SampleTimelinePageBase/> With selected assay re-import event 1`] = `
                 </td>
               </tr>
               <tr
-                className=""
+                className="grid-row"
               >
                 <td
                   style={
@@ -1810,7 +1810,7 @@ exports[`<SampleTimelinePageBase/> With selected job 1`] = `
             />
             <tbody>
               <tr
-                className=""
+                className="grid-row-alternate"
               >
                 <td
                   style={
@@ -1836,7 +1836,7 @@ exports[`<SampleTimelinePageBase/> With selected job 1`] = `
                 </td>
               </tr>
               <tr
-                className=""
+                className="grid-row"
               >
                 <td
                   style={
@@ -1862,7 +1862,7 @@ exports[`<SampleTimelinePageBase/> With selected job 1`] = `
                 </td>
               </tr>
               <tr
-                className=""
+                className="grid-row-alternate"
               >
                 <td
                   style={

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -6,8 +6,14 @@
   text-align: left;
 }
 
-.table-striped > tbody > tr.grid-row-highlight {
-  background-color: $yellow-shadow;
+.table-striped > tbody > tr.grid-row td {
+    background-color: $white;
+}
+.table-striped > tbody > tr.grid-row-alternate td {
+    background-color: $table-bg-accent;
+}
+.table-striped > tbody > tr.grid-row-highlight td {
+  background-color: $grid-action-item-hover-bg;
 }
 
 .panel.fixed-panel {

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -184,12 +184,10 @@
 
         th {
             background-color: $white;
-        }
-    }
 
-    /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
-    table thead th {
-        background-clip: padding-box
+            /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
+            background-clip: padding-box;
+        }
     }
 }
 
@@ -199,6 +197,9 @@
         position: sticky;
         left: -1px;
         z-index: 1;
+
+        /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
+        background-clip: padding-box;
     }
 }
 .grid-panel__grid.grid-panel__lock-left-with-checkboxes .table-responsive {
@@ -206,19 +207,8 @@
         position: sticky;
         left: 22px;
         z-index: 1;
-    }
-    thead th:nth-child(1), thead th:nth-child(2) {
-        background-color: $white;
-    }
-    tr td:nth-child(1), tr td:nth-child(2) {
-        background-color: $table-bg-accent;
-    }
-}
-.grid-panel__grid.grid-panel__lock-left-without-checkboxes .table-responsive {
-    thead th:nth-child(1) {
-        background-color: $white;
-    }
-    tr td:nth-child(1) {
-        background-color: $table-bg-accent;
+
+        /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
+        background-clip: padding-box;
     }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.2.4-fb-tableLeftColLock.0",
+  "version": "1.2.4-fb-tableLeftColLock.1",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.2.4-fb-tableLeftColLock.1",
+  "version": "1.3.0",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.2.4",
+  "version": "1.2.4-fb-tableLeftColLock.0",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/releaseNotes/themes.md
+++ b/packages/themes/releaseNotes/themes.md
@@ -1,8 +1,8 @@
 # @labkey/themes
 UI themes for LabKey Server.
 
-### version TBD
-*Released*: TBD
+### version 1.3.0
+*Released*: 26 August 2022
 * Issue 45857: Add left column locking to misc LKS HTML tables
 
 ### version 1.2.4

--- a/packages/themes/releaseNotes/themes.md
+++ b/packages/themes/releaseNotes/themes.md
@@ -1,6 +1,10 @@
 # @labkey/themes
 UI themes for LabKey Server.
 
+### version TBD
+*Released*: TBD
+* Issue 45857: Add left column locking to misc LKS HTML tables
+
 ### version 1.2.4
 *Released*: 19 July 2022
 * Issue 45857: Add header locking to misc LKS HTML tables

--- a/packages/themes/styles/scss/labkey/components/_dataRegion.scss
+++ b/packages/themes/styles/scss/labkey/components/_dataRegion.scss
@@ -408,12 +408,23 @@ td.labkey-blank-cell, th.labkey-blank-cell {
 }
 
 /*
-    This is for HTML tables that have a header row as the first tr child to lock the header at the
-    top of the browser window on vertical scroll for tall tables.
+    For tall HTML tables that have a header row as the first tr child, lock the header at the
+    top of the browser window on vertical scroll.
 */
 table.labkey-data-region-header-lock tr:first-child {
     position: sticky;
     top: -1px;
+    z-index: 2;
+}
+/*
+    For wide HTML tables, lock the left most column at the left side of the screen on horizontal scroll.
+*/
+table.labkey-data-region-column-lock thead th:nth-child(1),
+table.labkey-data-region-column-lock tr th:nth-child(1),
+table.labkey-data-region-column-lock tr td:nth-child(1) {
+    position: sticky;
+    left: -1px;
+    z-index: 1;
 }
 
 .unselectable {

--- a/packages/themes/styles/scss/labkey/components/_dataRegion.scss
+++ b/packages/themes/styles/scss/labkey/components/_dataRegion.scss
@@ -411,10 +411,16 @@ td.labkey-blank-cell, th.labkey-blank-cell {
     For tall HTML tables that have a header row as the first tr child, lock the header at the
     top of the browser window on vertical scroll.
 */
+table.labkey-data-region-header-lock thead,
 table.labkey-data-region-header-lock tr:first-child {
     position: sticky;
     top: -1px;
     z-index: 2;
+}
+table.labkey-data-region-header-lock thead th,
+table.labkey-data-region-header-lock tr:first-child th {
+    /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
+    background-clip: padding-box;
 }
 /*
     For wide HTML tables, lock the left most column at the left side of the screen on horizontal scroll.
@@ -425,6 +431,9 @@ table.labkey-data-region-column-lock tr td:nth-child(1) {
     position: sticky;
     left: -1px;
     z-index: 1;
+
+    /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
+    background-clip: padding-box;
 }
 
 .unselectable {


### PR DESCRIPTION
#### Rationale
[https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45857](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45857)

This PR adds styling for both LKS and app grids/tables to allow for left column locking on horizontal scroll. Note that for the apps, this is still an experimental feature and for the LKS tables, it needs to be applied on a per table bases using the CSS class names.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/943
* https://github.com/LabKey/platform/pull/3641
* https://github.com/LabKey/inventory/pull/530
* https://github.com/LabKey/sampleManagement/pull/1180
* https://github.com/LabKey/biologics/pull/1537

#### Changes
* components package SCSS updates for improving styling for left column locking in app grids (experimental feature)
* themes package CSS for adding left column locking to misc LKS HTML tables
