### PR TITLE
TabbedGridPanel fix to not assume that component is wrapped in NotificationsContextProvider

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.218.1",
+  "version": "2.218.1-fb-modStartLinkFixin.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.218.1-fb-modStartLinkFixin.0",
+  "version": "2.218.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD September 2022
+* TabbedGridPanel fix to not assume that component is wrapped in NotificationsContextProvider
+
 ### version 2.218.1
 *Released*: 16 September 2022
 * Issue 46256: Custom view handling of slash in fieldKey

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD September 2022
+### version 2.218.2
+*Released*: 20 September 2022
 * TabbedGridPanel fix to not assume that component is wrapped in NotificationsContextProvider
 
 ### version 2.218.1


### PR DESCRIPTION
#### Rationale
See related PRs for rationale. This PR is a small fix for the TabbedGridPanel so that it does not assume that the component is wrapped in the NotificationsContextProvider.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/960
* https://github.com/LabKey/tutorialModules/pull/100
* https://github.com/LabKey/moduleEditor/pull/72
* https://github.com/LabKey/commonAssays/pull/516
* https://github.com/LabKey/provenance/pull/124
* https://github.com/LabKey/puppeteer/pull/44
* https://github.com/LabKey/platform/pull/3688
* https://github.com/LabKey/ontology/pull/101

#### Changes
* wrap usage of useNotificationsContext() in try/catch and add null check to createNotification() call
