### PR TITLE
@labkey/components package update to split out assay components as separate subpackage

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.3.0",
+  "version": "6.3.0-fb-assaySubpackage.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.3.0",
+      "version": "6.3.0-fb-assaySubpackage.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.17.8",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.3.0-fb-assaySubpackage.0",
+  "version": "6.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.3.0-fb-assaySubpackage.0",
+      "version": "6.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.17.8",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.3.0-fb-assaySubpackage.0",
+  "version": "6.3.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.3.0",
+  "version": "6.3.0-fb-assaySubpackage.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -3,8 +3,8 @@
 ### version TBD
 *Released*: TBD October 2022
 * webpack updates for @labkey/components `assay` subpackage
-  * add `@labkey/components/entities` alias for `npm run start-link`
-  * add `@labkey/components/entities` to "externals" to keep it out of bundles
+  * add `@labkey/components/assay` alias for `npm run start-link`
+  * add `@labkey/components/assay` to "externals" to keep it out of bundles
 
 ### version 6.3.0
 *Released*: 10 October 2022

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
-### version TBD
-*Released*: TBD October 2022
+### version 6.3.1
+*Released*: 20 October 2022
 * webpack updates for @labkey/components `assay` subpackage
   * add `@labkey/components/assay` alias for `npm run start-link`
   * add `@labkey/components/assay` to "externals" to keep it out of bundles

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,11 @@
 # @labkey/build
 
+### version TBD
+*Released*: TBD October 2022
+* webpack updates for @labkey/components `assay` subpackage
+  * add `@labkey/components/entities` alias for `npm run start-link`
+  * add `@labkey/components/entities` to "externals" to keep it out of bundles
+
 ### version 6.3.0
 *Released*: 10 October 2022
 * Revert changes for build packages as ES Modules

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -160,6 +160,7 @@ const TS_CHECKER_DEV_CONFIG = {
                 "paths": {
                     "@labkey/components": [labkeyUIComponentsPath],
                     "@labkey/components/entities": [labkeyUIComponentsPath + '/entities'],
+                    "@labkey/components/assay": [labkeyUIComponentsPath + '/assay'],
                     "@labkey/freezermanager": [freezerManagerPath],
                     "@labkey/workflow": [workflowPath],
                     "@labkey/eln": [elnPath],
@@ -251,6 +252,7 @@ module.exports = {
             // seem to cause any problems.
             '@labkey/components': labkeyUIComponentsPath,
             '@labkey/components/entities': labkeyUIComponentsPath + '/entities',
+            '@labkey/components/assay': labkeyUIComponentsPath + '/assay',
             '@labkey/freezermanager': freezerManagerPath,
             '@labkey/workflow': workflowPath,
             '@labkey/eln': elnPath,

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -86,6 +86,7 @@ module.exports = {
         '@labkey/api',
         '@labkey/components',
         '@labkey/components/entities',
+        '@labkey/components/assay',
         '@remirror/pm',
         'boostrap-sass',
         'classnames',

--- a/packages/components/docs/localDev.md
+++ b/packages/components/docs/localDev.md
@@ -147,7 +147,7 @@ and for the Sample Manager app build it would look like:
    3. Note: any code in this subpackage should not be imported / used by the code in the `src/internal` directory
 2. Update the `packages/components/package.config.js` file to add the new entry
    1. adding the `import` path to the `index.ts` file mentioned in step 1.i
-   2. in most cases, the new entry will also `dependOn: 'compoenents'`
+   2. in most cases, the new entry will also `dependOn: 'components'`
 3. Update the `packages/components/package.json` file to add the new subpackage
    1. add to `"exports"` to indicate the location of the subpackage generated JS file
    2. add to `"typesVersions"` to indicate the location of the subpackage typings file

--- a/packages/components/package.config.js
+++ b/packages/components/package.config.js
@@ -13,6 +13,10 @@ module.exports = merge(baseConfig, {
             import: './src/entities/index.ts',
             dependOn: 'components',
         },
+        assay: {
+            import: './src/assay/index.ts',
+            dependOn: 'components',
+        },
     },
     output: {
         filename: '[name].js',

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -93,7 +93,7 @@
     "vis-network": "~6.5.2"
   },
   "devDependencies": {
-    "@labkey/build": "6.3.0-fb-assaySubpackage.0",
+    "@labkey/build": "6.3.1",
     "@labkey/eslint-config-react": "~0.0.12",
     "@types/history": "~4.7.9",
     "@types/node": "~16.11.26",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.235.0",
+  "version": "2.235.0-fb-assaySubpackage.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.0",
+  "version": "2.236.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/components.js",
-    "./entities": "./dist/entities.js"
+    "./entities": "./dist/entities.js",
+    "./assay": "./dist/assay.js"
   },
   "typesVersions": {
     "*": {
@@ -20,6 +21,9 @@
       ],
       "entities": [
         "dist/entities/index.d.ts"
+      ],
+      "assay": [
+        "dist/assay/index.d.ts"
       ]
     }
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.1",
+  "version": "2.236.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -93,7 +93,7 @@
     "vis-network": "~6.5.2"
   },
   "devDependencies": {
-    "@labkey/build": "6.3.0",
+    "@labkey/build": "6.3.0-fb-assaySubpackage.0",
     "@labkey/eslint-config-react": "~0.0.12",
     "@types/history": "~4.7.9",
     "@types/node": "~16.11.26",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD October 2022
 * Components package update to split out `assay` components as separate entry point (subpackage)
   * Create new /assay/index.ts file and dir and move assay related app components
+  * add assay entry point to package.config.js and package.json
 
 ### version 2.235.0
 *Released*: 19 October 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2022
+* Components package update to split out `assay` components as separate entry point (subpackage)
+  * Create new /assay/index.ts file and dir and move assay related app components
+
 ### version 2.235.0
 *Released*: 19 October 2022
 * EditInlineField: Add showToggle prop

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2022
+### version 2.236.1
+*Released*: 20 October 2022
 * Components package update to split out `assay` components as separate entry point (subpackage)
   * Create new /assay/index.ts file and dir and move assay related app components
   * add assay entry point to package.config.js and package.json

--- a/packages/components/src/assay/AssayDesignDeleteConfirmModal.spec.tsx
+++ b/packages/components/src/assay/AssayDesignDeleteConfirmModal.spec.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import { ConfirmModal } from '../base/ConfirmModal';
+import { ConfirmModal } from '../internal/components/base/ConfirmModal';
 
 import { AssayDesignDeleteConfirmModal } from './AssayDesignDeleteConfirmModal';
 

--- a/packages/components/src/assay/AssayDesignDeleteConfirmModal.tsx
+++ b/packages/components/src/assay/AssayDesignDeleteConfirmModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ConfirmModal } from '../base/ConfirmModal';
+import { ConfirmModal } from '../internal/components/base/ConfirmModal';
 
 interface Props {
     assayDesignName?: string;

--- a/packages/components/src/assay/AssayDesignDeleteModal.tsx
+++ b/packages/components/src/assay/AssayDesignDeleteModal.tsx
@@ -1,19 +1,22 @@
 import React, { FC, memo, useState, useEffect, useCallback } from 'react';
 
-import { deleteErrorMessage, deleteSuccessMessage } from '../../util/messaging';
-import { AssayDefinitionModel } from '../../AssayDefinitionModel';
-import { useNotificationsContext } from '../notifications/NotificationsContext';
-import { SchemaQuery } from '../../../public/SchemaQuery';
+import { Ajax, Utils } from '@labkey/api';
 
-import { isLoading } from '../../../public/LoadingState';
-import { LoadingModal } from '../base/LoadingModal';
+import { deleteErrorMessage, deleteSuccessMessage } from '../internal/util/messaging';
+import { AssayDefinitionModel } from '../internal/AssayDefinitionModel';
+import { useNotificationsContext } from '../internal/components/notifications/NotificationsContext';
+import { SchemaQuery } from '../public/SchemaQuery';
 
-import { Progress } from '../base/Progress';
+import { isLoading } from '../public/LoadingState';
+import { LoadingModal } from '../internal/components/base/LoadingModal';
 
-import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
+import { Progress } from '../internal/components/base/Progress';
+
+import { InjectedQueryModels, withQueryModels } from '../public/QueryModel/withQueryModels';
+
+import { buildURL } from '../internal/url/AppURL';
 
 import { AssayDesignDeleteConfirmModal } from './AssayDesignDeleteConfirmModal';
-import { deleteAssayDesign } from './actions';
 
 const ASSAY_RUN_MODEL_ID = 'assay-runs-all';
 
@@ -90,3 +93,22 @@ const AssayDesignDeleteModalImpl: FC<Props & InjectedQueryModels> = memo(props =
 });
 
 export const AssayDesignDeleteModal = withQueryModels<Props>(AssayDesignDeleteModalImpl);
+
+function deleteAssayDesign(rowId: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+        return Ajax.request({
+            url: buildURL('experiment', 'deleteProtocolByRowIdsAPI.api'),
+            method: 'POST',
+            params: {
+                singleObjectRowId: rowId,
+                forceDelete: true,
+            },
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response);
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                reject(response);
+            }),
+        });
+    });
+}

--- a/packages/components/src/assay/AssayPageHOC.tsx
+++ b/packages/components/src/assay/AssayPageHOC.tsx
@@ -32,6 +32,8 @@ export function assayPage<Props>(
         const hasProtocol = assayName !== undefined;
         const { user } = useServerContext();
 
+        // TODO should this check for isAssayEnabled()?
+
         if (!userCanReadAssays(user)) {
             return <InsufficientPermissionsPage title="Assays" />;
         }

--- a/packages/components/src/assay/AssayPageHOC.tsx
+++ b/packages/components/src/assay/AssayPageHOC.tsx
@@ -1,0 +1,59 @@
+import React, { ComponentType, FC } from 'react';
+import { WithRouterProps } from 'react-router';
+
+import { useServerContext } from '../internal/components/base/ServerContext';
+import { userCanReadAssays } from '../internal/app/utils';
+import { InsufficientPermissionsPage } from '../internal/components/permissions/InsufficientPermissionsPage';
+import { isLoading } from '../public/LoadingState';
+import { LoadingPage } from '../internal/components/base/LoadingPage';
+import { NotFound } from '../internal/components/base/NotFound';
+import { Alert } from '../internal/components/base/Alert';
+import { getActionErrorMessage } from '../internal/util/messaging';
+import {
+    InjectedAssayModel,
+    WithAssayModelProps,
+    withAssayModelsFromLocation,
+} from '../internal/components/assay/withAssayModels';
+
+/**
+ * Returns a higher-order component wrapped with [[withAssayModelsFromLocation]] that provides common
+ * "page"-level handling for edge cases (e.g. loading, protocol not found, errors during loading, etc).
+ * @param ComponentToWrap: The component definition (e.g. class, function) to wrap.
+ * This will have [[InjectedAssayModel]] props injected into it.
+ * @param defaultProps: Provide alternative "defaultProps" for this wrapped component.
+ */
+export function assayPage<Props>(
+    ComponentToWrap: ComponentType<Props & InjectedAssayModel>,
+    defaultProps?: WithAssayModelProps
+): ComponentType<Props & WithAssayModelProps & WithRouterProps> {
+    const AssayPageImpl: FC<Props & InjectedAssayModel & WithRouterProps> = props => {
+        const { assayModel, params } = props;
+        const assayName = params?.protocol;
+        const hasProtocol = assayName !== undefined;
+        const { user } = useServerContext();
+
+        if (!userCanReadAssays(user)) {
+            return <InsufficientPermissionsPage title="Assays" />;
+        }
+        if (
+            isLoading(assayModel.definitionsLoadingState) ||
+            (hasProtocol && isLoading(assayModel.protocolLoadingState))
+        ) {
+            return <LoadingPage />;
+        }
+
+        if (assayModel.definitionsError || assayModel.protocolError) {
+            if (hasProtocol && assayModel.getByName(assayName) === undefined) {
+                return <NotFound />;
+            }
+
+            return (
+                <Alert>{getActionErrorMessage('There was a problem loading the assay design.', 'assay design')}</Alert>
+            );
+        }
+
+        return <ComponentToWrap {...props} />;
+    };
+
+    return withAssayModelsFromLocation(AssayPageImpl, defaultProps);
+}

--- a/packages/components/src/assay/AssayReimportRunButton.tsx
+++ b/packages/components/src/assay/AssayReimportRunButton.tsx
@@ -1,10 +1,10 @@
 import React, { FC, memo } from 'react';
 import { MenuItem, OverlayTrigger, Popover } from 'react-bootstrap';
 
-import { applyURL, AppURL } from '../../url/AppURL';
-import { AssayLink } from '../../AssayDefinitionModel';
+import { applyURL, AppURL } from '../internal/url/AppURL';
+import { AssayLink } from '../internal/AssayDefinitionModel';
 
-import { AssayContextConsumer } from './withAssayModels';
+import { AssayContextConsumer } from '../internal/components/assay/withAssayModels';
 
 interface AssayReImportRunButtonProps {
     replacedByRunId?: string | number;

--- a/packages/components/src/assay/AssayResolver.spec.ts
+++ b/packages/components/src/assay/AssayResolver.spec.ts
@@ -1,0 +1,68 @@
+import { Map } from 'immutable';
+
+import { AppURL } from '../internal/url/AppURL';
+
+import { AssayResolver, AssayRunResolver } from './AssayResolver';
+
+describe('Assay Route Resolvers', () => {
+    test('Should resolve /assays routes', () => {
+        const routes = Map<number, { name: string; provider: string }>().asMutable();
+        routes.set(13, {
+            provider: 'general',
+            name: 'thirteen',
+        });
+        routes.set(91, {
+            provider: 'specific',
+            name: 'ninety-one',
+        });
+        const assayResolver = new AssayResolver(routes.asImmutable());
+
+        // test regex
+        expect.assertions(8);
+        expect(assayResolver.matches(undefined)).toBe(false);
+        expect(assayResolver.matches('/assays/91f')).toBe(false);
+        expect(assayResolver.matches('/assays/91')).toBe(true);
+        expect(assayResolver.matches('/assays/91/foo')).toBe(true);
+        expect(assayResolver.matches('/assays/91/foo?bar=1')).toBe(true);
+
+        return Promise.all([
+            assayResolver.fetch(['assays', 'foo']).then((result: boolean) => {
+                expect(result).toBe(true);
+            }),
+            assayResolver.fetch(['assays', '13']).then((url: AppURL) => {
+                expect(url.toString()).toBe('/assays/general/thirteen');
+            }),
+            assayResolver.fetch(['assays', '91', 'foo bar']).then((url: AppURL) => {
+                expect(url.toString()).toBe('/assays/specific/ninety-one/foo%20bar');
+            }),
+        ]);
+    });
+
+    test('Should resolve /rd/assayrun routes', () => {
+        const routes = Map<number, number>().asMutable();
+        routes.set(595, 13);
+        routes.set(923, 15);
+
+        const assayRunResolver = new AssayRunResolver(routes.asImmutable());
+
+        // test regex
+        expect.assertions(8);
+        expect(assayRunResolver.matches(undefined)).toBe(false);
+        expect(assayRunResolver.matches('/rd/assayrun/91f')).toBe(false);
+        expect(assayRunResolver.matches('/rd/assayrun/91')).toBe(true);
+        expect(assayRunResolver.matches('/rd/assayrun/91/foo')).toBe(true);
+        expect(assayRunResolver.matches('/rd/assayrun/91/foo?bar=1')).toBe(true);
+
+        return Promise.all([
+            assayRunResolver.fetch(['rd', 'assayrun', 'boom']).then(result => {
+                expect(result).toBe(true);
+            }),
+            assayRunResolver.fetch(['rd', 'assayrun', '923']).then(result => {
+                expect(result.toString()).toBe('/assays/15/runs/923');
+            }),
+            assayRunResolver.fetch(['rd', 'assayrun', '595', 'extra']).then(result => {
+                expect(result.toString()).toBe('/assays/13/runs/595/extra');
+            }),
+        ]);
+    });
+});

--- a/packages/components/src/assay/AssayResolver.ts
+++ b/packages/components/src/assay/AssayResolver.ts
@@ -1,0 +1,114 @@
+import { Map } from 'immutable';
+
+import { Filter } from '@labkey/api';
+
+import { AppRouteResolver } from '../internal/url/models';
+import { AppURL, spliceURL } from '../internal/url/AppURL';
+import { fetchProtocol } from '../internal/components/domainproperties/assay/actions';
+import { AssayProtocolModel } from '../internal/components/domainproperties/assay/models';
+import { selectRows } from '../internal/query/selectRows';
+
+import { SCHEMAS } from '../internal/schemas';
+import { caseInsensitive } from '../internal/util/utils';
+
+/**
+ * Resolves Assay routes dynamically
+ * /assays/44/... -> /assays/providerName/assayName/...
+ */
+export class AssayResolver implements AppRouteResolver {
+    datas: Map<number, { name: string; provider: string }>; // Map<AssayProtocolId, {name, provider}>
+
+    constructor(datas?: Map<number, { name: string; provider: string }>) {
+        this.datas = datas !== undefined ? datas : Map<number, { name: string; provider: string }>();
+    }
+
+    matches(route: string): boolean {
+        return /\/assays\/(\d+$|\d+\/)/.test(route);
+    }
+
+    fetch(parts: any[]): Promise<AppURL | boolean> {
+        const assayRowIdIndex = 1;
+        const assayRowId: number = parseInt(parts[assayRowIdIndex], 10);
+
+        if (isNaN(assayRowId)) {
+            return Promise.resolve(true);
+        } else if (this.datas.has(assayRowId)) {
+            const context = this.datas.get(assayRowId);
+            const newParts = [context.provider, context.name];
+            return Promise.resolve(spliceURL(parts, newParts, assayRowIdIndex));
+        } else {
+            return new Promise(resolve => {
+                return fetchProtocol(assayRowId)
+                    .then((assay: AssayProtocolModel) => {
+                        const context = {
+                            name: encodeURIComponent(assay.name),
+                            provider: assay.providerName,
+                        };
+
+                        this.datas = this.datas.set(assayRowId, context);
+                        const newParts = [context.provider, context.name];
+                        return resolve(spliceURL(parts, newParts, assayRowIdIndex));
+                    })
+                    .catch(() => {
+                        return resolve(true);
+                    });
+            });
+        }
+    }
+}
+
+/**
+ * Resolves Assay Run routes dynamically
+ * /rd/assayrun/543/... -> /assays/44/runs/584/...
+ */
+export class AssayRunResolver implements AppRouteResolver {
+    datas: Map<number, number>;
+
+    constructor(datas?: Map<number, number>) {
+        this.datas = datas !== undefined ? datas : Map<number, number>();
+    }
+
+    matches(route: string): boolean {
+        return /\/rd\/assayrun\/(\d+$|\d+\/)/.test(route);
+    }
+
+    async fetch(parts: any[]): Promise<AppURL | boolean> {
+        // ["rd", "assayrun", "543", ...]
+        const assayRunIdIndex = 2;
+        const assayRunId: number = parseInt(parts[assayRunIdIndex], 10);
+
+        if (isNaN(assayRunId)) {
+            // skip it
+            return true;
+        } else if (this.datas.has(assayRunId)) {
+            // resolve it
+            const newParts = ['assays', this.datas.get(assayRunId), 'runs'];
+            return spliceURL(parts, newParts, 0, assayRunIdIndex);
+        }
+
+        // fetch it
+        try {
+            const result = await selectRows({
+                columns: 'RowId,Protocol/RowId',
+                filterArray: [Filter.create('RowId', assayRunId)],
+                schemaQuery: SCHEMAS.EXP_TABLES.ASSAY_RUNS,
+            });
+
+            if (result.rows.length === 1) {
+                const assayProtocolId = caseInsensitive(result.rows[0], 'Protocol/RowId').value;
+
+                // cache
+                this.datas.set(assayRunId, assayProtocolId);
+
+                // resolve it
+                const newParts = ['assays', assayProtocolId, 'runs'];
+                return spliceURL(parts, newParts, 0, assayRunIdIndex);
+            }
+        } catch (e) {
+            // skip it
+        }
+
+        // skip it
+        return true;
+    }
+}

--- a/packages/components/src/assay/AssayResultDeleteModal.spec.tsx
+++ b/packages/components/src/assay/AssayResultDeleteModal.spec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { mountWithAppServerContext } from '../../testHelpers';
+import { mountWithAppServerContext } from '../internal/testHelpers';
 
-import { SCHEMAS } from '../../schemas';
+import { SCHEMAS } from '../internal/schemas';
 
 import { AssayResultDeleteModal } from './AssayResultDeleteModal';
 

--- a/packages/components/src/assay/AssayResultDeleteModal.tsx
+++ b/packages/components/src/assay/AssayResultDeleteModal.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useMemo, useState } from 'react';
 
-import { deleteErrorMessage, deleteSuccessMessage } from '../../util/messaging';
-import { SchemaQuery } from '../../../public/SchemaQuery';
-import { useNotificationsContext } from '../notifications/NotificationsContext';
-import { deleteRows } from '../../query/api';
-import { ConfirmModal } from '../base/ConfirmModal';
-import { Progress } from '../base/Progress';
+import { deleteErrorMessage, deleteSuccessMessage } from '../internal/util/messaging';
+import { SchemaQuery } from '../public/SchemaQuery';
+import { useNotificationsContext } from '../internal/components/notifications/NotificationsContext';
+import { deleteRows } from '../internal/query/api';
+import { ConfirmModal } from '../internal/components/base/ConfirmModal';
+import { Progress } from '../internal/components/base/Progress';
 
 interface Props {
     afterDelete: () => void;

--- a/packages/components/src/assay/AssayResultTemplateDownloadRenderer.tsx
+++ b/packages/components/src/assay/AssayResultTemplateDownloadRenderer.tsx
@@ -4,9 +4,9 @@ import { Map } from 'immutable';
 
 import { Assay } from '@labkey/api';
 
-import { TemplateDownloadButton } from '../../public/files/TemplateDownloadButton';
+import { TemplateDownloadButton } from '../public/files/TemplateDownloadButton';
 
-import { downloadAttachment } from '../util/utils';
+import { downloadAttachment } from '../internal/util/utils';
 
 interface Props {
     excludeColumns?: string[];

--- a/packages/components/src/assay/AssayRunDeleteModal.tsx
+++ b/packages/components/src/assay/AssayRunDeleteModal.tsx
@@ -1,13 +1,13 @@
 import React, { FC, useState } from 'react';
+import { Ajax, Utils } from '@labkey/api';
 
-import { deleteErrorMessage, deleteSuccessMessage } from '../../util/messaging';
-import { AssayRunDataType } from '../entities/constants';
+import { deleteErrorMessage, deleteSuccessMessage } from '../internal/util/messaging';
+import { AssayRunDataType } from '../internal/components/entities/constants';
 
-import { useNotificationsContext } from '../notifications/NotificationsContext';
-import { EntityDeleteConfirmModal } from '../entities/EntityDeleteConfirmModal';
-import { Progress } from '../base/Progress';
-
-import { deleteAssayRuns } from './actions';
+import { useNotificationsContext } from '../internal/components/notifications/NotificationsContext';
+import { EntityDeleteConfirmModal } from '../internal/components/entities/EntityDeleteConfirmModal';
+import { Progress } from '../internal/components/base/Progress';
+import { buildURL } from '../internal/url/AppURL';
 
 interface Props {
     afterDelete: () => void;
@@ -93,3 +93,29 @@ export const AssayRunDeleteModal: FC<Props> = props => {
         </>
     );
 };
+
+function deleteAssayRuns(
+    selectionKey?: string,
+    rowIds?: string[],
+    cascadeDeleteReplacedRuns = false,
+    containerPath?: string
+): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const jsonData: any = selectionKey ? { dataRegionSelectionKey: selectionKey } : { rowIds };
+        jsonData.cascade = cascadeDeleteReplacedRuns;
+
+        return Ajax.request({
+            url: buildURL('experiment', 'deleteRuns.api', undefined, {
+                container: containerPath,
+            }),
+            method: 'POST',
+            jsonData,
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response);
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                reject(response);
+            }),
+        });
+    });
+}

--- a/packages/components/src/assay/AssaySubNavMenu.tsx
+++ b/packages/components/src/assay/AssaySubNavMenu.tsx
@@ -6,13 +6,13 @@ import React, { Component } from 'react';
 import { List } from 'immutable';
 import { WithRouterProps } from 'react-router';
 
-import { ASSAYS_KEY } from '../../app/constants';
-import { AppURL } from '../../url/AppURL';
+import { ASSAYS_KEY } from '../internal/app/constants';
+import { AppURL } from '../internal/url/AppURL';
 
-import { ITab } from '../navigation/types';
-import { SubNav } from '../navigation/SubNav';
+import { ITab } from '../internal/components/navigation/types';
+import { SubNav } from '../internal/components/navigation/SubNav';
 
-import { InjectedAssayModel, withAssayModelsFromLocation } from './withAssayModels';
+import { InjectedAssayModel, withAssayModelsFromLocation } from '../internal/components/assay/withAssayModels';
 
 const BATCHES_TAB = 'Batches';
 const TABS_WITHOUT_BATCHES = List<string>(['Overview', 'Runs', 'Results']);
@@ -23,7 +23,7 @@ interface AssaySubNavMenuProps {
 
 type Props = InjectedAssayModel & WithRouterProps & AssaySubNavMenuProps;
 
-export class AssaySubNavMenuImpl extends Component<Props> {
+class AssaySubNavMenuImpl extends Component<Props> {
     PARENT_TAB: ITab = {
         text: 'Assays',
         url: AppURL.create(ASSAYS_KEY),

--- a/packages/components/src/assay/AssayTypeStatusGrid.spec.tsx
+++ b/packages/components/src/assay/AssayTypeStatusGrid.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Filter } from '@labkey/api';
 
-import { mountWithAppServerContext } from '../../testHelpers';
-import { TEST_USER_EDITOR } from '../../userFixtures';
+import { mountWithAppServerContext } from '../internal/testHelpers';
+import { TEST_USER_EDITOR } from '../internal/userFixtures';
 
-import { StatusGrid, StatusGridWithModels } from './StatusGrid';
+import { AssayTypeStatusGrid, AssayTypeStatusGridWithModels } from './AssayTypeStatusGrid';
 
 describe('StatusGrid', () => {
     const validate = (filter: Filter.IFilter[], filterType: string, value: string[], filterLength: number) => {
@@ -17,11 +17,11 @@ describe('StatusGrid', () => {
     // If assayTypes exists, col filter on Type should be those in assayTypes
     test('StatusGrid assayTypes', () => {
         const wrapper = mountWithAppServerContext(
-            <StatusGrid assayTypes={['General']} />,
+            <AssayTypeStatusGrid assayTypes={['General']} />,
             {},
             { user: TEST_USER_EDITOR }
         );
-        const statusGridWithModelsProps = wrapper.find(StatusGridWithModels).props();
+        const statusGridWithModelsProps = wrapper.find(AssayTypeStatusGridWithModels).props();
 
         const activeFilter = statusGridWithModelsProps.queryConfigs.active.baseFilters;
         validate(activeFilter, 'Equals One Of', ['General'], 2);
@@ -35,13 +35,13 @@ describe('StatusGrid', () => {
     // If excludedAssayProviders exists, col filter on Type should be those not in excludedAssayProviders
     test('StatusGrid excludedAssayProviders', () => {
         const wrapper = mountWithAppServerContext(
-            <StatusGrid excludedAssayProviders={['Luminex']} />,
+            <AssayTypeStatusGrid excludedAssayProviders={['Luminex']} />,
             {},
             {
                 user: TEST_USER_EDITOR,
             }
         );
-        const statusGridWithModelsProps = wrapper.find(StatusGridWithModels).props();
+        const statusGridWithModelsProps = wrapper.find(AssayTypeStatusGridWithModels).props();
 
         const activeFilter = statusGridWithModelsProps.queryConfigs.active.baseFilters;
         validate(activeFilter, 'Does Not Equal Any Of', ['Luminex'], 2);
@@ -55,11 +55,11 @@ describe('StatusGrid', () => {
     // If both exist, only assayTypes is used
     test('StatusGrid assayTypes and excludedAssayProviders', () => {
         const wrapper = mountWithAppServerContext(
-            <StatusGrid assayTypes={['General']} excludedAssayProviders={['Luminex']} />,
+            <AssayTypeStatusGrid assayTypes={['General']} excludedAssayProviders={['Luminex']} />,
             {},
             { user: TEST_USER_EDITOR }
         );
-        const statusGridWithModelsProps = wrapper.find(StatusGridWithModels).props();
+        const statusGridWithModelsProps = wrapper.find(AssayTypeStatusGridWithModels).props();
 
         const activeFilter = statusGridWithModelsProps.queryConfigs.active.baseFilters;
         validate(activeFilter, 'Equals One Of', ['General'], 2);
@@ -72,8 +72,8 @@ describe('StatusGrid', () => {
 
     // If neither exist, no col filter on Type is used
     test('StatusGrid assayTypes nor excludedAssayProviders', () => {
-        const wrapper = mountWithAppServerContext(<StatusGrid />, {}, { user: TEST_USER_EDITOR });
-        const statusGridWithModelsProps = wrapper.find(StatusGridWithModels).props();
+        const wrapper = mountWithAppServerContext(<AssayTypeStatusGrid />, {}, { user: TEST_USER_EDITOR });
+        const statusGridWithModelsProps = wrapper.find(AssayTypeStatusGridWithModels).props();
 
         const activeFilter = statusGridWithModelsProps.queryConfigs.active.baseFilters;
         expect(activeFilter.length).toBe(1);

--- a/packages/components/src/assay/AssayTypeStatusGrid.tsx
+++ b/packages/components/src/assay/AssayTypeStatusGrid.tsx
@@ -2,16 +2,16 @@ import React, { FC, memo, useMemo } from 'react';
 
 import { Filter, PermissionTypes } from '@labkey/api';
 
-import { Status } from '../domainproperties/assay/models';
+import { Status } from '../internal/components/domainproperties/assay/models';
 
-import { SCHEMAS } from '../../schemas';
+import { SCHEMAS } from '../internal/schemas';
 
-import { TabbedGridPanel } from '../../../public/QueryModel/TabbedGridPanel';
+import { TabbedGridPanel } from '../public/QueryModel/TabbedGridPanel';
 
-import { hasAnyPermissions } from '../base/models/User';
-import { useServerContext } from '../base/ServerContext';
+import { hasAnyPermissions } from '../internal/components/base/models/User';
+import { useServerContext } from '../internal/components/base/ServerContext';
 
-import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
+import { InjectedQueryModels, withQueryModels } from '../public/QueryModel/withQueryModels';
 
 const ACTIVE_GRID_ID = 'active';
 const ALL_GRID_ID = 'all';
@@ -28,7 +28,7 @@ interface OwnProps {
     excludedAssayProviders?: string[];
 }
 
-export const StatusGridImpl: FC<InjectedQueryModels> = memo(props => {
+const AssayTypeStatusGridImpl: FC<InjectedQueryModels> = memo(props => {
     const { actions, queryModels } = props;
 
     return (
@@ -43,9 +43,9 @@ export const StatusGridImpl: FC<InjectedQueryModels> = memo(props => {
     );
 });
 
-export const StatusGridWithModels = withQueryModels(StatusGridImpl);
+export const AssayTypeStatusGridWithModels = withQueryModels(AssayTypeStatusGridImpl);
 
-export const StatusGrid: FC<OwnProps> = memo(props => {
+export const AssayTypeStatusGrid: FC<OwnProps> = memo(props => {
     const { assayTypes, excludedAssayProviders } = props;
     const { user } = useServerContext();
 
@@ -87,5 +87,5 @@ export const StatusGrid: FC<OwnProps> = memo(props => {
         };
     }, [assayTypes, excludedAssayProviders]);
 
-    return <StatusGridWithModels queryConfigs={queryConfigs} />;
+    return <AssayTypeStatusGridWithModels queryConfigs={queryConfigs} />;
 });

--- a/packages/components/src/assay/AssayTypeSummary.spec.tsx
+++ b/packages/components/src/assay/AssayTypeSummary.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { initUnitTestMocks } from '../../../test/testHelperMocks';
-import { selectOptionByText, SELECT_INPUT_CONTROL_SELECTOR } from '../forms/input/SelectInputTestUtils';
-import { mountWithAppServerContext } from '../../testHelpers';
-import { TEST_USER_EDITOR } from '../../userFixtures';
+import { initUnitTestMocks } from '../test/testHelperMocks';
+import { selectOptionByText, SELECT_INPUT_CONTROL_SELECTOR } from '../internal/components/forms/input/SelectInputTestUtils';
+import { mountWithAppServerContext } from '../internal/testHelpers';
+import { TEST_USER_EDITOR } from '../internal/userFixtures';
 
 import { AssayTypeSummary } from './AssayTypeSummary';
 

--- a/packages/components/src/assay/AssayTypeSummary.tsx
+++ b/packages/components/src/assay/AssayTypeSummary.tsx
@@ -1,9 +1,9 @@
 import React, { FC, memo, useState } from 'react';
 
-import { SelectView, SelectViewInput } from '../base/SelectViewInput';
-import { AppURL } from '../../url/AppURL';
+import { SelectView, SelectViewInput } from '../internal/components/base/SelectViewInput';
+import { AppURL } from '../internal/url/AppURL';
 
-import { StatusGrid } from './StatusGrid';
+import { StatusGrid } from '../internal/components/assay/StatusGrid';
 import { AssaysHeatMap } from './AssaysHeatMap';
 
 const ASSAY_VIEWS = [SelectView.Grid, SelectView.Heatmap];

--- a/packages/components/src/assay/AssayTypeSummary.tsx
+++ b/packages/components/src/assay/AssayTypeSummary.tsx
@@ -3,7 +3,7 @@ import React, { FC, memo, useState } from 'react';
 import { SelectView, SelectViewInput } from '../internal/components/base/SelectViewInput';
 import { AppURL } from '../internal/url/AppURL';
 
-import { StatusGrid } from '../internal/components/assay/StatusGrid';
+import { AssayTypeStatusGrid } from './AssayTypeStatusGrid';
 import { AssaysHeatMap } from './AssaysHeatMap';
 
 const ASSAY_VIEWS = [SelectView.Grid, SelectView.Heatmap];
@@ -30,7 +30,7 @@ export const AssayTypeSummary: FC<AssayTypeSummaryProps> = memo(props => {
                 <AssaysHeatMap navigate={navigate} excludedAssayProviders={excludedAssayProviders} />
             )}
             {selectedView === SelectView.Grid && (
-                <StatusGrid assayTypes={assayTypes} excludedAssayProviders={excludedAssayProviders} />
+                <AssayTypeStatusGrid assayTypes={assayTypes} excludedAssayProviders={excludedAssayProviders} />
             )}
         </>
     );

--- a/packages/components/src/assay/AssaysHeatMap.tsx
+++ b/packages/components/src/assay/AssaysHeatMap.tsx
@@ -1,11 +1,11 @@
 import React, { FC, memo, useMemo } from 'react';
 import { Filter } from '@labkey/api';
 
-import { ASSAYS_KEY } from '../../app/constants';
-import { AppURL } from '../../url/AppURL';
-import { HeatMap, HeatMapCell } from '../heatmap/HeatMap';
-import { Alert } from '../base/Alert';
-import { SCHEMAS } from '../../schemas';
+import { ASSAYS_KEY } from '../internal/app/constants';
+import { AppURL } from '../internal/url/AppURL';
+import { HeatMap, HeatMapCell } from '../internal/components/heatmap/HeatMap';
+import { Alert } from '../internal/components/base/Alert';
+import { SCHEMAS } from '../internal/schemas';
 
 interface Props {
     excludedAssayProviders?: string[];

--- a/packages/components/src/assay/index.ts
+++ b/packages/components/src/assay/index.ts
@@ -1,0 +1,25 @@
+import { AssayDesignDeleteModal } from './AssayDesignDeleteModal';
+import { assayPage } from './AssayPageHOC';
+import { AssayReimportRunButton } from './AssayReimportRunButton';
+import { AssayResolver, AssayRunResolver } from './AssayResolver';
+import { AssayResultDeleteModal } from './AssayResultDeleteModal';
+import { AssayResultTemplateDownloadRenderer } from './AssayResultTemplateDownloadRenderer';
+import { AssayRunDeleteModal } from './AssayRunDeleteModal';
+import { AssaySubNavMenu } from './AssaySubNavMenu';
+import { AssayTypeSummary } from './AssayTypeSummary';
+import { getAssayImportNotificationMsg, getAssayRunDeleteMessage } from './utils';
+
+export {
+    assayPage,
+    getAssayImportNotificationMsg,
+    getAssayRunDeleteMessage,
+    AssayDesignDeleteModal,
+    AssayReimportRunButton,
+    AssayResolver,
+    AssayRunResolver,
+    AssayResultDeleteModal,
+    AssayResultTemplateDownloadRenderer,
+    AssayRunDeleteModal,
+    AssaySubNavMenu,
+    AssayTypeSummary,
+};

--- a/packages/components/src/assay/utils.spec.tsx
+++ b/packages/components/src/assay/utils.spec.tsx
@@ -1,8 +1,8 @@
+import React from 'react';
 import { mount } from 'enzyme';
 
-import { LoadingSpinner } from '../base/LoadingSpinner';
-import React from 'react';
 import { getAssayRunDeleteMessage } from './utils';
+import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 
 describe('getAssayDeleteMessage', () => {
     test('loading', () => {

--- a/packages/components/src/assay/utils.tsx
+++ b/packages/components/src/assay/utils.tsx
@@ -1,0 +1,70 @@
+import React, { ReactNode } from 'react';
+
+import { AssayDefinitionModel } from '../internal/AssayDefinitionModel';
+import { AppURL } from '../internal/url/AppURL';
+import { ASSAYS_KEY } from '../internal/app/constants';
+import { AssayUploadResultModel } from '../internal/components/assay/models';
+import { getPipelineLinkMsg, getWorkflowLinkMsg } from '../internal/components/pipeline/utils';
+import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
+
+function getAssayImportSuccessMsg(
+    runId: number,
+    isBackgroundJob: boolean,
+    reimport: boolean,
+    assayDefinition: AssayDefinitionModel = null
+): ReactNode {
+    if (!isBackgroundJob) {
+        const msg = `Successfully ${reimport ? 're-imported' : 'created'} assay run`;
+        if (assayDefinition) {
+            // Displayed if 'Save and Import Another Run' chosen
+            const href = AppURL.create(ASSAYS_KEY, assayDefinition.type, assayDefinition.name, 'runs', runId).toHref();
+            return (
+                <>
+                    {msg} <a href={href}>#{runId}</a>.{' '}
+                </>
+            );
+        } else {
+            // Displayed if 'Save and Finish' chosen
+            return <> {msg}. </>;
+        }
+    } else {
+        return (
+            <>
+                Successfully started {reimport ? 're-importing' : 'creating'} assay run. You'll be notified when it's
+                done.{' '}
+            </>
+        );
+    }
+}
+
+export function getAssayImportNotificationMsg(
+    response: AssayUploadResultModel,
+    isBackgroundJob: boolean,
+    reimport: boolean,
+    assayDefinition: AssayDefinitionModel,
+    workflowJobId?: string,
+    workflowTaskId?: string
+): ReactNode {
+    return (
+        <span>
+            {getAssayImportSuccessMsg(response.runId, isBackgroundJob, reimport, assayDefinition)}
+            {isBackgroundJob ? getPipelineLinkMsg(response) : null}
+            {!assayDefinition ? getWorkflowLinkMsg(workflowJobId, workflowTaskId) : null}
+        </span>
+    );
+}
+
+export function getAssayRunDeleteMessage(canDelete: boolean, deleteInfoError: boolean): ReactNode {
+    let deleteMsg;
+    if (canDelete === undefined) {
+        deleteMsg = <LoadingSpinner msg="Loading delete confirmation data..." />;
+    } else if (!canDelete) {
+        deleteMsg = 'This assay run cannot be deleted because ';
+        if (deleteInfoError) {
+            deleteMsg += 'there was a problem loading the delete confirmation data.';
+        } else {
+            deleteMsg += 'it has references in one or more active notebooks.';
+        }
+    }
+    return deleteMsg;
+}

--- a/packages/components/src/entities/AssayImportSubMenuItem.spec.tsx
+++ b/packages/components/src/entities/AssayImportSubMenuItem.spec.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { MenuItem, OverlayTrigger } from 'react-bootstrap';
 import { mount } from 'enzyme';
 
-import { TEST_ASSAY_STATE_MODEL } from '../../../test/data/constants';
+import { TEST_ASSAY_STATE_MODEL } from '../test/data/constants';
 
-import { SubMenuItem } from '../menus/SubMenuItem';
+import { SubMenuItem } from '../internal/components/menus/SubMenuItem';
 
-import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
-import { SchemaQuery } from '../../../public/SchemaQuery';
+import { makeTestQueryModel } from '../public/QueryModel/testUtils';
+import { SchemaQuery } from '../public/SchemaQuery';
 
-import { GENERAL_ASSAY_PROVIDER_NAME } from './actions';
+import { GENERAL_ASSAY_PROVIDER_NAME } from '../internal/components/assay/actions';
 import { AssayImportSubMenuItemImpl } from './AssayImportSubMenuItem';
 
 const DEFAULT_PROPS = {

--- a/packages/components/src/entities/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/entities/AssayImportSubMenuItem.tsx
@@ -1,15 +1,14 @@
 import React, { FC, useMemo } from 'react';
 import { MenuItem, OverlayTrigger, Popover } from 'react-bootstrap';
 
-import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
+import { MAX_EDITABLE_GRID_ROWS } from '../internal/constants';
 
-import { SubMenuItem, SubMenuItemProps } from '../menus/SubMenuItem';
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
-import { DisableableMenuItem } from '../samples/DisableableMenuItem';
+import { SubMenuItem, SubMenuItemProps } from '../internal/components/menus/SubMenuItem';
+import { QueryModel } from '../public/QueryModel/QueryModel';
+import { DisableableMenuItem } from '../internal/components/samples/DisableableMenuItem';
 
-import { getImportItemsForAssayDefinitions } from './actions';
-
-import { InjectedAssayModel, withAssayModels } from './withAssayModels';
+import { InjectedAssayModel, withAssayModels } from '../internal/components/assay/withAssayModels';
+import { getImportItemsForAssayDefinitions } from './utils';
 
 interface Props extends SubMenuItemProps {
     currentProductId?: string;

--- a/packages/components/src/entities/EntityFieldFilterModal.tsx
+++ b/packages/components/src/entities/EntityFieldFilterModal.tsx
@@ -24,8 +24,6 @@ import { AssayResultDataType } from '../internal/components/entities/constants';
 
 import { COLUMN_NOT_IN_FILTER_TYPE } from '../internal/query/filter';
 
-import { AssaySampleColumnProp } from '../internal/components/assay/actions';
-
 import { FieldFilter, FilterProps } from '../internal/components/search/models';
 import {
     getDataTypeFiltersWithNotInQueryUpdate,
@@ -34,6 +32,8 @@ import {
     isValidFilterFieldExcludeLookups,
 } from '../internal/components/search/utils';
 import { QueryFilterPanel } from '../internal/components/search/QueryFilterPanel';
+
+import { AssaySampleColumnProp } from './models';
 
 interface Props {
     api?: ComponentsAPIWrapper;

--- a/packages/components/src/entities/SampleAssayDetail.tsx
+++ b/packages/components/src/entities/SampleAssayDetail.tsx
@@ -3,7 +3,6 @@ import { Button, MenuItem, Panel, SplitButton } from 'react-bootstrap';
 import { Filter, getServerContext } from '@labkey/api';
 
 import { InjectedAssayModel, withAssayModels } from '../internal/components/assay/withAssayModels';
-import { getImportItemsForAssayDefinitions } from '../internal/components/assay/actions';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../internal/APIWrapper';
 
@@ -20,16 +19,15 @@ import { isLoading } from '../public/LoadingState';
 import { caseInsensitive } from '../internal/util/utils';
 import { SchemaQuery } from '../public/SchemaQuery';
 
-import {
-    InjectedQueryModels,
-    RequiresModelAndActions,
-    withQueryModels,
-} from '../public/QueryModel/withQueryModels';
+import { InjectedQueryModels, RequiresModelAndActions, withQueryModels } from '../public/QueryModel/withQueryModels';
 
 import { ALIQUOT_FILTER_MODE, SampleOperation } from '../internal/components/samples/constants';
-import { SampleAliquotViewSelector } from './SampleAliquotViewSelector';
+
 import { getSampleStatusType, isSampleOperationPermitted } from '../internal/components/samples/utils';
 import { getSampleAssayQueryConfigs, SampleAssayResultViewConfig } from '../internal/components/samples/actions';
+
+import { SampleAliquotViewSelector } from './SampleAliquotViewSelector';
+import { getImportItemsForAssayDefinitions } from './utils';
 
 interface Props {
     api?: ComponentsAPIWrapper;

--- a/packages/components/src/entities/SampleFinderSection.tsx
+++ b/packages/components/src/entities/SampleFinderSection.tsx
@@ -8,10 +8,8 @@ import { EntityDataType } from '../internal/components/entities/models';
 import { Section } from '../internal/components/base/Section';
 import { SchemaQuery } from '../public/SchemaQuery';
 
-import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SAMPLE_DATA_EXPORT_CONFIG } from '../internal/components/samples/constants';
 import { User } from '../internal/components/base/models/User';
-import { SamplesEditableGridProps } from './SamplesEditableGrid';
 
 import { SamplesEditButtonSections } from '../internal/components/samples/utils';
 import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
@@ -37,8 +35,6 @@ import {
 
 import { InjectedAssayModel, withAssayModels } from '../internal/components/assay/withAssayModels';
 
-import { AssaySampleColumnProp, getAssayDefinitionsWithResultSampleLookup } from '../internal/components/assay/actions';
-
 import { isLoading } from '../public/LoadingState';
 
 import { AssayResultDataType } from '../internal/components/entities/constants';
@@ -50,7 +46,7 @@ import {
     saveFinderSearch,
 } from '../internal/components/search/actions';
 import { FilterCards } from '../internal/components/search/FilterCards';
-import { getSampleFinderLocalStorageKey } from './utils';
+
 import {
     getFinderStartText,
     getFinderViewColumnsConfig,
@@ -62,13 +58,25 @@ import {
     searchFiltersFromJson,
     searchFiltersToJson,
 } from '../internal/components/search/utils';
-import { EntityFieldFilterModal } from './EntityFieldFilterModal';
 
 import { FieldFilter, FilterProps, FinderReport } from '../internal/components/search/models';
+
+import { SAMPLE_FINDER_SESSION_PREFIX } from '../internal/components/search/constants';
+
+import { AssayStateModel } from '../internal/components/assay/models';
+
+import { AssayDomainTypes } from '../internal/AssayDefinitionModel';
+
+import { getSampleFinderLocalStorageKey } from './utils';
+import { EntityFieldFilterModal } from './EntityFieldFilterModal';
+
 import { SampleFinderSavedViewsMenu } from './SampleFinderSavedViewsMenu';
 import { SampleFinderSaveViewModal } from './SampleFinderSaveViewModal';
 import { SampleFinderManageViewsModal } from './SampleFinderManageViewsModal';
-import { SAMPLE_FINDER_SESSION_PREFIX } from '../internal/components/search/constants';
+
+import { SamplesEditableGridProps } from './SamplesEditableGrid';
+import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
+import { AssaySampleColumnProp } from './models';
 
 interface SampleFinderSamplesGridProps {
     columnDisplayNames?: { [key: string]: string };
@@ -615,3 +623,25 @@ const SampleFinderSamples: FC<SampleFinderSamplesProps> = memo(props => {
         />
     );
 });
+
+function getAssayDefinitionsWithResultSampleLookup(
+    assayStateModel: AssayStateModel,
+    providerType?: string
+): { [key: string]: AssaySampleColumnProp } {
+    const assays = assayStateModel.definitions.filter(
+        assay => providerType === undefined || assay.type?.toLowerCase() === providerType?.toLowerCase()
+    );
+
+    const results = {};
+    assays.forEach(assay => {
+        const sampleCol = assay.getSampleColumn(AssayDomainTypes.RESULT)?.column;
+        if (sampleCol) {
+            results[assay.name?.toLowerCase()] = {
+                fieldKey: sampleCol.fieldKey,
+                lookupFieldKey: sampleCol.lookup.keyColumn,
+            };
+        }
+    });
+
+    return results;
+}

--- a/packages/components/src/entities/SamplesAssayButton.spec.tsx
+++ b/packages/components/src/entities/SamplesAssayButton.spec.tsx
@@ -8,7 +8,7 @@ import { QueryInfo } from '../public/QueryInfo';
 import { mountWithServerContext } from '../internal/testHelpers';
 import { TEST_USER_EDITOR, TEST_USER_READER } from '../internal/userFixtures';
 import { SCHEMAS } from '../internal/schemas';
-import { AssayImportSubMenuItem } from '../internal/components/assay/AssayImportSubMenuItem';
+import { AssayImportSubMenuItem } from './AssayImportSubMenuItem';
 
 import { GENERAL_ASSAY_PROVIDER_NAME } from '../internal/components/assay/actions';
 

--- a/packages/components/src/entities/SamplesAssayButton.tsx
+++ b/packages/components/src/entities/SamplesAssayButton.tsx
@@ -4,7 +4,7 @@ import { PermissionTypes } from '@labkey/api';
 
 import { QueryModel } from '../public/QueryModel/QueryModel';
 
-import { AssayImportSubMenuItem } from '../internal/components/assay/AssayImportSubMenuItem';
+import { AssayImportSubMenuItem } from './AssayImportSubMenuItem';
 import { InjectedAssayModel, withAssayModels } from '../internal/components/assay/withAssayModels';
 
 import { isLoading } from '../public/LoadingState';

--- a/packages/components/src/entities/SamplesResolver.spec.ts
+++ b/packages/components/src/entities/SamplesResolver.spec.ts
@@ -1,0 +1,43 @@
+import { List, Map } from 'immutable';
+
+import { AppURL } from '../internal/url/AppURL';
+
+import { SamplesResolver } from './SamplesResolver';
+
+describe('SamplesResolver', () => {
+    test('Should resolve /rd/samples/### routes', () => {
+        const routes = Map<number, List<string>>().asMutable();
+        routes.set(7, List(['samples', 'Elway']));
+        routes.set(30, List(['samples', 'TD']));
+        routes.set(80, List(['samples', 'RodSmith']));
+        routes.set(24, List(['media', 'Woodson']));
+        const samplesResolver = new SamplesResolver(routes.asImmutable());
+
+        // test regex
+        expect.assertions(11);
+        expect(samplesResolver.matches(undefined)).toBe(false);
+        expect(samplesResolver.matches('/rd/samples/f23')).toBe(false);
+        expect(samplesResolver.matches('/rd/samples/2.3')).toBe(false);
+        expect(samplesResolver.matches('/rd/samples/80')).toBe(true);
+        expect(samplesResolver.matches('/rd/samples/3221/foo/bar')).toBe(true);
+        expect(samplesResolver.matches('/rd/samples/919/foo/bar?bar=1')).toBe(true);
+
+        return Promise.all([
+            samplesResolver.fetch(['rd', 'samples', 'notvalid', 14]).then((result: boolean) => {
+                expect(result).toBe(true);
+            }),
+            samplesResolver.fetch(['rd', 'samples', 30]).then((url: AppURL) => {
+                expect(url.toString()).toBe('/samples/TD/30');
+            }),
+            samplesResolver.fetch(['rd', 'samples', '80', 'wideOut']).then((url: AppURL) => {
+                expect(url.toString()).toBe('/samples/RodSmith/80/wideOut');
+            }),
+            samplesResolver.fetch(['rd', 'samples', '7', 77, '?']).then((url: AppURL) => {
+                expect(url.toString()).toBe('/samples/Elway/7/77/%3F');
+            }),
+            samplesResolver.fetch(['rd', 'samples', 24]).then((url: AppURL) => {
+                expect(url.toString()).toBe('/media/Woodson/24');
+            }),
+        ]);
+    });
+});

--- a/packages/components/src/entities/SamplesResolver.ts
+++ b/packages/components/src/entities/SamplesResolver.ts
@@ -1,0 +1,87 @@
+import { List, Map } from 'immutable';
+
+import { Filter } from '@labkey/api';
+
+import { AppRouteResolver } from '../internal/url/models';
+import { AppURL, spliceURL } from '../internal/url/AppURL';
+import { selectRows } from '../internal/query/selectRows';
+import { SCHEMAS } from '../internal/schemas';
+
+import { caseInsensitive } from '../internal/util/utils';
+import { getQueryDetails } from '../internal/query/api';
+import { MEDIA_KEY } from '../internal/app/constants';
+
+/**
+ * Resolves sample routes dynamically
+ * /rd/samples/14/... -> /samples/sampleSetByName/14/... || /media/batches/14
+ */
+export class SamplesResolver implements AppRouteResolver {
+    samples: Map<number, List<string>>; // Map<SampleRowId, List<'samples' | 'media', sampleSetName | 'batches'>>
+
+    constructor(samples?: Map<number, List<string>>) {
+        this.samples = samples !== undefined ? samples : Map<number, List<string>>();
+    }
+
+    matches(route: string): boolean {
+        return /\/rd\/samples\/(\d+$|\d+\/)/.test(route);
+    }
+
+    async fetch(parts: any[]): Promise<AppURL | boolean> {
+        // ["rd", "samples", "118", ...]
+        const sampleRowIdIndex = 2;
+        const sampleRowId: number = parseInt(parts[sampleRowIdIndex], 10);
+
+        if (isNaN(sampleRowId)) {
+            // skip it
+            return true;
+        } else if (this.samples.has(sampleRowId)) {
+            // resolve it
+            const newParts = this.samples.get(sampleRowId).toArray();
+            return spliceURL(parts, newParts, 0, 2);
+        }
+
+        // fetch it
+        try {
+            const result = await selectRows({
+                schemaQuery: SCHEMAS.EXP_TABLES.MATERIALS,
+                columns: 'RowId,SampleSet',
+                filterArray: [Filter.create('RowId', sampleRowId)],
+            });
+
+            if (result.rows.length === 1) {
+                const sampleTypeName = caseInsensitive(result.rows[0], 'SampleSet').displayValue.toLowerCase();
+
+                const info = await getQueryDetails({
+                    schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
+                    queryName: sampleTypeName,
+                });
+
+                // fulfill cache
+                let value: List<string>;
+                if (info?.isMedia) {
+                    // for supporting MIXTURE_BATCHES => mixturebatches
+                    const mediaTypeName =
+                        info.name.toLowerCase() === SCHEMAS.SAMPLE_SETS.MIXTURE_BATCHES.queryName.toLowerCase()
+                            ? 'mixturebatches'
+                            : info.name;
+                    value = List([MEDIA_KEY, encodeURIComponent(mediaTypeName)]);
+                } else {
+                    value = List([SCHEMAS.SAMPLE_SETS.SCHEMA.toLowerCase(), encodeURIComponent(sampleTypeName)]);
+                }
+
+                this.samples = this.samples.set(sampleRowId, value);
+
+                if (this.samples.has(sampleRowId)) {
+                    // resolve it
+                    const newParts = this.samples.get(sampleRowId).toArray();
+                    return spliceURL(parts, newParts, 0, 2);
+                }
+            }
+        } catch (e) {
+            // skip it
+        }
+
+        // skip it
+        return true;
+    }
+}

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -46,6 +46,8 @@ import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SampleTypeTemplateDownloadRenderer, downloadSampleTypeTemplate } from './SampleTypeTemplateDownloadRenderer';
 import { SampleTypePage } from './SampleTypePage';
 import { SampleIndexNav, SampleTypeIndexNav } from './SampleNav';
+import { SamplesResolver } from './SamplesResolver';
+import { AssayImportSubMenuItem } from './AssayImportSubMenuItem';
 
 export {
     PICKLIST_SAMPLES_FILTER,
@@ -60,6 +62,7 @@ export {
     getSampleWizardURL,
     isFindByIdsSchema,
     loadSampleTypes,
+    AssayImportSubMenuItem,
     CreateSamplesSubMenu,
     CreateSamplesSubMenuBase,
     EntityCrossProjectSelectionConfirmModal,
@@ -87,6 +90,7 @@ export {
     SampleFinderSection,
     SampleIndexNav,
     SampleLineageGraph,
+    SamplesResolver,
     SampleSetDeleteModal,
     SampleTimelinePageBase,
     SampleTypeIndexNav,

--- a/packages/components/src/entities/models.ts
+++ b/packages/components/src/entities/models.ts
@@ -1,5 +1,10 @@
 import { Filter } from '@labkey/api';
 
+export interface AssaySampleColumnProp {
+    fieldKey: string;
+    lookupFieldKey: string;
+}
+
 /**
  * This implements the filter corresponding to PicklistSampleCompareType.  Updates there should also be reflected here.
  */

--- a/packages/components/src/entities/utils.spec.tsx
+++ b/packages/components/src/entities/utils.spec.tsx
@@ -19,6 +19,12 @@ import { makeQueryInfo } from '../internal/testHelpers';
 import mixturesQueryInfo from '../test/data/mixtures-getQueryDetails.json';
 import { SampleTypeDataType } from '../internal/components/entities/constants';
 
+import { makeTestQueryModel } from '../public/QueryModel/testUtils';
+import { AssayStateModel } from '../internal/components/assay/models';
+import { ASSAY_DEFINITION_MODEL, TEST_ASSAY_STATE_MODEL } from '../test/data/constants';
+import sampleSet2QueryInfo from '../test/data/sampleSet2-getQueryDetails.json';
+import { GENERAL_ASSAY_PROVIDER_NAME } from '../internal/components/assay/actions';
+
 import {
     getSampleWizardURL,
     filterSampleRowsForOperation,
@@ -29,6 +35,7 @@ import {
     createEntityParentKey,
     parentValuesDiffer,
     getUpdatedLineageRowsForBulkEdit,
+    getImportItemsForAssayDefinitions,
 } from './utils';
 
 describe('getCrossFolderSelectionMsg', () => {
@@ -802,5 +809,39 @@ describe('getUpdatedLineageRowsForBulkEdit', () => {
                 'MaterialInputs/Label 1': 'Val1,Val2',
             },
         ]);
+    });
+});
+
+describe('getImportItemsForAssayDefinitions', () => {
+    test('empty list', () => {
+        const sampleModel = makeTestQueryModel(SchemaQuery.create('samples', 'samples'));
+        const items = getImportItemsForAssayDefinitions(new AssayStateModel(), sampleModel);
+        expect(items.size).toBe(0);
+    });
+
+    test('with expected match', () => {
+        const assayStateModel = new AssayStateModel({ definitions: [ASSAY_DEFINITION_MODEL] });
+        let queryInfo = QueryInfo.create(sampleSet2QueryInfo);
+
+        // with a query name that DOES NOT match the assay def sampleColumn lookup
+        queryInfo = queryInfo.set('schemaQuery', SchemaQuery.create('samples', 'Sample set 1')) as QueryInfo;
+        let sampleModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);
+        let items = getImportItemsForAssayDefinitions(assayStateModel, sampleModel);
+        expect(items.size).toBe(0);
+
+        // with a query name that DOES match the assay def sampleColumn lookup
+        queryInfo = queryInfo.set('schemaQuery', SchemaQuery.create('samples', 'Sample set 10')) as QueryInfo;
+        sampleModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);
+        items = getImportItemsForAssayDefinitions(assayStateModel, sampleModel);
+        expect(items.size).toBe(1);
+    });
+
+    test('providerType filter', () => {
+        let items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, undefined);
+        expect(items.size).toBe(5);
+        items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, GENERAL_ASSAY_PROVIDER_NAME);
+        expect(items.size).toBe(2);
+        items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, 'NAb');
+        expect(items.size).toBe(1);
     });
 });

--- a/packages/components/src/entities/utils.tsx
+++ b/packages/components/src/entities/utils.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { List, Set } from 'immutable';
+import { List, OrderedMap, Set } from 'immutable';
 import { ActionURL, Utils } from '@labkey/api';
 
 import {
@@ -24,8 +24,12 @@ import { caseInsensitive, parseCsvString } from '../internal/util/utils';
 import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 import { getPrimaryAppProperties, isELNEnabled } from '../internal/app/utils';
 import { QueryInfo } from '../public/QueryInfo';
-import { naturalSort } from '../public/sort';
+import { naturalSort, naturalSortByProperty } from '../public/sort';
 import { DELIMITER } from '../internal/components/forms/constants';
+import { AssayStateModel } from '../internal/components/assay/models';
+import { QueryModel } from '../public/QueryModel/QueryModel';
+import { AssayDefinitionModel } from '../internal/AssayDefinitionModel';
+import { AssayUploadTabs } from '../internal/constants';
 
 export function getCrossFolderSelectionMsg(
     crossFolderSelectionCount: number,
@@ -310,4 +314,40 @@ export function getUpdatedLineageRowsForBulkEdit(
 
 export function getSampleFinderLocalStorageKey(): string {
     return getPrimaryAppProperties().productId + ActionURL.getContainer() + '-SampleFinder';
+}
+
+export function getImportItemsForAssayDefinitions(
+    assayStateModel: AssayStateModel,
+    sampleModel?: QueryModel,
+    providerType?: string,
+    isPicklist?: boolean,
+    currentProductId?: string,
+    targetProductId?: string,
+    ignoreFilter?: boolean
+): OrderedMap<AssayDefinitionModel, string> {
+    let targetSQ;
+    const selectionKey = sampleModel?.id;
+
+    if (sampleModel?.queryInfo) {
+        targetSQ = sampleModel.queryInfo.schemaQuery;
+    }
+
+    return assayStateModel.definitions
+        .filter(assay => providerType === undefined || assay.type === providerType)
+        .filter(assay => !targetSQ || assay.hasLookup(targetSQ, isPicklist))
+        .sort(naturalSortByProperty('name'))
+        .reduce((items, assay) => {
+            const href = assay.getImportUrl(
+                selectionKey ? AssayUploadTabs.Grid : AssayUploadTabs.Files,
+                selectionKey,
+                // Check for the existence of the "queryInfo" before getting filters from the model.
+                // This avoids `QueryModel` throwing an error when the "queryInfo" is not yet available.
+                sampleModel?.queryInfo ? List(sampleModel.filters) : undefined,
+                isPicklist,
+                currentProductId,
+                targetProductId,
+                ignoreFilter
+            );
+            return items.set(assay, href);
+        }, OrderedMap<AssayDefinitionModel, string>());
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -33,12 +33,7 @@ import { insertColumnFilter, QueryColumn, QueryLookup } from './public/QueryColu
 import { QuerySort } from './public/QuerySort';
 import { LastActionStatus, MessageLevel } from './internal/LastActionStatus';
 import { InferDomainResponse } from './public/InferDomainResponse';
-import {
-    getAssayImportNotificationMsg,
-    getAssayRunDeleteMessage,
-    getServerFilePreview,
-    inferDomainFromFile,
-} from './internal/components/assay/utils';
+import { getServerFilePreview, inferDomainFromFile } from './internal/components/assay/utils';
 import { ViewInfo } from './internal/ViewInfo';
 import { QueryInfo, QueryInfoStatus } from './public/QueryInfo';
 import { SchemaDetails } from './internal/SchemaDetails';
@@ -213,13 +208,7 @@ import {
 import { getLocation, pushParameter, replaceParameter, replaceParameters, resetParameters } from './internal/util/URL';
 import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
 import { getHelpLink, HELP_LINK_REFERRER, HelpLink, SAMPLE_ALIQUOT_TOPIC } from './internal/util/helpLinks';
-import {
-    AssayResolver,
-    AssayRunResolver,
-    ExperimentRunResolver,
-    ListResolver,
-    SamplesResolver,
-} from './internal/url/AppURLResolver';
+import { ExperimentRunResolver, ListResolver } from './internal/url/AppURLResolver';
 import { loadEditorModelData } from './internal/components/editable/utils';
 import { EditableGridPanel } from './internal/components/editable/EditableGridPanel';
 import { EditableGridPanelForUpdate } from './internal/components/editable/EditableGridPanelForUpdate';
@@ -237,7 +226,6 @@ import { AliasRenderer } from './internal/renderers/AliasRenderer';
 import { ANCESTOR_LOOKUP_CONCEPT_URI, AncestorRenderer } from './internal/renderers/AncestorRenderer';
 import { StorageStatusRenderer } from './internal/renderers/StorageStatusRenderer';
 import { SampleStatusRenderer } from './internal/renderers/SampleStatusRenderer';
-import { AssayResultTemplateDownloadRenderer } from './internal/renderers/TemplateDownloadRenderer';
 import { AppendUnits } from './internal/renderers/AppendUnits';
 import { AttachmentCard } from './internal/renderers/AttachmentCard';
 import { DefaultRenderer } from './internal/renderers/DefaultRenderer';
@@ -342,29 +330,17 @@ import {
 } from './internal/components/samples/utils';
 import {
     AssayContextConsumer,
-    assayPage,
     withAssayModels,
     withAssayModelsFromLocation,
 } from './internal/components/assay/withAssayModels';
-import { AssayDesignDeleteConfirmModal } from './internal/components/assay/AssayDesignDeleteConfirmModal';
-import { AssayDesignDeleteModal } from './internal/components/assay/AssayDesignDeleteModal';
-import { AssayResultDeleteModal } from './internal/components/assay/AssayResultDeleteModal';
-import { AssayRunDeleteModal } from './internal/components/assay/AssayRunDeleteModal';
 import { AssayDesignEmptyAlert } from './internal/components/assay/AssayDesignEmptyAlert';
-import { AssaysHeatMap } from './internal/components/assay/AssaysHeatMap';
-import { AssaySubNavMenu } from './internal/components/assay/AssaySubNavMenu';
-import { AssayTypeSummary } from './internal/components/assay/AssayTypeSummary';
 import { AssayPicker, AssayPickerTabs } from './internal/components/assay/AssayPicker';
-import { AssayImportSubMenuItem } from './internal/components/assay/AssayImportSubMenuItem';
-import { AssayReimportRunButton } from './internal/components/assay/AssayReimportRunButton';
 import { AssayStateModel, AssayUploadResultModel } from './internal/components/assay/models';
 import {
     allowReimportAssayRun,
     clearAssayDefinitionCache,
-    deleteAssayDesign,
     fetchAllAssays,
     GENERAL_ASSAY_PROVIDER_NAME,
-    importAssayRun,
     RUN_PROPERTIES_REQUIRED_COLUMNS,
 } from './internal/components/assay/actions';
 import { BaseBarChart } from './internal/components/chart/BaseBarChart';
@@ -894,10 +870,7 @@ export {
     URL_MAPPERS,
     URLResolver,
     URLService,
-    AssayResolver,
-    AssayRunResolver,
     ListResolver,
-    SamplesResolver,
     ExperimentRunResolver,
     getLocation,
     getHref,
@@ -919,7 +892,6 @@ export {
     ANCESTOR_LOOKUP_CONCEPT_URI,
     AncestorRenderer,
     AppendUnits,
-    AssayResultTemplateDownloadRenderer,
     DefaultRenderer,
     FileColumnRenderer,
     LabelColorRenderer,
@@ -1088,26 +1060,14 @@ export {
     showPremiumFeatures,
     // assay
     AssayUploadResultModel,
-    AssayDesignDeleteModal,
-    AssayDesignDeleteConfirmModal,
     AssayDesignEmptyAlert,
-    AssayResultDeleteModal,
-    AssayRunDeleteModal,
-    AssaysHeatMap,
-    AssaySubNavMenu,
-    AssayTypeSummary,
     AssayStateModel,
     AssayImportPanels,
     AssayPicker,
     AssayPickerTabs,
-    assayPage,
     withAssayModels,
     withAssayModelsFromLocation,
     AssayContextConsumer,
-    AssayImportSubMenuItem,
-    AssayReimportRunButton,
-    importAssayRun,
-    deleteAssayDesign,
     AssayDefinitionModel,
     AssayDomainTypes,
     AssayLink,
@@ -1200,7 +1160,6 @@ export {
     DOMAIN_RANGE_VALIDATOR,
     DomainDetails,
     inferDomainFromFile,
-    getAssayRunDeleteMessage,
     getServerFilePreview,
     InferDomainResponse,
     BasePropertiesPanel,
@@ -1416,7 +1375,6 @@ export {
     BACKGROUND_IMPORT_MIN_ROW_SIZE,
     DATA_IMPORT_FILE_SIZE_LIMITS,
     ACTIVE_JOB_INDICATOR_CLS,
-    getAssayImportNotificationMsg,
     // Test Helpers
     sleep,
     createMockWithRouteLeave,

--- a/packages/components/src/internal/components/assay/AssayContainerLocation.tsx
+++ b/packages/components/src/internal/components/assay/AssayContainerLocation.tsx
@@ -1,5 +1,4 @@
 import React, { FC, memo, useMemo, useCallback, ReactNode } from 'react';
-import { Col, Row } from 'react-bootstrap';
 
 interface AssayContainerLocationProps {
     selected: string;

--- a/packages/components/src/internal/components/assay/actions.spec.ts
+++ b/packages/components/src/internal/components/assay/actions.spec.ts
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 import { initQueryGridState } from '../../global';
-import { ASSAY_DEFINITION_MODEL, TEST_ASSAY_STATE_MODEL } from '../../../test/data/constants';
-
-import sampleSet2QueryInfo from '../../../test/data/sampleSet2-getQueryDetails.json';
 
 import { TEST_USER_EDITOR, TEST_USER_READER } from '../../userFixtures';
 
-import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
-import { SchemaQuery } from '../../../public/SchemaQuery';
-
-import { QueryInfo } from '../../../public/QueryInfo';
-
-import { AssayStateModel } from './models';
-import {
-    allowReimportAssayRun,
-    GENERAL_ASSAY_PROVIDER_NAME,
-    getImportItemsForAssayDefinitions,
-    getRunPropertiesFileName,
-} from './actions';
+import { allowReimportAssayRun, getRunPropertiesFileName } from './actions';
 
 beforeAll(() => {
     initQueryGridState();
@@ -48,40 +34,6 @@ describe('allowReimportAssayRun', () => {
         expect(allowReimportAssayRun(TEST_USER_EDITOR, '', '')).toBe(false);
         expect(allowReimportAssayRun(TEST_USER_EDITOR, 'a', 'A')).toBe(false);
         expect(allowReimportAssayRun(TEST_USER_EDITOR, 'B', 'B')).toBe(true);
-    });
-});
-
-describe('getImportItemsForAssayDefinitions', () => {
-    test('empty list', () => {
-        const sampleModel = makeTestQueryModel(SchemaQuery.create('samples', 'samples'));
-        const items = getImportItemsForAssayDefinitions(new AssayStateModel(), sampleModel);
-        expect(items.size).toBe(0);
-    });
-
-    test('with expected match', () => {
-        const assayStateModel = new AssayStateModel({ definitions: [ASSAY_DEFINITION_MODEL] });
-        let queryInfo = QueryInfo.create(sampleSet2QueryInfo);
-
-        // with a query name that DOES NOT match the assay def sampleColumn lookup
-        queryInfo = queryInfo.set('schemaQuery', SchemaQuery.create('samples', 'Sample set 1')) as QueryInfo;
-        let sampleModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);
-        let items = getImportItemsForAssayDefinitions(assayStateModel, sampleModel);
-        expect(items.size).toBe(0);
-
-        // with a query name that DOES match the assay def sampleColumn lookup
-        queryInfo = queryInfo.set('schemaQuery', SchemaQuery.create('samples', 'Sample set 10')) as QueryInfo;
-        sampleModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);
-        items = getImportItemsForAssayDefinitions(assayStateModel, sampleModel);
-        expect(items.size).toBe(1);
-    });
-
-    test('providerType filter', () => {
-        let items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, undefined);
-        expect(items.size).toBe(5);
-        items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, GENERAL_ASSAY_PROVIDER_NAME);
-        expect(items.size).toBe(2);
-        items = getImportItemsForAssayDefinitions(TEST_ASSAY_STATE_MODEL, undefined, 'NAb');
-        expect(items.size).toBe(1);
     });
 });
 

--- a/packages/components/src/internal/components/assay/utils.tsx
+++ b/packages/components/src/internal/components/assay/utils.tsx
@@ -1,18 +1,9 @@
+import React from 'react';
 import { Ajax, Utils } from '@labkey/api';
 
-import React, { ReactNode } from 'react';
-
-import { AppURL, buildURL } from '../../url/AppURL';
+import { buildURL } from '../../url/AppURL';
 import { InferDomainResponse } from '../../../public/InferDomainResponse';
 import { processRequest } from '../../query/api';
-
-import { AssayDefinitionModel } from '../../AssayDefinitionModel';
-import { getPipelineLinkMsg, getWorkflowLinkMsg } from '../pipeline/utils';
-
-import { ASSAYS_KEY } from '../../app/constants';
-
-import { AssayUploadResultModel } from './models';
-import { LoadingSpinner } from '../base/LoadingSpinner';
 
 export function inferDomainFromFile(
     file: File,
@@ -68,66 +59,4 @@ export function getServerFilePreview(file: string, numLinesToInclude: number): P
             }),
         });
     });
-}
-
-function getAssayImportSuccessMsg(
-    runId: number,
-    isBackgroundJob: boolean,
-    reimport: boolean,
-    assayDefinition: AssayDefinitionModel = null
-): ReactNode {
-    if (!isBackgroundJob) {
-        const msg = `Successfully ${reimport ? 're-imported' : 'created'} assay run`;
-        if (assayDefinition) {
-            // Displayed if 'Save and Import Another Run' chosen
-            const href = AppURL.create(ASSAYS_KEY, assayDefinition.type, assayDefinition.name, 'runs', runId).toHref();
-            return (
-                <>
-                    {msg} <a href={href}>#{runId}</a>.{' '}
-                </>
-            );
-        } else {
-            // Displayed if 'Save and Finish' chosen
-            return <> {msg}.{' '} </>;
-        }
-    } else {
-        return (
-            <>
-                Successfully started {reimport ? 're-importing' : 'creating'} assay run. You'll be notified when it's
-                done.{' '}
-            </>
-        );
-    }
-}
-
-export function getAssayImportNotificationMsg(
-    response: AssayUploadResultModel,
-    isBackgroundJob: boolean,
-    reimport: boolean,
-    assayDefinition: AssayDefinitionModel,
-    workflowJobId?: string,
-    workflowTaskId?: string
-): ReactNode {
-    return (
-        <span>
-            {getAssayImportSuccessMsg(response.runId, isBackgroundJob, reimport, assayDefinition)}
-            {isBackgroundJob ? getPipelineLinkMsg(response) : null}
-            {!assayDefinition ? getWorkflowLinkMsg(workflowJobId, workflowTaskId) : null}
-        </span>
-    );
-}
-
-export function getAssayRunDeleteMessage(canDelete: boolean, deleteInfoError: boolean): ReactNode {
-    let deleteMsg;
-    if (canDelete === undefined) {
-        deleteMsg = <LoadingSpinner msg="Loading delete confirmation data..." />;
-    } else if (!canDelete) {
-        deleteMsg = 'This assay run cannot be deleted because ';
-        if (deleteInfoError) {
-            deleteMsg += 'there was a problem loading the delete confirmation data.';
-        } else {
-            deleteMsg += 'it has references in one or more active notebooks.'
-        }
-    }
-    return deleteMsg;
 }

--- a/packages/components/src/internal/components/domainproperties/assay/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/assay/actions.ts
@@ -91,7 +91,7 @@ export function saveAssayDesign(model: AssayProtocolModel): Promise<AssayProtoco
     });
 }
 
-export function setAssayDomainException(model: AssayProtocolModel, exception: DomainException): AssayProtocolModel {
+function setAssayDomainException(model: AssayProtocolModel, exception: DomainException): AssayProtocolModel {
     let updatedModel;
 
     // If a domain is identified in the exception, attach to that domain

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -19,13 +19,7 @@ import { initMockServerContext, registerDefaultURLMappers } from '../testHelpers
 
 import { initUnitTestMocks } from '../../test/testHelperMocks';
 
-import {
-    AssayResolver,
-    AssayRunResolver,
-    ExperimentRunResolver,
-    ListResolver,
-    SamplesResolver,
-} from './AppURLResolver';
+import { ExperimentRunResolver, ListResolver, SamplesResolver } from './AppURLResolver';
 import { URLResolver } from './URLResolver';
 import { AppURL } from './AppURL';
 import { encodeListResolverPath } from './utils';
@@ -430,67 +424,6 @@ describe('URL Resolvers', () => {
 });
 
 describe('App Route Resolvers', () => {
-    test('Should resolve /assays routes', () => {
-        const routes = Map<number, { name: string; provider: string }>().asMutable();
-        routes.set(13, {
-            provider: 'general',
-            name: 'thirteen',
-        });
-        routes.set(91, {
-            provider: 'specific',
-            name: 'ninety-one',
-        });
-        const assayResolver = new AssayResolver(routes.asImmutable());
-
-        // test regex
-        expect.assertions(8);
-        expect(assayResolver.matches(undefined)).toBe(false);
-        expect(assayResolver.matches('/assays/91f')).toBe(false);
-        expect(assayResolver.matches('/assays/91')).toBe(true);
-        expect(assayResolver.matches('/assays/91/foo')).toBe(true);
-        expect(assayResolver.matches('/assays/91/foo?bar=1')).toBe(true);
-
-        return Promise.all([
-            assayResolver.fetch(['assays', 'foo']).then((result: boolean) => {
-                expect(result).toBe(true);
-            }),
-            assayResolver.fetch(['assays', '13']).then((url: AppURL) => {
-                expect(url.toString()).toBe('/assays/general/thirteen');
-            }),
-            assayResolver.fetch(['assays', '91', 'foo bar']).then((url: AppURL) => {
-                expect(url.toString()).toBe('/assays/specific/ninety-one/foo%20bar');
-            }),
-        ]);
-    });
-
-    test('Should resolve /rd/assayrun routes', () => {
-        const routes = Map<number, number>().asMutable();
-        routes.set(595, 13);
-        routes.set(923, 15);
-
-        const assayRunResolver = new AssayRunResolver(routes.asImmutable());
-
-        // test regex
-        expect.assertions(8);
-        expect(assayRunResolver.matches(undefined)).toBe(false);
-        expect(assayRunResolver.matches('/rd/assayrun/91f')).toBe(false);
-        expect(assayRunResolver.matches('/rd/assayrun/91')).toBe(true);
-        expect(assayRunResolver.matches('/rd/assayrun/91/foo')).toBe(true);
-        expect(assayRunResolver.matches('/rd/assayrun/91/foo?bar=1')).toBe(true);
-
-        return Promise.all([
-            assayRunResolver.fetch(['rd', 'assayrun', 'boom']).then(result => {
-                expect(result).toBe(true);
-            }),
-            assayRunResolver.fetch(['rd', 'assayrun', '923']).then(result => {
-                expect(result.toString()).toBe('/assays/15/runs/923');
-            }),
-            assayRunResolver.fetch(['rd', 'assayrun', '595', 'extra']).then(result => {
-                expect(result.toString()).toBe('/assays/13/runs/595/extra');
-            }),
-        ]);
-    });
-
     test('Should resolve /q/lists routes', () => {
         const routes = Map<string, string>().asMutable();
         routes.set('/bulls|23', 'Jordan');

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fromJS, List, Map } from 'immutable';
+import { fromJS, Map } from 'immutable';
 
 import { initMockServerContext, registerDefaultURLMappers } from '../testHelpers';
 
 import { initUnitTestMocks } from '../../test/testHelperMocks';
 
-import { ExperimentRunResolver, ListResolver, SamplesResolver } from './AppURLResolver';
+import { ExperimentRunResolver, ListResolver } from './AppURLResolver';
 import { URLResolver } from './URLResolver';
 import { AppURL } from './AppURL';
 import { encodeListResolverPath } from './utils';
@@ -459,42 +459,6 @@ describe('App Route Resolvers', () => {
                 .then((url: AppURL) => {
                     expect(url.toString()).toBe('/q/lists/PistolPete/17/%3F');
                 }),
-        ]);
-    });
-
-    test('Should resolve /rd/samples/### routes', () => {
-        const routes = Map<number, List<string>>().asMutable();
-        routes.set(7, List(['samples', 'Elway']));
-        routes.set(30, List(['samples', 'TD']));
-        routes.set(80, List(['samples', 'RodSmith']));
-        routes.set(24, List(['media', 'Woodson']));
-        const samplesResolver = new SamplesResolver(routes.asImmutable());
-
-        // test regex
-        expect.assertions(11);
-        expect(samplesResolver.matches(undefined)).toBe(false);
-        expect(samplesResolver.matches('/rd/samples/f23')).toBe(false);
-        expect(samplesResolver.matches('/rd/samples/2.3')).toBe(false);
-        expect(samplesResolver.matches('/rd/samples/80')).toBe(true);
-        expect(samplesResolver.matches('/rd/samples/3221/foo/bar')).toBe(true);
-        expect(samplesResolver.matches('/rd/samples/919/foo/bar?bar=1')).toBe(true);
-
-        return Promise.all([
-            samplesResolver.fetch(['rd', 'samples', 'notvalid', 14]).then((result: boolean) => {
-                expect(result).toBe(true);
-            }),
-            samplesResolver.fetch(['rd', 'samples', 30]).then((url: AppURL) => {
-                expect(url.toString()).toBe('/samples/TD/30');
-            }),
-            samplesResolver.fetch(['rd', 'samples', '80', 'wideOut']).then((url: AppURL) => {
-                expect(url.toString()).toBe('/samples/RodSmith/80/wideOut');
-            }),
-            samplesResolver.fetch(['rd', 'samples', '7', 77, '?']).then((url: AppURL) => {
-                expect(url.toString()).toBe('/samples/Elway/7/77/%3F');
-            }),
-            samplesResolver.fetch(['rd', 'samples', 24]).then((url: AppURL) => {
-                expect(url.toString()).toBe('/media/Woodson/24');
-            }),
         ]);
     });
 

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -13,124 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List, Map } from 'immutable';
+import { Map } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { SAMPLE_MANAGEMENT, SCHEMAS } from '../schemas';
 
-import { fetchProtocol } from '../components/domainproperties/assay/actions';
-import { AssayProtocolModel } from '../components/domainproperties/assay/models';
 import { selectRows } from '../query/selectRows';
 import { caseInsensitive } from '../util/utils';
-import { getQueryDetails } from '../query/api';
-
-import { MEDIA_KEY } from '../app/constants';
 
 import { AppRouteResolver } from './models';
 import { decodeListResolverPath } from './utils';
 import { AppURL, spliceURL } from './AppURL';
-
-/**
- * Resolves Data Class routes dynamically
- * /assays/44/... -> /assays/providerName/assayName/...
- */
-export class AssayResolver implements AppRouteResolver {
-    datas: Map<number, { name: string; provider: string }>; // Map<AssayProtocolId, {name, provider}>
-
-    constructor(datas?: Map<number, { name: string; provider: string }>) {
-        this.datas = datas !== undefined ? datas : Map<number, { name: string; provider: string }>();
-    }
-
-    matches(route: string): boolean {
-        return /\/assays\/(\d+$|\d+\/)/.test(route);
-    }
-
-    fetch(parts: any[]): Promise<AppURL | boolean> {
-        const assayRowIdIndex = 1;
-        const assayRowId: number = parseInt(parts[assayRowIdIndex], 10);
-
-        if (isNaN(assayRowId)) {
-            return Promise.resolve(true);
-        } else if (this.datas.has(assayRowId)) {
-            const context = this.datas.get(assayRowId);
-            const newParts = [context.provider, context.name];
-            return Promise.resolve(spliceURL(parts, newParts, assayRowIdIndex));
-        } else {
-            return new Promise(resolve => {
-                return fetchProtocol(assayRowId)
-                    .then((assay: AssayProtocolModel) => {
-                        const context = {
-                            name: encodeURIComponent(assay.name),
-                            provider: assay.providerName,
-                        };
-
-                        this.datas = this.datas.set(assayRowId, context);
-                        const newParts = [context.provider, context.name];
-                        return resolve(spliceURL(parts, newParts, assayRowIdIndex));
-                    })
-                    .catch(() => {
-                        return resolve(true);
-                    });
-            });
-        }
-    }
-}
-
-/**
- * Resolves Assay Run routes dynamically
- * /rd/assayrun/543/... -> /assays/44/runs/584/...
- */
-export class AssayRunResolver implements AppRouteResolver {
-    datas: Map<number, number>;
-
-    constructor(datas?: Map<number, number>) {
-        this.datas = datas !== undefined ? datas : Map<number, number>();
-    }
-
-    matches(route: string): boolean {
-        return /\/rd\/assayrun\/(\d+$|\d+\/)/.test(route);
-    }
-
-    async fetch(parts: any[]): Promise<AppURL | boolean> {
-        // ["rd", "assayrun", "543", ...]
-        const assayRunIdIndex = 2;
-        const assayRunId: number = parseInt(parts[assayRunIdIndex], 10);
-
-        if (isNaN(assayRunId)) {
-            // skip it
-            return true;
-        } else if (this.datas.has(assayRunId)) {
-            // resolve it
-            const newParts = ['assays', this.datas.get(assayRunId), 'runs'];
-            return spliceURL(parts, newParts, 0, assayRunIdIndex);
-        }
-
-        // fetch it
-        try {
-            const result = await selectRows({
-                columns: 'RowId,Protocol/RowId',
-                filterArray: [Filter.create('RowId', assayRunId)],
-                schemaQuery: SCHEMAS.EXP_TABLES.ASSAY_RUNS,
-            });
-
-            if (result.rows.length === 1) {
-                const assayProtocolId = caseInsensitive(result.rows[0], 'Protocol/RowId').value;
-
-                // cache
-                this.datas.set(assayRunId, assayProtocolId);
-
-                // resolve it
-                const newParts = ['assays', assayProtocolId, 'runs'];
-                return spliceURL(parts, newParts, 0, assayRunIdIndex);
-            }
-        } catch (e) {
-            // skip it
-        }
-
-        // skip it
-        return true;
-    }
-}
 
 /**
  * Resolves list routes dynamically
@@ -195,81 +88,6 @@ export class ListResolver implements AppRouteResolver {
                 // resolve it
                 const newParts = [this.lists.get(key)];
                 return spliceURL(parts, newParts, containerPathIndex, 2);
-            }
-        } catch (e) {
-            // skip it
-        }
-
-        // skip it
-        return true;
-    }
-}
-
-/**
- * Resolves sample routes dynamically
- * /rd/samples/14/... -> /samples/sampleSetByName/14/... || /media/batches/14
- */
-export class SamplesResolver implements AppRouteResolver {
-    samples: Map<number, List<string>>; // Map<SampleRowId, List<'samples' | 'media', sampleSetName | 'batches'>>
-
-    constructor(samples?: Map<number, List<string>>) {
-        this.samples = samples !== undefined ? samples : Map<number, List<string>>();
-    }
-
-    matches(route: string): boolean {
-        return /\/rd\/samples\/(\d+$|\d+\/)/.test(route);
-    }
-
-    async fetch(parts: any[]): Promise<AppURL | boolean> {
-        // ["rd", "samples", "118", ...]
-        const sampleRowIdIndex = 2;
-        const sampleRowId: number = parseInt(parts[sampleRowIdIndex], 10);
-
-        if (isNaN(sampleRowId)) {
-            // skip it
-            return true;
-        } else if (this.samples.has(sampleRowId)) {
-            // resolve it
-            const newParts = this.samples.get(sampleRowId).toArray();
-            return spliceURL(parts, newParts, 0, 2);
-        }
-
-        // fetch it
-        try {
-            const result = await selectRows({
-                schemaQuery: SCHEMAS.EXP_TABLES.MATERIALS,
-                columns: 'RowId,SampleSet',
-                filterArray: [Filter.create('RowId', sampleRowId)],
-            });
-
-            if (result.rows.length === 1) {
-                const sampleTypeName = caseInsensitive(result.rows[0], 'SampleSet').displayValue.toLowerCase();
-
-                const info = await getQueryDetails({
-                    schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
-                    queryName: sampleTypeName,
-                });
-
-                // fulfill cache
-                let value: List<string>;
-                if (info?.isMedia) {
-                    // for supporting MIXTURE_BATCHES => mixturebatches
-                    const mediaTypeName =
-                        info.name.toLowerCase() === SCHEMAS.SAMPLE_SETS.MIXTURE_BATCHES.queryName.toLowerCase()
-                            ? 'mixturebatches'
-                            : info.name;
-                    value = List([MEDIA_KEY, encodeURIComponent(mediaTypeName)]);
-                } else {
-                    value = List([SCHEMAS.SAMPLE_SETS.SCHEMA.toLowerCase(), encodeURIComponent(sampleTypeName)]);
-                }
-
-                this.samples = this.samples.set(sampleRowId, value);
-
-                if (this.samples.has(sampleRowId)) {
-                    // resolve it
-                    const newParts = this.samples.get(sampleRowId).toArray();
-                    return spliceURL(parts, newParts, 0, 2);
-                }
             }
         } catch (e) {
             // skip it

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1657,10 +1657,10 @@
   resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz#f8495eb3acbea7282ad8e34015145cc1f0f6ccf9"
   integrity sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg==
 
-"@labkey/build@6.3.0-fb-assaySubpackage.0":
-  version "6.3.0-fb-assaySubpackage.0"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.3.0-fb-assaySubpackage.0.tgz#300191eb8445b688ea791265c54cc84854cc6d29"
-  integrity sha512-8n4aO5clUyTK/FbR2X48lH3wcLOUsdRed7tZBgftW47c75Uxo7sSdNjh+Snry3kip/z6j6RJRX4Ouc4T6P7kAA==
+"@labkey/build@6.3.1":
+  version "6.3.1"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.3.1.tgz#5aa153166eeecd554b8d0afe7b9f6ff747f9607d"
+  integrity sha512-dqiL2nZ5br2QMKEgeoIeZpDnG+ZCkzNKrC8+V4JNlR1k9/Ie8pRoppc0a6hhKwhlJhVOU2Nfe0XRLrxfbllBCA==
   dependencies:
     "@babel/core" "~7.17.8"
     "@babel/plugin-proposal-class-properties" "~7.16.7"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1657,10 +1657,10 @@
   resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz#f8495eb3acbea7282ad8e34015145cc1f0f6ccf9"
   integrity sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg==
 
-"@labkey/build@6.3.0":
-  version "6.3.0"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.3.0.tgz#68671b313e3af31db269546e0d1439ffcabe7f5a"
-  integrity sha512-7NQTEBLUWgRMQRKMJFznPFHqfizHDmvYJ5cld6k7ni7sLfeUdcP/xwq/X/5hy6U6dyHvhPrXnL82rZcEHXN7Tg==
+"@labkey/build@6.3.0-fb-assaySubpackage.0":
+  version "6.3.0-fb-assaySubpackage.0"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.3.0-fb-assaySubpackage.0.tgz#300191eb8445b688ea791265c54cc84854cc6d29"
+  integrity sha512-8n4aO5clUyTK/FbR2X48lH3wcLOUsdRed7tZBgftW47c75Uxo7sSdNjh+Snry3kip/z6j6RJRX4Ouc4T6P7kAA==
   dependencies:
     "@babel/core" "~7.17.8"
     "@babel/plugin-proposal-class-properties" "~7.16.7"


### PR DESCRIPTION
#### Rationale
To improve app build tree shaking and to better organize code, we are creating an "assay" subpackage within the @labkey/components package. We will add more to this subpackage during the App Assay Consistency work.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/989
* https://github.com/LabKey/platform/pull/3774
* https://github.com/LabKey/biologics/pull/1669
* https://github.com/LabKey/inventory/pull/568
* https://github.com/LabKey/sampleManagement/pull/1305

#### Changes
* @labkey/build webpack updates for @labkey/components `assay` subpackage
  * add `@labkey/components/assay` alias for `npm run start-link`
  * add `@labkey/components/assay` to "externals" to keep it out of bundles
* @labkey/components package update to split out `assay` components as separate entry point (subpackage)
  * Create new /assay/index.ts file and dir and move assay related app components
  * add assay entry point to package.config.js and package.json
