### PR TITLE
Consistent labeling of fields (title casing and no trailing colons) and remove extra lines

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.1-consistencyFixes.5",
+  "version": "2.242.1-consistencyFixes.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.241.4-consistencyFixes.0",
+  "version": "2.241.4-consistencyFixes.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.241.4-consistencyFixes.2",
+  "version": "2.241.4-consistencyFixes.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.241.4-consistencyFixes.3",
+  "version": "2.241.4-consistencyFixes.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.241.4-consistencyFixes.1",
+  "version": "2.241.4-consistencyFixes.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.241.3",
+  "version": "2.241.4-consistencyFixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.1-consistencyFixes.4",
+  "version": "2.242.1-consistencyFixes.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.1-consistencyFixes.6",
+  "version": "2.242.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Update sample type download template URL to use query name as prefix
 * Remove colon after field label for audit details
+* Remove colons from user detail labels as well
 
 ### version 2.241.3
 *Released*: 27 October 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Remove colon after field label for audit details
 * Remove colons after user detail labels
 * Remove colons after EditInlineField labels
+* Don't put empty aliquots message in the table (remove extraneous horizontal line)
 
 ### version 2.241.3
 *Released*: 27 October 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Update sample type download template URL to use query name as prefix
+* Remove colon after field label for audit details
 
 ### version 2.241.3
 *Released*: 27 October 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -8,6 +8,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Remove colons after user detail labels
 * Remove colons after EditInlineField labels
 * Don't put empty aliquots message in the table (remove extraneous horizontal line)
+* In ParentEntityEditPanel, don't show hr unless editing when there are no parents
 
 ### version 2.241.3
 *Released*: 27 October 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.242.1
+*Released*: 31 October 2022
 * Update sample type download template URL to use query name as prefix
 * Remove colon after field label for audit details
 * Remove colons after user detail labels

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Update sample type download template URL to use query name as prefix
+
 ### version 2.241.3
 *Released*: 27 October 2022
 * Fix Issue 45553

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,7 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Update sample type download template URL to use query name as prefix
 * Remove colon after field label for audit details
-* Remove colons from user detail labels as well
+* Remove colons after user detail labels
+* Remove colons after EditInlineField labels
 
 ### version 2.241.3
 *Released*: 27 October 2022

--- a/packages/components/src/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/entities/ParentEntityEditPanel.tsx
@@ -353,7 +353,7 @@ export class ParentEntityEditPanel extends Component<Props, State> {
 
         return (
             <div>
-                {!this.compactEditDisplay() && <hr />}
+                {editing && !this.compactEditDisplay() && <hr />}
                 <SingleParentEntityPanel
                     editing={editing}
                     containerPath={childContainerPath}

--- a/packages/components/src/entities/SampleAliquotsSummary.tsx
+++ b/packages/components/src/entities/SampleAliquotsSummary.tsx
@@ -119,21 +119,16 @@ export class SampleAliquotsSummaryWithModels extends PureComponent<Props & Sampl
             <Panel>
                 <Panel.Heading>Aliquots</Panel.Heading>
                 <Panel.Body>
+                    {!stats && (
+                        <span className="sample-aliquots-stats-empty">This sample has no aliquots.</span>
+                    )}
+                    {!!stats && (
                     <table className="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-stats-table">
                         <tbody>
-                            {stats ? (
-                                this.renderStats(stats, hideAssayData)
-                            ) : (
-                                <tr>
-                                    <td>
-                                        <span className="sample-aliquots-stats-empty">
-                                            This sample has no aliquots.
-                                        </span>
-                                    </td>
-                                </tr>
-                            )}
+                            {this.renderStats(stats, hideAssayData)}
                         </tbody>
                     </table>
+                    )}
                 </Panel.Body>
             </Panel>
         );

--- a/packages/components/src/entities/SampleTimelinePageBase.tsx
+++ b/packages/components/src/entities/SampleTimelinePageBase.tsx
@@ -146,7 +146,7 @@ export const SampleTimelinePageBaseImpl: FC<OwnProps & InjectedQueryModels> = me
     };
 
     const auditDetailValueRenderer = (field: string, value: string, displayValue: any): any => {
-        if (field.toLowerCase() === 'sampleid') {
+        if (field.toLowerCase() === 'sample id') {
             const sampleLink = AppURL.create(SAMPLES_KEY, sampleSet, sampleId).toHref();
             return <a href={sampleLink}>{value}</a>;
         }

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -285,7 +285,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
                         showParentLabelPrefix={showParentLabelPrefix}
                         metricUnitProps={{
                             includeMetricUnitProperty: includeStorageOptions,
-                            metricUnitLabel: 'Display stored amount in',
+                            metricUnitLabel: 'Stored Amount Display Units',
                             metricUnitRequired: includeStorageOptions && (!isUpdate || metricUnit != null), // allow existing sample types without unit to continue to have blank unit
                             metricUnitHelpMsg:
                                 'Sample storage amount will be displayed using the selected metric unit.',

--- a/packages/components/src/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
+++ b/packages/components/src/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
@@ -4896,7 +4896,6 @@ exports[`ParentEntityEditPanel error state 1`] = `
                 </b>
               </div>
               <div>
-                <hr />
                 <Memo()
                   childNounSingular="Testing"
                   containerFilter="CurrentPlusProjectAndShared"

--- a/packages/components/src/entities/__snapshots__/SampleTimelinePageBase.spec.tsx.snap
+++ b/packages/components/src/entities/__snapshots__/SampleTimelinePageBase.spec.tsx.snap
@@ -2729,7 +2729,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               ModifiedBy
-              :
             </span>
           </div>
           <div
@@ -2752,7 +2751,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               LSID
-              :
             </span>
           </div>
           <div
@@ -2775,7 +2773,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               _rowNumber
-              :
             </span>
           </div>
           <div
@@ -2798,7 +2795,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               Created
-              :
             </span>
           </div>
           <div
@@ -2821,7 +2817,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               Modified
-              :
             </span>
           </div>
           <div
@@ -2844,7 +2839,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               GenId
-              :
             </span>
           </div>
           <div
@@ -2867,7 +2861,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               Name
-              :
             </span>
           </div>
           <div
@@ -2890,7 +2883,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               Folder
-              :
             </span>
           </div>
           <div
@@ -2913,7 +2905,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               MaterialInputs/Test
-              :
             </span>
           </div>
           <div
@@ -2936,7 +2927,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               RowId
-              :
             </span>
           </div>
           <div
@@ -2959,7 +2949,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               CpasType
-              :
             </span>
           </div>
           <div
@@ -2982,7 +2971,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               Description
-              :
             </span>
           </div>
           <div
@@ -3005,7 +2993,6 @@ exports[`<SampleTimelinePageBase/> With selected sample registration event 1`] =
               className="audit-detail-row-label right-spacing"
             >
               CreatedBy
-              :
             </span>
           </div>
           <div
@@ -3861,7 +3848,6 @@ exports[`<SampleTimelinePageBase/> With selected sample update event 1`] = `
               className="audit-detail-row-label right-spacing"
             >
               Description
-              :
             </span>
           </div>
           <div
@@ -3892,7 +3878,6 @@ exports[`<SampleTimelinePageBase/> With selected sample update event 1`] = `
               className="audit-detail-row-label right-spacing"
             >
               Modified
-              :
             </span>
           </div>
           <div

--- a/packages/components/src/entities/utils.spec.tsx
+++ b/packages/components/src/entities/utils.spec.tsx
@@ -267,7 +267,27 @@ describe('getSampleDeleteMessage', () => {
 
 describe('getSampleTypeTemplateUrl', () => {
     const BASE_URL =
-        '/labkey/query/ExportExcelTemplate.view?exportAlias.name=Sample%20ID&exportAlias.aliquotedFromLSID=AliquotedFrom&exportAlias.sampleState=Status&schemaName=schema&query.queryName=query&headerType=DisplayFieldKey&excludeColumn=flag&excludeColumn=Ancestors&includeColumn=StorageLocation&includeColumn=StorageRow&includeColumn=StorageCol&includeColumn=StoredAmount&includeColumn=Units&includeColumn=FreezeThawCount&includeColumn=EnteredStorage&includeColumn=CheckedOut&includeColumn=CheckedOutBy&includeColumn=StorageComment&includeColumn=AliquotedFrom';
+        '/labkey/query/ExportExcelTemplate.view?' +
+        'exportAlias.name=Sample%20ID' +
+        '&exportAlias.aliquotedFromLSID=AliquotedFrom' +
+        '&exportAlias.sampleState=Status' +
+        '&schemaName=schema' +
+        '&query.queryName=query' +
+        '&headerType=DisplayFieldKey' +
+        '&excludeColumn=flag' +
+        '&excludeColumn=Ancestors' +
+        '&includeColumn=StorageLocation' +
+        '&includeColumn=StorageRow' +
+        '&includeColumn=StorageCol' +
+        '&includeColumn=StoredAmount' +
+        '&includeColumn=Units' +
+        '&includeColumn=FreezeThawCount' +
+        '&includeColumn=EnteredStorage' +
+        '&includeColumn=CheckedOut' +
+        '&includeColumn=CheckedOutBy' +
+        '&includeColumn=StorageComment' +
+        '&includeColumn=AliquotedFrom' +
+        '&filenamePrefix=query';
 
     test('no schemaQuery', () => {
         expect(getSampleTypeTemplateUrl(QueryInfo.create({}), undefined)).toBe(undefined);

--- a/packages/components/src/entities/utils.tsx
+++ b/packages/components/src/entities/utils.tsx
@@ -185,6 +185,7 @@ export const getSampleTypeTemplateUrl = (
             ? excludeColumns.concat(queryInfo.getFileColumnFieldKeys())
             : queryInfo.getFileColumnFieldKeys(),
         includeColumn: extraColumns,
+        filenamePrefix: schemaQuery.getQuery(),
     });
 };
 

--- a/packages/components/src/internal/components/EditInlineField.spec.tsx
+++ b/packages/components/src/internal/components/EditInlineField.spec.tsx
@@ -36,7 +36,7 @@ describe('EditInlineField', () => {
         expect(wrapper.find('.edit-inline-field__toggle')).toHaveLength(!editing && allowEdit ? 1 : 0);
         expect(wrapper.find('.fa-pencil')).toHaveLength(!editing && allowEdit ? 1 : 0);
         if (!editing) {
-            expect(wrapper.find('.edit-inline-field__label').text()).toBe('Test Label:');
+            expect(wrapper.find('.edit-inline-field__label').text()).toBe('Test Label');
         }
 
         expect(wrapper.find(DateInput)).toHaveLength(type?.date ?? 0);

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -221,7 +221,7 @@ export const EditInlineField: FC<Props> = memo(props => {
                             unselectable="on"
                             title={allowEdit ? tooltip : undefined}
                         >
-                            {label}:
+                            {label}
                         </span>
                     )}
                     <span

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -159,7 +159,7 @@ export class AuditDetails extends Component<Props, State> {
         return (
             <Row className="margin-bottom" key={field}>
                 <Col className="left-spacing right-spacing">
-                    <span className="audit-detail-row-label right-spacing">{capitalizeFirstChar(field)}:</span>
+                    <span className="audit-detail-row-label right-spacing">{capitalizeFirstChar(field)}</span>
                 </Col>
                 <Col className="left-spacing right-spacing">
                     {valueRenderer(this.getValueDisplay(field, oldVal), this.getValueDisplay(field, newVal))}

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -47,7 +47,7 @@ export class AuditDetails extends Component<Props, State> {
     };
 
     static isUserFieldLabel(field: string): boolean {
-        return ['createdby', 'modifiedby'].indexOf(field.toLowerCase()) > -1;
+        return ['createdby', 'created by', 'modifiedby', 'modified by'].indexOf(field.toLowerCase()) > -1;
     }
 
     constructor(props: Props) {

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -47,7 +47,7 @@ export class AuditDetails extends Component<Props, State> {
     };
 
     static isUserFieldLabel(field: string): boolean {
-        return ['createdby', 'created by', 'modifiedby', 'modified by'].indexOf(field.toLowerCase()) > -1;
+        return ['created by', 'modified by'].indexOf(field.toLowerCase()) > -1;
     }
 
     constructor(props: Props) {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.spec.tsx
@@ -177,7 +177,7 @@ describe('<SampleTypePropertiesPanel/>', () => {
                 appPropertiesOnly={true}
                 metricUnitProps={{
                     includeMetricUnitProperty: true,
-                    metricUnitLabel: 'Display stored amount in',
+                    metricUnitLabel: 'Stored Amount Display Unit',
                     metricUnitRequired: true,
                     metricUnitHelpMsg: 'Sample storage volume will be displayed using the selected metric unit.',
                     metricUnitOptions: [

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -1460,11 +1460,11 @@ exports[`<SampleTypePropertiesPanel/> metricUnitOptions 1`] = `
       <div
         className="col-xs-2"
       >
-        Display stored amount 
+        Stored Amount Display 
         <span
           className="domain-no-wrap"
         >
-          in
+          Unit
           <span
             className="label-help-target"
             onMouseOut={[Function]}

--- a/packages/components/src/internal/components/permissions/EffectiveRolesList.tsx
+++ b/packages/components/src/internal/components/permissions/EffectiveRolesList.tsx
@@ -35,7 +35,7 @@ export class EffectiveRolesList extends React.PureComponent<Props, any> {
         return (
             <>
                 <hr className="principal-hr" />
-                <div className="principal-detail-label">Effective Roles:</div>
+                <div className="principal-detail-label">Effective Roles</div>
                 <ul className="permissions-groups-ul">
                     {assignments.map(assignment => {
                         const role = rolesByUniqueName.get(assignment.role);

--- a/packages/components/src/internal/components/permissions/MembersList.tsx
+++ b/packages/components/src/internal/components/permissions/MembersList.tsx
@@ -14,7 +14,7 @@ export const MembersList: FC<Props> = memo(props => {
     ) : (
         <>
             <hr className="principal-hr" />
-            <div className="principal-detail-label">Members:</div>
+            <div className="principal-detail-label">Members</div>
             <ul className="permissions-groups-ul">
                 {members.map(member => (
                     <li key={member.id}>{member.name}</li>

--- a/packages/components/src/internal/components/permissions/__snapshots__/EffectiveRolesList.spec.tsx.snap
+++ b/packages/components/src/internal/components/permissions/__snapshots__/EffectiveRolesList.spec.tsx.snap
@@ -8,7 +8,7 @@ Array [
   <div
     className="principal-detail-label"
   >
-    Effective Roles:
+    Effective Roles
   </div>,
   <ul
     className="permissions-groups-ul"
@@ -45,7 +45,7 @@ Array [
   <div
     className="principal-detail-label"
   >
-    Effective Roles:
+    Effective Roles
   </div>,
   <ul
     className="permissions-groups-ul"
@@ -65,7 +65,7 @@ Array [
   <div
     className="principal-detail-label"
   >
-    Effective Roles:
+    Effective Roles
   </div>,
   <ul
     className="permissions-groups-ul"

--- a/packages/components/src/internal/components/permissions/__snapshots__/GroupDetailsPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/permissions/__snapshots__/GroupDetailsPanel.spec.tsx.snap
@@ -86,7 +86,7 @@ exports[`<GroupDetailsPanel/> as site group 1`] = `
     <div
       className="principal-detail-label"
     >
-      Effective Roles:
+      Effective Roles
     </div>
     <ul
       className="permissions-groups-ul"
@@ -207,7 +207,7 @@ exports[`<GroupDetailsPanel/> with principal and members 1`] = `
     <div
       className="principal-detail-label"
     >
-      Effective Roles:
+      Effective Roles
     </div>
     <ul
       className="permissions-groups-ul"

--- a/packages/components/src/internal/components/permissions/__snapshots__/GroupDetailsPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/permissions/__snapshots__/GroupDetailsPanel.spec.tsx.snap
@@ -24,7 +24,6 @@ exports[`<GroupDetailsPanel/> as site group 1`] = `
         className="principal-detail-label col-xs-4"
       >
         User Count
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -39,7 +38,6 @@ exports[`<GroupDetailsPanel/> as site group 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Group Count
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -57,7 +55,6 @@ exports[`<GroupDetailsPanel/> as site group 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Created
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -72,7 +69,6 @@ exports[`<GroupDetailsPanel/> as site group 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Site Group
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -101,7 +97,7 @@ exports[`<GroupDetailsPanel/> as site group 1`] = `
     <div
       className="principal-detail-label"
     >
-      Members:
+      Members
     </div>
     <ul
       className="permissions-groups-ul"
@@ -160,7 +156,6 @@ exports[`<GroupDetailsPanel/> with principal and members 1`] = `
         className="principal-detail-label col-xs-4"
       >
         User Count
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -175,7 +170,6 @@ exports[`<GroupDetailsPanel/> with principal and members 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Group Count
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -193,7 +187,6 @@ exports[`<GroupDetailsPanel/> with principal and members 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Created
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -222,7 +215,7 @@ exports[`<GroupDetailsPanel/> with principal and members 1`] = `
     <div
       className="principal-detail-label"
     >
-      Members:
+      Members
     </div>
     <ul
       className="permissions-groups-ul"

--- a/packages/components/src/internal/components/user/GroupsList.tsx
+++ b/packages/components/src/internal/components/user/GroupsList.tsx
@@ -10,7 +10,7 @@ export const MembersList: FC<Props> = memo(props => {
     return (
         <>
             <hr className="principal-hr" />
-            <div className="principal-detail-label">Member of:</div>
+            <div className="principal-detail-label">Member of</div>
             <ul className="permissions-groups-ul">
                 {groups.length > 0 ? (
                     groups.map(group => <li key={group}>{group}</li>)

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -121,7 +121,7 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
         return (
             <Row>
                 <Col xs={4} className="principal-detail-label">
-                    {title}:
+                    {title}
                 </Col>
                 <Col xs={8} className="principal-detail-value">
                     {value}

--- a/packages/components/src/internal/components/user/UserProperties.tsx
+++ b/packages/components/src/internal/components/user/UserProperties.tsx
@@ -12,7 +12,7 @@ export const UserProperties: FC<Props> = memo(props => {
     return (
         <Row>
             <Col xs={4} className="principal-detail-label">
-                {title}:
+                {title}
             </Col>
             <Col xs={8} className="principal-detail-value">
                 {prop}

--- a/packages/components/src/internal/components/user/__snapshots__/UserDetailsPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/user/__snapshots__/UserDetailsPanel.spec.tsx.snap
@@ -43,7 +43,6 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Email
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -58,7 +57,6 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
         className="principal-detail-label col-xs-4"
       >
         First Name
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -73,7 +71,6 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Last Name
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -91,7 +88,6 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Description
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -109,7 +105,6 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Created
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -124,7 +119,6 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Last Login
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -138,7 +132,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
     <div
       className="principal-detail-label"
     >
-      Member of:
+      Member of
     </div>
     <ul
       className="permissions-groups-ul"
@@ -214,7 +208,6 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
         className="principal-detail-label col-xs-4"
       >
         Email
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -229,7 +222,6 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
         className="principal-detail-label col-xs-4"
       >
         First Name
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -244,7 +236,6 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
         className="principal-detail-label col-xs-4"
       >
         Last Name
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -262,7 +253,6 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
         className="principal-detail-label col-xs-4"
       >
         Description
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -280,7 +270,6 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
         className="principal-detail-label col-xs-4"
       >
         Created
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -295,7 +284,6 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
         className="principal-detail-label col-xs-4"
       >
         Last Login
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -309,7 +297,7 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
     <div
       className="principal-detail-label"
     >
-      Member of:
+      Member of
     </div>
     <ul
       className="permissions-groups-ul"
@@ -364,7 +352,6 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Email
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -379,7 +366,6 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
         className="principal-detail-label col-xs-4"
       >
         First Name
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -394,7 +380,6 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Last Name
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -412,7 +397,6 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Description
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -430,7 +414,6 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Created
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -445,7 +428,6 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
         className="principal-detail-label col-xs-4"
       >
         Last Login
-        :
       </div>
       <div
         className="principal-detail-value col-xs-8"
@@ -459,7 +441,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
     <div
       className="principal-detail-label"
     >
-      Effective Roles:
+      Effective Roles
     </div>
     <ul
       className="permissions-groups-ul"
@@ -489,7 +471,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
     <div
       className="principal-detail-label"
     >
-      Member of:
+      Member of
     </div>
     <ul
       className="permissions-groups-ul"


### PR DESCRIPTION
#### Rationale
We want consistent labeling of fields in our applications. For the moment, at least, this means using title casing (except for some known exceptional treatment of the word "by") and removing trailing colons.  This PR also tidies up a few separating lines that would show up in panels that are otherwise "intentionally left blank".

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1291
- https://github.com/LabKey/platform/pull/3800
- https://github.com/LabKey/biologics/pull/1691
- https://github.com/LabKey/inventory/pull/585
- https://github.com/LabKey/sampleManagement/pull/1337

#### Changes
* Update sample type download template URL to use query name as prefix
* Remove colon after field label for audit details
* Remove colons after user detail labels
* Remove colons after EditInlineField labels
* Don't put empty aliquots message in the table (remove extraneous horizontal line)
* In ParentEntityEditPanel, don't show hr unless editing when there are no parents
