### PR TITLE
Use functional substitution when decoding key for MenuItem names

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.7-fb-trickyNames.0",
+  "version": "2.242.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.7",
+  "version": "2.242.7-fb-trickyNames.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.242.TBD
+*Released*: TBD
+* Better Fix Issue 45944: Use functional substitution when decoding key for MenuItem keys.
+
 ### version 2.242.7
 *Released*: 4 November 2022
 * Issue 46648: Add missing dependencies in SampleFinderSection for assay loading state

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,9 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.242.TBD
-*Released*: TBD
-* Better Fix Issue 45944: Use functional substitution when decoding key for MenuItem keys.
+### version 2.242.8
+*Released*: 4 Nov 2022
+* Better Fix for Issue 45944: Use functional substitution when decoding key for MenuItem keys.
 
 ### version 2.242.7
 *Released*: 4 November 2022

--- a/packages/components/src/internal/components/navigation/model.spec.ts
+++ b/packages/components/src/internal/components/navigation/model.spec.ts
@@ -112,12 +112,15 @@ describe('MenuItemModel', () => {
 
     test('$ in key escaped correctly', () => {
         //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
-        verifyModelKey("key $$", "key $$");
-        verifyModelKey("key $&", "key $&");
-        verifyModelKey("key $`", "key $`");
-        verifyModelKey("key $'", "key $'");
-        verifyModelKey("key $200", "key $200");
-        verifyModelKey("key $widget", "key $widget");
+        verifyModelKey("key $D$D", "key $$");
+        verifyModelKey("key $D$A", "key $&");
+        verifyModelKey("key $D`", "key $`");
+        verifyModelKey("key $D'", "key $'");
+        verifyModelKey("key $D200", "key $200");
+        verifyModelKey("key $Dwidget", "key $widget");
+        verifyModelKey("key $D$D$D$D", "key $$$$");
+        verifyModelKey("key $D$DD", "key $$D");
+        verifyModelKey("key $Dwidget$D$D$D$A$D`$D'$D200", "key $widget$$$&$`$'$200");
     });
 
     test('key decoded correctly', () => {

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -90,8 +90,8 @@ export class MenuItemModel extends Record({
                     .filter(val => val !== '')
                     .map(QueryKey.decodePart);
 
-                const decodedPart = subParts.join('/').replace('$','$$$$'); // Need to escape any '$' in the replacement string https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
-                const decodedKey = rawData.key.replace(parts[0], decodedPart);
+                const decoded = subParts.join('/');
+                const decodedKey = rawData.key.replace(parts[0], () => decoded); //use the functional version to skip any additional pattern substitutions https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
 
                 let params;
                 if (parts.length > 1 && parts[1]) {


### PR DESCRIPTION
#### Rationale
[Sample Type tricky name test failure](https://teamcity.labkey.org/buildConfiguration/LabKey_2211Release_Premium_ProductSuites_SampleManager_SampleManagerDPostgres/2095527?buildTab=tests&name=SMSampleTypeDesignerTest.testCreateSampleTypeWithTrickyName)

#### Related Pull Requests
* [Initial issue](https://github.com/LabKey/labkey-ui-components/pull/1010)
* Bumps to Components
  * [Platform](https://github.com/LabKey/platform/pull/3823)
  * [Biologics](https://github.com/LabKey/biologics/pull/1709)
  * [SampleManager](https://github.com/LabKey/sampleManagement/pull/1368)
  * [Inventory](https://github.com/LabKey/inventory/pull/599) 

#### Changes
* Switch to use method substitution to avoid any additional pattern matching during replacement
* Additional Jest tests
