### PR TITLE
App sample type consistency - SampleTypePage and SampleNav

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.232.0-fb-sampleTypeConsistencyV2.2",
+  "version": "2.232.0-fb-sampleTypeConsistencyV2.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.232.0",
+  "version": "2.232.0-fb-sampleTypeConsistencyV2.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.232.0-fb-sampleTypeConsistencyV2.1",
+  "version": "2.232.0-fb-sampleTypeConsistencyV2.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.232.0-fb-sampleTypeConsistencyV2.0",
+  "version": "2.232.0-fb-sampleTypeConsistencyV2.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.232.0-fb-sampleTypeConsistencyV2.3",
+  "version": "2.233.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2022
+### version 2.233.0
+*Released*: 13 October 2022
 * App Sample Type Consistency
   * Refactor SampleTypePage from apps to share via entities subpackage
   * Refactor SampleNav from apps to share via entities subpackage

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * App Sample Type Consistency
   * Refactor SampleTypePage from apps to share via entities subpackage
   * Refactor SampleNav from apps to share via entities subpackage
+* Issue 45792: When dragging and dropping columns from grid headers, menu stays open and in the original location
 
 ### version 2.232.0
 *Released*: 10 October 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2022
+* App Sample Type Consistency
+  * Refactor SampleTypePage from apps to share via entities subpackage
+
 ### version 2.232.0
 *Released*: 10 October 2022
 * Components package update to split out `entities` components as separate entry point (subpackage)

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD October 2022
 * App Sample Type Consistency
   * Refactor SampleTypePage from apps to share via entities subpackage
+  * Refactor SampleNav from apps to share via entities subpackage
 
 ### version 2.232.0
 *Released*: 10 October 2022

--- a/packages/components/src/entities/SampleNav.spec.tsx
+++ b/packages/components/src/entities/SampleNav.spec.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { ReactWrapper } from 'enzyme';
+
+import { initQueryGridState } from '../internal/global';
+
+import { SubNav } from '../internal/components/navigation/SubNav';
+import { mountWithServerContext } from '../internal/testHelpers';
+import { AppContextProvider } from '../internal/AppContext';
+import { TEST_USER_READER, TEST_USER_STORAGE_EDITOR } from '../internal/userFixtures';
+
+import {
+    TEST_LKS_STARTER_MODULE_CONTEXT,
+    TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
+    TEST_LKSM_STARTER_MODULE_CONTEXT,
+} from '../internal/productFixtures';
+
+import { SampleTypeDetailsNav } from './SampleNav';
+
+beforeAll(() => {
+    initQueryGridState();
+});
+
+describe('SampleDetailsNavImpl', () => {
+    function validateTabText(wrapper: ReactWrapper, showLineage = true, showAssay = true, showWorkflow = true) {
+        const subNav = wrapper.find(SubNav);
+        const tabs = subNav.prop('tabs').toJS();
+        let expectedLength = 3;
+        if (showLineage) expectedLength++;
+        if (showAssay) expectedLength++;
+        if (showWorkflow) expectedLength++;
+        expect(tabs).toHaveLength(expectedLength);
+        let index = 0;
+        expect(tabs[index].text).toBe('Overview');
+        index++;
+        if (showLineage) {
+            expect(tabs[index].text).toBe('Lineage');
+            index++;
+        }
+        expect(tabs[index].text).toBe('Aliquots');
+        index++;
+        if (showAssay) {
+            expect(tabs[index].text).toBe('Assays');
+            index++;
+        }
+        if (showWorkflow) {
+            expect(tabs[index].text).toBe('Jobs');
+            index++;
+        }
+        expect(tabs[index].text).toBe('Timeline');
+        index++;
+    }
+
+    test('reader', () => {
+        const wrapper = mountWithServerContext(
+            <AppContextProvider initialContext={{}}>
+                <SampleTypeDetailsNav
+                    params={{ sampleSet: 'test', id: '123' }}
+                    location={undefined}
+                    router={undefined}
+                    routes={undefined}
+                />
+            </AppContextProvider>,
+            { user: TEST_USER_READER }
+        );
+        validateTabText(wrapper, true, false, false);
+    });
+
+    test('storage editor', () => {
+        const wrapper = mountWithServerContext(
+            <AppContextProvider initialContext={{}}>
+                <SampleTypeDetailsNav
+                    params={{ sampleSet: 'test', id: '123' }}
+                    location={undefined}
+                    router={undefined}
+                    routes={undefined}
+                />
+            </AppContextProvider>,
+            { user: TEST_USER_STORAGE_EDITOR }
+        );
+        validateTabText(wrapper, false, false, false);
+    });
+
+    test('reader, LKS starter', () => {
+        LABKEY.moduleContext = { ...TEST_LKS_STARTER_MODULE_CONTEXT };
+        const wrapper = mountWithServerContext(
+            <AppContextProvider initialContext={{}}>
+                <SampleTypeDetailsNav
+                    params={{ sampleSet: 'test', id: '123' }}
+                    location={undefined}
+                    router={undefined}
+                    routes={undefined}
+                />
+            </AppContextProvider>,
+            { user: TEST_USER_READER }
+        );
+        validateTabText(wrapper, true, true, false);
+    });
+
+    test('reader, LKSM starter', () => {
+        LABKEY.moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT };
+        const wrapper = mountWithServerContext(
+            <AppContextProvider initialContext={{}}>
+                <SampleTypeDetailsNav
+                    params={{ sampleSet: 'test', id: '123' }}
+                    location={undefined}
+                    router={undefined}
+                    routes={undefined}
+                />
+            </AppContextProvider>,
+            { user: TEST_USER_READER }
+        );
+        validateTabText(wrapper, true, false, false);
+    });
+
+    test('reader, LKSM professional', () => {
+        LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
+        const wrapper = mountWithServerContext(
+            <AppContextProvider initialContext={{}}>
+                <SampleTypeDetailsNav
+                    params={{ sampleSet: 'test', id: '123' }}
+                    location={undefined}
+                    router={undefined}
+                    routes={undefined}
+                />
+            </AppContextProvider>,
+            { user: TEST_USER_READER }
+        );
+        validateTabText(wrapper, true, true, true);
+    });
+
+    test('LKSM professional, storage editor', () => {
+        LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
+        const wrapper = mountWithServerContext(
+            <AppContextProvider initialContext={{}}>
+                <SampleTypeDetailsNav
+                    params={{ sampleSet: 'test', id: '123' }}
+                    location={undefined}
+                    router={undefined}
+                    routes={undefined}
+                />
+            </AppContextProvider>,
+            { user: TEST_USER_STORAGE_EDITOR }
+        );
+        validateTabText(wrapper, false, false, true);
+    });
+});

--- a/packages/components/src/entities/SampleNav.spec.tsx
+++ b/packages/components/src/entities/SampleNav.spec.tsx
@@ -14,13 +14,13 @@ import {
     TEST_LKSM_STARTER_MODULE_CONTEXT,
 } from '../internal/productFixtures';
 
-import { SampleTypeDetailsNav } from './SampleNav';
+import { SampleNav } from './SampleNav';
 
 beforeAll(() => {
     initQueryGridState();
 });
 
-describe('SampleDetailsNavImpl', () => {
+describe('SampleNav', () => {
     function validateTabText(wrapper: ReactWrapper, showLineage = true, showAssay = true, showWorkflow = true) {
         const subNav = wrapper.find(SubNav);
         const tabs = subNav.prop('tabs').toJS();
@@ -53,7 +53,7 @@ describe('SampleDetailsNavImpl', () => {
     test('reader', () => {
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleTypeDetailsNav
+                <SampleNav
                     params={{ sampleSet: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
@@ -68,7 +68,7 @@ describe('SampleDetailsNavImpl', () => {
     test('storage editor', () => {
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleTypeDetailsNav
+                <SampleNav
                     params={{ sampleSet: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
@@ -84,7 +84,7 @@ describe('SampleDetailsNavImpl', () => {
         LABKEY.moduleContext = { ...TEST_LKS_STARTER_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleTypeDetailsNav
+                <SampleNav
                     params={{ sampleSet: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
@@ -100,7 +100,7 @@ describe('SampleDetailsNavImpl', () => {
         LABKEY.moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleTypeDetailsNav
+                <SampleNav
                     params={{ sampleSet: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
@@ -116,7 +116,7 @@ describe('SampleDetailsNavImpl', () => {
         LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleTypeDetailsNav
+                <SampleNav
                     params={{ sampleSet: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
@@ -132,7 +132,7 @@ describe('SampleDetailsNavImpl', () => {
         LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleTypeDetailsNav
+                <SampleNav
                     params={{ sampleSet: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}

--- a/packages/components/src/entities/SampleNav.spec.tsx
+++ b/packages/components/src/entities/SampleNav.spec.tsx
@@ -14,13 +14,13 @@ import {
     TEST_LKSM_STARTER_MODULE_CONTEXT,
 } from '../internal/productFixtures';
 
-import { SampleNav } from './SampleNav';
+import { SampleIndexNav } from './SampleNav';
 
 beforeAll(() => {
     initQueryGridState();
 });
 
-describe('SampleNav', () => {
+describe('SampleIndexNav', () => {
     function validateTabText(wrapper: ReactWrapper, showLineage = true, showAssay = true, showWorkflow = true) {
         const subNav = wrapper.find(SubNav);
         const tabs = subNav.prop('tabs').toJS();
@@ -53,8 +53,8 @@ describe('SampleNav', () => {
     test('reader', () => {
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleNav
-                    params={{ sampleSet: 'test', id: '123' }}
+                <SampleIndexNav
+                    params={{ sampleType: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
                     routes={undefined}
@@ -68,8 +68,8 @@ describe('SampleNav', () => {
     test('storage editor', () => {
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleNav
-                    params={{ sampleSet: 'test', id: '123' }}
+                <SampleIndexNav
+                    params={{ sampleType: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
                     routes={undefined}
@@ -84,8 +84,8 @@ describe('SampleNav', () => {
         LABKEY.moduleContext = { ...TEST_LKS_STARTER_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleNav
-                    params={{ sampleSet: 'test', id: '123' }}
+                <SampleIndexNav
+                    params={{ sampleType: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
                     routes={undefined}
@@ -100,8 +100,8 @@ describe('SampleNav', () => {
         LABKEY.moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleNav
-                    params={{ sampleSet: 'test', id: '123' }}
+                <SampleIndexNav
+                    params={{ sampleType: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
                     routes={undefined}
@@ -116,8 +116,8 @@ describe('SampleNav', () => {
         LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleNav
-                    params={{ sampleSet: 'test', id: '123' }}
+                <SampleIndexNav
+                    params={{ sampleType: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
                     routes={undefined}
@@ -132,8 +132,8 @@ describe('SampleNav', () => {
         LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
         const wrapper = mountWithServerContext(
             <AppContextProvider initialContext={{}}>
-                <SampleNav
-                    params={{ sampleSet: 'test', id: '123' }}
+                <SampleIndexNav
+                    params={{ sampleType: 'test', id: '123' }}
                     location={undefined}
                     router={undefined}
                     routes={undefined}

--- a/packages/components/src/entities/SampleNav.tsx
+++ b/packages/components/src/entities/SampleNav.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import React, { FC, memo, useEffect, useMemo, useState } from 'react';
+import { List } from 'immutable';
+import { WithRouterProps } from 'react-router';
+
+import { useServerContext } from '../internal/components/base/ServerContext';
+import { ITab } from '../internal/components/navigation/types';
+import { SCHEMAS } from '../internal/schemas';
+import { getQueryDetails } from '../internal/query/api';
+import { AppURL } from '../internal/url/AppURL';
+import { SAMPLES_KEY } from '../internal/app/constants';
+import { naturalSortByProperty } from '../public/sort';
+import {
+    isAssayEnabled,
+    isMediaEnabled,
+    isWorkflowEnabled,
+    userCanReadAssays,
+    userCanReadDataClasses,
+} from '../internal/app/utils';
+
+import { SubNav } from '../internal/components/navigation/SubNav';
+
+import { loadSampleTypes } from './actions';
+
+export const SampleTypeDetailsNav: FC<WithRouterProps> = memo(({ params }) => {
+    const { id, sampleSet } = params;
+    const [noun, setNoun] = useState<ITab>();
+    const { user } = useServerContext();
+
+    useEffect(() => {
+        (async () => {
+            const queryInfo = await getQueryDetails({ schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA, queryName: sampleSet });
+            setNoun({
+                text: queryInfo?.title ?? '',
+                url: AppURL.create(SAMPLES_KEY, sampleSet),
+            });
+        })();
+    }, [sampleSet]);
+
+    const tabText = ['Overview'];
+    if (userCanReadDataClasses(user)) tabText.push('Lineage');
+    tabText.push('Aliquots');
+    if (userCanReadAssays(user) && isAssayEnabled()) tabText.push('Assays');
+    if (isWorkflowEnabled()) tabText.push('Jobs');
+    tabText.push('Timeline');
+
+    const tabs = useMemo(
+        () =>
+            tabText.reduce((tabs, text) => {
+                const parts = [SAMPLES_KEY, sampleSet, id];
+                if (text !== 'Overview') {
+                    parts.push(text.toLowerCase());
+                }
+                return tabs.push({ text, url: AppURL.create(...parts) });
+            }, List<ITab>()),
+        [id, sampleSet]
+    );
+
+    return <SubNav noun={noun} tabs={tabs} />;
+});
+
+export const SampleIndexNav: FC<WithRouterProps> = memo(location => {
+    const [tabs, setTabs] = useState<List<ITab>>(() => List());
+    const noun = useMemo(() => ({ text: 'Samples', url: AppURL.create(SAMPLES_KEY) }), []);
+    const { moduleContext } = useServerContext();
+
+    useEffect(() => {
+        (async () => {
+            const includeMedia = isMediaEnabled(moduleContext);
+            const allSampleTypes = await loadSampleTypes(includeMedia);
+            const tabs_ = allSampleTypes
+                .filter(qi => !qi.isMedia)
+                .sort(naturalSortByProperty('title'))
+                .map(queryInfo => ({
+                    text: queryInfo.title,
+                    url: AppURL.create(SAMPLES_KEY, queryInfo.name),
+                }));
+            setTabs(List(tabs_));
+        })();
+    }, [location, moduleContext]);
+
+    return <SubNav noun={noun} tabs={tabs} />;
+});

--- a/packages/components/src/entities/SampleNav.tsx
+++ b/packages/components/src/entities/SampleNav.tsx
@@ -25,20 +25,20 @@ import { SubNav } from '../internal/components/navigation/SubNav';
 
 import { loadSampleTypes } from './actions';
 
-export const SampleNav: FC<WithRouterProps> = memo(({ params }) => {
-    const { id, sampleSet } = params;
+export const SampleIndexNav: FC<WithRouterProps> = memo(({ params }) => {
+    const { id, sampleType } = params;
     const [noun, setNoun] = useState<ITab>();
     const { user } = useServerContext();
 
     useEffect(() => {
         (async () => {
-            const queryInfo = await getQueryDetails({ schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA, queryName: sampleSet });
+            const queryInfo = await getQueryDetails({ schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA, queryName: sampleType });
             setNoun({
                 text: queryInfo?.title ?? '',
-                url: AppURL.create(SAMPLES_KEY, sampleSet),
+                url: AppURL.create(SAMPLES_KEY, sampleType),
             });
         })();
-    }, [sampleSet]);
+    }, [sampleType]);
 
     const tabText = ['Overview'];
     if (userCanReadDataClasses(user)) tabText.push('Lineage');
@@ -50,19 +50,19 @@ export const SampleNav: FC<WithRouterProps> = memo(({ params }) => {
     const tabs = useMemo(
         () =>
             tabText.reduce((tabs, text) => {
-                const parts = [SAMPLES_KEY, sampleSet, id];
+                const parts = [SAMPLES_KEY, sampleType, id];
                 if (text !== 'Overview') {
                     parts.push(text.toLowerCase());
                 }
                 return tabs.push({ text, url: AppURL.create(...parts) });
             }, List<ITab>()),
-        [id, sampleSet]
+        [id, sampleType]
     );
 
     return <SubNav noun={noun} tabs={tabs} />;
 });
 
-export const SampleTypeNav: FC<WithRouterProps> = memo(location => {
+export const SampleTypeIndexNav: FC<WithRouterProps> = memo(location => {
     const [tabs, setTabs] = useState<List<ITab>>(() => List());
     const noun = useMemo(() => ({ text: 'Samples', url: AppURL.create(SAMPLES_KEY) }), []);
     const { moduleContext } = useServerContext();

--- a/packages/components/src/entities/SampleNav.tsx
+++ b/packages/components/src/entities/SampleNav.tsx
@@ -25,7 +25,7 @@ import { SubNav } from '../internal/components/navigation/SubNav';
 
 import { loadSampleTypes } from './actions';
 
-export const SampleTypeDetailsNav: FC<WithRouterProps> = memo(({ params }) => {
+export const SampleNav: FC<WithRouterProps> = memo(({ params }) => {
     const { id, sampleSet } = params;
     const [noun, setNoun] = useState<ITab>();
     const { user } = useServerContext();
@@ -62,7 +62,7 @@ export const SampleTypeDetailsNav: FC<WithRouterProps> = memo(({ params }) => {
     return <SubNav noun={noun} tabs={tabs} />;
 });
 
-export const SampleIndexNav: FC<WithRouterProps> = memo(location => {
+export const SampleTypeNav: FC<WithRouterProps> = memo(location => {
     const [tabs, setTabs] = useState<List<ITab>>(() => List());
     const noun = useMemo(() => ({ text: 'Samples', url: AppURL.create(SAMPLES_KEY) }), []);
     const { moduleContext } = useServerContext();

--- a/packages/components/src/entities/SampleNav.tsx
+++ b/packages/components/src/entities/SampleNav.tsx
@@ -69,15 +69,12 @@ export const SampleTypeIndexNav: FC<WithRouterProps> = memo(location => {
 
     useEffect(() => {
         (async () => {
-            const includeMedia = isMediaEnabled(moduleContext);
-            const allSampleTypes = await loadSampleTypes(includeMedia);
+            const allSampleTypes = await loadSampleTypes(
+                false /* don't include media here since it is showing only in the sample type landing pages */
+            );
             const tabs_ = allSampleTypes
-                .filter(qi => !qi.isMedia)
                 .sort(naturalSortByProperty('title'))
-                .map(queryInfo => ({
-                    text: queryInfo.title,
-                    url: AppURL.create(SAMPLES_KEY, queryInfo.name),
-                }));
+                .map(queryInfo => ({ text: queryInfo.title, url: AppURL.create(SAMPLES_KEY, queryInfo.name) }));
             setTabs(List(tabs_));
         })();
     }, [location, moduleContext]);

--- a/packages/components/src/entities/SampleTypePage.tsx
+++ b/packages/components/src/entities/SampleTypePage.tsx
@@ -14,7 +14,7 @@ import { RequiresPermission } from '../internal/components/base/Permissions';
 
 import { SampleTypeEmptyAlert } from '../internal/components/samples/SampleEmptyAlert';
 
-import { SampleSetSummary } from './SampleSetSummary';
+import { SampleTypeSummary } from './SampleTypeSummary';
 
 interface Props {
     buttons: ReactNode;
@@ -48,7 +48,7 @@ export const SampleTypePage: FC<Props> = memo(props => {
                 }
             >
                 {hasSampleTypes && (
-                    <SampleSetSummary excludedSampleSets={excludedSampleTypes} navigate={navigate} user={user} />
+                    <SampleTypeSummary excludedSampleSets={excludedSampleTypes} navigate={navigate} user={user} />
                 )}
                 {!hasSampleTypes && <SampleTypeEmptyAlert user={user} />}
             </Section>

--- a/packages/components/src/entities/SampleTypePage.tsx
+++ b/packages/components/src/entities/SampleTypePage.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import React, { ReactNode, FC, memo } from 'react';
+import { PermissionTypes } from '@labkey/api';
+
+import { AppURL } from '../internal/url/AppURL';
+import { useServerContext } from '../internal/components/base/ServerContext';
+import { Page } from '../internal/components/base/Page';
+import { Section } from '../internal/components/base/Section';
+import { isSampleStatusEnabled } from '../internal/app/utils';
+import { RequiresPermission } from '../internal/components/base/Permissions';
+
+import { SampleTypeEmptyAlert } from '../internal/components/samples/SampleEmptyAlert';
+
+import { SampleSetSummary } from './SampleSetSummary';
+
+interface Props {
+    buttons: ReactNode;
+    caption: string;
+    excludedSampleTypes?: string[];
+    hasSampleTypes: boolean;
+    navigate: (url: string | AppURL) => void;
+}
+
+export const SampleTypePage: FC<Props> = memo(props => {
+    const { caption, buttons, excludedSampleTypes, hasSampleTypes, navigate } = props;
+    const { user } = useServerContext();
+    const title = 'Sample Types';
+
+    return (
+        <Page title={title}>
+            <Section
+                title={title}
+                caption={caption}
+                context={
+                    <>
+                        {isSampleStatusEnabled() && (
+                            <RequiresPermission perms={PermissionTypes.Admin}>
+                                <a href={AppURL.create('admin', 'settings').toHref()} className="right-spacing">
+                                    Manage Sample Statuses
+                                </a>
+                            </RequiresPermission>
+                        )}
+                        {buttons}
+                    </>
+                }
+            >
+                {hasSampleTypes && (
+                    <SampleSetSummary excludedSampleSets={excludedSampleTypes} navigate={navigate} user={user} />
+                )}
+                {!hasSampleTypes && <SampleTypeEmptyAlert user={user} />}
+            </Section>
+        </Page>
+    );
+});

--- a/packages/components/src/entities/SampleTypeSummary.spec.tsx
+++ b/packages/components/src/entities/SampleTypeSummary.spec.tsx
@@ -5,15 +5,15 @@ import { initUnitTestMocks } from '../test/testHelperMocks';
 import { TEST_USER_APP_ADMIN } from '../internal/userFixtures';
 import { selectOptionByText, SELECT_INPUT_CONTROL_SELECTOR } from '../internal/components/forms/input/SelectInputTestUtils';
 
-import { SampleSetSummary } from './SampleSetSummary';
+import { SampleTypeSummary } from './SampleTypeSummary';
 
 beforeAll(() => {
     initUnitTestMocks();
 });
 
-describe('<SampleSetSummary />', () => {
+describe('<SampleTypeSummary />', () => {
     test('Summary display', async () => {
-        const component = mount(<SampleSetSummary navigate={jest.fn()} user={TEST_USER_APP_ADMIN} />);
+        const component = mount(<SampleTypeSummary navigate={jest.fn()} user={TEST_USER_APP_ADMIN} />);
 
         expect(component.find('.heatmap-container')).toHaveLength(0);
         expect(component.find('.grid-panel')).toHaveLength(1);

--- a/packages/components/src/entities/SampleTypeSummary.tsx
+++ b/packages/components/src/entities/SampleTypeSummary.tsx
@@ -24,13 +24,13 @@ const SAMPLE_QUERY_CONFIG = {
     containerFilter: Query.containerFilter.currentPlusProjectAndShared,
 };
 
-interface SampleSetSummaryProps {
+interface Props {
     excludedSampleSets?: string[];
     navigate: (url: string | AppURL) => any;
     user: User;
 }
 
-export const SampleSetSummary: FC<SampleSetSummaryProps> = memo(props => {
+export const SampleTypeSummary: FC<Props> = memo(props => {
     const { navigate, user, excludedSampleSets } = props;
     const [selectedView, setSelectedView] = useState(SelectView.Grid);
 

--- a/packages/components/src/entities/actions.ts
+++ b/packages/components/src/entities/actions.ts
@@ -1,12 +1,13 @@
 import { List, Map } from 'immutable';
 import { Filter, Query } from '@labkey/api';
 
-import { selectRowsDeprecated } from '../internal/query/api';
+import { loadQueriesFromTable, selectRowsDeprecated } from '../internal/query/api';
 import { SCHEMAS } from '../internal/schemas';
 import { resolveErrorMessage } from '../internal/util/messaging';
 import { EntityChoice, EntityDataType, IEntityTypeOption } from '../internal/components/entities/models';
 import { getParentTypeDataForLineage } from '../internal/components/samples/actions';
 import { getInitialParentChoices } from '../internal/components/entities/utils';
+import { QueryInfo } from '../public/QueryInfo';
 
 // TODO: this file is temporary as we move things into an @labkey/components/entities subpackage. Instead of adding
 // anything to this file, we should create an API wrapper to be used for any new actions in this subpackage.
@@ -93,3 +94,12 @@ export const getOriginalParentsFromLineage = async (
 
     return { originalParents, parentTypeOptions };
 };
+
+export const loadSampleTypes = (includeMedia: boolean): Promise<QueryInfo[]> =>
+    loadQueriesFromTable(
+        SCHEMAS.EXP_TABLES.SAMPLE_SETS,
+        'Name',
+        SCHEMAS.SAMPLE_SETS.SCHEMA,
+        Query.containerFilter.currentPlusProjectAndShared,
+        includeMedia ? undefined : [Filter.create('category', 'media', Filter.Types.NOT_EQUAL_OR_MISSING)]
+    );

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -45,6 +45,7 @@ import { PicklistOverview } from './PicklistOverview';
 import { PicklistSubNav } from './PicklistSubnav';
 import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SampleTypeTemplateDownloadRenderer, downloadSampleTypeTemplate } from './SampleTypeTemplateDownloadRenderer';
+import { SampleTypePage } from './SampleTypePage';
 
 export {
     PICKLIST_SAMPLES_FILTER,
@@ -87,6 +88,7 @@ export {
     SampleSetDeleteModal,
     SampleSetSummary,
     SampleTimelinePageBase,
+    SampleTypePage,
     SampleTypeBasePage,
     SampleTypeInsightsPanel,
     SampleTypeTemplateDownloadRenderer,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -46,7 +46,7 @@ import { PicklistSubNav } from './PicklistSubnav';
 import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SampleTypeTemplateDownloadRenderer, downloadSampleTypeTemplate } from './SampleTypeTemplateDownloadRenderer';
 import { SampleTypePage } from './SampleTypePage';
-import { SampleTypeDetailsNav, SampleIndexNav } from './SampleNav';
+import { SampleNav, SampleTypeNav } from './SampleNav';
 
 export {
     PICKLIST_SAMPLES_FILTER,
@@ -86,12 +86,12 @@ export {
     SampleCreationTypeModal,
     SampleDetailEditing,
     SampleFinderSection,
-    SampleIndexNav,
     SampleLineageGraph,
     SampleSetDeleteModal,
     SampleSetSummary,
     SampleTimelinePageBase,
-    SampleTypeDetailsNav,
+    SampleNav,
+    SampleTypeNav,
     SampleTypePage,
     SampleTypeBasePage,
     SampleTypeInsightsPanel,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -1,5 +1,5 @@
 import { PICKLIST_SAMPLES_FILTER } from './models';
-import { getSampleTypes, getOriginalParentsFromLineage } from './actions';
+import { getSampleTypes, getOriginalParentsFromLineage, loadSampleTypes } from './actions';
 import {
     getSampleWizardURL,
     filterSampleRowsForOperation,
@@ -46,6 +46,7 @@ import { PicklistSubNav } from './PicklistSubnav';
 import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SampleTypeTemplateDownloadRenderer, downloadSampleTypeTemplate } from './SampleTypeTemplateDownloadRenderer';
 import { SampleTypePage } from './SampleTypePage';
+import { SampleTypeDetailsNav, SampleIndexNav } from './SampleNav';
 
 export {
     PICKLIST_SAMPLES_FILTER,
@@ -59,6 +60,7 @@ export {
     getSampleTypes,
     getSampleWizardURL,
     isFindByIdsSchema,
+    loadSampleTypes,
     CreateSamplesSubMenu,
     CreateSamplesSubMenuBase,
     EntityCrossProjectSelectionConfirmModal,
@@ -84,10 +86,12 @@ export {
     SampleCreationTypeModal,
     SampleDetailEditing,
     SampleFinderSection,
+    SampleIndexNav,
     SampleLineageGraph,
     SampleSetDeleteModal,
     SampleSetSummary,
     SampleTimelinePageBase,
+    SampleTypeDetailsNav,
     SampleTypePage,
     SampleTypeBasePage,
     SampleTypeInsightsPanel,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -18,7 +18,6 @@ import { SampleAssayDetail } from './SampleAssayDetail';
 import { SampleDetailEditing } from './SampleDetailEditing';
 import { SampleLineageGraph } from './SampleLineageGraph';
 import { SampleSetDeleteModal } from './SampleSetDeleteModal';
-import { SampleSetSummary } from './SampleSetSummary';
 import { SamplesDeriveButtonBase } from './SamplesDeriveButtonBase';
 import { SamplesEditButton } from './SamplesEditButton';
 import { SampleAliquotDetailHeader } from './SampleAliquotDetailHeader';
@@ -89,7 +88,6 @@ export {
     SampleIndexNav,
     SampleLineageGraph,
     SampleSetDeleteModal,
-    SampleSetSummary,
     SampleTimelinePageBase,
     SampleTypeIndexNav,
     SampleTypePage,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -46,7 +46,7 @@ import { PicklistSubNav } from './PicklistSubnav';
 import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SampleTypeTemplateDownloadRenderer, downloadSampleTypeTemplate } from './SampleTypeTemplateDownloadRenderer';
 import { SampleTypePage } from './SampleTypePage';
-import { SampleNav, SampleTypeNav } from './SampleNav';
+import { SampleIndexNav, SampleTypeIndexNav } from './SampleNav';
 
 export {
     PICKLIST_SAMPLES_FILTER,
@@ -86,12 +86,12 @@ export {
     SampleCreationTypeModal,
     SampleDetailEditing,
     SampleFinderSection,
+    SampleIndexNav,
     SampleLineageGraph,
     SampleSetDeleteModal,
     SampleSetSummary,
     SampleTimelinePageBase,
-    SampleNav,
-    SampleTypeNav,
+    SampleTypeIndexNav,
     SampleTypePage,
     SampleTypeBasePage,
     SampleTypeInsightsPanel,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -192,6 +192,8 @@ import {
     selectDistinctRows,
     selectRowsDeprecated,
     updateRows,
+    loadQueries,
+    loadQueriesFromTable,
 } from './internal/query/api';
 import { registerFilterType } from './internal/query/filter';
 import { selectRows } from './internal/query/selectRows';
@@ -629,6 +631,7 @@ import {
     userCanReadAssays,
     userCanReadMedia,
     userCanReadNotebooks,
+    userCanReadDataClasses,
     userCanReadRegistry,
     userCanReadSources,
 } from './internal/app/utils';
@@ -766,6 +769,7 @@ const App = {
     userCanReadAssays,
     userCanReadNotebooks,
     userCanReadMedia,
+    userCanReadDataClasses,
     userCanReadRegistry,
     userCanReadSources,
     userCanDeletePublicPicklists,
@@ -873,6 +877,8 @@ export {
     invalidateQueryDetailsCache,
     invalidateQueryDetailsCacheKey,
     registerFilterType,
+    loadQueries,
+    loadQueriesFromTable,
     // editable grid related items
     loadEditorModelData,
     MAX_EDITABLE_GRID_ROWS,

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -107,7 +107,7 @@ export function userCanReadRegistry(user: User): boolean {
     return userCanReadDataClasses(user);
 }
 
-function userCanReadDataClasses(user: User): boolean {
+export function userCanReadDataClasses(user: User): boolean {
     return hasAllPermissions(user, [PermissionTypes.ReadDataClass]);
 }
 

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -114,7 +114,9 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
     readonly state: State = { dragTarget: undefined };
 
     _handleClick(column: GridColumn, evt: any): void {
-        const isHeaderCellClick = evt.target.className?.startsWith('grid-header-cell');
+        const isHeaderCellClick =
+            evt.target.className?.startsWith('grid-header-cell') ||
+            evt.target.parentElement?.className?.startsWith('grid-header-cell');
         evt.stopPropagation();
         if (this.props.onCellClick && isHeaderCellClick) {
             this.props.onCellClick(column);

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1031,7 +1031,7 @@ export function loadQueries(schemaQueries: SchemaQuery[]): Promise<QueryInfo[]> 
  * found on the "Name" column. The sample types themselves are on the "samples" schema. Here is what the parameters
  * would look like to load sample type QueryInfo's for each row in the "exp.SampleSets" table.
  *
- * targetSchemaQuery: exp.SampleSets
+ * tableSchemaQuery: exp.SampleSets
  * tableFieldKey: Name
  * targetSchemaName: samples
  *

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1015,3 +1015,68 @@ export function selectDistinctRows(options: Query.SelectDistinctOptions): Promis
         });
     });
 }
+
+export function loadQueries(schemaQueries: SchemaQuery[]): Promise<QueryInfo[]> {
+    return Promise.all(
+        schemaQueries.map(sq => getQueryDetails({ schemaName: sq.getSchema(), queryName: sq.getQuery() }))
+    );
+}
+
+/**
+ * Loads a set of QueryInfo's sourced from a table (tableSchemaQuery)
+ * where the key field (tableFieldKey) specifies the query name on the specified schema (targetSchemaName).
+ *
+ * Example:
+ * The table "exp.SampleSets" contains a row per sample type defined in the container. The name of the sample type is
+ * found on the "Name" column. The sample types themselves are on the "samples" schema. Here is what the parameters
+ * would look like to load sample type QueryInfo's for each row in the "exp.SampleSets" table.
+ *
+ * targetSchemaQuery: exp.SampleSets
+ * tableFieldKey: Name
+ * targetSchemaName: samples
+ *
+ * @param tableSchemaQuery - The "meta" table containing a row per query found on the "targetSchemaName" schema.
+ * @param tableFieldKey - The fieldKey on a given row in the "tableSchemaQuery" that contains the name of the query.
+ * @param targetSchemaName - The target schemaName where the queries found on "tableFieldKey" can be found.
+ * @param containerFilter - Optional Query.ContainerFilter applied to tables request.
+ * @param filters - Optional Query filters applied to tables request.
+ */
+export async function loadQueriesFromTable(
+    tableSchemaQuery: SchemaQuery,
+    tableFieldKey: string,
+    targetSchemaName: string,
+    containerFilter?: Query.ContainerFilter,
+    filters?: Filter.IFilter[]
+): Promise<QueryInfo[]> {
+    const info = await getQueryDetails({
+        queryName: tableSchemaQuery.getQuery(),
+        schemaName: tableSchemaQuery.getSchema(),
+    });
+
+    const queryNameField = info.getColumn(tableFieldKey);
+
+    if (queryNameField) {
+        const { key, models } = await selectRowsDeprecated({
+            containerFilter,
+            columns: info
+                .getPkCols()
+                .map(col => col.fieldKey)
+                .toSet()
+                .add(queryNameField.name)
+                .join(','),
+            filterArray: filters,
+            queryName: tableSchemaQuery.getQuery(),
+            schemaName: tableSchemaQuery.getSchema(),
+            viewName: tableSchemaQuery.getView(),
+        });
+
+        const schemaQueries: SchemaQuery[] = Object.values(models[key])
+            .map(row => caseInsensitive(row, queryNameField.name)?.value)
+            .filter(queryName => queryName !== undefined)
+            .map(queryName => SchemaQuery.create(targetSchemaName, queryName));
+
+        return await loadQueries(schemaQueries);
+    }
+
+    return [];
+}

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -244,7 +244,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
 
     return (
         <>
-            <span onClick={evt => onToggleClick(!open, evt)}>
+            <span>
                 <EditableColumnTitle
                     column={col}
                     onChange={onColumnTitleUpdate}


### PR DESCRIPTION
#### Rationale
Moving some more components out of the apps into the @labkey/components/entities subpackage so that they can be shared in LKB and LKSM to get consistency.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/981
* https://github.com/LabKey/sampleManagement/pull/1291
* https://github.com/LabKey/biologics/pull/1655

#### Changes
* Refactor SampleTypePage from apps to share via entities subpackage
* Refactor SampleNav from apps to share via entities subpackage
