### PR TITLE
ThreadBlock: Don't render user avatars

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.2",
+  "version": "2.236.2-fb-entry-layout.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.2-fb-entry-layout.0",
+  "version": "2.236.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.236.2
+*Released*: 24 October 2022
+* ThreadBlock: Don't render user avatars
+
 ### version 2.236.1
 *Released*: 20 October 2022
 * Components package update to split out `assay` components as separate entry point (subpackage)

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,11 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.236.2
+### version 2.236.3
 *Released*: 24 October 2022
 * ThreadBlock: Don't render user avatars
 
-### version 2.236.1
+### version 2.236.2
 *Released*: 20 October 2022
 * Components package update to split out `assay` components as separate entry point (subpackage)
   * Create new /assay/index.ts file and dir and move assay related app components

--- a/packages/components/src/internal/announcements/ThreadBlock.spec.tsx
+++ b/packages/components/src/internal/announcements/ThreadBlock.spec.tsx
@@ -26,7 +26,7 @@ describe('ThreadBlock', () => {
         expect(wrapper.find('.thread-editor').exists()).toEqual(false);
 
         // Displays header
-        expect(wrapper.find('.thread-block-header__avatar').text()).toEqual(COMMENTER.displayName);
+        expect(wrapper.find('.thread-block-header__user').text()).toEqual(COMMENTER.displayName);
 
         // Allows for reply
         expect(wrapper.find('.thread-block__reply').exists()).toEqual(true);

--- a/packages/components/src/internal/announcements/ThreadBlock.tsx
+++ b/packages/components/src/internal/announcements/ThreadBlock.tsx
@@ -72,8 +72,7 @@ const ThreadBlockHeader: FC<ThreadBlockHeaderProps> = props => {
 
     return (
         <div className="thread-block-header">
-            <span className="thread-block-header__avatar">
-                <UserAvatar avatar={user.avatar} displayName={user.displayName} id={user.id} />
+            <span className="thread-block-header__user">
                 <span>{user.displayName}</span>
             </span>
             <div className="pull-right">

--- a/packages/components/src/theme/announcements.scss
+++ b/packages/components/src/theme/announcements.scss
@@ -111,6 +111,9 @@ $editor-padding-horizontal: 15px;
         color: #333333;
     }
 }
+.thread-block-header__avatar {
+    font-weight: 500;
+}
 .thread-block {
     margin: 15px 0;
 }

--- a/packages/components/src/theme/announcements.scss
+++ b/packages/components/src/theme/announcements.scss
@@ -111,7 +111,7 @@ $editor-padding-horizontal: 15px;
         color: #333333;
     }
 }
-.thread-block-header__avatar {
+.thread-block-header__user {
     font-weight: 500;
 }
 .thread-block {


### PR DESCRIPTION
#### Rationale
The updated designs for our ELN editor pages no longer includes rendering user avatars.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/990
- https://github.com/LabKey/labbook/pull/302
- https://github.com/LabKey/inventory/pull/570
- https://github.com/LabKey/biologics/pull/1672
- https://github.com/LabKey/sampleManagement/pull/1309

#### Changes
* ThreadBlock: Don't render user avatars
