### PR TITLE
Issues 46591 and 46651: Fix displays and links for freezer names that have slashes in them

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.9-slashedFreezer.0",
+  "version": "2.242.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.242.8",
+  "version": "2.242.9-slashedFreezer.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.242.9
+*Released*: 7 November 2022
 * Issues 46591 and 46651: Fix displays and links for freezer names that have slashes in them
 
 ### version 2.242.8

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issues 46591 and 46651: Fix displays and links for freezer names that have slashes in them
+
 ### version 2.242.8
 *Released*: 4 Nov 2022
 * Better Fix for Issue 45944: Use functional substitution when decoding key for MenuItem keys.

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -81,29 +81,22 @@ export class MenuItemModel extends Record({
             const dataProductId = rawData.productId ? rawData.productId.toLowerCase() : undefined;
 
             if (rawData.key && sectionKey !== 'user') {
-                const parts = rawData.key.split('?');  //TODO: This may cause issues with non-url keys that have '?' as they will be split unexpectedly. Issue #46611
-
-                // for assay name that contains slash, full raw key (protocol/assayname: general/a/b) is encoded using QueryKey.encodePart as general/a$Sb on server side
-                // use QueryKey.decodePart to decode the assay name so url can be correctly called by encodeURIComponent and key be used to display decoded assay name
-                const subParts = parts[0]
+                // for assay names and freezer names that contain slashes, full raw key (protocol/assayname: general/a/b) is encoded using QueryKey.encodePart as general/a$Sb on server side
+                // use QueryKey.decodePart to decode the name so url can be correctly called by encodeURIComponent and key be used to display decoded assay name
+                const subParts = rawData.key
                     .split('/')
                     .filter(val => val !== '')
                     .map(QueryKey.decodePart);
 
                 const decoded = subParts.join('/');
-                const decodedKey = rawData.key.replace(parts[0], () => decoded); //use the functional version to skip any additional pattern substitutions https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
-
-                let params;
-                if (parts.length > 1 && parts[1]) {
-                    params = ActionURL.getParameters(rawData.key);
-                }
+                const decodedKey = rawData.key.replace(rawData.key, () => decoded); //use the functional version to skip any additional pattern substitutions https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
 
                 return new MenuItemModel(
                     Object.assign({}, rawData, {
                         url: createProductUrlFromParts(
                             dataProductId,
                             currentProductId,
-                            params,
+                            undefined,
                             sectionKey,
                             ...subParts
                         ),


### PR DESCRIPTION
#### Rationale
Sometimes people use slashes in their freezer names, so we need to account for that.

#### Related Pull Requests

- https://github.com/LabKey/sampleManagement/pull/1369
- https://github.com/LabKey/inventory/pull/600
- https://github.com/LabKey/biologics/pull/1714

#### Changes
* When creating menu items, don't expect a `?` that has URL parameters after it (those should come with the URL property)

