### PR TITLE
Fix issue with special characters in Sample Type names 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.4",
+  "version": "2.242.4-fb-specialChars.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.5-fb-specialChars.0",
+  "version": "2.242.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-## version 2.TBD
-*Released*: TBD
+## version 2.242.6
+*Released*: 3 Nov 2022
 * Fix Issue 45944: Decode $ in MenuItem keys
 
 ### version 2.242.5

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+## version 2.TBD
+*Released*: TBD
+* Fix Issue 45944: Decode $ in MenuItem keys
+
 ### version 2.242.4
 *Released*: 2 November 2022
 * EditInlineField: remove showToggle prop, always render edit icon at end of content

--- a/packages/components/src/internal/components/navigation/model.spec.ts
+++ b/packages/components/src/internal/components/navigation/model.spec.ts
@@ -95,4 +95,40 @@ describe('MenuItemModel', () => {
 
         expect(model.url).toBe('/labkey/product2/app.view#/menuItem');
     });
+
+    //Check that $ in item keys are correctly escaped. see Issue #45944
+    function verifyModelKey(rawKey: string, expectedKey: string) {
+        const model = MenuItemModel.create(
+            {
+                productId: 'product2',
+                key: rawKey,
+                url: '#/menuItem',
+            },
+            'sectionKey',
+            'product1'
+        );
+        expect(model.key).toBe(expectedKey);
+    }
+
+    test('$ in key escaped correctly', () => {
+        //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
+        verifyModelKey("key $$", "key $$");
+        verifyModelKey("key $&", "key $&");
+        verifyModelKey("key $`", "key $`");
+        verifyModelKey("key $'", "key $'");
+        verifyModelKey("key $200", "key $200");
+        verifyModelKey("key $widget", "key $widget");
+    });
+
+    test('key decoded correctly', () => {
+        // keys come from server encoded using api-js QueryKey ensure that any special characters are decoded as expected
+        verifyModelKey("key $C", 'key ,');
+        verifyModelKey("key $T", 'key ~');
+        verifyModelKey("key $B", 'key }');
+        verifyModelKey("key $A", 'key &');
+        verifyModelKey("key $S", 'key /');
+        verifyModelKey("key $D", 'key $');
+    });
+
+
 });

--- a/packages/components/src/internal/components/navigation/model.spec.ts
+++ b/packages/components/src/internal/components/navigation/model.spec.ts
@@ -129,6 +129,4 @@ describe('MenuItemModel', () => {
         verifyModelKey("key $S", 'key /');
         verifyModelKey("key $D", 'key $');
     });
-
-
 });

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -81,7 +81,7 @@ export class MenuItemModel extends Record({
             const dataProductId = rawData.productId ? rawData.productId.toLowerCase() : undefined;
 
             if (rawData.key && sectionKey !== 'user') {
-                const parts = rawData.key.split('?');
+                const parts = rawData.key.split('?');  //TODO: This may cause issues with non-url keys that have '?' as they will be split unexpectedly. Issue #46611
 
                 // for assay name that contains slash, full raw key (protocol/assayname: general/a/b) is encoded using QueryKey.encodePart as general/a$Sb on server side
                 // use QueryKey.decodePart to decode the assay name so url can be correctly called by encodeURIComponent and key be used to display decoded assay name
@@ -90,7 +90,7 @@ export class MenuItemModel extends Record({
                     .filter(val => val !== '')
                     .map(QueryKey.decodePart);
 
-                const decodedPart = subParts.join('/');
+                const decodedPart = subParts.join('/').replace('$','$$$$'); // Need to escape any '$' in the replacement string https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
                 const decodedKey = rawData.key.replace(parts[0], decodedPart);
 
                 let params;


### PR DESCRIPTION
#### Rationale
[Issue 45944: LKSM: Error with Metacharacter(s) in Sample Type Name](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45944)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement

Javascript string object's `replace` method has special behaviors when substituting with `$`

#### Related Pull Requests
* [platform](https://github.com/LabKey/platform/pull/3815)
* [inventory](https://github.com/LabKey/inventory/pull/595)
* [samplemanager](https://github.com/LabKey/sampleManagement/pull/1359) -- adds test case
* [biologics](https://github.com/LabKey/biologics/pull/1701)

#### Changes
* Escape '$' when using string replace
