### PR TITLE
Reenable AssayQC features

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.237.0",
+  "version": "2.237.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.237.1
+*Released*: 25 October 2022
+* Update logic for `isAssayQCEnabled` check.
+
 ### version 2.237.0
 *Released*: 25 October 2022
 * App Sample Type Consistency for Sample Type Designer

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -436,25 +436,23 @@ describe('utils', () => {
     });
 
     test('isAssayQCEnabled', () => {
-        // TODO: These checks can be re-enabled once isAssayQCEnabled() has been reassessed. See isAssayQCEnabled().
-        // expect(isAssayQCEnabled({ api: { moduleNames: [] } })).toBeFalsy();
-        // expect(isAssayQCEnabled({ api: { moduleNames: ['assay'] } })).toBeFalsy();
-        // expect(
-        //     isAssayQCEnabled({ api: { moduleNames: [] }, core: { productFeatures: [ProductFeature.AssayQC] } })
-        // ).toBeFalsy();
-        // expect(
-        //     isAssayQCEnabled({
-        //         api: { moduleNames: ['assay'] },
-        //         core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
-        //     })
-        // ).toBeFalsy();
-        // expect(
-        //     isAssayQCEnabled({
-        //         api: { moduleNames: ['assay', 'premium'] },
-        //         core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
-        //     })
-        // ).toBeTruthy();
-        expect(isAssayQCEnabled()).toBeTruthy();
+        expect(isAssayQCEnabled({ api: { moduleNames: [] } })).toBeFalsy();
+        expect(isAssayQCEnabled({ api: { moduleNames: ['assay'] } })).toBeFalsy();
+        expect(
+            isAssayQCEnabled({ api: { moduleNames: [] }, core: { productFeatures: [ProductFeature.AssayQC] } })
+        ).toBeFalsy();
+        expect(
+            isAssayQCEnabled({
+                api: { moduleNames: ['assay'] },
+                core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
+            })
+        ).toBeFalsy();
+        expect(
+            isAssayQCEnabled({
+                api: { moduleNames: ['assay', 'premium'] },
+                core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
+            })
+        ).toBeTruthy();
     });
 
     test('isAssayRequestsEnabled', () => {

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -436,23 +436,25 @@ describe('utils', () => {
     });
 
     test('isAssayQCEnabled', () => {
-        expect(isAssayQCEnabled({ api: { moduleNames: [] } })).toBeFalsy();
-        expect(isAssayQCEnabled({ api: { moduleNames: ['assay'] } })).toBeFalsy();
-        expect(
-            isAssayQCEnabled({ api: { moduleNames: [] }, core: { productFeatures: [ProductFeature.AssayQC] } })
-        ).toBeFalsy();
-        expect(
-            isAssayQCEnabled({
-                api: { moduleNames: ['assay'] },
-                core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
-            })
-        ).toBeFalsy();
-        expect(
-            isAssayQCEnabled({
-                api: { moduleNames: ['assay', 'premium'] },
-                core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
-            })
-        ).toBeTruthy();
+        // TODO: These checks can be re-enabled once isAssayQCEnabled() has been reassessed. See isAssayQCEnabled().
+        // expect(isAssayQCEnabled({ api: { moduleNames: [] } })).toBeFalsy();
+        // expect(isAssayQCEnabled({ api: { moduleNames: ['assay'] } })).toBeFalsy();
+        // expect(
+        //     isAssayQCEnabled({ api: { moduleNames: [] }, core: { productFeatures: [ProductFeature.AssayQC] } })
+        // ).toBeFalsy();
+        // expect(
+        //     isAssayQCEnabled({
+        //         api: { moduleNames: ['assay'] },
+        //         core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
+        //     })
+        // ).toBeFalsy();
+        // expect(
+        //     isAssayQCEnabled({
+        //         api: { moduleNames: ['assay', 'premium'] },
+        //         core: { productFeatures: [ProductFeature.Assay, ProductFeature.AssayQC] },
+        //     })
+        // ).toBeTruthy();
+        expect(isAssayQCEnabled()).toBeTruthy();
     });
 
     test('isAssayRequestsEnabled', () => {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -220,11 +220,15 @@ export function isAssayEnabled(moduleContext?: ModuleContext): boolean {
 }
 
 export function isAssayQCEnabled(moduleContext?: ModuleContext): boolean {
-    return (
-        isAssayEnabled(moduleContext) &&
-        hasPremiumModule(moduleContext) &&
-        isFeatureEnabled(ProductFeature.AssayQC, moduleContext)
-    );
+    // NK: The product tiers which include Assay QC are not fully defined.
+    // For now (v22.11+), we're going to continue offering Assay QC features until
+    // we can fully define all desired product tiers.
+    // return (
+    //     isAssayEnabled(moduleContext) &&
+    //     hasPremiumModule(moduleContext) &&
+    //     isFeatureEnabled(ProductFeature.AssayQC, moduleContext)
+    // );
+    return true;
 }
 
 export function isAssayRequestsEnabled(moduleContext?: ModuleContext): boolean {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -222,13 +222,10 @@ export function isAssayEnabled(moduleContext?: ModuleContext): boolean {
 export function isAssayQCEnabled(moduleContext?: ModuleContext): boolean {
     // NK: The product tiers which include Assay QC are not fully defined.
     // For now (v22.11+), we're going to continue offering Assay QC features until
-    // we can fully define all desired product tiers.
-    // return (
-    //     isAssayEnabled(moduleContext) &&
-    //     hasPremiumModule(moduleContext) &&
-    //     isFeatureEnabled(ProductFeature.AssayQC, moduleContext)
-    // );
-    return true;
+    // we can fully define all desired product tiers. Once that is done we can respect
+    // the associated feature flag instead.
+    // isFeatureEnabled(ProductFeature.AssayQC, moduleContext)
+    return isAssayEnabled(moduleContext) && hasPremiumModule(moduleContext);
 }
 
 export function isAssayRequestsEnabled(moduleContext?: ModuleContext): boolean {


### PR DESCRIPTION
#### Rationale
This reenables Assay QC functionality broadly throughout our products.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/992
* https://github.com/LabKey/biologics/pull/1675
* https://github.com/LabKey/sampleManagement/pull/1312
* https://github.com/LabKey/inventory/pull/572
* https://github.com/LabKey/platform/pull/3779

#### Changes
* Update logic for `isAssayQCEnabled` check.
