### PR TITLE
App Sample Type Consistency for Sample Type Designer

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.2-fb-sampleTypeDesignerRefactor.1",
+  "version": "2.236.2-fb-sampleTypeDesignerRefactor.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.2-fb-sampleTypeDesignerRefactor.0",
+  "version": "2.236.2-fb-sampleTypeDesignerRefactor.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.2",
+  "version": "2.236.2-fb-sampleTypeDesignerRefactor.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.4-fb-sampleTypeDesignerRefactor.0",
+  "version": "2.237.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.4",
+  "version": "2.236.4-fb-sampleTypeDesignerRefactor.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.2-fb-sampleTypeDesignerRefactor.3",
+  "version": "2.236.2-fb-sampleTypeDesignerRefactor.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.236.2-fb-sampleTypeDesignerRefactor.2",
+  "version": "2.236.2-fb-sampleTypeDesignerRefactor.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2022
+### version 2.237.0
+*Released*: 25 October 2022
 * App Sample Type Consistency for Sample Type Designer
   * refactor SampleTypeDesignPage from LKB app to be used in LKSM as well
   * add SampleTypeAppContext to pass app specific properties to the designer

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2022
+* App Sample Type Consistency for Sample Type Designer
+  * refactor SampleTypeDesignPage from LKB app to be used in LKSM as well
+  * add SampleTypeAppContext to pass app specific properties to the designer
+
 ### version 2.236.1
 *Released*: 20 October 2022
 * Components package update to split out `assay` components as separate entry point (subpackage)

--- a/packages/components/src/entities/SampleTypeAppContext.tsx
+++ b/packages/components/src/entities/SampleTypeAppContext.tsx
@@ -1,0 +1,35 @@
+import { ExtendableAppContext, useAppContext } from '../internal/AppContext';
+import { DomainDetails } from '../internal/components/domainproperties/models';
+
+export interface SampleTypeAppContext {
+    dataClassAliasCaption?: string;
+    dataClassParentageLabel?: string;
+    dataClassTypeCaption?: string;
+    getMetricUnitOptions: () => any[];
+    hideConditionalFormatting: boolean;
+    isValidParentOptionFn?: (row: any, isDataClass: boolean) => boolean;
+    readOnlyQueryNames?: string[];
+    showParentLabelPrefix: boolean;
+    showStudyProperties: boolean;
+    useSeparateDataClassesAliasMenu: boolean;
+    validateNewSampleTypeUnit: (sampleSet: DomainDetails, newUnit: string) => Promise<any>;
+}
+
+// If your App extends AppContext to add attributes other than SampleType use this e.g.:
+// type MyAppContext = ExtendableAppContext<WithMyAppContext & WithSampleTypeAppContext>;
+export interface WithSampleTypeAppContext {
+    sampleType: SampleTypeAppContext;
+}
+
+// If your App only extends the AppContext to add support for SampleType use this.
+export type AppContextWithSampleType = ExtendableAppContext<WithSampleTypeAppContext>;
+
+export const useSampleTypeAppContext = (): SampleTypeAppContext => {
+    const appContext = useAppContext<AppContextWithSampleType>();
+
+    if (appContext.sampleType === undefined) {
+        throw new Error('AppContext was not initialized with a sampleType attribute (SampleTypeAppContext)');
+    }
+
+    return appContext.sampleType;
+};

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -85,6 +85,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
         useSeparateDataClassesAliasMenu,
         validateNewSampleTypeUnit,
     } = useSampleTypeAppContext();
+    const [loadingSampleType, setLoadingSampleType] = useState<boolean>(true);
     const [sampleType, setSampleType] = useState<DomainDetails>();
     const [hasError, setHasError] = useState(false);
     const [_, setIsDirty] = useRouteLeave(router, routes);
@@ -108,6 +109,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
         if (queryName) {
             // Clear the current sample type so the Designer gets unmounted
             setSampleType(undefined);
+            setLoadingSampleType(true);
 
             try {
                 // Load the associated queryInfo to determine where the domain resides
@@ -149,6 +151,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
                 setSampleType(createDefaultSampleType());
             }
         }
+        setLoadingSampleType(false);
     };
 
     useEffect(() => {
@@ -174,8 +177,8 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
 
     const onCancel = useCallback(() => {
         setIsDirty(false);
-        goToSampleType();
-    }, [goToSampleType, setIsDirty]);
+        router.goBack();
+    }, [router, setIsDirty]);
 
     const onComplete = useCallback(
         (domain: DomainDesign) => {
@@ -205,7 +208,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
 
     const title = sampleType?.domainDesign?.name ?? 'Sample Type';
     const pageTitle = isUpdate ? 'Edit Sample Type Design' : 'Create a New Sample Type';
-    const saveButtonText = isUpdate ? 'Finish Updating Sample Type' : 'Finish Creating Sample Type';
+    const saveButtonText = isUpdate ? `Finish Updating ${title}` : `Finish Creating ${title}`;
     const hasActiveJob = hasActivePipelineJob(menu, SAMPLES_KEY, queryName);
 
     const validateStorageUnit = useCallback(
@@ -230,7 +233,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
         };
     }, [hideConditionalFormatting]);
 
-    if (menu.isLoaded && !sampleType) {
+    if (menu.isLoaded && !loadingSampleType && !sampleType) {
         return <NotFound />;
     } else if (menu.isLoading || !domainContainerUser.isLoaded || !sampleType) {
         return <LoadingPage title={pageTitle} />;

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -15,9 +15,7 @@ import { useContainerUser } from '../internal/components/container/actions';
 import { MEDIA_KEY, SAMPLES_KEY } from '../internal/app/constants';
 import { SchemaQuery } from '../public/SchemaQuery';
 import { SCHEMAS } from '../internal/schemas';
-import { getQueryDetails, invalidateQueryDetailsCache } from '../internal/query/api';
-import { getSampleTypeDetails } from '../internal/components/samples/actions';
-import { loadNameExpressionOptions } from '../internal/components/settings/actions';
+import { invalidateQueryDetailsCache } from '../internal/query/api';
 import { AppURL } from '../internal/url/AppURL';
 import { invalidateLineageResults } from '../internal/components/lineage/actions';
 import { hasActivePipelineJob } from '../internal/components/pipeline/utils';
@@ -32,6 +30,7 @@ import { ProductMenuModel } from '../internal/components/navigation/model';
 
 import { SampleTypeBasePage } from './SampleTypeBasePage';
 import { useSampleTypeAppContext } from './SampleTypeAppContext';
+import {useAppContext} from "../internal/AppContext";
 
 const DESIGNER_HEADER =
     'Sample types help you organize samples in your lab and allow you to add properties for easy tracking of data.';
@@ -90,6 +89,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
     const [hasError, setHasError] = useState(false);
     const [_, setIsDirty] = useRouteLeave(router, routes);
     const [domainContainerPath, setDomainContainerPath] = useState<string>();
+    const { api } = useAppContext();
     const { container } = useServerContext();
     const { createNotification } = useNotificationsContext();
     const domainContainerUser = useContainerUser(domainContainerPath);
@@ -113,14 +113,14 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
 
             try {
                 // Load the associated queryInfo to determine where the domain resides
-                const details = await getQueryDetails({
+                const details = await api.query.getQueryDetails({
                     queryName: schemaQuery.queryName,
                     schemaName: schemaQuery.schemaName,
                 });
                 setDomainContainerPath(details.domainContainerPath);
 
                 // Request the DomainDetails from the domain's container path
-                const sampleType_ = await getSampleTypeDetails(schemaQuery, undefined, details.domainContainerPath);
+                const sampleType_ = await api.samples.getSampleTypeDetails(schemaQuery, undefined, details.domainContainerPath);
                 setHasError(false);
 
                 // Because LKB is not yet integrated with Study, we do not display timepoint-related field Data Types
@@ -140,8 +140,8 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
             }
         } else {
             try {
-                const sampleType_ = await getSampleTypeDetails();
-                const expressionOptions = await loadNameExpressionOptions();
+                const sampleType_ = await api.samples.getSampleTypeDetails();
+                const expressionOptions = await api.entity.loadNameExpressionOptions();
                 setDomainContainerPath(container.path);
                 setSampleType(
                     createDefaultSampleType(sampleType_.domainDesign, expressionOptions.prefix, showStudyProperties)

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2018-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { WithRouterProps } from 'react-router';
+import { fromJS, Map } from 'immutable';
+import { Domain } from '@labkey/api';
+
+import { DomainDesign, DomainDetails } from '../internal/components/domainproperties/models';
+import { useRouteLeave } from '../internal/util/RouteLeave';
+import { useServerContext } from '../internal/components/base/ServerContext';
+import { useNotificationsContext } from '../internal/components/notifications/NotificationsContext';
+import { useContainerUser } from '../internal/components/container/actions';
+import { MEDIA_KEY, SAMPLES_KEY } from '../internal/app/constants';
+import { SchemaQuery } from '../public/SchemaQuery';
+import { SCHEMAS } from '../internal/schemas';
+import { getQueryDetails, invalidateQueryDetailsCache } from '../internal/query/api';
+import { getSampleTypeDetails } from '../internal/components/samples/actions';
+import { loadNameExpressionOptions } from '../internal/components/settings/actions';
+import { AppURL } from '../internal/url/AppURL';
+import { invalidateLineageResults } from '../internal/components/lineage/actions';
+import { hasActivePipelineJob } from '../internal/components/pipeline/utils';
+import { DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS } from '../internal/components/domainproperties/constants';
+import { NotFound } from '../internal/components/base/NotFound';
+import { LoadingPage } from '../internal/components/base/LoadingPage';
+import { InsufficientPermissionsPage } from '../internal/components/permissions/InsufficientPermissionsPage';
+import { Alert } from '../internal/components/base/Alert';
+import { getActionErrorMessage } from '../internal/util/messaging';
+import { SampleTypeDesigner } from '../internal/components/domainproperties/samples/SampleTypeDesigner';
+import { ProductMenuModel } from '../internal/components/navigation/model';
+
+import { SampleTypeBasePage } from './SampleTypeBasePage';
+import { useSampleTypeAppContext } from './SampleTypeAppContext';
+
+const DESIGNER_HEADER =
+    'Sample types help you organize samples in your lab and allow you to add properties for easy tracking of data.';
+const BRAND_PRIMARY_COLOR = '#2980b9';
+
+function createDefaultSampleType(
+    domainDesign?: DomainDesign,
+    prefix?: string,
+    showStudyProperties = false
+): DomainDetails {
+    const nameExpressionVal = (prefix ?? '') + 'S-${genId}';
+
+    return DomainDetails.create(
+        Map<string, any>({
+            domainDesign: {
+                ...domainDesign?.toJS(),
+                domainKindName: Domain.KINDS.SAMPLE_TYPE,
+                allowTimepointProperties: showStudyProperties, // Because LKB is not yet integrated with Study, we do not display timepoint-related field Data Types
+            },
+            options: Map<string, any>(
+                fromJS({
+                    nameExpression: nameExpressionVal,
+                    labelColor: BRAND_PRIMARY_COLOR,
+                })
+            ),
+            domainKindName: Domain.KINDS.SAMPLE_TYPE,
+        })
+    );
+}
+
+interface OwnProps {
+    menu: ProductMenuModel;
+    menuInit: (invalidate?: boolean) => void;
+    navigate: (url: string | AppURL, replace?: boolean) => void;
+}
+
+type Props = OwnProps & WithRouterProps;
+
+export const SampleTypeDesignPage: FC<Props> = memo(props => {
+    const { params, menu, menuInit, navigate, router, routes } = props;
+    const {
+        dataClassAliasCaption,
+        dataClassParentageLabel,
+        dataClassTypeCaption,
+        getMetricUnitOptions,
+        hideConditionalFormatting,
+        isValidParentOptionFn,
+        readOnlyQueryNames,
+        showStudyProperties,
+        showParentLabelPrefix,
+        useSeparateDataClassesAliasMenu,
+        validateNewSampleTypeUnit,
+    } = useSampleTypeAppContext();
+    const [sampleType, setSampleType] = useState<DomainDetails>();
+    const [hasError, setHasError] = useState(false);
+    const [_, setIsDirty] = useRouteLeave(router, routes);
+    const [domainContainerPath, setDomainContainerPath] = useState<string>();
+    const { container } = useServerContext();
+    const { createNotification } = useNotificationsContext();
+    const domainContainerUser = useContainerUser(domainContainerPath);
+    const isInOtherFolder = domainContainerPath !== container.path;
+    const isMedia = useMemo(() => routes[1]?.path === MEDIA_KEY, [routes]);
+    const queryName = useMemo(() => {
+        let query = params.sampleType;
+        if (isMedia) {
+            query = routes[2]?.path;
+        }
+        return query;
+    }, [isMedia, params, routes]);
+
+    const schemaQuery = useMemo(() => SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, queryName), [queryName]);
+
+    const init = async () => {
+        if (queryName) {
+            // Clear the current sample type so the Designer gets unmounted
+            setSampleType(undefined);
+
+            try {
+                // Load the associated queryInfo to determine where the domain resides
+                const details = await getQueryDetails({
+                    queryName: schemaQuery.queryName,
+                    schemaName: schemaQuery.schemaName,
+                });
+                setDomainContainerPath(details.domainContainerPath);
+
+                // Request the DomainDetails from the domain's container path
+                const sampleType_ = await getSampleTypeDetails(schemaQuery, undefined, details.domainContainerPath);
+                setHasError(false);
+
+                // Because LKB is not yet integrated with Study, we do not display timepoint-related field Data Types
+                let updatedSampleSet = sampleType_.setIn(
+                    ['domainDesign', 'allowTimepointProperties'],
+                    showStudyProperties
+                ) as DomainDetails;
+
+                if (readOnlyQueryNames?.indexOf(queryName.toLowerCase()) > -1) {
+                    updatedSampleSet = updatedSampleSet.set('nameReadOnly', true) as DomainDetails;
+                }
+
+                setSampleType(updatedSampleSet);
+            } catch (reason) {
+                console.error(reason);
+                setHasError(true);
+            }
+        } else {
+            try {
+                const sampleType_ = await getSampleTypeDetails();
+                const expressionOptions = await loadNameExpressionOptions();
+                setDomainContainerPath(container.path);
+                setSampleType(
+                    createDefaultSampleType(sampleType_.domainDesign, expressionOptions.prefix, showStudyProperties)
+                );
+            } catch (reason) {
+                console.error(reason);
+                setSampleType(createDefaultSampleType());
+            }
+        }
+    };
+
+    useEffect(() => {
+        init();
+    }, [queryName]);
+
+    const goToSampleType = useCallback(
+        (name?: string) => {
+            const queryName_ = name ?? schemaQuery.queryName;
+            if (queryName_) {
+                const key = isMedia ? MEDIA_KEY : SAMPLES_KEY;
+                navigate(AppURL.create(key, queryName_), true);
+            } else {
+                router.goBack();
+            }
+        },
+        [isMedia, navigate, router, schemaQuery.queryName]
+    );
+
+    const onChange = useCallback(() => {
+        setIsDirty(true);
+    }, [setIsDirty]);
+
+    const onCancel = useCallback(() => {
+        setIsDirty(false);
+        goToSampleType();
+    }, [goToSampleType, setIsDirty]);
+
+    const onComplete = useCallback(
+        (domain: DomainDesign) => {
+            setIsDirty(false);
+            invalidateQueryDetailsCache(schemaQuery);
+            invalidateLineageResults();
+            menuInit();
+
+            const newName = domain.name;
+            const hasNameChange = newName !== schemaQuery.queryName;
+            goToSampleType(hasNameChange ? newName : undefined);
+
+            // wait a bit for the invalidation to take
+            const action = queryName ? 'updated' : 'created';
+            createNotification(`Successfully ${action} sample type.`, true);
+        },
+        [setIsDirty, queryName, schemaQuery, goToSampleType, createNotification, menuInit]
+    );
+
+    const isUpdate = useMemo(() => {
+        return !!params?.sampleType || isMedia;
+    }, [params, isMedia]);
+
+    const metricUnit = useMemo(() => {
+        return sampleType?.get('options')?.get('metricUnit');
+    }, [sampleType]);
+
+    const title = sampleType?.domainDesign?.name ?? 'Sample Type';
+    const pageTitle = isUpdate ? 'Edit Sample Type Design' : 'Create a New Sample Type';
+    const saveButtonText = isUpdate ? 'Finish Updating Sample Type' : 'Finish Creating Sample Type';
+    const hasActiveJob = hasActivePipelineJob(menu, SAMPLES_KEY, queryName);
+
+    const validateStorageUnit = useCallback(
+        designerDetails => {
+            const newUnit = designerDetails['metricUnit'];
+            return validateNewSampleTypeUnit(sampleType, newUnit);
+        },
+        [sampleType]
+    );
+
+    const includeStorageOptions = useMemo(() => {
+        return !isMedia;
+    }, [isMedia]);
+
+    const domainFormDisplayOptions = useMemo(() => {
+        return {
+            ...DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
+            ...{
+                domainKindDisplayName: 'sample type',
+                hideConditionalFormatting,
+            },
+        };
+    }, [hideConditionalFormatting]);
+
+    if (menu.isLoaded && !sampleType) {
+        return <NotFound />;
+    } else if (menu.isLoading || !domainContainerUser.isLoaded || !sampleType) {
+        return <LoadingPage title={pageTitle} />;
+    } else if (!domainContainerUser.user.hasDesignSampleSetsPermission()) {
+        return <InsufficientPermissionsPage title={pageTitle} />;
+    }
+
+    return (
+        <SampleTypeBasePage
+            title={title}
+            hasActiveJob={hasActiveJob}
+            subtitle={pageTitle}
+            description={DESIGNER_HEADER}
+        >
+            {hasError && (
+                <Alert>
+                    {getActionErrorMessage('There was a problem loading the sample type design.', 'sample type')}
+                </Alert>
+            )}
+            {!hasError && sampleType && (
+                <>
+                    {isInOtherFolder && (
+                        <Alert bsStyle="warning">
+                            This is a shared sample type. Changes made here may affect other folders.
+                        </Alert>
+                    )}
+                    <SampleTypeDesigner
+                        initModel={sampleType}
+                        saveBtnText={saveButtonText}
+                        onChange={onChange}
+                        onComplete={onComplete}
+                        onCancel={onCancel}
+                        includeDataClasses
+                        useSeparateDataClassesAliasMenu={useSeparateDataClassesAliasMenu}
+                        sampleAliasCaption="Parent Alias"
+                        dataClassAliasCaption={dataClassAliasCaption}
+                        dataClassTypeCaption={dataClassTypeCaption}
+                        dataClassParentageLabel={dataClassParentageLabel}
+                        isValidParentOptionFn={isValidParentOptionFn}
+                        useTheme={false}
+                        appPropertiesOnly={includeStorageOptions}
+                        showAliquotOptions
+                        showLinkToStudy={showStudyProperties}
+                        showParentLabelPrefix={showParentLabelPrefix}
+                        metricUnitProps={{
+                            includeMetricUnitProperty: includeStorageOptions,
+                            metricUnitLabel: 'Display stored amount in',
+                            metricUnitRequired: includeStorageOptions && (!isUpdate || metricUnit != null), // allow existing sample types without unit to continue to have blank unit
+                            metricUnitHelpMsg:
+                                'Sample storage amount will be displayed using the selected metric unit.',
+                            metricUnitOptions: getMetricUnitOptions(),
+                        }}
+                        aliquotNamePatternProps={{
+                            showAliquotNameExpression: true,
+                        }}
+                        validateProperties={isUpdate && includeStorageOptions ? validateStorageUnit : undefined}
+                        domainFormDisplayOptions={domainFormDisplayOptions}
+                        showGenIdBanner={isUpdate}
+                    />
+                </>
+            )}
+        </SampleTypeBasePage>
+    );
+});

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -28,9 +28,10 @@ import { getActionErrorMessage } from '../internal/util/messaging';
 import { SampleTypeDesigner } from '../internal/components/domainproperties/samples/SampleTypeDesigner';
 import { ProductMenuModel } from '../internal/components/navigation/model';
 
+import { useAppContext } from '../internal/AppContext';
+
 import { SampleTypeBasePage } from './SampleTypeBasePage';
 import { useSampleTypeAppContext } from './SampleTypeAppContext';
-import {useAppContext} from "../internal/AppContext";
 
 const DESIGNER_HEADER =
     'Sample types help you organize samples in your lab and allow you to add properties for easy tracking of data.';
@@ -120,7 +121,11 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
                 setDomainContainerPath(details.domainContainerPath);
 
                 // Request the DomainDetails from the domain's container path
-                const sampleType_ = await api.samples.getSampleTypeDetails(schemaQuery, undefined, details.domainContainerPath);
+                const sampleType_ = await api.samples.getSampleTypeDetails(
+                    schemaQuery,
+                    undefined,
+                    details.domainContainerPath
+                );
                 setHasError(false);
 
                 // Because LKB is not yet integrated with Study, we do not display timepoint-related field Data Types

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -257,7 +257,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
                 <>
                     {isInOtherFolder && (
                         <Alert bsStyle="warning">
-                            This is a shared sample type. Changes made here may affect other folders.
+                            This is a shared sample type. Changes made here may affect other projects.
                         </Alert>
                     )}
                     <SampleTypeDesigner

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -124,16 +124,16 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
                 setHasError(false);
 
                 // Because LKB is not yet integrated with Study, we do not display timepoint-related field Data Types
-                let updatedSampleSet = sampleType_.setIn(
+                let updatedSampleType = sampleType_.setIn(
                     ['domainDesign', 'allowTimepointProperties'],
                     showStudyProperties
                 ) as DomainDetails;
 
                 if (readOnlyQueryNames?.indexOf(queryName.toLowerCase()) > -1) {
-                    updatedSampleSet = updatedSampleSet.set('nameReadOnly', true) as DomainDetails;
+                    updatedSampleType = updatedSampleType.set('nameReadOnly', true) as DomainDetails;
                 }
 
-                setSampleType(updatedSampleSet);
+                setSampleType(updatedSampleType);
             } catch (reason) {
                 console.error(reason);
                 setHasError(true);
@@ -237,7 +237,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
         return <NotFound />;
     } else if (menu.isLoading || !domainContainerUser.isLoaded || !sampleType) {
         return <LoadingPage title={pageTitle} />;
-    } else if (!domainContainerUser.user.hasDesignSampleSetsPermission()) {
+    } else if (!domainContainerUser.user.hasDesignSampleTypesPermission()) {
         return <InsufficientPermissionsPage title={pageTitle} />;
     }
 

--- a/packages/components/src/entities/SampleTypeDesignerPage.spec.tsx
+++ b/packages/components/src/entities/SampleTypeDesignerPage.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ReactWrapper } from 'enzyme';
 import { PermissionTypes } from '@labkey/api';
 
-import {TEST_FOLDER_CONTAINER, TEST_PROJECT_CONTAINER} from '../test/data/constants';
+import { TEST_FOLDER_CONTAINER, TEST_PROJECT_CONTAINER } from '../test/data/constants';
 import { createMockWithRouterProps } from '../internal/mockUtils';
 import { getTestAPIWrapper } from '../internal/APIWrapper';
 import { getQueryTestAPIWrapper } from '../internal/query/APIWrapper';
@@ -52,7 +52,7 @@ describe('SampleTypeDesignPage', () => {
         getMetricUnitOptions: () => [],
         showStudyProperties: true,
         hideConditionalFormatting: false,
-        readOnlyQueryNames: []
+        readOnlyQueryNames: [],
     } as SampleTypeAppContext;
 
     const DEFAULT_PROPS = {
@@ -95,7 +95,9 @@ describe('SampleTypeDesignPage', () => {
             expect(wrapper.find(SampleTypeDesigner).prop('metricUnitProps').includeMetricUnitProperty).toBe(!isMedia);
             expect(wrapper.find(SampleTypeDesigner).prop('showGenIdBanner')).toBe(isUpdate);
             expect(wrapper.find(SampleTypeDesigner).prop('appPropertiesOnly')).toBe(!isMedia);
-            expect(wrapper.find(SampleTypeDesigner).prop('domainFormDisplayOptions').hideConditionalFormatting).toBe(hideConditionalFormatting);
+            expect(wrapper.find(SampleTypeDesigner).prop('domainFormDisplayOptions').hideConditionalFormatting).toBe(
+                hideConditionalFormatting
+            );
 
             const validatePropertiesFn = wrapper.find(SampleTypeDesigner).prop('validateProperties');
             if (isUpdate && !isMedia) expect(validatePropertiesFn).toBeDefined();

--- a/packages/components/src/entities/SampleTypeDesignerPage.spec.tsx
+++ b/packages/components/src/entities/SampleTypeDesignerPage.spec.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import { ReactWrapper } from 'enzyme';
+import { PermissionTypes } from '@labkey/api';
+
+import {TEST_FOLDER_CONTAINER, TEST_PROJECT_CONTAINER} from '../test/data/constants';
+import { createMockWithRouterProps } from '../internal/mockUtils';
+import { getTestAPIWrapper } from '../internal/APIWrapper';
+import { getQueryTestAPIWrapper } from '../internal/query/APIWrapper';
+import { TEST_USER_FOLDER_ADMIN } from '../internal/userFixtures';
+import { SampleTypeDesigner } from '../internal/components/domainproperties/samples/SampleTypeDesigner';
+import { ProductMenuModel } from '../internal/components/navigation/model';
+import { mountWithAppServerContext, waitForLifecycle } from '../internal/testHelpers';
+import { QueryInfo } from '../public/QueryInfo';
+import { getSamplesTestAPIWrapper } from '../internal/components/samples/APIWrapper';
+import { getSecurityTestAPIWrapper } from '../internal/components/security/APIWrapper';
+import { DomainDetails } from '../internal/components/domainproperties/models';
+
+import { Container } from '../internal/components/base/models/Container';
+
+import { getEntityTestAPIWrapper } from '../internal/components/entities/APIWrapper';
+
+import { SampleTypeAppContext } from './SampleTypeAppContext';
+
+import { SampleTypeBasePage } from './SampleTypeBasePage';
+import { SampleTypeDesignPage } from './SampleTypeDesignPage';
+
+describe('SampleTypeDesignPage', () => {
+    const QUERY_INFO = QueryInfo.create({ domainContainerPath: TEST_PROJECT_CONTAINER.path });
+
+    const API = getTestAPIWrapper(jest.fn, {
+        entity: getEntityTestAPIWrapper(jest.fn, {
+            loadNameExpressionOptions: () => Promise.resolve({ allowUserSpecifiedNames: false, prefix: 'PREFIX' }),
+        }),
+        query: getQueryTestAPIWrapper(jest.fn, {
+            getQueryDetails: () => Promise.resolve(QUERY_INFO),
+        }),
+        samples: getSamplesTestAPIWrapper(jest.fn, {
+            getSampleTypeDetails: () => Promise.resolve(DomainDetails.create()),
+        }),
+        security: getSecurityTestAPIWrapper(jest.fn, {
+            fetchContainers: () =>
+                Promise.resolve([
+                    {
+                        ...TEST_PROJECT_CONTAINER,
+                        effectivePermissions: [PermissionTypes.DesignSampleSet],
+                    } as Container,
+                ]),
+        }),
+    });
+
+    const SAMPLE_TYPE_APP_CONTEXT = {
+        getMetricUnitOptions: () => [],
+        showStudyProperties: true,
+        hideConditionalFormatting: false,
+        readOnlyQueryNames: []
+    } as SampleTypeAppContext;
+
+    const DEFAULT_PROPS = {
+        menu: new ProductMenuModel({
+            isLoaded: true,
+            isLoading: false,
+        }),
+        navigate: jest.fn(),
+        menuInit: jest.fn(),
+        routes: [{ path: '#' }, { path: 'sampleType' }, { path: 'Blood' }],
+        params: { sampleType: 'Blood' },
+    };
+
+    function validate(
+        wrapper: ReactWrapper,
+        hasPerm = true,
+        isUpdate = true,
+        showStudyProps = true,
+        isMedia = false,
+        hideConditionalFormatting = false,
+        nameReadOnly?: boolean
+    ): void {
+        expect(wrapper.find(SampleTypeBasePage)).toHaveLength(hasPerm ? 1 : 0);
+        expect(wrapper.find(SampleTypeDesigner)).toHaveLength(hasPerm ? 1 : 0);
+
+        if (hasPerm) {
+            expect(wrapper.find(SampleTypeBasePage).prop('title')).toBe('Sample Type');
+            expect(wrapper.find(SampleTypeBasePage).prop('subtitle')).toBe(
+                isUpdate ? 'Edit Sample Type Design' : 'Create a New Sample Type'
+            );
+            expect(wrapper.find(SampleTypeDesigner).prop('saveBtnText')).toBe(
+                isUpdate ? 'Finish Updating Sample Type' : 'Finish Creating Sample Type'
+            );
+            expect(wrapper.find(SampleTypeDesigner).prop('initModel').domainDesign.allowTimepointProperties).toBe(
+                showStudyProps
+            );
+            expect(wrapper.find(SampleTypeDesigner).prop('initModel').nameReadOnly).toBe(nameReadOnly);
+            expect(wrapper.find(SampleTypeDesigner).prop('showLinkToStudy')).toBe(showStudyProps);
+            expect(wrapper.find(SampleTypeDesigner).prop('metricUnitProps').metricUnitRequired).toBe(!isUpdate);
+            expect(wrapper.find(SampleTypeDesigner).prop('metricUnitProps').includeMetricUnitProperty).toBe(!isMedia);
+            expect(wrapper.find(SampleTypeDesigner).prop('showGenIdBanner')).toBe(isUpdate);
+            expect(wrapper.find(SampleTypeDesigner).prop('appPropertiesOnly')).toBe(!isMedia);
+            expect(wrapper.find(SampleTypeDesigner).prop('domainFormDisplayOptions').hideConditionalFormatting).toBe(hideConditionalFormatting);
+
+            const validatePropertiesFn = wrapper.find(SampleTypeDesigner).prop('validateProperties');
+            if (isUpdate && !isMedia) expect(validatePropertiesFn).toBeDefined();
+            else expect(validatePropertiesFn).toBeUndefined();
+        }
+    }
+
+    test('default props', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage {...createMockWithRouterProps(jest.fn)} {...DEFAULT_PROPS} />,
+            { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper);
+        expect(wrapper.find('.alert-warning')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('create sample type', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage {...createMockWithRouterProps(jest.fn)} {...DEFAULT_PROPS} params={{}} />,
+            { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper, true, false);
+        wrapper.unmount();
+    });
+
+    test('isMedia', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage
+                {...createMockWithRouterProps(jest.fn)}
+                {...DEFAULT_PROPS}
+                routes={[{ path: '#' }, { path: 'media' }, { path: 'RawMaterials' }]}
+            />,
+            { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper, true, true, true, true);
+        wrapper.unmount();
+    });
+
+    test('insufficient permissions', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage {...createMockWithRouterProps(jest.fn)} {...DEFAULT_PROPS} />,
+            {
+                sampleType: SAMPLE_TYPE_APP_CONTEXT,
+                api: {
+                    ...API,
+                    security: getSecurityTestAPIWrapper(jest.fn, {
+                        fetchContainers: () =>
+                            Promise.resolve([
+                                {
+                                    ...TEST_PROJECT_CONTAINER,
+                                    effectivePermissions: [],
+                                } as Container,
+                            ]),
+                    }),
+                },
+            },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper, false);
+        wrapper.unmount();
+    });
+
+    test('showStudyProperties false', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage {...createMockWithRouterProps(jest.fn)} {...DEFAULT_PROPS} />,
+            {
+                sampleType: {
+                    ...SAMPLE_TYPE_APP_CONTEXT,
+                    showStudyProperties: false,
+                },
+                api: API,
+            },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper, true, true, false);
+        wrapper.unmount();
+    });
+
+    test('hideConditionalFormatting true', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage {...createMockWithRouterProps(jest.fn)} {...DEFAULT_PROPS} />,
+            {
+                sampleType: {
+                    ...SAMPLE_TYPE_APP_CONTEXT,
+                    hideConditionalFormatting: true,
+                },
+                api: API,
+            },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper, true, true, true, false, true);
+        wrapper.unmount();
+    });
+
+    test('readOnlyQueryNames', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage {...createMockWithRouterProps(jest.fn)} {...DEFAULT_PROPS} />,
+            {
+                sampleType: {
+                    ...SAMPLE_TYPE_APP_CONTEXT,
+                    readOnlyQueryNames: ['blood'],
+                },
+                api: API,
+            },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper, true, true, true, false, false, true);
+        wrapper.unmount();
+    });
+
+    test('isInOtherFolder', async () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleTypeDesignPage {...createMockWithRouterProps(jest.fn)} {...DEFAULT_PROPS} />,
+            { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
+            { user: TEST_USER_FOLDER_ADMIN, container: TEST_FOLDER_CONTAINER }
+        );
+        await waitForLifecycle(wrapper, 1000);
+        validate(wrapper);
+        expect(wrapper.find('.alert-warning')).toHaveLength(1);
+        expect(wrapper.find('.alert-warning').text()).toContain('This is a shared sample type');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -49,6 +49,8 @@ import { SampleTypePage } from './SampleTypePage';
 import { SampleIndexNav, SampleTypeIndexNav } from './SampleNav';
 import { SamplesResolver } from './SamplesResolver';
 import { AssayImportSubMenuItem } from './AssayImportSubMenuItem';
+import { useSampleTypeAppContext } from './SampleTypeAppContext';
+import { SampleTypeDesignPage } from './SampleTypeDesignPage';
 
 export {
     PICKLIST_SAMPLES_FILTER,
@@ -64,6 +66,7 @@ export {
     getSampleWizardURL,
     isFindByIdsSchema,
     loadSampleTypes,
+    useSampleTypeAppContext,
     AssayImportSubMenuItem,
     CreateSamplesSubMenu,
     CreateSamplesSubMenuBase,
@@ -98,6 +101,7 @@ export {
     SampleTypeIndexNav,
     SampleTypePage,
     SampleTypeBasePage,
+    SampleTypeDesignPage,
     SampleTypeInsightsPanel,
     SampleTypeTemplateDownloadRenderer,
     SamplesAssayButton,
@@ -106,4 +110,9 @@ export {
     SamplesTabbedGridPanel,
 };
 
+//  Due to babel-loader & typescript babel plugins we need to export/import types separately. The babel plugins require
+//  the typescript compiler option "isolatedModules", which do not export types from modules, so types must be exported
+//  separately.
+//  https://github.com/babel/babel-loader/issues/603
 export type { SamplesEditableGridProps } from './SamplesEditableGrid';
+export type { SampleTypeAppContext, WithSampleTypeAppContext, AppContextWithSampleType } from './SampleTypeAppContext';

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -16,6 +16,7 @@
 import React, { createContext, PropsWithChildren, ReactElement, useContext, useMemo } from 'react';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from './APIWrapper';
+import {SampleTypeAppContext} from "../entities";
 
 export interface NavigationSettings {
     showCurrentContainer: boolean;
@@ -24,6 +25,7 @@ export interface NavigationSettings {
 export interface AppContext {
     api?: ComponentsAPIWrapper;
     navigation?: NavigationSettings;
+    sampleType?: SampleTypeAppContext;
 }
 
 export type ExtendableAppContext<T> = T & AppContext;

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -15,8 +15,9 @@
  */
 import React, { createContext, PropsWithChildren, ReactElement, useContext, useMemo } from 'react';
 
+import { SampleTypeAppContext } from '../entities';
+
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from './APIWrapper';
-import {SampleTypeAppContext} from "../entities";
 
 export interface NavigationSettings {
     showCurrentContainer: boolean;

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -356,7 +356,7 @@ export function addSamplesSectionConfig(
         maxItemsPerColumn: 12,
         seeAllURL: appBase + AppURL.create(SAMPLES_KEY).addParam('viewAs', 'cards').toHref(),
     });
-    if (user.hasDesignSampleSetsPermission()) {
+    if (user.hasDesignSampleTypesPermission()) {
         samplesMenuConfig = samplesMenuConfig.merge({
             emptyURL: appBase + NEW_SAMPLE_TYPE_HREF.toHref(),
             emptyURLText: 'Create a sample type',

--- a/packages/components/src/internal/components/base/models/User.spec.tsx
+++ b/packages/components/src/internal/components/base/models/User.spec.tsx
@@ -132,15 +132,15 @@ describe('User permissions', () => {
         expect(TEST_USER_APP_ADMIN.hasDesignAssaysPermission()).toBeTruthy();
     });
 
-    test('hasDesignSampleSetsPermission', () => {
-        expect(TEST_USER_GUEST.hasDesignSampleSetsPermission()).toBeFalsy();
-        expect(TEST_USER_READER.hasDesignSampleSetsPermission()).toBeFalsy();
-        expect(TEST_USER_AUTHOR.hasDesignSampleSetsPermission()).toBeFalsy();
-        expect(TEST_USER_EDITOR.hasDesignSampleSetsPermission()).toBeFalsy();
-        expect(TEST_USER_ASSAY_DESIGNER.hasDesignSampleSetsPermission()).toBeFalsy();
-        expect(TEST_USER_FOLDER_ADMIN.hasDesignSampleSetsPermission()).toBeTruthy();
-        expect(TEST_USER_PROJECT_ADMIN.hasDesignSampleSetsPermission()).toBeTruthy();
-        expect(TEST_USER_APP_ADMIN.hasDesignSampleSetsPermission()).toBeTruthy();
+    test('hasDesignSampleTypesPermission', () => {
+        expect(TEST_USER_GUEST.hasDesignSampleTypesPermission()).toBeFalsy();
+        expect(TEST_USER_READER.hasDesignSampleTypesPermission()).toBeFalsy();
+        expect(TEST_USER_AUTHOR.hasDesignSampleTypesPermission()).toBeFalsy();
+        expect(TEST_USER_EDITOR.hasDesignSampleTypesPermission()).toBeFalsy();
+        expect(TEST_USER_ASSAY_DESIGNER.hasDesignSampleTypesPermission()).toBeFalsy();
+        expect(TEST_USER_FOLDER_ADMIN.hasDesignSampleTypesPermission()).toBeTruthy();
+        expect(TEST_USER_PROJECT_ADMIN.hasDesignSampleTypesPermission()).toBeTruthy();
+        expect(TEST_USER_APP_ADMIN.hasDesignSampleTypesPermission()).toBeTruthy();
     });
 
     test('hasManageUsersPermission', () => {

--- a/packages/components/src/internal/components/base/models/User.ts
+++ b/packages/components/src/internal/components/base/models/User.ts
@@ -85,7 +85,7 @@ export class User extends Record(defaultUser) implements IUserProps {
         return hasAllPermissions(this, [PermissionTypes.DesignAssay]);
     }
 
-    hasDesignSampleSetsPermission(): boolean {
+    hasDesignSampleTypesPermission(): boolean {
         return hasAllPermissions(this, [PermissionTypes.DesignSampleSet]);
     }
 

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -34,8 +34,8 @@ function applyPermissions(container: Container, user: User): User {
 
 export interface ContainerUser {
     container: Container;
-    user: User;
     containerUsers?: { [key: string]: ContainerUser };
+    user: User;
 }
 
 export interface UseContainerUser extends ContainerUser {

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -69,7 +69,7 @@ export interface UseContainerUser extends ContainerUser {
  *                    <span>Folder Path: {container.path}</span>
  *                    {user.hasInsertPermission() && <span>{user.displayName} can insert data into {container.path}.</span>>}
  *                    {user.hasDeletePermission() && <span>{user.displayName} can delete data in {container.path}.</span>>}
- *                    {user.hasDesignSampleSetsPermission() && <span>{user.displayName} can design sample types in {container.path}.</span>>}
+ *                    {user.hasDesignSampleTypesPermission() && <span>{user.displayName} can design sample types in {container.path}.</span>>}
  *                </>
  *            )}
  *        </div>

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -1047,6 +1047,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
         },
         "entity": EntityServerAPIWrapper {
           "getDataOperationConfirmationData": [Function],
+          "loadNameExpressionOptions": [Function],
         },
         "folder": ServerFolderAPIWrapper {
           "createProject": [Function],
@@ -1078,6 +1079,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
           "getSampleOperationConfirmationData": [Function],
           "getSampleStatuses": [Function],
           "getSampleStorageId": [Function],
+          "getSampleTypeDetails": [Function],
           "getSelectionLineageData": [Function],
           "getTimelineEvents": [Function],
           "loadFinderSearches": [Function],

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -1,7 +1,8 @@
+import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../settings/actions';
+
 import { getDataOperationConfirmationData } from './actions';
 import { DataOperation } from './constants';
 import { OperationConfirmationData } from './models';
-import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../settings/actions';
 
 export interface EntityAPIWrapper {
     getDataOperationConfirmationData: (

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -1,17 +1,21 @@
 import { getDataOperationConfirmationData } from './actions';
 import { DataOperation } from './constants';
 import { OperationConfirmationData } from './models';
+import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../settings/actions';
 
 export interface EntityAPIWrapper {
-    getDataOperationConfirmationData(
+    getDataOperationConfirmationData: (
         operation: DataOperation,
         selectionKey: string,
         rowIds?: string[] | number[]
-    ): Promise<OperationConfirmationData>;
+    ) => Promise<OperationConfirmationData>;
+
+    loadNameExpressionOptions: (containerPath?: string) => Promise<GetNameExpressionOptionsResponse>;
 }
 
 export class EntityServerAPIWrapper implements EntityAPIWrapper {
     getDataOperationConfirmationData = getDataOperationConfirmationData;
+    loadNameExpressionOptions = loadNameExpressionOptions;
 }
 
 /**
@@ -23,6 +27,7 @@ export function getEntityTestAPIWrapper(
 ): EntityAPIWrapper {
     return {
         getDataOperationConfirmationData: mockFn(),
+        loadNameExpressionOptions: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -20,10 +20,13 @@ import {
     getSampleStatuses,
     getSampleStorageId,
     getTimelineEvents,
+    getSampleTypeDetails,
     SampleAssayResultViewConfig,
 } from './actions';
 import { SampleState } from './models';
 import { SampleOperation } from './constants';
+import {SchemaQuery} from "../../../public/SchemaQuery";
+import {DomainDetails} from "../domainproperties/models";
 
 export interface SamplesAPIWrapper {
     getFieldLookupFromSelection: (
@@ -58,6 +61,13 @@ export interface SamplesAPIWrapper {
     getTimelineEvents: (sampleId: number, timezone?: string) => Promise<TimelineEventModel[]>;
 
     loadFinderSearches: () => Promise<FinderReport[]>;
+
+    getSampleTypeDetails: (
+        query?: SchemaQuery,
+        domainId?: number,
+        containerPath?: string,
+        includeNamePreview?: boolean
+    ) => Promise<DomainDetails>;
 }
 
 export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
@@ -70,6 +80,7 @@ export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
     getFieldLookupFromSelection = getFieldLookupFromSelection;
     loadFinderSearches = loadFinderSearches;
     getTimelineEvents = getTimelineEvents;
+    getSampleTypeDetails = getSampleTypeDetails;
 }
 
 /**
@@ -89,6 +100,7 @@ export function getSamplesTestAPIWrapper(
         getFieldLookupFromSelection: mockFn(),
         loadFinderSearches: mockFn(),
         getTimelineEvents: mockFn(),
+        getSampleTypeDetails: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -12,6 +12,10 @@ import { loadFinderSearches } from '../search/actions';
 
 import { TimelineEventModel } from '../auditlog/models';
 
+import { SchemaQuery } from '../../../public/SchemaQuery';
+
+import { DomainDetails } from '../domainproperties/models';
+
 import {
     getSampleAliquotRows,
     getSampleAssayResultViewConfigs,
@@ -25,8 +29,6 @@ import {
 } from './actions';
 import { SampleState } from './models';
 import { SampleOperation } from './constants';
-import {SchemaQuery} from "../../../public/SchemaQuery";
-import {DomainDetails} from "../domainproperties/models";
 
 export interface SamplesAPIWrapper {
     getFieldLookupFromSelection: (
@@ -50,6 +52,13 @@ export interface SamplesAPIWrapper {
 
     getSampleStorageId: (sampleRowId: number) => Promise<number>;
 
+    getSampleTypeDetails: (
+        query?: SchemaQuery,
+        domainId?: number,
+        containerPath?: string,
+        includeNamePreview?: boolean
+    ) => Promise<DomainDetails>;
+
     getSelectionLineageData: (
         selection: List<any>,
         schema: string,
@@ -61,13 +70,6 @@ export interface SamplesAPIWrapper {
     getTimelineEvents: (sampleId: number, timezone?: string) => Promise<TimelineEventModel[]>;
 
     loadFinderSearches: () => Promise<FinderReport[]>;
-
-    getSampleTypeDetails: (
-        query?: SchemaQuery,
-        domainId?: number,
-        containerPath?: string,
-        includeNamePreview?: boolean
-    ) => Promise<DomainDetails>;
 }
 
 export class SamplesServerAPIWrapper implements SamplesAPIWrapper {


### PR DESCRIPTION
#### Rationale
Moving some more components out of the apps into the @labkey/components/entities subpackage so that they can be shared in LKB and LKSM to get consistency.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/991
* https://github.com/LabKey/sampleManagement/pull/1311
* https://github.com/LabKey/biologics/pull/1674
* https://github.com/LabKey/inventory/pull/571

#### Changes
* refactor SampleTypeDesignPage from LKB app to be used in LKSM as well
* add SampleTypeAppContext to pass app specific properties to the designer
