### PR TITLE
Assure assay domain designer functionality is available in community edition

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.213.2-communityAssay.0",
+  "version": "2.213.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.213.1",
+  "version": "2.213.2-communityAssay.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.213.2
+*Released*: 6 September 2022
 * Make sure assay functionality is enabled in community edition
 
 ### version 2.213.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,9 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Make sure assay functionality is enabled in community edition
+
 ### version 2.213.1
 *Released*: 1 September 2022
-* Issue 4457: Editable grid Bulk Insert and Bulk Update error with lookup to sample table with String key
+* Issue 44457: Editable grid Bulk Insert and Bulk Update error with lookup to sample table with String key
   * fix in actions.ts to only call parseInt on val if !isNaN
 
 ### version 2.213.0

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -398,21 +398,42 @@ describe('utils', () => {
                 productFeatures: [],
             },
         };
-        expect(isAssayEnabled()).toBe(false);
+        expect(isAssayEnabled()).toBe(true); // LK Community
         LABKEY.moduleContext = {
             api: { moduleNames: [] },
             core: {
                 productFeatures: [ProductFeature.Assay],
             },
         };
-        expect(isAssayEnabled()).toBe(false);
+        expect(isAssayEnabled()).toBe(false); // no assay module
         LABKEY.moduleContext = {
             api: { moduleNames: ['assay'] },
             core: {
                 productFeatures: [ProductFeature.Assay],
             },
         };
-        expect(isAssayEnabled()).toBe(true);
+        expect(isAssayEnabled()).toBe(true); // assay module with assay feature
+        LABKEY.moduleContext = {
+            api: { moduleNames: ['assay', 'sampleManagement'] },
+            core: {
+                productFeatures: [ProductFeature.Assay],
+            },
+        };
+        expect(isAssayEnabled()).toBe(true); // LKSM Starter
+        LABKEY.moduleContext = {
+            api: { moduleNames: ['assay', 'sampleManagement', 'premium'] },
+            core: {
+                productFeatures: [ProductFeature.Assay],
+            },
+        };
+        expect(isAssayEnabled()).toBe(true); // LKS Starter
+        LABKEY.moduleContext = {
+            api: { moduleNames: ['assay', 'sampleManagement', 'premium', 'professional', 'labbook'] },
+            core: {
+                productFeatures: [ProductFeature.Assay],
+            },
+        };
+        expect(isAssayEnabled()).toBe(true); // LKS Professional
     });
 
     test('isWorkflowEnabled', () => {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -216,7 +216,7 @@ export function isRequestsEnabled(moduleContext?: any): boolean {
 }
 
 export function isAssayEnabled(moduleContext?: any): boolean {
-    return hasModule('assay', moduleContext) && isFeatureEnabled(ProductFeature.Assay, moduleContext);
+    return hasModule('assay', moduleContext) && (isCommunityDistribution() || isFeatureEnabled(ProductFeature.Assay, moduleContext));
 }
 
 export function isWorkflowEnabled(moduleContext?: any): boolean {


### PR DESCRIPTION
#### Rationale
The changes to implement our product tiering didn't account for the use of the assay designer in our community edition. For the time being, at least, I've added a specific check for community edition in the `isAssayEnabled` method. It could be that we'll register a feature set for LKS and/or LKS Starter, but that's more of a change than I want for this fix (and it's not clear we'd get away from special logic here anyway since assay gets removed from LKSM Starter).

#### Related Pull Requests
* #936 

#### Changes
* Check for community edition deployment to enable assay functionality.
