### PR TITLE
Issue 45944: LKSM: Error with Metacharacter(s) in Sample Type Name

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.0",
+  "version": "2.242.0-fb-specialCharNames.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.TBD
+*Released*: TBD
+* Fix Issue 45944: Decode $ in MenuItem keys
+
 ### version 2.242.0
 *Released*: 28 October 2022
 * Issue 46460: Filter by date only (not time)

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -81,7 +81,7 @@ export class MenuItemModel extends Record({
             const dataProductId = rawData.productId ? rawData.productId.toLowerCase() : undefined;
 
             if (rawData.key && sectionKey !== 'user') {
-                const parts = rawData.key.split('?');
+                const parts = rawData.key.split('?');  //TODO: This may cause issues with non-url keys that have '?' as they will be split unexpectedly. Issue #46611
 
                 // for assay name that contains slash, full raw key (protocol/assayname: general/a/b) is encoded using QueryKey.encodePart as general/a$Sb on server side
                 // use QueryKey.decodePart to decode the assay name so url can be correctly called by encodeURIComponent and key be used to display decoded assay name
@@ -90,7 +90,7 @@ export class MenuItemModel extends Record({
                     .filter(val => val !== '')
                     .map(QueryKey.decodePart);
 
-                const decodedPart = subParts.join('/');
+                const decodedPart = subParts.join('/').replace('$','$$$$'); // Need to escape any '$' in the replacement string https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
                 const decodedKey = rawData.key.replace(parts[0], decodedPart);
 
                 let params;


### PR DESCRIPTION
#### Rationale
[Issue 45944: LKSM: Error with Metacharacter(s) in Sample Type Name](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45944)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement

#### Related Pull Requests
* [biologics](https://github.com/LabKey/biologics/pull/1689)
* [samplemanagement](https://github.com/LabKey/sampleManagement/pull/1335)
* [inventory](https://github.com/LabKey/inventory/pull/583)
* [platform](https://github.com/LabKey/platform/pull/3798)
* [labbook](https://github.com/LabKey/labbook/pull/306)

#### Changes
* Escape '$' when using string replace
