### PR TITLE
Refactor ListDesignerPanels and related components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.251.0",
+  "version": "2.252.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.252.0
+*Released*: ?? November 2022
+* Refactor ListDesignerPanels and related components
+  * No longer use custom checkbox component
+  * Convert most components to FC
+  * Add types to props, improve other types
+  * Use children instead of custom prop to pass components
+  * Don't use inline defined anonymous functions for handlers
+
 ### version 2.251.0
 *Released*: 16 November 2022
 * Assay display pages consistency

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.252.0
-*Released*: ?? November 2022
+*Released*: 17 November 2022
 * Refactor ListDesignerPanels and related components
   * No longer use custom checkbox component
   * Convert most components to FC

--- a/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
@@ -45,6 +45,7 @@ export function withBaseDomainDesigner<Props>(
             };
         }
 
+        // TODO: having a child component pass a callback to a parent is a big red flag
         onTogglePanel = (index: number, collapsed: boolean, callback: () => any): void => {
             const { visitedPanels, currentPanelIndex } = this.state;
             const updatedVisitedPanels = getUpdatedVisitedPanelsList(visitedPanels, index);

--- a/packages/components/src/internal/components/domainproperties/list/ListPropertiesAdvancedSettings.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListPropertiesAdvancedSettings.spec.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { List } from 'immutable';
+import { wrapper } from 'react-bootstrap/lib/utils/deprecationWarning';
 
 import renderer from 'react-test-renderer';
 
@@ -83,25 +84,36 @@ describe('AdvancedSettings', () => {
     });
 
     test("either search indexing options 'index entire list' or 'index each item' may be open, but not both", () => {
-        const searchIndexing = mount(
+        const wrapper = mount(
             <SearchIndexing
                 onRadioChange={jest.fn()}
                 onInputChange={jest.fn()}
                 onCheckboxChange={jest.fn()}
-                entireListIndexSettings=""
-                eachItemIndexSettings=""
+                eachItemIndex={false}
+                entireListIndexSettings={{
+                    entireListBodySetting: undefined,
+                    entireListBodyTemplate: undefined,
+                    entireListIndexSetting: undefined,
+                    entireListTitleTemplate: undefined,
+                }}
+                entireListIndex={false}
+                eachItemIndexSettings={{
+                    eachItemBodySetting: undefined,
+                    eachItemBodyTemplate: undefined,
+                    eachItemTitleTemplate: undefined,
+                }}
                 fileAttachmentIndex={false}
             />
         );
 
-        searchIndexing.setState({ expanded: 'entireListIndex' });
-        expect(searchIndexing.find(SingleDocumentIndexFields)).toHaveLength(1);
-        expect(searchIndexing.find(SeparateDocumentIndexFields)).toHaveLength(0);
+        wrapper.find('.fa-angle-right').at(0).simulate('click');
+        expect(wrapper.find(SingleDocumentIndexFields)).toHaveLength(1);
+        expect(wrapper.find(SeparateDocumentIndexFields)).toHaveLength(0);
 
-        searchIndexing.setState({ expanded: 'eachItemIndex' });
-        expect(searchIndexing.find(SingleDocumentIndexFields)).toHaveLength(0);
-        expect(searchIndexing.find(SeparateDocumentIndexFields)).toHaveLength(1);
-        searchIndexing.unmount();
+        wrapper.find('.fa-angle-right').at(0).simulate('click');
+        expect(wrapper.find(SingleDocumentIndexFields)).toHaveLength(0);
+        expect(wrapper.find(SeparateDocumentIndexFields)).toHaveLength(1);
+        wrapper.unmount();
     });
 
     test("setting 'index using custom template' generates a text input field", () => {

--- a/packages/components/src/internal/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
@@ -1,24 +1,36 @@
-import React, { ReactNode } from 'react';
+import React, { ChangeEvent, FC, FormEventHandler, memo, ReactNode, useCallback, useState } from 'react';
 import classNames from 'classnames';
 import { Button, FormControl, FormGroup, Modal, Radio } from 'react-bootstrap';
 
 import { DomainFieldLabel } from '../DomainFieldLabel';
 
-import { helpLinkNode } from '../../../util/helpLinks';
+import { HelpLink } from '../../../util/helpLinks';
 
 import { SelectInput } from '../../forms/input/SelectInput';
 
 import { LabelHelpTip } from '../../base/LabelHelpTip';
 
-import { CheckBox } from './ListPropertiesPanelFormElements';
-import { AdvancedSettingsForm, ListModel } from './models';
-import {
-    CUSTOM_TEMPLATE_TIP,
-    DATA_INDEXING_TIP,
-    DISCUSSION_LINKS_TIP,
-    DOCUMENT_TITLE_TIP,
-    SEARCH_INDEXING_TIP,
-} from './constants';
+import { AdvancedSettingsForm, EachItemSettings, EntireListSettings, ListModel } from './models';
+
+export const DATA_INDEXING_TIP =
+    'Not recommend for large lists with frequent updates, since updating any item will cause re-indexing of the entire list.';
+export const DOCUMENT_TITLE_TIP =
+    'Any text you want displayed and indexed as the search result title (ex. ListName - ${Key} ${value}). Leave the document title blank to use the default title.';
+export const CUSTOM_TEMPLATE_TIP = 'Example: ${Key} ${value}';
+
+export const DISPLAY_TITLE_TIP = (
+    <>
+        Choose a field to identify this list when other lists or datasets have lookups into this list. When “Auto” is
+        enabled, LabKey will select the title field for you by using:
+        <ul>
+            <li>The first non-lookup string column</li>
+            <li>The primary key, if there are no string fields</li>
+        </ul>
+    </>
+);
+export const DISCUSSION_LINKS_TIP =
+    'Optionally allow one or more discussion links to be shown on the details view of each list item.';
+export const SEARCH_INDEXING_TIP = 'Controls how this list is indexed for search within LabKey Server.';
 
 interface DisplayTitleProps {
     model: ListModel;
@@ -26,418 +38,346 @@ interface DisplayTitleProps {
     titleColumn: string;
 }
 
-export class DisplayTitle extends React.PureComponent<DisplayTitleProps> {
-    render() {
-        const { model, onSelectChange, titleColumn } = this.props;
-        const fields = model.domain.fields;
-        const disabled = fields.size === 0;
-        const placeholder = disabled ? 'No fields have been defined yet' : 'Auto';
+export const DisplayTitle: FC<DisplayTitleProps> = memo(({ model, onSelectChange, titleColumn }) => {
+    const fields = model.domain.fields;
+    const disabled = fields.size === 0;
+    const placeholder = disabled ? 'No fields have been defined yet' : 'Auto';
 
-        return (
-            <div className="list__advanced-settings-modal__display-title">
-                <SelectInput
-                    name="titleColumn"
-                    options={fields.toArray()}
-                    placeholder={placeholder}
-                    inputClass="" // This attr is necessary for proper styling
-                    valueKey="name"
-                    labelKey="name"
-                    key="name"
-                    disabled={disabled}
-                    onChange={onSelectChange}
-                    value={titleColumn}
-                />
-            </div>
-        );
-    }
-}
+    return (
+        <div className="list__advanced-settings-modal__display-title">
+            <SelectInput
+                name="titleColumn"
+                options={fields.toArray()}
+                placeholder={placeholder}
+                inputClass="" // This attr is necessary for proper styling
+                valueKey="name"
+                labelKey="name"
+                disabled={disabled}
+                onChange={onSelectChange}
+                value={titleColumn}
+            />
+        </div>
+    );
+});
 
 interface DiscussionLinksProps {
     discussionSetting: number;
-    onRadioChange: (evt: any) => any;
+    onRadioChange: (evt: any) => void;
 }
 
-class DiscussionLinks extends React.PureComponent<DiscussionLinksProps> {
-    render() {
-        const { onRadioChange, discussionSetting } = this.props;
-        const radioName = 'discussionSetting';
+// TODO: use RadioGroupInput instead
+const DISCUSSION_RADIO_NAME = 'discussionSetting';
+const DiscussionInputs: FC<DiscussionLinksProps> = memo(({ onRadioChange, discussionSetting }) => (
+    <FormGroup>
+        <Radio name={DISCUSSION_RADIO_NAME} value={0} checked={discussionSetting === 0} onChange={onRadioChange}>
+            Disable discussions
+        </Radio>
 
-        return (
-            <>
-                <FormGroup>
-                    <Radio name={radioName} value={0} checked={discussionSetting == 0} onChange={onRadioChange}>
-                        Disable discussions
-                    </Radio>
-                    <Radio name={radioName} value={1} checked={discussionSetting == 1} onChange={onRadioChange}>
-                        Allow one discussion per item
-                    </Radio>
-                    <Radio name={radioName} value={2} checked={discussionSetting == 2} onChange={onRadioChange}>
-                        Allow multiple discussions per item
-                    </Radio>
-                </FormGroup>
-            </>
-        );
-    }
-}
+        <Radio name={DISCUSSION_RADIO_NAME} value={1} checked={discussionSetting === 1} onChange={onRadioChange}>
+            Allow one discussion per item
+        </Radio>
+
+        <Radio name={DISCUSSION_RADIO_NAME} value={2} checked={discussionSetting === 2} onChange={onRadioChange}>
+            Allow multiple discussions per item
+        </Radio>
+    </FormGroup>
+));
 
 interface TitleIndexFieldProps {
     name: string;
-    onInputChange: (evt: any) => any;
+    onInputChange: (evt: any) => void;
     titleTemplate: string;
 }
 
-class TitleIndexField extends React.PureComponent<TitleIndexFieldProps> {
-    render() {
-        const { name, titleTemplate, onInputChange } = this.props;
-        const title = titleTemplate == null ? '' : titleTemplate;
-        return (
-            <div>
-                <DomainFieldLabel label="Document title" helpTipBody={DOCUMENT_TITLE_TIP} />
-                <span>
-                    <FormControl
-                        className="list__advanced-settings-modal__text-field"
-                        id={name}
-                        type="text"
-                        placeholder="Use default"
-                        value={title}
-                        onChange={onInputChange}
-                    />
-                </span>
-            </div>
-        );
-    }
-}
+const TitleIndexField: FC<TitleIndexFieldProps> = memo(({ name, titleTemplate, onInputChange }) => (
+    <div>
+        <DomainFieldLabel label="Document title" helpTipBody={DOCUMENT_TITLE_TIP} />
+        <span>
+            <FormControl
+                className="list__advanced-settings-modal__text-field"
+                id={name}
+                type="text"
+                placeholder="Use default"
+                value={titleTemplate == null ? '' : titleTemplate}
+                onChange={onInputChange}
+            />
+        </span>
+    </div>
+));
 
 interface MetadataIndexFieldProps {
     indexSetting: number;
     name: string;
-    onRadioChange: (evt: any) => any;
+    onRadioChange: (evt: any) => void;
 }
 
-class MetadataIndexField extends React.PureComponent<MetadataIndexFieldProps> {
-    render() {
-        const { indexSetting, name, onRadioChange } = this.props;
-
-        // Note: Currently the radio values go from high to low in order to correspond with the previous
-        // designer's order of radio options. Once the old designer is deprecated, we could change these to
-        // count from low to high.
-        return (
-            <div>
-                <FormGroup>
-                    <Radio name={name} value={2} checked={indexSetting === 2} onChange={onRadioChange}>
-                        Include both metadata and data
-                        <LabelHelpTip title="Warning">{DATA_INDEXING_TIP}</LabelHelpTip>
-                    </Radio>
-                    <Radio name={name} value={1} checked={indexSetting === 1} onChange={onRadioChange}>
-                        Include data only
-                        <LabelHelpTip title="Warning">{DATA_INDEXING_TIP}</LabelHelpTip>
-                    </Radio>
-                    <Radio name={name} value={0} checked={indexSetting === 0} onChange={onRadioChange}>
-                        Include metadata only (name and description of list and fields)
-                    </Radio>
-                </FormGroup>
-            </div>
-        );
-    }
-}
+// Note: Currently the radio values go from high to low in order to correspond with the previous
+// designer's order of radio options. Once the old designer is deprecated, we could change these to
+// count from low to high.
+// TODO: use RadioGroupInput instead
+const MetadataIndexField: FC<MetadataIndexFieldProps> = memo(({ indexSetting, name, onRadioChange }) => (
+    <FormGroup>
+        <Radio name={name} value={2} checked={indexSetting === 2} onChange={onRadioChange}>
+            Include both metadata and data
+            <LabelHelpTip title="Warning">{DATA_INDEXING_TIP}</LabelHelpTip>
+        </Radio>
+        <Radio name={name} value={1} checked={indexSetting === 1} onChange={onRadioChange}>
+            Include data only
+            <LabelHelpTip title="Warning">{DATA_INDEXING_TIP}</LabelHelpTip>
+        </Radio>
+        <Radio name={name} value={0} checked={indexSetting === 0} onChange={onRadioChange}>
+            Include metadata only (name and description of list and fields)
+        </Radio>
+    </FormGroup>
+));
 
 interface IndexFieldProps {
     bodySetting: number;
     bodyTemplate: string;
     name: string;
-    onInputChange: (evt: any) => any;
-    onRadioChange: (evt: any) => any;
+    onInputChange: (evt: any) => void;
+    onRadioChange: (evt: any) => void;
 }
 
-export class IndexField extends React.PureComponent<IndexFieldProps> {
-    render() {
-        const { name, onRadioChange, bodySetting, bodyTemplate, onInputChange } = this.props;
-        const id = name === 'entireListBodySetting' ? 'entireListBodyTemplate' : 'eachItemBodyTemplate';
+export const IndexField: FC<IndexFieldProps> = memo(props => {
+    const { name, onRadioChange, bodySetting, bodyTemplate, onInputChange } = props;
+    const id = name === 'entireListBodySetting' ? 'entireListBodyTemplate' : 'eachItemBodyTemplate';
 
-        return (
-            <div>
-                <FormGroup>
-                    <Radio name={name} value={0} checked={bodySetting === 0} onChange={onRadioChange}>
-                        Index all non-PHI text fields
-                    </Radio>
-                    <Radio name={name} value={1} checked={bodySetting === 1} onChange={onRadioChange}>
-                        Index all non-PHI fields (text, number, date, and boolean)
-                    </Radio>
-                    <Radio name={name} value={2} checked={bodySetting === 2} onChange={onRadioChange}>
-                        Index using custom template
-                        <LabelHelpTip>{CUSTOM_TEMPLATE_TIP}</LabelHelpTip>
-                    </Radio>
-                </FormGroup>
+    // TODO: Use RadioGroupInput instead
+    return (
+        <div>
+            <FormGroup>
+                <Radio name={name} value={0} checked={bodySetting === 0} onChange={onRadioChange}>
+                    Index all non-PHI text fields
+                </Radio>
+                <Radio name={name} value={1} checked={bodySetting === 1} onChange={onRadioChange}>
+                    Index all non-PHI fields (text, number, date, and boolean)
+                </Radio>
+                <Radio name={name} value={2} checked={bodySetting === 2} onChange={onRadioChange}>
+                    Index using custom template
+                    <LabelHelpTip>{CUSTOM_TEMPLATE_TIP}</LabelHelpTip>
+                </Radio>
+            </FormGroup>
 
-                {bodySetting == 2 && (
-                    <FormControl
-                        id={id}
-                        type="text"
-                        value={bodyTemplate}
-                        onChange={onInputChange}
-                        className="list__advanced-settings-modal__custom-template-text-field"
-                    />
-                )}
-            </div>
-        );
-    }
-}
-
-interface SingleDocumentIndexFieldsProps {
-    entireListBodySetting: number;
-    entireListBodyTemplate: string;
-    entireListIndexSetting: number;
-    entireListTitleTemplate: string;
-    onInputChange: (evt: any) => any;
-    onRadioChange: (evt: any) => any;
-}
-
-export class SingleDocumentIndexFields extends React.PureComponent<SingleDocumentIndexFieldsProps> {
-    render() {
-        const {
-            onRadioChange,
-            onInputChange,
-            entireListTitleTemplate,
-            entireListIndexSetting,
-            entireListBodySetting,
-            entireListBodyTemplate,
-        } = this.props;
-
-        return (
-            <div className="list__advanced-settings-modal__single-doc-fields">
-                <TitleIndexField
-                    titleTemplate={entireListTitleTemplate}
-                    name="entireListTitleTemplate"
-                    onInputChange={onInputChange}
+            {bodySetting === 2 && (
+                <FormControl
+                    id={id}
+                    type="text"
+                    value={bodyTemplate}
+                    onChange={onInputChange}
+                    className="list__advanced-settings-modal__custom-template-text-field"
                 />
+            )}
+        </div>
+    );
+});
 
-                <MetadataIndexField
-                    name="entireListIndexSetting"
-                    onRadioChange={onRadioChange}
-                    indexSetting={entireListIndexSetting}
-                />
-
-                <IndexField
-                    name="entireListBodySetting"
-                    onRadioChange={onRadioChange}
-                    onInputChange={onInputChange}
-                    bodySetting={entireListBodySetting}
-                    bodyTemplate={entireListBodyTemplate}
-                />
-            </div>
-        );
-    }
+interface SingleDocumentIndexFieldsProps extends EntireListSettings {
+    onInputChange: (evt: any) => void;
+    onRadioChange: (evt: any) => void;
 }
 
-interface SeparateDocumentIndexFieldsProps {
-    eachItemBodySetting: number;
-    eachItemBodyTemplate: string;
-    eachItemTitleTemplate: string;
-    onInputChange: (evt: any) => any;
-    onRadioChange: (evt: any) => any;
+export const SingleDocumentIndexFields: FC<SingleDocumentIndexFieldsProps> = memo(props => {
+    const {
+        onRadioChange,
+        onInputChange,
+        entireListTitleTemplate,
+        entireListIndexSetting,
+        entireListBodySetting,
+        entireListBodyTemplate,
+    } = props;
+
+    return (
+        <div className="list__advanced-settings-modal__single-doc-fields">
+            <TitleIndexField
+                titleTemplate={entireListTitleTemplate}
+                name="entireListTitleTemplate"
+                onInputChange={onInputChange}
+            />
+
+            <MetadataIndexField
+                name="entireListIndexSetting"
+                onRadioChange={onRadioChange}
+                indexSetting={entireListIndexSetting}
+            />
+
+            <IndexField
+                name="entireListBodySetting"
+                onRadioChange={onRadioChange}
+                onInputChange={onInputChange}
+                bodySetting={entireListBodySetting}
+                bodyTemplate={entireListBodyTemplate}
+            />
+        </div>
+    );
+});
+
+interface SeparateDocumentIndexFieldsProps extends EachItemSettings {
+    onInputChange: (evt: any) => void;
+    onRadioChange: (evt: any) => void;
 }
 
-export class SeparateDocumentIndexFields extends React.PureComponent<SeparateDocumentIndexFieldsProps> {
-    render() {
-        const { onRadioChange, onInputChange, eachItemTitleTemplate, eachItemBodySetting, eachItemBodyTemplate } =
-            this.props;
+export const SeparateDocumentIndexFields: FC<SeparateDocumentIndexFieldsProps> = memo(props => {
+    const { onRadioChange, onInputChange, eachItemTitleTemplate, eachItemBodySetting, eachItemBodyTemplate } = props;
 
-        return (
-            <div className="list__advanced-settings-modal__single-doc-fields">
-                <TitleIndexField
-                    titleTemplate={eachItemTitleTemplate}
-                    name="eachItemTitleTemplate"
-                    onInputChange={onInputChange}
-                />
+    return (
+        <div className="list__advanced-settings-modal__single-doc-fields">
+            <TitleIndexField
+                titleTemplate={eachItemTitleTemplate}
+                name="eachItemTitleTemplate"
+                onInputChange={onInputChange}
+            />
 
-                <IndexField
-                    name="eachItemBodySetting"
-                    onRadioChange={onRadioChange}
-                    onInputChange={onInputChange}
-                    bodySetting={eachItemBodySetting}
-                    bodyTemplate={eachItemBodyTemplate}
-                />
-            </div>
-        );
-    }
-}
+            <IndexField
+                name="eachItemBodySetting"
+                onRadioChange={onRadioChange}
+                onInputChange={onInputChange}
+                bodySetting={eachItemBodySetting}
+                bodyTemplate={eachItemBodyTemplate}
+            />
+        </div>
+    );
+});
 
 interface CollapsibleFieldsProps {
     checked: boolean;
     collapseFields: () => void;
     expandFields: (expandedSection: string) => void;
     expanded: boolean;
-    fields: JSX.Element;
     identifier: string;
     onCheckboxChange: (name: string, checked: boolean) => void;
     title: string;
 }
 
-class CollapsibleFields extends React.PureComponent<CollapsibleFieldsProps> {
-    expand = (): void => {
-        const { expanded, expandFields, identifier } = this.props;
-        const set = expanded ? '' : identifier;
-        expandFields(set);
-    };
+const CollapsibleFields: FC<CollapsibleFieldsProps> = memo(props => {
+    const { checked, children, collapseFields, expandFields, expanded, identifier, onCheckboxChange, title } = props;
+    const icon = classNames('fa', 'fa-lg', { 'fa-angle-down': expanded, 'fa-angle-right': !expanded });
+    const expand = useCallback((): void => {
+        // The logic in here could be moved up to the parent component.
+        expandFields(expanded ? '' : identifier);
+    }, [expandFields, expanded, identifier]);
+    const onChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>): void => {
+            const checked_ = event.target.checked;
+            onCheckboxChange(identifier, checked_);
 
-    onClick = (): void => {
-        const { identifier, checked, onCheckboxChange, collapseFields, expanded } = this.props;
-        onCheckboxChange(identifier, checked);
-        if (expanded && !checked) {
-            // If options are expanded, changing a checkbox from unchecked to checked does not expand or collapse
-        } else if (!checked) {
-            this.expand();
-        } else {
-            collapseFields();
-        }
-    };
+            if (checked_ && !expanded) {
+                expand();
+            } else if (!checked_ && expanded) {
+                collapseFields();
+            }
+        },
+        [collapseFields, expand, expanded, identifier, onCheckboxChange]
+    );
 
-    render(): ReactNode {
-        const { expanded, fields, title, checked } = this.props;
-        const icon = classNames('fa', 'fa-lg', { 'fa-angle-down': expanded, 'fa-angle-right': !expanded });
-        const classes = classNames('list__advanced-settings-model__collapsible-field list__properties__no-highlight', {
-            'list__properties__checkbox-unchecked': !checked,
-        });
+    return (
+        <div className="list__advanced-settings-modal__collapsible-field">
+            <span className={icon} onClick={expand} />
 
-        return (
-            <div>
-                <span onClick={this.expand} className={classes}>
-                    <span className={icon} />
-                </span>
-                <span className="list__advanced-settings-modal__index-checkbox">
-                    <CheckBox checked={checked} onClick={this.onClick} />
-                    <span className="list__advanced-settings-modal__index-text">
-                        <span className="list__clickable" onClick={this.onClick}>
-                            {title}
-                        </span>
-                        {expanded && fields}
-                    </span>
-                </span>
+            <div className="form-group">
+                <label>
+                    <input checked={checked} onChange={onChange} type="checkbox" />
+
+                    {title}
+                </label>
             </div>
-        );
-    }
-}
+
+            {expanded && children}
+        </div>
+    );
+});
 
 interface SearchIndexingProps {
-    eachItemIndexSettings: any;
-    entireListIndexSettings: any;
+    eachItemIndex: boolean;
+    eachItemIndexSettings: EachItemSettings;
+    entireListIndex: boolean;
+    entireListIndexSettings: EntireListSettings;
     fileAttachmentIndex: boolean;
     onCheckboxChange: (name, checked) => void;
-    onInputChange: (evt: any) => any;
-    onRadioChange: (evt: any) => any;
+    onInputChange: (evt: any) => void;
+    onRadioChange: (evt: any) => void;
 }
 
-interface SearchIndexingState {
-    expanded: string;
-}
+export const SearchIndexing: FC<SearchIndexingProps> = memo(props => {
+    const {
+        onRadioChange,
+        onCheckboxChange,
+        onInputChange,
+        entireListIndex,
+        entireListIndexSettings,
+        eachItemIndex,
+        eachItemIndexSettings,
+        fileAttachmentIndex,
+    } = props;
+    const [expanded, setExpanded] = useState<string>('');
+    const collapseFields = useCallback(() => setExpanded(''), []);
+    const onIndexFileAttachmentsChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>): void => {
+            onCheckboxChange('fileAttachmentIndex', event.target.checked);
+        },
+        [onCheckboxChange]
+    );
 
-export class SearchIndexing extends React.PureComponent<SearchIndexingProps, SearchIndexingState> {
-    constructor(props) {
-        super(props);
-        this.state = {
-            expanded: '', // Neither section initially expanded
-        };
-    }
-
-    expandFields = expandedSection => {
-        this.setState({ expanded: expandedSection });
-    };
-
-    collapseFields = () => {
-        this.setState({ expanded: '' });
-    };
-
-    render() {
-        const {
-            onRadioChange,
-            onCheckboxChange,
-            onInputChange,
-            entireListIndexSettings,
-            eachItemIndexSettings,
-            fileAttachmentIndex,
-        } = this.props;
-
-        const { expanded } = this.state;
-
-        const singleDocTitle = 'Index entire list as a single document';
-        const separateDocTitle = 'Index each item as a separate document';
-
-        return (
-            <div>
-                <CollapsibleFields
-                    expanded={expanded === 'entireListIndex'}
-                    fields={
-                        <SingleDocumentIndexFields
-                            onRadioChange={onRadioChange}
-                            onInputChange={onInputChange}
-                            {...entireListIndexSettings}
-                        />
-                    }
-                    title={singleDocTitle}
-                    identifier="entireListIndex"
-                    expandFields={this.expandFields}
-                    collapseFields={this.collapseFields}
-                    checked={entireListIndexSettings.entireListIndex}
-                    onCheckboxChange={onCheckboxChange}
+    return (
+        <div>
+            <CollapsibleFields
+                expanded={expanded === 'entireListIndex'}
+                title="Index entire list as a single document"
+                identifier="entireListIndex"
+                expandFields={setExpanded}
+                collapseFields={collapseFields}
+                checked={entireListIndex}
+                onCheckboxChange={onCheckboxChange}
+            >
+                <SingleDocumentIndexFields
+                    onRadioChange={onRadioChange}
+                    onInputChange={onInputChange}
+                    {...entireListIndexSettings}
                 />
+            </CollapsibleFields>
 
-                <CollapsibleFields
-                    expanded={expanded === 'eachItemIndex'}
-                    fields={
-                        <SeparateDocumentIndexFields
-                            onRadioChange={onRadioChange}
-                            onInputChange={onInputChange}
-                            {...eachItemIndexSettings}
-                        />
-                    }
-                    title={separateDocTitle}
-                    identifier="eachItemIndex"
-                    expandFields={this.expandFields}
-                    collapseFields={this.collapseFields}
-                    checked={eachItemIndexSettings.eachItemIndex}
-                    onCheckboxChange={onCheckboxChange}
+            <CollapsibleFields
+                expanded={expanded === 'eachItemIndex'}
+                title="Index each item as a separate document"
+                identifier="eachItemIndex"
+                expandFields={setExpanded}
+                collapseFields={collapseFields}
+                checked={eachItemIndex}
+                onCheckboxChange={onCheckboxChange}
+            >
+                <SeparateDocumentIndexFields
+                    onRadioChange={onRadioChange}
+                    onInputChange={onInputChange}
+                    {...eachItemIndexSettings}
                 />
+            </CollapsibleFields>
 
-                <span className="list__advanced-settings-model__index-checkbox">
-                    <CheckBox
-                        checked={fileAttachmentIndex}
-                        onClick={() => onCheckboxChange('fileAttachmentIndex', fileAttachmentIndex)}
-                    />
-                    <span
-                        className="list__advanced-settings-modal__index-text list__clickable"
-                        onClick={() => onCheckboxChange('fileAttachmentIndex', fileAttachmentIndex)}
-                    >
-                        Index file attachments
-                    </span>
-                </span>
+            <div className="list__advanced-settings-modal__index-checkbox form-group">
+                <label>
+                    <input checked={fileAttachmentIndex} onChange={onIndexFileAttachmentsChange} type="checkbox" />
+                    Index file attachments
+                </label>
             </div>
-        );
-    }
-}
+        </div>
+    );
+});
 
 interface SettingsContainerProps {
-    fieldComponent: JSX.Element;
     tipBody: string | JSX.Element;
     tipTitle?: string;
     title: string;
 }
 
-class SettingsContainer extends React.PureComponent<SettingsContainerProps> {
-    render() {
-        const { fieldComponent, title, tipBody, tipTitle } = this.props;
+const SettingsContainer: FC<SettingsContainerProps> = memo(({ children, title, tipBody, tipTitle }) => (
+    <div className="list__advanced-settings-modal__section-container">
+        <div className="list__advanced-settings-modal__heading">
+            <span className="list__bold-text"> {title} </span>
+            <LabelHelpTip title={tipTitle || title}>{tipBody}</LabelHelpTip>
+        </div>
 
-        return (
-            <div className="list__advanced-settings-modal__section-container">
-                <div className="list__advanced-settings-modal__heading">
-                    <span className="list__bold-text"> {title} </span>
-                    <LabelHelpTip title={tipTitle || title}>{tipBody}</LabelHelpTip>
-                </div>
-
-                {fieldComponent}
-            </div>
-        );
-    }
-}
+        {children}
+    </div>
+));
 
 interface AdvancedSettingsProps {
     applyAdvancedProperties: (advancedSettingsForm: AdvancedSettingsForm) => void;
@@ -450,7 +390,7 @@ interface AdvancedSettingsState extends AdvancedSettingsForm {
     modalOpen?: boolean;
 }
 
-export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps, AdvancedSettingsState> {
+export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps, Partial<AdvancedSettingsState>> {
     constructor(props) {
         super(props);
         const initialState = this.getInitialState();
@@ -461,7 +401,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
         } as AdvancedSettingsState;
     }
 
-    getInitialState = () => {
+    getInitialState = (): AdvancedSettingsState => {
         const model = this.props.model;
 
         return {
@@ -498,17 +438,21 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
         }
     };
 
-    onRadioChange = e => {
+    openModal = (): void => this.toggleModal(true);
+
+    closeModal = (): void => this.toggleModal(false);
+
+    onRadioChange = (e: ChangeEvent<HTMLInputElement>): void => {
         const name = e.currentTarget.name;
         const value = e.target.value;
-        this.setState({ [name]: parseInt(value) });
+        this.setState({ [name]: parseInt(value, 10) });
     };
 
-    onCheckboxChange = (name, checked) => {
-        this.setState({ [name]: !checked });
+    onCheckboxChange = (name, checked): void => {
+        this.setState({ [name]: checked });
     };
 
-    onInputChange = e => {
+    onInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
         const id = e.target.id;
         const value = e.target.value;
 
@@ -521,13 +465,13 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
     };
 
     applyChanges = (): void => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { modalOpen, ...advancedSettingsForm } = this.state;
-
         this.props.applyAdvancedProperties(advancedSettingsForm as AdvancedSettingsForm);
         this.toggleModal(false);
     };
 
-    render() {
+    render(): ReactNode {
         const {
             modalOpen,
             discussionSetting,
@@ -546,7 +490,6 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
         const { title, model, successBsStyle } = this.props;
 
         const entireListIndexSettings = {
-            entireListIndex,
             entireListTitleTemplate,
             entireListIndexSetting,
             entireListBodySetting,
@@ -554,97 +497,65 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
         };
 
         const eachItemIndexSettings = {
-            eachItemIndex,
             eachItemTitleTemplate,
             eachItemBodySetting,
             eachItemBodyTemplate,
         };
 
-        const displayTitleTip = (
-            <>
-                Choose a field to identify this list when other lists or datasets have lookups into this list. When
-                “Auto” is enabled, LabKey will select the title field for you by using:
-                <ul>
-                    <li>The first non-lookup string column</li>
-                    <li>The primary key, if there are no string fields</li>
-                </ul>
-            </>
-        ) as JSX.Element;
-
         return (
             <>
-                <Button className="domain-field-float-right" onClick={() => this.toggleModal(true)}>
+                <Button className="domain-field-float-right" onClick={this.openModal}>
                     {title}
                 </Button>
 
-                <Modal show={modalOpen} onHide={() => this.toggleModal(false)}>
+                <Modal show={modalOpen} onHide={this.closeModal}>
                     <Modal.Header closeButton>
                         <Modal.Title> Advanced List Settings </Modal.Title>
                     </Modal.Header>
 
                     <Modal.Body>
-                        <SettingsContainer
-                            title="Default Display Field"
-                            tipBody={displayTitleTip}
-                            fieldComponent={
-                                <DisplayTitle
-                                    model={model}
-                                    onSelectChange={this.onSelectChange}
-                                    titleColumn={titleColumn}
-                                />
-                            }
-                        />
+                        <SettingsContainer title="Default Display Field" tipBody={DISPLAY_TITLE_TIP}>
+                            <DisplayTitle
+                                model={model}
+                                onSelectChange={this.onSelectChange}
+                                titleColumn={titleColumn}
+                            />
+                        </SettingsContainer>
 
-                        <SettingsContainer
-                            title="Discussion Threads"
-                            tipBody={DISCUSSION_LINKS_TIP}
-                            fieldComponent={
-                                <DiscussionLinks
-                                    onRadioChange={this.onRadioChange}
-                                    discussionSetting={discussionSetting}
-                                />
-                            }
-                        />
+                        <SettingsContainer title="Discussion Threads" tipBody={DISCUSSION_LINKS_TIP}>
+                            <DiscussionInputs onRadioChange={this.onRadioChange} discussionSetting={discussionSetting} />
+                        </SettingsContainer>
 
-                        <SettingsContainer
-                            title="Search Indexing Options"
-                            tipBody={SEARCH_INDEXING_TIP}
-                            fieldComponent={
-                                <SearchIndexing
-                                    onRadioChange={this.onRadioChange}
-                                    onCheckboxChange={this.onCheckboxChange}
-                                    onInputChange={this.onInputChange}
-                                    entireListIndexSettings={entireListIndexSettings}
-                                    eachItemIndexSettings={eachItemIndexSettings}
-                                    fileAttachmentIndex={fileAttachmentIndex}
-                                />
-                            }
-                        />
+                        <SettingsContainer title="Search Indexing Options" tipBody={SEARCH_INDEXING_TIP}>
+                            <SearchIndexing
+                                onRadioChange={this.onRadioChange}
+                                onCheckboxChange={this.onCheckboxChange}
+                                onInputChange={this.onInputChange}
+                                entireListIndex={entireListIndex}
+                                entireListIndexSettings={entireListIndexSettings}
+                                eachItemIndex={eachItemIndex}
+                                eachItemIndexSettings={eachItemIndexSettings}
+                                fileAttachmentIndex={fileAttachmentIndex}
+                            />
+                        </SettingsContainer>
                     </Modal.Body>
 
                     <Modal.Footer>
-                        <>
-                            <Button
-                                onClick={() => this.toggleModal(false)}
-                                className="domain-adv-footer domain-adv-cancel-btn"
-                            >
-                                Cancel
-                            </Button>
+                        <Button onClick={this.closeModal} className="domain-adv-footer domain-adv-cancel-btn">
+                            Cancel
+                        </Button>
 
-                            {helpLinkNode(
-                                'createListOptions#advanced',
-                                'Get help with list settings',
-                                'domain-adv-footer domain-adv-link'
-                            )}
+                        <HelpLink className="domain-adv-footer domain-adv-link" topic="createListOptions#advanced">
+                            Get help with list settings
+                        </HelpLink>
 
-                            <Button
-                                onClick={this.applyChanges}
-                                bsStyle={successBsStyle || 'success'}
-                                className="domain-adv-footer domain-adv-apply-btn"
-                            >
-                                Apply
-                            </Button>
-                        </>
+                        <Button
+                            onClick={this.applyChanges}
+                            bsStyle={successBsStyle || 'success'}
+                            className="domain-adv-footer domain-adv-apply-btn"
+                        >
+                            Apply
+                        </Button>
                     </Modal.Footer>
                 </Modal>
             </>

--- a/packages/components/src/internal/components/domainproperties/list/ListPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListPropertiesPanel.tsx
@@ -59,28 +59,24 @@ export class ListPropertiesPanelImpl extends React.PureComponent<
         );
     };
 
-    onChange = (identifier, value): void => {
+    onChange = (name, value): void => {
         const { model } = this.props;
 
         // Name must be set on Domain as well
         let newDomain = model.domain;
-        if (identifier == 'name') {
+        if (name === 'name') {
             newDomain = model.domain.merge({ name: value }) as DomainDesign;
         }
 
         const newModel = model.merge({
-            [identifier]: value,
+            [name]: value,
             domain: newDomain,
         }) as ListModel;
 
         this.updateValidStatus(newModel);
     };
 
-    onCheckBoxChange = (name, checked): void => {
-        this.onChange(name, !checked);
-    };
-
-    onInputChange = e => {
+    onInputChange = (e): void => {
         const id = e.target.id;
         let value = e.target.value;
 
@@ -118,7 +114,7 @@ export class ListPropertiesPanelImpl extends React.PureComponent<
                 </Row>
                 <Form>
                     <BasicPropertiesFields model={model} onInputChange={this.onInputChange} />
-                    <AllowableActions model={model} onCheckBoxChange={this.onCheckBoxChange} />
+                    <AllowableActions model={model} onChange={this.onChange} />
                     <AdvancedSettings
                         title="Advanced Settings"
                         model={model}

--- a/packages/components/src/internal/components/domainproperties/list/ListPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListPropertiesPanelFormElements.tsx
@@ -1,5 +1,4 @@
-import classNames from 'classnames';
-import React, { FC, memo, useCallback } from 'react';
+import React, { ChangeEvent, FC, memo, useCallback } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 
 import { SectionHeading } from '../SectionHeading';
@@ -65,33 +64,28 @@ export const BasicPropertiesFields: FC<BasicPropertiesInputsProps> = memo(({ mod
     </Col>
 ));
 
-interface CheckBoxProps {
-    checked: boolean;
-    onClick: () => void;
-}
-
-export const CheckBox: FC<CheckBoxProps> = memo(({ checked, onClick }) => (
-    <span className="list__properties__no-highlight" onClick={onClick}>
-        <span
-            className={classNames('fa', 'fa-lg', { 'fa-check-square': checked, 'fa-square': !checked })}
-            style={{ color: checked ? '#0073BB' : '#ADADAD' }}
-        />
-    </span>
-));
-
 interface CheckBoxRowProps {
     checked: boolean;
     name: string;
-    onCheckBoxChange: (name, checked) => void;
+    onChange: (name: string, checked: boolean) => void;
     text: string;
 }
 
-export const CheckBoxRow: FC<CheckBoxRowProps> = memo(({ checked, onCheckBoxChange, name, text }) => {
-    const onClick = useCallback(() => onCheckBoxChange(name, checked), [checked, name, onCheckBoxChange]);
+export const CheckBoxRow: FC<CheckBoxRowProps> = memo(({ checked, onChange, name, text }) => {
+    const onChange_ = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => {
+            onChange(name, event.target.checked);
+        },
+        [name, onChange]
+    );
     return (
         <div className="list__properties__checkbox-row">
-            <CheckBox checked={checked} onClick={onClick} />
-            <span className="list__properties__checkbox-text">{text}</span>
+            <div className="form-group">
+                <label>
+                    <input checked={checked} onChange={onChange_} type="checkbox" />
+                    {text}
+                </label>
+            </div>
         </div>
     );
 });
@@ -99,29 +93,24 @@ CheckBoxRow.displayName = 'CheckBoxRow';
 
 interface AllowableActionContainerProps {
     model: ListModel;
-    onCheckBoxChange: (name, checked) => void;
+    onChange: (name: string, checked: boolean) => void;
 }
-const AllowableActionContainer: FC<AllowableActionContainerProps> = memo(({ model, onCheckBoxChange }) => (
+const AllowableActionContainer: FC<AllowableActionContainerProps> = memo(({ model, onChange }) => (
     <div className="list__properties__allowable-actions">
-        <CheckBoxRow text="Delete" checked={model.allowDelete} onCheckBoxChange={onCheckBoxChange} name="allowDelete" />
-        <CheckBoxRow text="Upload" checked={model.allowUpload} onCheckBoxChange={onCheckBoxChange} name="allowUpload" />
-        <CheckBoxRow
-            text="Export & Print"
-            checked={model.allowExport}
-            onCheckBoxChange={onCheckBoxChange}
-            name="allowExport"
-        />
+        <CheckBoxRow text="Delete" checked={model.allowDelete} onChange={onChange} name="allowDelete" />
+        <CheckBoxRow text="Upload" checked={model.allowUpload} onChange={onChange} name="allowUpload" />
+        <CheckBoxRow text="Export & Print" checked={model.allowExport} onChange={onChange} name="allowExport" />
     </div>
 ));
 
 interface AllowableActionsProps {
     model: ListModel;
-    onCheckBoxChange: (name: string, checked: boolean) => void;
+    onChange: (name: string, checked: boolean) => void;
 }
-export const AllowableActions: FC<AllowableActionsProps> = memo(({ model, onCheckBoxChange }) => (
+export const AllowableActions: FC<AllowableActionsProps> = memo(({ model, onChange }) => (
     <Col xs={12} md={3}>
         <SectionHeading title="Allow these Actions" />
-        <AllowableActionContainer model={model} onCheckBoxChange={onCheckBoxChange} />
+        <AllowableActionContainer model={model} onChange={onChange} />
     </Col>
 ));
 AllowableActions.displayName = 'AllowableActions';

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListDesignerPanels.spec.tsx.snap
@@ -13484,7 +13484,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                           "category": undefined,
                                         }
                                       }
-                                      onCheckBoxChange={[Function]}
+                                      onChange={[Function]}
                                     >
                                       <Col
                                         bsClass="col"
@@ -14815,7 +14815,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                 "category": undefined,
                                               }
                                             }
-                                            onCheckBoxChange={[Function]}
+                                            onChange={[Function]}
                                           >
                                             <div
                                               className="list__properties__allowable-actions"
@@ -14823,103 +14823,70 @@ exports[`ListDesignerPanel existing list 1`] = `
                                               <CheckBoxRow
                                                 checked={true}
                                                 name="allowDelete"
-                                                onCheckBoxChange={[Function]}
+                                                onChange={[Function]}
                                                 text="Delete"
                                               >
                                                 <div
                                                   className="list__properties__checkbox-row"
                                                 >
-                                                  <Memo()
-                                                    checked={true}
-                                                    onClick={[Function]}
+                                                  <div
+                                                    className="form-group"
                                                   >
-                                                    <span
-                                                      className="list__properties__no-highlight"
-                                                      onClick={[Function]}
-                                                    >
-                                                      <span
-                                                        className="fa fa-lg fa-check-square"
-                                                        style={
-                                                          {
-                                                            "color": "#0073BB",
-                                                          }
-                                                        }
+                                                    <label>
+                                                      <input
+                                                        checked={true}
+                                                        onChange={[Function]}
+                                                        type="checkbox"
                                                       />
-                                                    </span>
-                                                  </Memo()>
-                                                  <span
-                                                    className="list__properties__checkbox-text"
-                                                  >
-                                                    Delete
-                                                  </span>
+                                                      Delete
+                                                    </label>
+                                                  </div>
                                                 </div>
                                               </CheckBoxRow>
                                               <CheckBoxRow
                                                 checked={true}
                                                 name="allowUpload"
-                                                onCheckBoxChange={[Function]}
+                                                onChange={[Function]}
                                                 text="Upload"
                                               >
                                                 <div
                                                   className="list__properties__checkbox-row"
                                                 >
-                                                  <Memo()
-                                                    checked={true}
-                                                    onClick={[Function]}
+                                                  <div
+                                                    className="form-group"
                                                   >
-                                                    <span
-                                                      className="list__properties__no-highlight"
-                                                      onClick={[Function]}
-                                                    >
-                                                      <span
-                                                        className="fa fa-lg fa-check-square"
-                                                        style={
-                                                          {
-                                                            "color": "#0073BB",
-                                                          }
-                                                        }
+                                                    <label>
+                                                      <input
+                                                        checked={true}
+                                                        onChange={[Function]}
+                                                        type="checkbox"
                                                       />
-                                                    </span>
-                                                  </Memo()>
-                                                  <span
-                                                    className="list__properties__checkbox-text"
-                                                  >
-                                                    Upload
-                                                  </span>
+                                                      Upload
+                                                    </label>
+                                                  </div>
                                                 </div>
                                               </CheckBoxRow>
                                               <CheckBoxRow
                                                 checked={true}
                                                 name="allowExport"
-                                                onCheckBoxChange={[Function]}
+                                                onChange={[Function]}
                                                 text="Export & Print"
                                               >
                                                 <div
                                                   className="list__properties__checkbox-row"
                                                 >
-                                                  <Memo()
-                                                    checked={true}
-                                                    onClick={[Function]}
+                                                  <div
+                                                    className="form-group"
                                                   >
-                                                    <span
-                                                      className="list__properties__no-highlight"
-                                                      onClick={[Function]}
-                                                    >
-                                                      <span
-                                                        className="fa fa-lg fa-check-square"
-                                                        style={
-                                                          {
-                                                            "color": "#0073BB",
-                                                          }
-                                                        }
+                                                    <label>
+                                                      <input
+                                                        checked={true}
+                                                        onChange={[Function]}
+                                                        type="checkbox"
                                                       />
-                                                    </span>
-                                                  </Memo()>
-                                                  <span
-                                                    className="list__properties__checkbox-text"
-                                                  >
-                                                    Export & Print
-                                                  </span>
+                                                      Export & Print
+                                                    </label>
+                                                  </div>
                                                 </div>
                                               </CheckBoxRow>
                                             </div>
@@ -45910,68 +45877,50 @@ exports[`ListDesignerPanel new list 1`] = `
               <div
                 className="list__properties__checkbox-row"
               >
-                <span
-                  className="list__properties__no-highlight"
-                  onClick={[Function]}
+                <div
+                  className="form-group"
                 >
-                  <span
-                    className="fa fa-lg fa-check-square"
-                    style={
-                      {
-                        "color": "#0073BB",
-                      }
-                    }
-                  />
-                </span>
-                <span
-                  className="list__properties__checkbox-text"
-                >
-                  Delete
-                </span>
+                  <label>
+                    <input
+                      checked={true}
+                      onChange={[Function]}
+                      type="checkbox"
+                    />
+                    Delete
+                  </label>
+                </div>
               </div>
               <div
                 className="list__properties__checkbox-row"
               >
-                <span
-                  className="list__properties__no-highlight"
-                  onClick={[Function]}
+                <div
+                  className="form-group"
                 >
-                  <span
-                    className="fa fa-lg fa-check-square"
-                    style={
-                      {
-                        "color": "#0073BB",
-                      }
-                    }
-                  />
-                </span>
-                <span
-                  className="list__properties__checkbox-text"
-                >
-                  Upload
-                </span>
+                  <label>
+                    <input
+                      checked={true}
+                      onChange={[Function]}
+                      type="checkbox"
+                    />
+                    Upload
+                  </label>
+                </div>
               </div>
               <div
                 className="list__properties__checkbox-row"
               >
-                <span
-                  className="list__properties__no-highlight"
-                  onClick={[Function]}
+                <div
+                  className="form-group"
                 >
-                  <span
-                    className="fa fa-lg fa-check-square"
-                    style={
-                      {
-                        "color": "#0073BB",
-                      }
-                    }
-                  />
-                </span>
-                <span
-                  className="list__properties__checkbox-text"
-                >
-                  Export & Print
-                </span>
+                  <label>
+                    <input
+                      checked={true}
+                      onChange={[Function]}
+                      type="checkbox"
+                    />
+                    Export & Print
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanel.spec.tsx.snap
@@ -140,68 +140,50 @@ exports[`ListPropertiesPanel existing list 1`] = `
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Delete
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Delete
+              </label>
+            </div>
           </div>
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Upload
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Upload
+              </label>
+            </div>
           </div>
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Export & Print
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Export & Print
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -364,68 +346,50 @@ exports[`ListPropertiesPanel list with error 1`] = `
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Delete
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Delete
+              </label>
+            </div>
           </div>
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Upload
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Upload
+              </label>
+            </div>
           </div>
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Export & Print
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Export & Print
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -575,68 +539,50 @@ exports[`ListPropertiesPanel new list 1`] = `
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Delete
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Delete
+              </label>
+            </div>
           </div>
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Upload
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Upload
+              </label>
+            </div>
           </div>
           <div
             className="list__properties__checkbox-row"
           >
-            <span
-              className="list__properties__no-highlight"
-              onClick={[Function]}
+            <div
+              className="form-group"
             >
-              <span
-                className="fa fa-lg fa-check-square"
-                style={
-                  {
-                    "color": "#0073BB",
-                  }
-                }
-              />
-            </span>
-            <span
-              className="list__properties__checkbox-text"
-            >
-              Export & Print
-            </span>
+              <label>
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Export & Print
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanelFormElements.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanelFormElements.spec.tsx.snap
@@ -15,68 +15,50 @@ exports[`AllowableActions existing list, existing properties 1`] = `
     <div
       className="list__properties__checkbox-row"
     >
-      <span
-        className="list__properties__no-highlight"
-        onClick={[Function]}
+      <div
+        className="form-group"
       >
-        <span
-          className="fa fa-lg fa-check-square"
-          style={
-            {
-              "color": "#0073BB",
-            }
-          }
-        />
-      </span>
-      <span
-        className="list__properties__checkbox-text"
-      >
-        Delete
-      </span>
+        <label>
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Delete
+        </label>
+      </div>
     </div>
     <div
       className="list__properties__checkbox-row"
     >
-      <span
-        className="list__properties__no-highlight"
-        onClick={[Function]}
+      <div
+        className="form-group"
       >
-        <span
-          className="fa fa-lg fa-check-square"
-          style={
-            {
-              "color": "#0073BB",
-            }
-          }
-        />
-      </span>
-      <span
-        className="list__properties__checkbox-text"
-      >
-        Upload
-      </span>
+        <label>
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Upload
+        </label>
+      </div>
     </div>
     <div
       className="list__properties__checkbox-row"
     >
-      <span
-        className="list__properties__no-highlight"
-        onClick={[Function]}
+      <div
+        className="form-group"
       >
-        <span
-          className="fa fa-lg fa-check-square"
-          style={
-            {
-              "color": "#0073BB",
-            }
-          }
-        />
-      </span>
-      <span
-        className="list__properties__checkbox-text"
-      >
-        Export & Print
-      </span>
+        <label>
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Export & Print
+        </label>
+      </div>
     </div>
   </div>
 </div>
@@ -97,68 +79,50 @@ exports[`AllowableActions new list, default properties 1`] = `
     <div
       className="list__properties__checkbox-row"
     >
-      <span
-        className="list__properties__no-highlight"
-        onClick={[Function]}
+      <div
+        className="form-group"
       >
-        <span
-          className="fa fa-lg fa-check-square"
-          style={
-            {
-              "color": "#0073BB",
-            }
-          }
-        />
-      </span>
-      <span
-        className="list__properties__checkbox-text"
-      >
-        Delete
-      </span>
+        <label>
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Delete
+        </label>
+      </div>
     </div>
     <div
       className="list__properties__checkbox-row"
     >
-      <span
-        className="list__properties__no-highlight"
-        onClick={[Function]}
+      <div
+        className="form-group"
       >
-        <span
-          className="fa fa-lg fa-check-square"
-          style={
-            {
-              "color": "#0073BB",
-            }
-          }
-        />
-      </span>
-      <span
-        className="list__properties__checkbox-text"
-      >
-        Upload
-      </span>
+        <label>
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Upload
+        </label>
+      </div>
     </div>
     <div
       className="list__properties__checkbox-row"
     >
-      <span
-        className="list__properties__no-highlight"
-        onClick={[Function]}
+      <div
+        className="form-group"
       >
-        <span
-          className="fa fa-lg fa-check-square"
-          style={
-            {
-              "color": "#0073BB",
-            }
-          }
-        />
-      </span>
-      <span
-        className="list__properties__checkbox-text"
-      >
-        Export & Print
-      </span>
+        <label>
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Export & Print
+        </label>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/components/src/internal/components/domainproperties/list/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/list/constants.ts
@@ -1,13 +1,3 @@
-export const DATA_INDEXING_TIP =
-    'Not recommend for large lists with frequent updates, since updating any item will cause re-indexing of the entire list.';
-export const DOCUMENT_TITLE_TIP =
-    'Any text you want displayed and indexed as the search result title (ex. ListName - ${Key} ${value}). Leave the document title blank to use the default title.';
-export const CUSTOM_TEMPLATE_TIP = 'Example: ${Key} ${value}';
-
-export const DISCUSSION_LINKS_TIP =
-    'Optionally allow one or more discussion links to be shown on the details view of each list item.';
-export const SEARCH_INDEXING_TIP = 'Controls how this list is indexed for search within LabKey Server.';
-
 export const VAR_LIST = 'VarList';
 export const INT_LIST = 'IntList';
 export const PICKLIST = 'Picklist';

--- a/packages/components/src/internal/components/domainproperties/list/models.ts
+++ b/packages/components/src/internal/components/domainproperties/list/models.ts
@@ -18,22 +18,29 @@ import { Record } from 'immutable';
 import { DomainDesign, DomainField } from '../models';
 import { DOMAIN_FIELD_PRIMARY_KEY_LOCKED } from '../constants';
 
-import { INT_LIST, PICKLIST, VAR_LIST } from './constants';
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from '../../picklist/constants';
 
-export interface AdvancedSettingsForm {
-    titleColumn?: string;
-    discussionSetting?: number;
-    fileAttachmentIndex?: boolean;
-    entireListIndex?: boolean;
-    entireListTitleTemplate?: string;
-    entireListIndexSetting?: number;
-    entireListBodySetting?: number;
-    eachItemIndex?: boolean;
-    eachItemTitleTemplate?: string;
-    eachItemBodySetting?: number;
-    entireListBodyTemplate?: string;
-    eachItemBodyTemplate?: string;
+import { INT_LIST, PICKLIST, VAR_LIST } from './constants';
+
+export interface EachItemSettings {
+    eachItemBodySetting: number;
+    eachItemBodyTemplate: string;
+    eachItemTitleTemplate: string;
+}
+
+export interface EntireListSettings {
+    entireListBodySetting: number;
+    entireListBodyTemplate: string;
+    entireListIndexSetting: number;
+    entireListTitleTemplate: string;
+}
+
+export interface AdvancedSettingsForm extends EachItemSettings, EntireListSettings {
+    discussionSetting: number;
+    eachItemIndex: boolean;
+    entireListIndex: boolean;
+    fileAttachmentIndex: boolean;
+    titleColumn: string;
 }
 
 export class ListModel extends Record({

--- a/packages/components/src/theme/list.scss
+++ b/packages/components/src/theme/list.scss
@@ -63,13 +63,17 @@
     border-radius: 5px;
 }
 
-.list__advanced-settings-model__collapsible-field {
-    display: inline-block;
-    width: 15px;
+.list__advanced-settings-modal__collapsible-field {
+    .fa {
+        width: 16px;
+    }
+    .form-group {
+        display: inline-block;
+    }
 }
 
-.list__advanced-settings-model__index-checkbox {
-    margin-left: 22px;
+.list__advanced-settings-modal__index-checkbox {
+    margin-left: 16px;
 }
 
 .list__advanced-settings-modal__custom-template-text-field {


### PR DESCRIPTION
#### Rationale
Selenium tests are failing that use font awesome icons for checkbox components, this PR removes custom checkbox components.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1023
* https://github.com/LabKey/platform/pull/3850
* https://github.com/LabKey/biologics/pull/1729
* https://github.com/LabKey/sampleManagement/pull/1389
* https://github.com/LabKey/labbook/pull/322
* https://github.com/LabKey/inventory/pull/609
* https://github.com/LabKey/cas/pull/53
* https://github.com/LabKey/saml/pull/69
* https://github.com/LabKey/testAutomation/pull/1310

#### Changes
- No longer use custom checkbox component
- Convert most components to FC
- Add types to props, improve other types
- Use children instead of custom prop to pass components
- Don't use inline defined anonymous functions for handlers
