### PR TITLE
Projects: fix audit logs page link

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.4-fb-audit-link.0",
+  "version": "2.242.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.4",
+  "version": "2.242.4-fb-audit-link.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.242.5
+*Released*: 2 November 2022
+* Generate audit log URL using updated pattern from #965
+* Add explicit typings to constant `AuditQuery` instances.
+
 ### version 2.242.4
 *Released*: 2 November 2022
 * EditInlineField: remove showToggle prop, always render edit icon at end of content

--- a/packages/components/src/internal/components/administration/ProjectManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/ProjectManagementPage.tsx
@@ -9,6 +9,8 @@ import { SchemaQuery } from '../../../public/SchemaQuery';
 import { QueryConfig } from '../../../public/QueryModel/QueryModel';
 import { RequiresModelAndActions } from '../../../public/QueryModel/withQueryModels';
 import { ManageDropdownButton } from '../buttons/ManageDropdownButton';
+import { AUDIT_KEY } from '../../app/constants';
+import { AUDIT_EVENT_TYPE_PARAM, PROJECT_AUDIT_QUERY } from '../auditlog/constants';
 
 const Buttons: FC<RequiresModelAndActions> = memo(() => {
     return (
@@ -32,7 +34,11 @@ export const ProjectManagementPage: FC = memo(() => {
         () => () =>
             (
                 <ManageDropdownButton collapsed id="project-page-manage" pullRight>
-                    <MenuItem href={AppURL.create('audit', 'containerauditevent').toHref()}>
+                    <MenuItem
+                        href={AppURL.create(AUDIT_KEY)
+                            .addParam(AUDIT_EVENT_TYPE_PARAM, PROJECT_AUDIT_QUERY.value)
+                            .toHref()}
+                    >
                         View Audit History
                     </MenuItem>
                 </ManageDropdownButton>

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -7,6 +7,8 @@ import { fromJS, List, Map } from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 import { Query } from '@labkey/api';
 
+import { WithRouterProps } from 'react-router';
+
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { GridPanel } from '../../../public/QueryModel/GridPanel';
 
@@ -21,12 +23,11 @@ import { SelectInput } from '../forms/input/SelectInput';
 
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 
-import { AuditQuery, getAuditQueries } from './utils';
+import { getAuditQueries } from './utils';
 import { getAuditDetail } from './actions';
 import { AuditDetailsModel } from './models';
 import { AuditDetails } from './AuditDetails';
-import { WithRouterProps } from 'react-router';
-import { AUDIT_EVENT_TYPE_PARAM, SAMPLE_TIMELINE_AUDIT_QUERY } from './constants';
+import { AuditQuery, AUDIT_EVENT_TYPE_PARAM, SAMPLE_TIMELINE_AUDIT_QUERY } from './constants';
 
 interface OwnProps {
     params: any;
@@ -70,13 +71,14 @@ class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
     onSelectionChange = (_: any, selected: string): void => {
         const location = getLocation();
         const paramUpdates = location.query.map((value: string, key: string) => {
-            if (key.startsWith("query"))
+            if (key.startsWith('query')) {
                 return undefined; // get rid of filtering parameters that are likely not applicable to this new audit log
-            else if (key === AUDIT_EVENT_TYPE_PARAM)
+            } else if (key === AUDIT_EVENT_TYPE_PARAM) {
                 return selected;
-            else
+            } else {
                 return value;
-        } );
+            }
+        });
         replaceParameters(location, paramUpdates);
         this.setState(() => ({ selected, selectedRowId: undefined }));
     };

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -1,36 +1,54 @@
 import { Query } from '@labkey/api';
 
-export const ATTACHMENT_AUDIT_QUERY = {value: 'attachmentauditevent', label: 'Attachment Events'};
-export const DOMAIN_AUDIT_QUERY = {value: 'domainauditevent', label: 'Domain Events'};
-export const DOMAIN_PROPERTY_AUDIT_QUERY = {value: 'domainpropertyauditevent', label: 'Domain Property Events'};
-export const DATA_UPDATE_AUDIT_QUERY = {value: 'queryupdateauditevent', label: 'Data Update Events', hasDetail: true};
-export const INVENTORY_AUDIT_QUERY = {value: 'inventoryauditevent', label: 'Freezer Management Events', hasDetail: true};
-export const LIST_AUDIT_QUERY = {value: 'listauditevent', label: 'List Events'};
-export const GROUP_AUDIT_QUERY = {
+export type AuditQuery = {
+    containerFilter?: Query.ContainerFilter;
+    hasDetail?: boolean;
+    label: string;
+    value: string;
+};
+
+export const ATTACHMENT_AUDIT_QUERY: AuditQuery = { value: 'attachmentauditevent', label: 'Attachment Events' };
+export const DOMAIN_AUDIT_QUERY: AuditQuery = { value: 'domainauditevent', label: 'Domain Events' };
+export const DOMAIN_PROPERTY_AUDIT_QUERY: AuditQuery = {
+    value: 'domainpropertyauditevent',
+    label: 'Domain Property Events',
+};
+export const DATA_UPDATE_AUDIT_QUERY: AuditQuery = {
+    value: 'queryupdateauditevent',
+    label: 'Data Update Events',
+    hasDetail: true,
+};
+export const INVENTORY_AUDIT_QUERY: AuditQuery = {
+    value: 'inventoryauditevent',
+    label: 'Freezer Management Events',
+    hasDetail: true,
+};
+export const LIST_AUDIT_QUERY: AuditQuery = { value: 'listauditevent', label: 'List Events' };
+export const GROUP_AUDIT_QUERY: AuditQuery = {
     value: 'groupauditevent',
     label: 'Roles and Assignment Events',
     containerFilter: Query.ContainerFilter.allFolders,
 };
-export const PROJECT_AUDIT_QUERY = { value: 'containerauditevent', label: 'Project Events' };
-export const SAMPLE_TYPE_AUDIT_QUERY = {value: 'samplesetauditevent', label: 'Sample Type Events'};
-export const SAMPLE_TIMELINE_AUDIT_QUERY = {
+export const PROJECT_AUDIT_QUERY: AuditQuery = { value: 'containerauditevent', label: 'Project Events' };
+export const SAMPLE_TYPE_AUDIT_QUERY: AuditQuery = { value: 'samplesetauditevent', label: 'Sample Type Events' };
+export const SAMPLE_TIMELINE_AUDIT_QUERY: AuditQuery = {
     value: 'sampletimelineevent',
     label: 'Sample Timeline Events',
-    hasDetail: true
+    hasDetail: true,
 };
-export const USER_AUDIT_QUERY = {
+export const USER_AUDIT_QUERY: AuditQuery = {
     value: 'userauditevent',
     label: 'User Events',
-    containerFilter: Query.ContainerFilter.allFolders
+    containerFilter: Query.ContainerFilter.allFolders,
 };
-export const ASSAY_AUDIT_QUERY = {value: 'experimentauditevent', label: 'Assay Events'};
-export const WORKFLOW_AUDIT_QUERY = {
+export const ASSAY_AUDIT_QUERY: AuditQuery = { value: 'experimentauditevent', label: 'Assay Events' };
+export const WORKFLOW_AUDIT_QUERY: AuditQuery = {
     value: 'samplesworkflowauditevent',
     label: 'Sample Workflow Events',
-    hasDetail: true
+    hasDetail: true,
 };
-export const SOURCE_AUDIT_QUERY = {value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true};
-export const COMMON_AUDIT_QUERIES = [
+export const SOURCE_AUDIT_QUERY: AuditQuery = { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true };
+export const COMMON_AUDIT_QUERIES: AuditQuery[] = [
     ATTACHMENT_AUDIT_QUERY,
     DOMAIN_AUDIT_QUERY,
     DOMAIN_PROPERTY_AUDIT_QUERY,
@@ -43,14 +61,14 @@ export const COMMON_AUDIT_QUERIES = [
     USER_AUDIT_QUERY,
 ];
 
-export const NOTEBOOK_AUDIT_QUERY = {
+export const NOTEBOOK_AUDIT_QUERY: AuditQuery = {
     value: 'LabBookEvent',
-    label: 'Notebook Events'
-}
+    label: 'Notebook Events',
+};
 
-export const NOTEBOOK_REVIEW_AUDIT_QUERY = {
+export const NOTEBOOK_REVIEW_AUDIT_QUERY: AuditQuery = {
     value: 'NotebookEvent',
     label: 'Notebook Review Events',
-}
+};
 
 export const AUDIT_EVENT_TYPE_PARAM = 'eventType';

--- a/packages/components/src/internal/components/auditlog/utils.ts
+++ b/packages/components/src/internal/components/auditlog/utils.ts
@@ -4,7 +4,6 @@
  */
 import React, { ReactNode } from 'react';
 import { Map } from 'immutable';
-import { Query } from '@labkey/api';
 
 import {
     isAssayEnabled,
@@ -17,22 +16,17 @@ import {
 import { ASSAYS_KEY, BOXES_KEY, SAMPLES_KEY, USER_KEY, WORKFLOW_KEY } from '../../app/constants';
 import { naturalSortByProperty } from '../../../public/sort';
 import { AppURL } from '../../url/AppURL';
+
 import {
+    AuditQuery,
     ASSAY_AUDIT_QUERY,
     COMMON_AUDIT_QUERIES,
     NOTEBOOK_AUDIT_QUERY,
     NOTEBOOK_REVIEW_AUDIT_QUERY,
     PROJECT_AUDIT_QUERY,
     SOURCE_AUDIT_QUERY,
-    WORKFLOW_AUDIT_QUERY
+    WORKFLOW_AUDIT_QUERY,
 } from './constants';
-
-export type AuditQuery = {
-    containerFilter?: Query.ContainerFilter;
-    hasDetail?: boolean;
-    label: string;
-    value: string;
-};
 
 export function getAuditQueries(): AuditQuery[] {
     const queries = [...COMMON_AUDIT_QUERIES];


### PR DESCRIPTION
#### Rationale
This fixes the URL generated for linking to the audit logs from the project management page.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1700

#### Changes
* Generate audit log URL using updated pattern from #965
* Add explicit typings to constant `AuditQuery` instances.
* lint
