### PR TITLE
Issue 46504: Assay name is not correct in SampleFinder's Assay filter picker

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.233.1-fb-issue46504.1",
+  "version": "2.233.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.233.0",
+  "version": "2.233.1-fb-issue46504.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.233.1
+*Released*: 13 October 2022
+* Issue 46504: Assay name is not correct in SampleFinder's Assay filter picker
+  * Use assay label instead of name in facet selector
+
 ### version 2.233.0
 *Released*: 13 October 2022
 * App Sample Type Consistency

--- a/packages/components/src/entities/EntityFieldFilterModal.tsx
+++ b/packages/components/src/entities/EntityFieldFilterModal.tsx
@@ -83,7 +83,6 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
     const onEntityClick = useCallback(
         async (selectedQueryName: string) => {
             try {
-                console.log(selectedQueryName);
                 let schemaName = entityDataType.instanceSchemaName;
                 let queryName = selectedQueryName;
                 if (!schemaName && entityDataType.getInstanceSchemaQuery) {

--- a/packages/components/src/entities/EntityFieldFilterModal.tsx
+++ b/packages/components/src/entities/EntityFieldFilterModal.tsx
@@ -83,6 +83,7 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
     const onEntityClick = useCallback(
         async (selectedQueryName: string) => {
             try {
+                console.log(selectedQueryName);
                 let schemaName = entityDataType.instanceSchemaName;
                 let queryName = selectedQueryName;
                 if (!schemaName && entityDataType.getInstanceSchemaQuery) {
@@ -237,6 +238,12 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
         }.`;
     }, [entityDataType]);
 
+    const activeQueryLabel = useMemo(() => {
+        if (!entityQueries || !activeQuery)
+            return null;
+        return entityQueries.find(query => query.value.toLowerCase() === activeQuery.toLowerCase())?.label;
+    }, [entityQueries, activeQuery]);
+
     return (
         <Modal show bsSize="lg" onHide={closeModal}>
             <Modal.Header closeButton>
@@ -291,7 +298,7 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
                         queryInfo={activeQueryInfo}
                         skipDefaultViewCheck={skipDefaultViewCheck}
                         validFilterField={isValidFilterFieldExcludeLookups}
-                        hasNotInQueryFilterLabel={`Find Samples without ${activeQuery} results`}
+                        hasNotInQueryFilterLabel={`Find Samples without ${activeQueryLabel} results`}
                     />
                 </Row>
             </Modal.Body>

--- a/packages/components/src/entities/EntityFieldFilterModal.tsx
+++ b/packages/components/src/entities/EntityFieldFilterModal.tsx
@@ -239,7 +239,7 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
 
     const activeQueryLabel = useMemo(() => {
         if (!entityQueries || !activeQuery) return null;
-        return entityQueries.find(query => query.value.toLowerCase() === activeQuery.toLowerCase())?.label;
+        return entityQueries.find(query => query?.value?.toLowerCase() === activeQuery.toLowerCase())?.label;
     }, [entityQueries, activeQuery]);
 
     return (

--- a/packages/components/src/entities/EntityFieldFilterModal.tsx
+++ b/packages/components/src/entities/EntityFieldFilterModal.tsx
@@ -238,8 +238,7 @@ export const EntityFieldFilterModal: FC<Props> = memo(props => {
     }, [entityDataType]);
 
     const activeQueryLabel = useMemo(() => {
-        if (!entityQueries || !activeQuery)
-            return null;
+        if (!entityQueries || !activeQuery) return null;
         return entityQueries.find(query => query.value.toLowerCase() === activeQuery.toLowerCase())?.label;
     }, [entityQueries, activeQuery]);
 


### PR DESCRIPTION
#### Rationale
Fix assay label in "Find Samples without assayName results" facet options, use label instead name for display.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/984
* https://github.com/LabKey/sampleManagement/pull/1297
* https://github.com/LabKey/biologics/pull/1659

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
