### PR TITLE
Remove experimental feature flag for App grid lock left col on horizontal scroll

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.212.0",
+  "version": "2.212.0-fb-removeExpFeatureGridLockLeft.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.212.3",
+  "version": "2.212.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Remove experimental feature flag for App grid lock left col on horizontal scroll
+
 ### version 2.212.0
 *Released*: 30 August 2022
 * Remove circular dependencies

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.212.4
+*Released*: 31 August 2022
 * Remove experimental feature flag for App grid lock left col on horizontal scroll
 
 ### version 2.212.3

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -89,7 +89,6 @@ export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';
 export const EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR = 'experimental-sample-aliquot-selector';
-export const EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN = 'experimental-grid-lock-left-column';
 
 // The enum values here should align with the ProductFeature.java enum values (some not currently used but included for completeness)
 export enum ProductFeature {

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -6,8 +6,9 @@ import { AppURL } from '../url/AppURL';
 
 import { imageURL } from '../url/ActionURL';
 
-import { AppProperties } from './models';
 import { SAMPLE_MANAGER_SEARCH_PLACEHOLDER, SEARCH_PLACEHOLDER } from '../components/navigation/constants';
+
+import { AppProperties } from './models';
 
 // These ids should match what is used by the MenuProviders in the Java code so we can avoid toLowerCase comparisons.
 export const LKS_PRODUCT_ID = 'LabKeyServer';
@@ -127,4 +128,3 @@ export const FREEZER_MANAGER_APP_PROPERTIES: AppProperties = {
     controllerName: FREEZER_MANAGER_CONTROLLER_NAME,
     moduleName: 'inventory',
 };
-

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -19,7 +19,6 @@ import { AppProperties } from './models';
 import {
     ASSAYS_KEY,
     BIOLOGICS_APP_PROPERTIES,
-    EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN,
     EXPERIMENTAL_REQUESTS_MENU,
     EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR,
     ProductFeature,
@@ -233,13 +232,6 @@ export function isSampleAliquotSelectorEnabled(moduleContext?: any): boolean {
         (moduleContext ?? getServerContext().moduleContext)?.samplemanagement?.[
             EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR
         ] === true
-    );
-}
-
-export function isGridLockLeftColumnEnabled(moduleContext?: any): boolean {
-    return (
-        (moduleContext ?? getServerContext().moduleContext)?.samplemanagement?.[EXPERIMENTAL_GRID_LOCK_LEFT_COLUMN] ===
-        true
     );
 }
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -220,7 +220,10 @@ export function isAssayEnabled(moduleContext?: any): boolean {
 }
 
 export function isWorkflowEnabled(moduleContext?: any): boolean {
-    return hasModule(SAMPLE_MANAGER_APP_PROPERTIES.moduleName, moduleContext) && isFeatureEnabled(ProductFeature.Workflow, moduleContext);
+    return (
+        hasModule(SAMPLE_MANAGER_APP_PROPERTIES.moduleName, moduleContext) &&
+        isFeatureEnabled(ProductFeature.Workflow, moduleContext)
+    );
 }
 
 export function isFeatureEnabled(flag: ProductFeature, moduleContext?: any): boolean {

--- a/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -6489,7 +6489,7 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                   </Memo()>
                 </div>
                 <div
-                  className="grid-panel__grid"
+                  className="grid-panel__grid  grid-panel__lock-left grid-panel__lock-left-without-checkboxes"
                 />
               </div>
             </div>

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -20,8 +20,6 @@ import {
 
 import { hasServerContext, useServerContext } from '../../internal/components/base/ServerContext';
 
-import { isGridLockLeftColumnEnabled } from '../../internal/app/utils';
-
 import { Pagination } from '../../internal/components/pagination/Pagination';
 
 import { ViewInfo } from '../../internal/ViewInfo';
@@ -1082,7 +1080,6 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         let loadingMessage;
         const gridIsLoading = !hasGridError && isLoading;
         const selectionsAreLoading = !hasError && allowSelections && isLoadingSelections;
-        const lockLeftCol = isGridLockLeftColumnEnabled();
 
         if (gridIsLoading) {
             loadingMessage = 'Loading data...';
@@ -1146,10 +1143,9 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                         )}
 
                         <div
-                            className={classNames('grid-panel__grid', {
-                                'grid-panel__lock-left': lockLeftCol,
-                                'grid-panel__lock-left-with-checkboxes': lockLeftCol && allowSelections,
-                                'grid-panel__lock-left-without-checkboxes': lockLeftCol && !allowSelections,
+                            className={classNames('grid-panel__grid ', 'grid-panel__lock-left', {
+                                'grid-panel__lock-left-with-checkboxes': allowSelections,
+                                'grid-panel__lock-left-without-checkboxes': !allowSelections,
                             })}
                         >
                             {hasError && <Alert>{errorMsg || queryInfoError || rowsError || selectionsError}</Alert>}


### PR DESCRIPTION
#### Rationale
With the recent changes to the grid styling related to the app grids handling of the locked left columns on horizontal scroll, we are now ready to remove the experimental feature flag and turn it on for all app grids.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/950
* https://github.com/LabKey/sampleManagement/pull/1190
* https://github.com/LabKey/inventory/pull/535
* https://github.com/LabKey/biologics/pull/1549

#### Changes
* remove experimental feature flag check in GridPanel
