### PR TITLE
Remove ShowToggle, Don't render user icons, Issue 46604

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.3",
+  "version": "2.242.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.242.?
-*Released*: ?? November 2022
+### version 2.242.4
+*Released*: 2 November 2022
 * EditInlineField: remove showToggle prop, always render edit icon at end of content
 * ThreadEditor: Don't render user icon
 * Fix Issue 46604

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ?? November 2022
 * EditInlineField: remove showToggle prop, always render edit icon at end of content
 * ThreadEditor: Don't render user icon
+* Fix Issue 46604
+* Add scroll-margin to Domain Editor to assist with test failures
 
 ### version 2.242.3
 *Released*: 31 October 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.242.?
+*Released*: ?? November 2022
+* EditInlineField: remove showToggle prop, always render edit icon at end of content
+* ThreadEditor: Don't render user icon
+
 ### version 2.242.3
 *Released*: 31 October 2022
 * Issue 44598: PHI TextChoice domain fields now warn

--- a/packages/components/src/internal/announcements/Discussions.tsx
+++ b/packages/components/src/internal/announcements/Discussions.tsx
@@ -115,7 +115,6 @@ export const Discussions: FC<Props> = memo(props => {
                     nounSingular={nounSingular}
                     onCancel={onCancel}
                     onCreate={onCreate}
-                    user={user}
                 />
             )}
         </div>

--- a/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
@@ -5,7 +5,7 @@ import { waitForLifecycle } from '../testHelpers';
 
 import { applyList, applyTemplate, handleBulletedListEnter, olMapper, ThreadEditor, ulMapper } from './ThreadEditor';
 import { createTestAPIWrapper } from './test/utils';
-import { COMMENTER, NOUN_PLURAL, NOUN_SINGULAR, RESPONSE, THREAD } from './test/fixtures';
+import { NOUN_PLURAL, NOUN_SINGULAR, RESPONSE, THREAD } from './test/fixtures';
 
 const COMMENT_TEXTAREA = '.thread-editor textarea.form-control';
 const SUBMIT_BUTTON = '.thread-editor__create-btn';

--- a/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.spec.tsx
@@ -7,7 +7,7 @@ import { applyList, applyTemplate, handleBulletedListEnter, olMapper, ThreadEdit
 import { createTestAPIWrapper } from './test/utils';
 import { COMMENTER, NOUN_PLURAL, NOUN_SINGULAR, RESPONSE, THREAD } from './test/fixtures';
 
-const COMMENT_TEXTAREA = '.thread-editor__body textarea.form-control';
+const COMMENT_TEXTAREA = '.thread-editor textarea.form-control';
 const SUBMIT_BUTTON = '.thread-editor__create-btn';
 const TOOLBAR_BUTTON = '.editor-toolbar__button';
 
@@ -36,12 +36,8 @@ describe('ThreadEditor', () => {
                 nounPlural={NOUN_PLURAL}
                 nounSingular={NOUN_SINGULAR}
                 onCreate={onCreate}
-                user={COMMENTER}
             />
         );
-
-        // displays user avatar
-        expect(wrapper.find('.user-avatar').props().title).toEqual(COMMENTER.displayName);
 
         expect(wrapper.find(COMMENT_TEXTAREA).exists()).toEqual(true);
         wrapper.find(COMMENT_TEXTAREA).simulate('change', { target: { name: 'body', value: expectedBody } });
@@ -81,7 +77,6 @@ describe('ThreadEditor', () => {
                 nounSingular={NOUN_SINGULAR}
                 onUpdate={onUpdate}
                 thread={RESPONSE}
-                user={COMMENTER}
             />
         );
 
@@ -112,7 +107,6 @@ describe('ThreadEditor', () => {
                 containerPath={expectedContainerPath}
                 nounPlural={NOUN_PLURAL}
                 nounSingular={NOUN_SINGULAR}
-                user={COMMENTER}
             />
         );
 
@@ -137,7 +131,6 @@ describe('ThreadEditor', () => {
                 api={createTestAPIWrapper({ renderContent })}
                 nounPlural={NOUN_PLURAL}
                 nounSingular={NOUN_SINGULAR}
-                user={COMMENTER}
             />
         );
 
@@ -158,7 +151,6 @@ describe('ThreadEditor', () => {
                 api={createTestAPIWrapper()}
                 nounPlural={NOUN_PLURAL}
                 nounSingular={NOUN_SINGULAR}
-                user={COMMENTER}
             />
         );
 

--- a/packages/components/src/internal/announcements/ThreadEditor.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.tsx
@@ -260,7 +260,6 @@ export interface ThreadEditorProps {
     onUpdate?: (updatedThread: AnnouncementModel) => void;
     parent?: string;
     thread?: AnnouncementModel;
-    user: User;
 }
 
 export const ThreadEditor: FC<ThreadEditorProps> = props => {
@@ -275,7 +274,6 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         onUpdate,
         parent,
         thread,
-        user,
     } = props;
     const bodyInputRef = useRef<HTMLTextAreaElement>(null);
     const [error, setError] = useState<string>(undefined);
@@ -464,54 +462,48 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
 
     return (
         <div className="thread-editor">
-            <div>
-                <UserAvatar avatar={user.avatar} displayName={user.displayName} id={user.id} />
-            </div>
+            <ThreadEditorToolbar inputRef={bodyInputRef} setBody={setBody} setView={setView} view={view} />
 
-            <div className="thread-editor__body">
-                <ThreadEditorToolbar inputRef={bodyInputRef} setBody={setBody} setView={setView} view={view} />
+            {view === EditorView.edit && (
+                <div className={classNames('form-group', { 'has-error': hasError })}>
+                    <textarea
+                        autoFocus
+                        className="thread-editor__input form-control"
+                        name="body"
+                        onChange={onBodyChange}
+                        onKeyDown={onKeyDown}
+                        placeholder="Type your comment"
+                        ref={bodyInputRef}
+                        value={model.body}
+                    />
 
-                {view === EditorView.edit && (
-                    <div className={classNames('form-group', { 'has-error': hasError })}>
-                        <textarea
-                            autoFocus
-                            className="thread-editor__input form-control"
-                            name="body"
-                            onChange={onBodyChange}
-                            onKeyDown={onKeyDown}
-                            placeholder="Type your comment"
-                            ref={bodyInputRef}
-                            value={model.body}
-                        />
+                    {hasError && <span className="help-block">{error}</span>}
+                </div>
+            )}
 
-                        {hasError && <span className="help-block">{error}</span>}
-                    </div>
-                )}
+            {view === EditorView.preview && (
+                <Preview containerPath={containerPath} content={model.body} renderContent={api.renderContent} />
+            )}
 
-                {view === EditorView.preview && (
-                    <Preview containerPath={containerPath} content={model.body} renderContent={api.renderContent} />
-                )}
+            <ThreadAttachments attachments={attachments} error={attachmentError} onRemove={openRemoveModal} />
 
-                <ThreadAttachments attachments={attachments} error={attachmentError} onRemove={openRemoveModal} />
+            <button
+                type="button"
+                className="btn btn-default thread-editor__create-btn"
+                disabled={submitDisabled}
+                onClick={onSubmit}
+            >
+                {isCreate ? `Add ${nounSingular}` : 'Save Changes'}
+            </button>
 
-                <button
-                    type="button"
-                    className="btn btn-default thread-editor__create-btn"
-                    disabled={submitDisabled}
-                    onClick={onSubmit}
-                >
-                    {isCreate ? `Add ${nounSingular}` : 'Save Changes'}
-                </button>
+            <label className="thread-editor__attachment-input btn btn-default">
+                <span className="fa fa-paperclip" />
+                <input multiple onChange={onFileInputChange} type="file" />
+            </label>
 
-                <label className="thread-editor__attachment-input btn btn-default">
-                    <span className="fa fa-paperclip" />
-                    <input multiple onChange={onFileInputChange} type="file" />
-                </label>
-
-                <span className="clickable-text thread-editor__cancel-btn" onClick={onCancel}>
-                    Cancel
-                </span>
-            </div>
+            <span className="clickable-text thread-editor__cancel-btn" onClick={onCancel}>
+                Cancel
+            </span>
 
             {attachmentToRemove !== undefined && (
                 <RemoveAttachmentModal

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -22,7 +22,6 @@ interface Props {
     name: string;
     onChange?: (name: string, newValue: any) => void;
     placeholder?: string;
-    showToggle?: boolean;
     tooltip?: string; // only shown when component has a label and is allowEdit
     type: string;
     useJsonDateFormat?: boolean;
@@ -43,7 +42,6 @@ export const EditInlineField: FC<Props> = memo(props => {
         value,
         column,
         useJsonDateFormat,
-        showToggle = true,
         tooltip,
     } = props;
     const { container } = useServerContext();
@@ -230,14 +228,8 @@ export const EditInlineField: FC<Props> = memo(props => {
                         onKeyDown={toggleKeyDown}
                         tabIndex={1}
                     >
-                        {/* Edit pencil sits to the right of label for textarea with value below */}
-                        {showToggle && isTextArea && allowEdit && (
-                            <div>
-                                <span className="fa fa-pencil" />
-                            </div>
-                        )}
                         {displayValue}
-                        {showToggle && !isTextArea && allowEdit && <i className="fa fa-pencil" />}
+                        {allowEdit && <i className="fa fa-pencil" />}
                     </span>
                 </>
             )}

--- a/packages/components/src/theme/announcements.scss
+++ b/packages/components/src/theme/announcements.scss
@@ -73,12 +73,6 @@ $editor-padding-horizontal: 15px;
     margin-bottom: 10px;
     text-transform: capitalize;
 }
-.thread-editor {
-    display: flex;
-}
-.thread-editor__body {
-    flex: 1;
-}
 .thread-editor__create-btn {
     text-transform: capitalize;
 }

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -30,6 +30,18 @@
     display: inline-block;
 }
 
+.domain-form * {
+    scroll-margin: 78px;
+}
+
+.app-body .domain-form * {
+    scroll-margin: 134px;
+}
+
+.app-body.with-sub-nav .domain-form * {
+    scroll-margin: 231px;
+}
+
 .domain-form__file-preview__text {
   font-weight: bold;
   margin-bottom: 10px;

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -75,6 +75,12 @@
     }
 }
 
+// This is actually the default value for Bootstrap, but we have to set it again here because we override the default
+// value in the LKS themes.
+.input-group.grid-panel__input-group {
+    display: table;
+}
+
 .grid-panel__button {
     height: 34px;
 }


### PR DESCRIPTION
#### Rationale
This PR makes a few changes necessary to fix a few minor details in our ELN and fixes Issue 46604

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1006
* https://github.com/LabKey/platform/pull/3803
* https://github.com/LabKey/labbook/pull/311
* https://github.com/LabKey/inventory/pull/592
* https://github.com/LabKey/sampleManagement/pull/1348
* https://github.com/LabKey/biologics/pull/1695
* https://github.com/LabKey/testAutomation/pull/1293

#### Changes
* EditInlineField: remove showToggle prop, always render edit icon at end of content
* ThreadEditor: Don't render user icon
* [Fix Issue 46604](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46604)
* Add scroll-margin to Domain Editor to assist with test failures
