### PR TITLE
Issue 45878: Remove option to not send email to new users

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.228.0",
+  "version": "2.228.1-noEmailOptOut.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.228.1-noEmailOptOut.0",
+  "version": "2.229.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "main": "dist/components.js",
   "module": "dist/components.js",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBd
+*Released*: TBD
+* Issue 45878: LKSM: Remove option to not send an email to new users
+
 ### version 2.228.0
 *Released*: 03 October 2022
 * Group Management followup

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBd
-*Released*: TBD
+### version 2.229.0
+*Released*: 4 October 2022
 * Issue 45878: LKSM: Remove option to not send an email to new users
 
 ### version 2.228.0

--- a/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
@@ -38,9 +38,6 @@ describe('<CreateUsersModal/>', () => {
         expect(wrapper.find('textarea')).toHaveLength(2);
         expect(wrapper.find('textarea#create-users-email-input').props().value).toBe('');
         expect(wrapper.find('textarea#create-users-optionalMessage-input').props().value).toBe('');
-        expect(wrapper.find('textarea#create-users-optionalMessage-input').props().disabled).toBe(false);
-        expect(wrapper.find('Checkbox')).toHaveLength(1);
-        expect(wrapper.find('Checkbox').props().checked).toBe(true);
         expect(wrapper.find('SelectInput')).toHaveLength(0);
         expect(wrapper.find('.btn')).toHaveLength(2);
         expect(wrapper.find('.btn-success')).toHaveLength(1);
@@ -59,9 +56,6 @@ describe('<CreateUsersModal/>', () => {
         expect(wrapper.find('textarea')).toHaveLength(2);
         expect(wrapper.find('textarea#create-users-email-input').props().value).toBe('');
         expect(wrapper.find('textarea#create-users-optionalMessage-input').props().value).toBe('');
-        expect(wrapper.find('textarea#create-users-optionalMessage-input').props().disabled).toBe(false);
-        expect(wrapper.find('Checkbox')).toHaveLength(1);
-        expect(wrapper.find('Checkbox').props().checked).toBe(true);
         expect(wrapper.find('SelectInput')).toHaveLength(1);
         expect(wrapper.find('SelectInput').props().value).toStrictEqual([ROLE_OPTIONS[0].id]);
         expect(wrapper.find('.btn')).toHaveLength(2);
@@ -90,9 +84,6 @@ describe('<CreateUsersModal/>', () => {
         expect(wrapper.find('textarea')).toHaveLength(2);
         expect(wrapper.find('textarea#create-users-email-input').props().value).toBe('TestEmailText');
         expect(wrapper.find('textarea#create-users-optionalMessage-input').props().value).toBe('TestOptionalMessage');
-        expect(wrapper.find('textarea#create-users-optionalMessage-input').props().disabled).toBe(true);
-        expect(wrapper.find('Checkbox')).toHaveLength(1);
-        expect(wrapper.find('Checkbox').props().checked).toBe(false);
         expect(wrapper.find('SelectInput')).toHaveLength(1);
         expect(wrapper.find('SelectInput').props().value).toStrictEqual([ROLE_OPTIONS[1].id]);
         expect(wrapper.find('.btn')).toHaveLength(2);

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -24,12 +24,10 @@ interface State {
     isSubmitting: boolean;
     optionalMessage: string;
     roles: string[];
-    sendEmail: boolean;
 }
 
 const DEFAULT_STATE = {
     emailText: '',
-    sendEmail: true,
     optionalMessage: '',
     roles: undefined,
     isSubmitting: false,
@@ -53,22 +51,13 @@ export class CreateUsersModal extends React.Component<Props, State> {
         this.setState(() => ({ optionalMessage }));
     };
 
-    handleSendEmail = (evt: any): void => {
-        const sendEmail = evt.target.checked;
-        this.setState(state => ({
-            sendEmail,
-            // reset the optional message if we unchecked the sendEmail checkbox
-            optionalMessage: !sendEmail ? '' : state.optionalMessage,
-        }));
-    };
-
     handleRoles = (name, formValue, selectedOptions: Array<{ id: string; label: string }>): void => {
         const roles = selectedOptions ? selectedOptions.map(option => option.id) : undefined;
         this.setState({ roles });
     };
 
     createUsers = (): void => {
-        const { emailText, sendEmail, optionalMessage } = this.state;
+        const { emailText, optionalMessage } = this.state;
         this.setState(() => ({ isSubmitting: true, error: undefined }));
 
         // convert the email addresses from newline separated to semicolon separated
@@ -76,7 +65,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
 
         Security.createNewUser({
             email,
-            sendEmail,
+            sendEmail: true,
             optionalMessage: optionalMessage && optionalMessage.length > 0 ? optionalMessage : undefined,
             success: response => {
                 this.props.onComplete(response, this.getSelectedRoles());
@@ -99,7 +88,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
 
     renderForm(): ReactNode {
         const { userLimitSettings } = this.props;
-        const { emailText, sendEmail, optionalMessage } = this.state;
+        const { emailText, optionalMessage } = this.state;
 
         return (
             <>
@@ -137,15 +126,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
                         />
                     </>
                 )}
-                <Checkbox
-                    id="create-users-sendEmail-input"
-                    className="create-users-label-top"
-                    checked={sendEmail}
-                    onChange={this.handleSendEmail}
-                >
-                    Send notification emails to all new users?
-                </Checkbox>
-                <div className="create-users-label-bottom">Optional Message:</div>
+                <div className="create-users-label-bottom">Optional message to send to new users:</div>
                 <FormControl
                     componentClass="textarea"
                     className="form-control create-users-textarea"
@@ -153,7 +134,6 @@ export class CreateUsersModal extends React.Component<Props, State> {
                     rows={5}
                     value={optionalMessage || ''}
                     placeholder="Add your message to be included in the invite email..."
-                    disabled={!sendEmail}
                     onChange={this.handleOptionalMessage}
                 />
             </>


### PR DESCRIPTION
#### Rationale
[Issue 45878](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45878). When new users are not sent email about their new accounts, they don't have a way to verify their identity and set their password. This has been a cause of confusion for some clients and there's little reason to not send the verification email.  Here we remove that option.

#### Related Pull Requests
https://github.com/LabKey/sampleManagement/pull/1276
https://github.com/LabKey/biologics/pull/1640

#### Changes
* Take out checkbox for send email option.
