### PR TITLE
Module loader exclude path for Windows

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.2.0",
+  "version": "6.2.0-fb-windows-exclude-path.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.2.0-fb-windows-exclude-path.0",
+  "version": "6.2.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,11 @@
 # @labkey/build
 
+### version 6.2.1
+*Released*: 23 September 2022
+* Update typescript_dev module loader rule regex to match Windows and Unix path operators.
+
 ### version 6.2.0
-*Released*: ?? September 2022
+*Released*: 14 September 2022
 * Build packages as ES Modules
 * Add babel.config.js for jest tests
   * Needed for any package or app that consumes our packages, see the note in the file for more info.

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -240,7 +240,7 @@ module.exports = {
                 // For some reason the dev build needs to explicitly not exclude our packages so they get transpiled
                 // by Babel. For unknown reasons this is not needed for the prod build.
                 test: /^(?!.*spec\.tsx?$).*\.(js|ts|tsx)?$/,
-                exclude: /node_modules\/(?!(@labkey)\/).*/,
+                exclude: /node_modules[\\\/](?!(.labkey)[\\\/]).*/,
                 use: [BABEL_CONFIG]
             }
         ],


### PR DESCRIPTION
#### Rationale
Update typescript_dev module loader rule regex to match Windows and Unix path operators.

#### Changes
* Regex update
