### PR TITLE
46225: Error when editing alias in Samples

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.213.3",
+  "version": "2.213.3-229-fb-prevent-46225.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.213.3-229-fb-prevent-46225.0",
+  "version": "2.213.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.213.4
+*Released*: 8 September 2022
+* Add defensive type-check when calling `trim()` for form value processing.
+
 ### version 2.213.3
 *Released*: 6 September 2022
 * QuerySelect: Allow optionRenderer prop to be passed

--- a/packages/components/src/internal/components/forms/detail/utils.spec.ts
+++ b/packages/components/src/internal/components/forms/detail/utils.spec.ts
@@ -55,6 +55,7 @@ describe('extractChanges', () => {
         expect(extractChanges(QUERY_INFO, currentData, { strInput: undefined }).strInput).toBe(null);
         expect(extractChanges(QUERY_INFO, currentData, { strInput: null }).strInput).toBe(null);
         expect(extractChanges(QUERY_INFO, currentData, { strInput: '' }).strInput).toBe('');
+        expect(extractChanges(QUERY_INFO, currentData, { strInput: [] }).strInput).toStrictEqual([]);
         expect(extractChanges(QUERY_INFO, currentData, { strInput: 'abc' }).strInput).toBe(undefined);
         expect(extractChanges(QUERY_INFO, currentData, { strInput: ' abc ' }).strInput).toBe(undefined);
         expect(extractChanges(QUERY_INFO, currentData, { strInput: ' abcd ' }).strInput).toBe('abcd');

--- a/packages/components/src/internal/components/forms/detail/utils.ts
+++ b/packages/components/src/internal/components/forms/detail/utils.ts
@@ -81,7 +81,9 @@ export function extractChanges(
                     return false;
                 }
             } else if (column?.jsonType === 'string') {
-                newValue = newValue?.trim();
+                if (Utils.isString(newValue)) {
+                    newValue = newValue.trim();
+                }
                 if (existingValue === newValue) {
                     return false;
                 }


### PR DESCRIPTION
#### Rationale
I'm unable to reproduce the exact scenario that is described in Issue 46255, however, the underlying error can be defensively checked against by ensuring that `.trim()` is only called on strings.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/956
* https://github.com/LabKey/biologics/pull/1575
* https://github.com/LabKey/sampleManagement/pull/1205

#### Changes
* Add defensive check when calling `trim()` for form value processing.
* Add non-string type check regression test.
