### PR TITLE
Issue 46648: Add missing dependencies in SampleFinderSection for assay loading state

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.7-sfCheckAssayAvailability.0",
+  "version": "2.242.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.6",
+  "version": "2.242.7-sfCheckAssayAvailability.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-## version 2.242.6
+### version TBD
+*Released*: TBD
+* Issue 46648: Add missing dependencies in SampleFinderSection for assay loading state
+
+### version 2.242.6
 *Released*: 3 Nov 2022
 * Fix Issue 45944: Decode $ in MenuItem keys
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.242.7
+*Released*: 4 November 2022
 * Issue 46648: Add missing dependencies in SampleFinderSection for assay loading state
 
 ### version 2.242.6

--- a/packages/components/src/entities/SampleFinderSection.tsx
+++ b/packages/components/src/entities/SampleFinderSection.tsx
@@ -182,7 +182,7 @@ const SampleFinderSectionImpl: FC<Props & InjectedAssayModel> = memo(props => {
                 setUnsavedSessionViewName(finderSessionData.filterTimestamp);
             }
         }
-    }, [assayModel.definitions]);
+    }, [assayModel.definitionsLoadingState, assayModel.definitions, parentEntityDataTypes, clearSessionView]);
 
     const updateFilters = useCallback(
         (changeCounter: number, filterProps: FilterProps[], updateSession: boolean, isViewDirty: boolean) => {


### PR DESCRIPTION
#### Rationale
[Issue 46648](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46648)

#### Related Pull Requests

- https://github.com/LabKey/biologics/pull/1706
- https://github.com/LabKey/sampleManagement/pull/1365

#### Changes
* Update dependencies in useEffect
