### PR TITLE
WebDav helper for creating directories: createWebDavDirectory()

### DIFF
--- a/packages/components/docs/webdav.md
+++ b/packages/components/docs/webdav.md
@@ -1,18 +1,18 @@
 # Webdav API
 
-Below example walks you through how you can utilize LabKey's WebDAV API in your React development to get already uploaded
-files from the server, and to upload new files to the server.
+The examples below walk you through how you can utilize LabKey's WebDAV API in your React development to get already uploaded
+files from the server, create new directories on the server, and upload new files to the server.
 
-Additionally, FileAttachmentForm component allows users to select files to be uploaded via file
+Additionally, the `FileAttachmentForm` component allows users to select files to be uploaded via file
 selection or drag & drop - example to render FileAttachmentForm component [here](./fileAttachment.md).
 
 ## [WebDav](../src/public/files/WebDav.ts#L69)
 ```ts
-import { getWebDavFiles, WebDavFile, uploadWebDavFile } from '@labkey/components';
+import { getWebDavFiles, WebDavFile, uploadWebDavFile, createWebDavDirectory } from '@labkey/components';
 
 const ATTACHMENTS_DIR = 'MyUploads';
 
-export class AttachmentModel {
+class AttachmentModel {
     [immerable] = true;
 
     readonly savedFiles: string[]; // to get uploaded file names from the server
@@ -24,7 +24,7 @@ export class AttachmentModel {
 }
 
 // Action to get file(s)
-export function getFiles(container: string, directory?: string, includeSubdirectories?: boolean): Promise<AttachmentModel> {
+function getFiles(container: string, directory?: string, includeSubdirectories?: boolean): Promise<AttachmentModel> {
     return new Promise(async (resolve, reject) => {
         try {
             const webDavFilesResponse = await getWebDavFiles(container, directory, includeSubdirectories);
@@ -67,6 +67,20 @@ function uploadFiles(model: AttachmentModel): any {
                     });
             }
         }, this);
+    });
+}
+
+// Action to create a new directory on the server
+function createDir(directory: string): any {
+    return new Promise((resolve, reject) => {
+        // the 3rd param of true indicates that intermidiate directories should also be created
+        createWebDavDirectory(ActionURL.getContainer(), directory, true)
+            .then((name: string) => {
+                resolve(name);
+            })
+            .catch(reason => {
+                reject(reason);
+            });;
     });
 }
 ```

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.221.0",
+  "version": "2.222.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.220.0",
+  "version": "2.220.0-fb-webDavCreateDir46185.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.222.0
+*Released*: 27 September 2022
 * WebDav helper for creating directories: createWebDavDirectory()
 
 ### version 2.221.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* WebDav helper for creating directories: createWebDavDirectory()
+
 ### version 2.220.0
 *Released*: 26 September 2022
 * Introduce `GlobalStateContext` which is an extensible context made available to all of our applications.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -228,9 +228,7 @@ import {
     EditableGridPanelForUpdateWithLineage,
     UpdateGridTab,
 } from './internal/components/editable/EditableGridPanelForUpdateWithLineage';
-import {
-    LineageEditableGridLoaderFromSelection
-} from './internal/components/editable/LineageEditableGridLoaderFromSelection';
+import { LineageEditableGridLoaderFromSelection } from './internal/components/editable/LineageEditableGridLoaderFromSelection';
 
 import { EditableGridLoaderFromSelection } from './internal/components/editable/EditableGridLoaderFromSelection';
 
@@ -437,9 +435,7 @@ import {
 } from './internal/components/lineage/types';
 import { LineageDepthLimitMessage, LineageGraph } from './internal/components/lineage/LineageGraph';
 import { LineageGrid, LineageGridFromLocation } from './internal/components/lineage/grid/LineageGrid';
-import {
-    EntityCrossProjectSelectionConfirmModal
-} from './internal/components/entities/EntityCrossProjectSelectionConfirmModal';
+import { EntityCrossProjectSelectionConfirmModal } from './internal/components/entities/EntityCrossProjectSelectionConfirmModal';
 import { EntityDeleteConfirmModal } from './internal/components/entities/EntityDeleteConfirmModal';
 import { EntityTypeDeleteConfirmModal } from './internal/components/entities/EntityTypeDeleteConfirmModal';
 import { SampleTypeLineageCounts } from './internal/components/lineage/SampleTypeLineageCounts';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -129,7 +129,7 @@ import { DEFAULT_FILE } from './internal/components/files/models';
 import { FilesListing } from './internal/components/files/FilesListing';
 import { FilesListingForm } from './internal/components/files/FilesListingForm';
 import { FileAttachmentEntry } from './internal/components/files/FileAttachmentEntry';
-import { getWebDavFiles, uploadWebDavFile, WebDavFile } from './public/files/WebDav';
+import { getWebDavFiles, uploadWebDavFile, createWebDavDirectory, WebDavFile } from './public/files/WebDav';
 import { FileTree } from './internal/components/files/FileTree';
 import { Notifications } from './internal/components/notifications/Notifications';
 import { getPipelineActivityData, markAllNotificationsAsRead } from './internal/components/notifications/actions';
@@ -1330,6 +1330,7 @@ export {
     WebDavFile,
     getWebDavFiles,
     uploadWebDavFile,
+    createWebDavDirectory,
     // util functions
     getDateFormat,
     getDisambiguatedSelectInputOptions,

--- a/packages/components/src/public/files/WebDav.ts
+++ b/packages/components/src/public/files/WebDav.ts
@@ -130,3 +130,27 @@ export function uploadWebDavFile(
         });
     });
 }
+
+export function createWebDavDirectory(
+    containerPath: string,
+    directory: string,
+    createIntermediates?: boolean
+): Promise<string> {
+    return new Promise((resolve, reject) => {
+        Ajax.request({
+            url: getWebDavUrl(containerPath, directory, createIntermediates),
+            method: 'MKCOL',
+            success: Utils.getCallbackWrapper(() => {
+                resolve(directory);
+            }),
+            failure: Utils.getCallbackWrapper(
+                () => {
+                    console.error('failure creating directory ' + directory);
+                    reject(directory);
+                },
+                null,
+                false
+            ),
+        });
+    });
+}


### PR DESCRIPTION
#### Rationale
In the tutorialModules/demo module, we have a React example page that uses the FileAttachmentForm component and the webdav related helper function to get and put files in the LKS filesystem via webdav. This PR adds a helper function for creating new directories in the file system.

#### Related Pull Requests
* https://github.com/LabKey/tutorialModules/pull/103

#### Changes
* add new createWebDavDirectory
* update related webdav.md docs
