### PR TITLE
Remove redundant GET parameters from handleEntityFileImport util

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.211.3",
+  "version": "2.211.4-fb-springs5Upgrade.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.211.4-fb-springs5Upgrade.1",
+  "version": "2.211.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.211.2",
+  "version": "2.211.3-fb-spring5Upgrade.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.211.1
+*Released*: 25 August 2022
+* upgrade Spring from 4.x to 5.x
+    * Remove redundant GET parameters from handleEntityFileImport util
+
 ### version 2.211.2
 *Released*: 25 August 2022
 * Misc grid menu and button fixes for 22.9

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -519,8 +519,6 @@ export function handleEntityFileImport(
             file,
             importUrl: ActionURL.buildURL(importFileController ?? 'experiment', importAction, null, {
                 ...importParameters,
-                schemaName: schemaQuery.getSchema(),
-                'query.queryName': schemaQuery.getQuery(),
             }),
             importLookupByAlternateKey: true,
             useAsync,

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1,21 +1,8 @@
 import { ActionURL, Ajax, Filter, Query, Utils } from '@labkey/api';
 import { fromJS, List, Map } from 'immutable';
 
-
 import { getSelectedItemSamples } from '../samples/actions';
 
-import {
-    DisplayObject,
-    EntityDataType,
-    EntityIdCreationModel,
-    EntityParentType,
-    EntityTypeOption,
-    IEntityTypeOption,
-    IParentOption,
-    OperationConfirmationData,
-} from './models';
-import { DataClassDataType, DataOperation, SampleTypeDataType } from './constants';
-import { isDataClassEntity, isSampleEntity } from './utils';
 import { buildURL } from '../../url/AppURL';
 import { SampleOperation } from '../samples/constants';
 import { SchemaQuery } from '../../../public/SchemaQuery';
@@ -27,6 +14,19 @@ import { getSelected } from '../../actions';
 import { SHARED_CONTAINER_PATH } from '../../constants';
 import { naturalSort } from '../../../public/sort';
 import { QueryInfo } from '../../../public/QueryInfo';
+
+import { isDataClassEntity, isSampleEntity } from './utils';
+import { DataClassDataType, DataOperation, SampleTypeDataType } from './constants';
+import {
+    DisplayObject,
+    EntityDataType,
+    EntityIdCreationModel,
+    EntityParentType,
+    EntityTypeOption,
+    IEntityTypeOption,
+    IParentOption,
+    OperationConfirmationData,
+} from './models';
 
 export function getOperationConfirmationData(
     selectionKey: string,
@@ -80,9 +80,16 @@ export function getDeleteConfirmationData(
     if (isSampleEntity(dataType)) {
         return getSampleOperationConfirmationData(SampleOperation.Delete, selectionKey, rowIds);
     }
-    return getOperationConfirmationData(selectionKey, dataType, rowIds, isDataClassEntity(dataType) ? {
-        dataOperation: DataOperation.Delete
-    } : undefined);
+    return getOperationConfirmationData(
+        selectionKey,
+        dataType,
+        rowIds,
+        isDataClassEntity(dataType)
+            ? {
+                  dataOperation: DataOperation.Delete,
+              }
+            : undefined
+    );
 }
 
 export function getSampleOperationConfirmationData(


### PR DESCRIPTION
#### Rationale
handleEntityFileImport util contains a few redundant parameters that's causing problems for SPRING 5. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
