### PR TITLE
Issue 46621: Add ELN audit queries to audit log listing.

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.2-0",
+  "version": "2.242.2-elnAuditLogs.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.2-elnAuditLogs.0",
+  "version": "2.242.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.1",
+  "version": "2.242.2-0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.242.2
+*Released*: 31 October 2022
 * Add ELN audit queries to audit log listing.
 
 ### version 2.242.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add ELN audit queries to audit log listing.
+
 ### version 2.242.1
 *Released*: 31 October 2022
 * Update sample type download template URL to use query name as prefix

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -43,4 +43,14 @@ export const COMMON_AUDIT_QUERIES = [
     USER_AUDIT_QUERY,
 ];
 
+export const NOTEBOOK_AUDIT_QUERY = {
+    value: 'LabBookEvent',
+    label: 'Notebook Events'
+}
+
+export const NOTEBOOK_REVIEW_AUDIT_QUERY = {
+    value: 'NotebookEvent',
+    label: 'Notebook Review Events',
+}
+
 export const AUDIT_EVENT_TYPE_PARAM = 'eventType';

--- a/packages/components/src/internal/components/auditlog/utils.spec.ts
+++ b/packages/components/src/internal/components/auditlog/utils.spec.ts
@@ -14,7 +14,13 @@ import {
 } from '../../productFixtures';
 
 import { getAuditQueries, getEventDataValueDisplay, getTimelineEntityUrl } from './utils';
-import { ASSAY_AUDIT_QUERY, SOURCE_AUDIT_QUERY, WORKFLOW_AUDIT_QUERY } from './constants';
+import {
+    ASSAY_AUDIT_QUERY,
+    NOTEBOOK_AUDIT_QUERY,
+    NOTEBOOK_REVIEW_AUDIT_QUERY,
+    SOURCE_AUDIT_QUERY,
+    WORKFLOW_AUDIT_QUERY
+} from './constants';
 
 describe('getAuditQueries', () => {
     test('LKS starter', () => {
@@ -46,11 +52,13 @@ describe('getAuditQueries', () => {
             ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
         };
         const auditQueries = getAuditQueries();
-        expect(auditQueries.length).toBe(13);
+        expect(auditQueries.length).toBe(15);
         expect(auditQueries.findIndex(entry => entry.value === 'inventoryauditevent')).toBe(5);
         expect(auditQueries.findIndex(entry => entry == ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry == WORKFLOW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry == SOURCE_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
+        expect(auditQueries.findIndex(entry => entry == NOTEBOOK_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
+        expect(auditQueries.findIndex(entry => entry == NOTEBOOK_REVIEW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
     });
 
     test('LKB', () => {
@@ -66,10 +74,12 @@ describe('getAuditQueries', () => {
             },
         };
         const auditQueries = getAuditQueries();
-        expect(auditQueries.length).toBe(12);
+        expect(auditQueries.length).toBe(14);
         expect(auditQueries.findIndex(entry => entry.value === 'inventoryauditevent')).toBe(5);
         expect(auditQueries.findIndex(entry => entry == ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry == WORKFLOW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
+        expect(auditQueries.findIndex(entry => entry == NOTEBOOK_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
+        expect(auditQueries.findIndex(entry => entry == NOTEBOOK_REVIEW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry == SOURCE_AUDIT_QUERY)).toBe(-1);
     });
 });

--- a/packages/components/src/internal/components/auditlog/utils.ts
+++ b/packages/components/src/internal/components/auditlog/utils.ts
@@ -8,6 +8,7 @@ import { Query } from '@labkey/api';
 
 import {
     isAssayEnabled,
+    isELNEnabled,
     isProductProjectsEnabled,
     isSampleManagerEnabled,
     isWorkflowEnabled,
@@ -16,7 +17,15 @@ import {
 import { ASSAYS_KEY, BOXES_KEY, SAMPLES_KEY, USER_KEY, WORKFLOW_KEY } from '../../app/constants';
 import { naturalSortByProperty } from '../../../public/sort';
 import { AppURL } from '../../url/AppURL';
-import { ASSAY_AUDIT_QUERY, COMMON_AUDIT_QUERIES, PROJECT_AUDIT_QUERY, SOURCE_AUDIT_QUERY, WORKFLOW_AUDIT_QUERY } from './constants';
+import {
+    ASSAY_AUDIT_QUERY,
+    COMMON_AUDIT_QUERIES,
+    NOTEBOOK_AUDIT_QUERY,
+    NOTEBOOK_REVIEW_AUDIT_QUERY,
+    PROJECT_AUDIT_QUERY,
+    SOURCE_AUDIT_QUERY,
+    WORKFLOW_AUDIT_QUERY
+} from './constants';
 
 export type AuditQuery = {
     containerFilter?: Query.ContainerFilter;
@@ -31,6 +40,10 @@ export function getAuditQueries(): AuditQuery[] {
     if (isWorkflowEnabled()) queries.push(WORKFLOW_AUDIT_QUERY);
     if (isAssayEnabled()) queries.push(ASSAY_AUDIT_QUERY);
     if (isSampleManagerEnabled() && sampleManagerIsPrimaryApp()) queries.push(SOURCE_AUDIT_QUERY);
+    if (isELNEnabled()) {
+        queries.push(NOTEBOOK_AUDIT_QUERY);
+        queries.push(NOTEBOOK_REVIEW_AUDIT_QUERY);
+    }
     return queries.sort(naturalSortByProperty('label'));
 }
 


### PR DESCRIPTION
#### Rationale
We want to surface audit log entries for all features in the application. The entries for ELN are missing, currently.

#### Related Pull Requests

- https://github.com/LabKey/biologics/pull/1693
- https://github.com/LabKey/sampleManagement/pull/1343

#### Changes
* Add audit log entries for ELN CRUD and Notebook review
