### PR TITLE
Sample Finder, new paths to Sample Finder from assay results grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.249.0",
+  "version": "2.249.1-fb-assayFinderPath.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.249.1-fb-assayFinderPath.1",
+  "version": "2.249.1-fb-assayFinderPath.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.249.1-fb-assayFinderPath.3",
+  "version": "2.249.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.249.1-fb-assayFinderPath.2",
+  "version": "2.249.1-fb-assayFinderPath.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.XX
+*Released*: XX November 2022
+  * Add FindDerivativesMenuItem to SampleActionsButton
+  * Fix containerFilter for finding samples by assays queries
+  * Updated getSearchFiltersFromObjs util to set required assay card properties when coming from assay grids
+
 ### version 2.249.0
 *Released*: 10 November 2022
 * Assay Design page consistency

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.XX
-*Released*: XX November 2022
+### version 2.249.1
+*Released*: 15 November 2022
   * Add FindDerivativesMenuItem to SampleActionsButton
   * Fix containerFilter for finding samples by assays queries
   * Updated getSearchFiltersFromObjs util to set required assay card properties when coming from assay grids

--- a/packages/components/src/assay/AssayDesignPage.tsx
+++ b/packages/components/src/assay/AssayDesignPage.tsx
@@ -26,12 +26,13 @@ import { ProductMenuModel } from '../internal/components/navigation/model';
 
 import { DEFAULT_SAMPLE_FIELD_CONFIG } from '../internal/components/samples/constants';
 
+import { CommonPageProps } from '../internal/models';
+
 import { protocolHasSample, renderSampleRequiredPanelHeader } from './SampleRequiredDomainHeader';
 import { AssayHeader } from './AssayHeader';
 import { onAssayDesignChange } from './actions';
 import { useAssayAppContext } from './AssayAppContext';
 import { assayPage } from './AssayPageHOC';
-import { CommonPageProps } from '../internal/models';
 
 const ASSAY_DESIGNER_HEADER = 'Connect your experimental results to samples for rich data connections.';
 
@@ -56,18 +57,8 @@ interface OwnProps {
 type Props = CommonPageProps & OwnProps & InjectedAssayModel & WithRouterProps & InjectedRouteLeaveProps;
 
 const AssayDesignPageBody: FC<Props> = memo(props => {
-    const {
-        assayDefinition,
-        assayProtocol,
-        reloadAssays,
-        router,
-        routes,
-        goBack,
-        menu,
-        menuInit,
-        navigate,
-        params,
-    } = props;
+    const { assayDefinition, assayProtocol, reloadAssays, router, routes, goBack, menu, menuInit, navigate, params } =
+        props;
     const [hasError, setHasError] = useState(false);
     const [protocol, setProtocol] = useState<AssayProtocolModel>(undefined);
     const { user } = useServerContext();

--- a/packages/components/src/entities/FindDerivativesButton.tsx
+++ b/packages/components/src/entities/FindDerivativesButton.tsx
@@ -35,7 +35,7 @@ export const getFieldFilter = (model: QueryModel, filter: Filter.IFilter): Field
         fieldKey: colName,
         fieldCaption: column?.caption ?? colName,
         filter,
-        jsonType: column.isLookup() ? column.displayFieldJsonType : column?.jsonType ?? 'string',
+        jsonType: column?.isLookup() ? column.displayFieldJsonType : column?.jsonType ?? 'string',
     } as FieldFilter;
 };
 

--- a/packages/components/src/entities/SampleActionsButton.tsx
+++ b/packages/components/src/entities/SampleActionsButton.tsx
@@ -23,7 +23,7 @@ import { PicklistCreationMenuItem } from '../internal/components/picklist/Pickli
 import { AddToPicklistMenuItem } from '../internal/components/picklist/AddToPicklistMenuItem';
 
 import { AssayResultsForSamplesMenuItem } from './AssayResultsForSamplesButton';
-import { FindDerivativesMenuItem } from "./FindDerivativesButton";
+import { FindDerivativesMenuItem } from './FindDerivativesButton';
 
 interface Props {
     disabled?: boolean;

--- a/packages/components/src/entities/SampleActionsButton.tsx
+++ b/packages/components/src/entities/SampleActionsButton.tsx
@@ -23,16 +23,18 @@ import { PicklistCreationMenuItem } from '../internal/components/picklist/Pickli
 import { AddToPicklistMenuItem } from '../internal/components/picklist/AddToPicklistMenuItem';
 
 import { AssayResultsForSamplesMenuItem } from './AssayResultsForSamplesButton';
+import { FindDerivativesMenuItem } from "./FindDerivativesButton";
 
 interface Props {
     disabled?: boolean;
     metricFeatureArea?: string;
     model: QueryModel;
+    sampleFinderProps?: Record<string, any>;
     user: User;
 }
 
 export const SampleActionsButton: FC<Props> = memo(props => {
-    const { children, disabled, user, model, metricFeatureArea } = props;
+    const { children, disabled, user, model, metricFeatureArea, sampleFinderProps } = props;
     const sampleFieldKey = useMemo(() => model?.allColumns?.find(c => c.isSampleLookup())?.fieldKey, [model]);
     const id = 'sample-actions-menu';
     const hasPerms = hasAnyPermissions(user, [
@@ -45,6 +47,12 @@ export const SampleActionsButton: FC<Props> = memo(props => {
     if (!(!!children || hasPerms)) {
         return null;
     }
+
+    const findDerivativesProps = {
+        model,
+        entityDataType: sampleFinderProps?.entityDataType,
+        metricFeatureArea,
+    };
 
     return (
         <DropdownButton
@@ -78,6 +86,7 @@ export const SampleActionsButton: FC<Props> = memo(props => {
                 <>
                     <hr className="divider" />
                     <MenuItem header>Reports</MenuItem>
+                    {sampleFinderProps && <FindDerivativesMenuItem {...findDerivativesProps} />}
                     <AssayResultsForSamplesMenuItem
                         model={model}
                         user={user}

--- a/packages/components/src/entities/SampleActionsButton.tsx
+++ b/packages/components/src/entities/SampleActionsButton.tsx
@@ -52,6 +52,7 @@ export const SampleActionsButton: FC<Props> = memo(props => {
         model,
         entityDataType: sampleFinderProps?.entityDataType,
         metricFeatureArea,
+        baseFilter: sampleFinderProps?.baseFilters,
     };
 
     return (

--- a/packages/components/src/entities/SampleFinderSection.tsx
+++ b/packages/components/src/entities/SampleFinderSection.tsx
@@ -375,8 +375,7 @@ const SampleFinderSectionImpl: FC<Props & InjectedAssayModel> = memo(props => {
     }, []);
 
     useEffect(() => {
-        if (!assaySampleIdCols)
-            return;
+        if (!assaySampleIdCols) return;
 
         (async () => {
             try {

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -185,6 +185,9 @@ export function getExpDescendantOfFilter(
 
 export function getAssayFilter(card: FilterProps, cf?: Query.ContainerFilter): Filter.IFilter {
     const { schemaQuery, filterArray, selectColumnFieldKey, targetColumnFieldKey } = card;
+    if (!selectColumnFieldKey)
+        return null;
+
     const { schemaName, queryName } = schemaQuery;
 
     if (!filterArray || filterArray.length === 0) {

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -185,12 +185,9 @@ export function getExpDescendantOfFilter(
 
 export function getAssayFilter(card: FilterProps, cf?: Query.ContainerFilter): Filter.IFilter {
     const { schemaQuery, filterArray, selectColumnFieldKey, targetColumnFieldKey } = card;
-    if (!selectColumnFieldKey)
-        return null;
-
     const { schemaName, queryName } = schemaQuery;
 
-    if (!filterArray || filterArray.length === 0) {
+    if (selectColumnFieldKey && (!filterArray || filterArray.length === 0)) {
         // when finding from assay grid without filters
         return Filter.create(
             selectColumnFieldKey,
@@ -199,11 +196,14 @@ export function getAssayFilter(card: FilterProps, cf?: Query.ContainerFilter): F
         );
     }
 
-    const noAssayDataFilter = filterArray.find(
+    const noAssayDataFilter = filterArray?.find(
         fieldFilter => fieldFilter.filter.getFilterType().getURLSuffix() === COLUMN_NOT_IN_FILTER_TYPE.getURLSuffix()
     )?.filter;
 
     if (noAssayDataFilter) return noAssayDataFilter;
+
+    if (!selectColumnFieldKey)
+        return null;
 
     const whereConditions = getLabKeySqlWhere(filterArray, true);
     if (!whereConditions) return null;

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -191,7 +191,7 @@ export function getAssayFilter(card: FilterProps, cf?: Query.ContainerFilter): F
         // when finding from assay grid without filters
         return Filter.create(
             selectColumnFieldKey,
-            getLabKeySql(targetColumnFieldKey, schemaName, queryName),
+            getLabKeySql(targetColumnFieldKey, schemaName, queryName, null, cf),
             COLUMN_IN_FILTER_TYPE
         );
     }

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -495,7 +495,7 @@ export function getSearchFiltersFromObjs(
     const filters: FilterProps[] = [];
     filterPropsObj.forEach(filterPropObj => {
         const filterArray = [];
-        filterPropObj['filterArray']?.forEach(field => {
+        filterPropObj.filterArray?.forEach(field => {
             filterArray.push({
                 fieldKey: field.fieldKey,
                 fieldCaption: field.fieldCaption,
@@ -503,29 +503,29 @@ export function getSearchFiltersFromObjs(
                 jsonType: field.jsonType,
             });
         });
-        filterPropObj['filterArray'] = filterArray;
+        filterPropObj.filterArray = filterArray;
 
-        if (filterPropObj['entityDataType']?.['filterArray']) {
+        if (filterPropObj.entityDataType?.filterArray) {
             const filterArray = [];
-            filterPropObj['entityDataType']?.['filterArray']?.forEach(filter => {
+            filterPropObj.entityDataType?.filterArray?.forEach(filter => {
                 filterArray.push(filterFromJson(filter));
             });
 
-            filterPropObj['entityDataType']['filterArray'] = filterArray;
+            filterPropObj.entityDataType.filterArray = filterArray;
         }
 
-        if (filterPropObj['entityDataType']?.['descriptionSingular'] === AssayResultDataType.descriptionSingular) {
-            filterPropObj['entityDataType']['getInstanceSchemaQuery'] = AssayResultDataType.getInstanceSchemaQuery;
-            filterPropObj['entityDataType']['getInstanceDataType'] = AssayResultDataType.getInstanceDataType;
+        if (filterPropObj.entityDataType?.descriptionSingular === AssayResultDataType.descriptionSingular) {
+            filterPropObj.entityDataType.getInstanceSchemaQuery = AssayResultDataType.getInstanceSchemaQuery;
+            filterPropObj.entityDataType.getInstanceDataType = AssayResultDataType.getInstanceDataType;
 
             // when Finding from assays grid, the json lacks certain properties
-            if (!filterPropObj['selectColumnFieldKey'] && assaySampleCols) {
-                const assayDesign = AssayResultDataType.getInstanceDataType(filterPropObj['schemaQuery']);
+            if (!filterPropObj.selectColumnFieldKey && assaySampleCols) {
+                const assayDesign = AssayResultDataType.getInstanceDataType(filterPropObj.schemaQuery);
                 const assayCol = caseInsensitive(assaySampleCols, assayDesign);
                 if (assayCol) {
-                    filterPropObj['selectColumnFieldKey'] = assayCol.lookupFieldKey;
-                    filterPropObj['targetColumnFieldKey'] = assayCol.fieldKey;
-                    filterPropObj['dataTypeDisplayName'] = assayDesign;
+                    filterPropObj.selectColumnFieldKey = assayCol.lookupFieldKey;
+                    filterPropObj.targetColumnFieldKey = assayCol.fieldKey;
+                    filterPropObj.dataTypeDisplayName = assayDesign;
                 }
             }
         }
@@ -541,9 +541,9 @@ export function searchFiltersFromJson(
     assaySampleCols?: { [key: string]: AssaySampleColumnProp }
 ): SearchSessionStorageProps {
     const obj = JSON.parse(filterPropsStr);
-    const filterPropsObj: any[] = obj['filters'];
-    const filterChangeCounter: number = obj['filterChangeCounter'];
-    const filterTimestamp: string = obj['filterTimestamp'];
+    const filterPropsObj: any[] = obj.filters;
+    const filterChangeCounter: number = obj.filterChangeCounter;
+    const filterTimestamp: string = obj.filterTimestamp;
 
     return {
         filters: getSearchFiltersFromObjs(filterPropsObj, assaySampleCols),

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -35,10 +35,12 @@ import { getContainerFilter } from '../../query/api';
 
 import { AssayResultDataType } from '../entities/constants';
 
+import { AssaySampleColumnProp } from '../../../entities/models';
+
+import { caseInsensitive } from '../../util/utils';
+
 import { SearchScope, SAMPLE_FINDER_SESSION_PREFIX } from './constants';
 import { FieldFilter, FieldFilterOption, FilterProps, FilterSelection, SearchSessionStorageProps } from './models';
-import { AssaySampleColumnProp } from "../../../entities/models";
-import { caseInsensitive } from "../../util/utils";
 
 export const SAMPLE_FILTER_METRIC_AREA = 'sampleFinder';
 export const FIND_SAMPLE_BY_ID_METRIC_AREA = 'findSamplesById';
@@ -185,7 +187,8 @@ export function getAssayFilter(card: FilterProps, cf?: Query.ContainerFilter): F
     const { schemaQuery, filterArray, selectColumnFieldKey, targetColumnFieldKey } = card;
     const { schemaName, queryName } = schemaQuery;
 
-    if (!filterArray || filterArray.length === 0) { // when finding from assay grid without filters
+    if (!filterArray || filterArray.length === 0) {
+        // when finding from assay grid without filters
         return Filter.create(
             selectColumnFieldKey,
             getLabKeySql(targetColumnFieldKey, schemaName, queryName),
@@ -482,7 +485,10 @@ export function searchFiltersToJson(
     });
 }
 
-export function getSearchFiltersFromObjs(filterPropsObj: any[], assaySampleCols?: { [key: string]: AssaySampleColumnProp }): FilterProps[] {
+export function getSearchFiltersFromObjs(
+    filterPropsObj: any[],
+    assaySampleCols?: { [key: string]: AssaySampleColumnProp }
+): FilterProps[] {
     const filters: FilterProps[] = [];
     filterPropsObj.forEach(filterPropObj => {
         const filterArray = [];
@@ -527,7 +533,10 @@ export function getSearchFiltersFromObjs(filterPropsObj: any[], assaySampleCols?
     return filters;
 }
 
-export function searchFiltersFromJson(filterPropsStr: string, assaySampleCols?: { [key: string]: AssaySampleColumnProp }): SearchSessionStorageProps {
+export function searchFiltersFromJson(
+    filterPropsStr: string,
+    assaySampleCols?: { [key: string]: AssaySampleColumnProp }
+): SearchSessionStorageProps {
     const obj = JSON.parse(filterPropsStr);
     const filterPropsObj: any[] = obj['filters'];
     const filterChangeCounter: number = obj['filterChangeCounter'];


### PR DESCRIPTION
#### Rationale
Assay results have been added as a new filter type to Sample Finder. A button has been added to sources and samples grid to allow quick way of finding sample derivatives. This PR adds that Find button for assay results grids.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1020
* https://github.com/LabKey/sampleManagement/pull/1382
* https://github.com/LabKey/biologics/pull/1720

#### Changes
* Add FindDerivativesMenuItem to SampleActionsButton
* Fix containerFilter for finding samples by assays queries
* Updated getSearchFiltersFromObjs util to set required assay card properties when coming from assay grids
