### PR TITLE
EditableGrid: consistent processing of editable grid columns

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.258.0-fb-fix-46714.0",
+  "version": "2.259.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.258.0",
+  "version": "2.258.0-fb-fix-46714.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.259.0
+*Released*: 22 November 2022
+* Update `addColumns`, `changeColumn`, and `removeColumns` editable grid actions to update the new `columns` array on the `EditorModel`.
+* Process directly against `EditorModel.columns` in `EditorModel.getRawDataFromGridData()` rather than relying on all column oriented properties aligning with the initial configuration.
+* Introduce `EditorModel.getRawDataFromModel()` as a wrapped replacement for `EditorModel.getRawDataFromGridData()` to reduce redundant processing of the data on a `QueryModel`.
+* Remove concept of `getEditableValue` on the renderer for editable grid cells. This pattern is no longer needed.
+
 ### version 2.258.0
 *Released*: 22 November 2022
 * Update label on `ManageDropdownButton` to contain the word "Manage"

--- a/packages/components/src/entities/SamplesEditableGrid.tsx
+++ b/packages/components/src/entities/SamplesEditableGrid.tsx
@@ -159,6 +159,11 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
         if (this._hasError) this.props.dismissNotifications();
     }
 
+    get allAliquots(): boolean {
+        const { aliquots, displayQueryModel } = this.props;
+        return this.hasAliquots() && aliquots.length === displayQueryModel.selections.size;
+    }
+
     getReadOnlyColumns(): List<string> {
         const { displayQueryModel } = this.props;
 
@@ -186,8 +191,7 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     }
 
     getSchemaQuery = (): SchemaQuery => {
-        const { displayQueryModel } = this.props;
-        return displayQueryModel?.queryInfo?.schemaQuery;
+        return this.props.displayQueryModel?.queryInfo?.schemaQuery;
     };
 
     initLineageEditableGrid = async (): Promise<void> => {
@@ -202,8 +206,7 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     };
 
     hasParentDataTypes = (): boolean => {
-        const { parentDataTypes } = this.props;
-        return parentDataTypes?.size > 0;
+        return this.props.parentDataTypes?.size > 0;
     };
 
     updateAllTabRows = (updateDataRows: any[], skipConfirmDiscard?: boolean): Promise<any> => {
@@ -399,8 +402,7 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     };
 
     hasAliquots = (): boolean => {
-        const { aliquots } = this.props;
-        return aliquots && aliquots.length > 0;
+        return this.props.aliquots?.length > 0;
     };
 
     getSamplesUpdateColumns = (tabInd: number): List<QueryColumn> => {
@@ -422,16 +424,12 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
         return updatedColumns;
     };
 
-    getExportColumnFilter = (col: QueryColumn): any => {
-        const { sampleTypeDomainFields } = this.props;
-
-        return sampleTypeDomainFields.aliquotFields.indexOf(col.fieldKey.toLowerCase()) === -1;
+    getExportColumnFilter = (col: QueryColumn): boolean => {
+        return this.props.sampleTypeDomainFields.aliquotFields.indexOf(col.fieldKey.toLowerCase()) === -1;
     };
 
     getSelectedSamplesNoun = (): string => {
-        const { aliquots, displayQueryModel } = this.props;
-        const allAliquots = this.hasAliquots() && aliquots.length === displayQueryModel.selections.size;
-        return allAliquots ? 'aliquot' : 'sample';
+        return this.allAliquots ? 'aliquot' : 'sample';
     };
 
     getCurrentTab = (tabInd: number): number => {
@@ -439,7 +437,7 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
         return tabInd === undefined ? includedTabs[0] : includedTabs[tabInd];
     };
 
-    onConfirmConsumedSamplesDialog = (shouldDiscard: boolean, comment: string): any => {
+    onConfirmConsumedSamplesDialog = (shouldDiscard: boolean, comment: string): void => {
         const { pendingUpdateDataRows } = this.state;
         this.setState(
             {
@@ -453,10 +451,8 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
         );
     };
 
-    onDismissConsumedSamplesDialog = (): any => {
-        this.setState({
-            showDiscardDialog: false,
-        });
+    onDismissConsumedSamplesDialog = (): void => {
+        this.setState({ showDiscardDialog: false });
     };
 
     render() {
@@ -487,12 +483,14 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
             includedTabs,
             parentTypeOptions,
         } = this.state;
-        const allAliquots = this.hasAliquots() && aliquots.length === displayQueryModel.selections.size;
 
-        if (determineLineage && this.hasParentDataTypes() && !originalParents) return <LoadingSpinner />;
+        if (determineLineage && this.hasParentDataTypes() && !originalParents) {
+            return <LoadingSpinner />;
+        }
 
         const loaders: IEditableGridLoader[] = [];
         if (determineSampleData) {
+            const allAliquots = this.allAliquots;
             loaders.push(
                 new EditableGridLoaderFromSelection(
                     SAMPLES_EDIT_GRID_ID,

--- a/packages/components/src/entities/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/entities/SamplesTabbedGridPanel.tsx
@@ -131,7 +131,7 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             setIsDirty?.(true);
             return Promise.resolve(editableGridDataForSelection);
         },
-        []
+        [setIsDirty]
     );
 
     const [activeActiveAliquotMode, setActiveAliquotMode] = useState<string>(

--- a/packages/components/src/internal/actions.spec.ts
+++ b/packages/components/src/internal/actions.spec.ts
@@ -306,7 +306,9 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('Description 1');
             expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('Description 2');
             expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
-            expect(updates.editorModelChanges.columns.find(fieldKey => fieldKey === firstInputColumn.fieldKey)).toBeUndefined();
+            expect(
+                updates.editorModelChanges.columns.find(fieldKey => fieldKey === firstInputColumn.fieldKey)
+            ).toBeUndefined();
             expect(updates.data.find(row => row.has(firstInputColumn.fieldKey))).toBeFalsy();
         });
 
@@ -324,7 +326,9 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('S-2');
             expect(updates.editorModelChanges.cellValues.has('5-0')).toBe(false);
             expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
-            expect(updates.editorModelChanges.columns.find(fieldKey => fieldKey === lastInputColumn.fieldKey)).toBeUndefined();
+            expect(
+                updates.editorModelChanges.columns.find(fieldKey => fieldKey === lastInputColumn.fieldKey)
+            ).toBeUndefined();
             expect(updates.data.find(row => row.has(lastInputColumn.fieldKey))).toBeFalsy();
         });
 

--- a/packages/components/src/internal/actions.spec.ts
+++ b/packages/components/src/internal/actions.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List, Map, OrderedMap, fromJS } from 'immutable';
+import { fromJS, List, Map, OrderedMap, Set } from 'immutable';
 
 import { Filter, Query } from '@labkey/api';
 
@@ -35,292 +35,317 @@ import {
 } from './actions';
 import { EXPORT_TYPES } from './constants';
 
-const editableGridWithData = {
-    cellMessages: Map<string, CellMessage>({
-        '1-0': 'description 1 message',
-    }),
-    cellValues: Map<string, List<ValueDescriptor>>({
-        '0-0': List<ValueDescriptor>([
-            {
-                display: 'S-1',
-                raw: 'S-1',
-            },
-        ]),
-        '0-1': List<ValueDescriptor>([
-            {
-                display: 'S-2',
-                raw: 'S-2',
-            },
-        ]),
-        '0-2': List<ValueDescriptor>([
-            {
-                display: 'S-3',
-                raw: 'S-3',
-            },
-        ]),
-        '1-0': List<ValueDescriptor>([
-            {
-                display: 'Description 1',
-                raw: 'Description 1',
-            },
-        ]),
-        '1-1': List<ValueDescriptor>([
-            {
-                display: 'Description 2',
-                raw: 'Description 2',
-            },
-        ]),
-        '1-2': List<ValueDescriptor>([
-            {
-                display: 'Description 3',
-                raw: 'Description 3',
-            },
-        ]),
-        '5-0': List<ValueDescriptor>([
-            {
-                display: 'requirement 1',
-                raw: 'requirement 1',
-            },
-        ]),
-    }),
-    colCount: 5,
-    id: 'insert-samples|samples/sample set 2',
-    isPasting: false,
-    focusColIdx: 1,
-    focusRowIdx: 1,
-    numPastedRows: 0,
-    rowCount: 3,
-    selectedColIdx: 1,
-    selectedRowIdx: 1,
-    selectionCells: [],
-};
+describe('column mutation actions', () => {
+    const queryInfo = QueryInfo.fromJSON(sampleSet2QueryInfo);
 
-const dataRows = {
-    '1': {
-        Description: 'S-1 Description',
-    },
-    '2': {
-        Description: 'S-2 Description',
-    },
-};
+    const insertColumnFieldKeys = queryInfo
+        .getInsertColumns()
+        .map(col => col.fieldKey)
+        .toList();
 
-const dataKeys = ['1', '2'];
-
-const queryModel = makeTestQueryModel(
-    new SchemaQuery({
-        schemaName: 'samples',
-        queryName: 'Sample Set 2',
-    }),
-    QueryInfo.fromJSON(sampleSet2QueryInfo),
-    dataRows,
-    dataKeys,
-    dataKeys.length,
-    'insert-samples|samples/sample set 2'
-);
-
-const queryColumn = new QueryColumn({
-    caption: 'Sample set 3 Parents',
-    conceptURI: null,
-    defaultValue: null,
-    description: 'Contains optional parent entity for this Sample set 3',
-    fieldKey: 'MaterialInputs/Sample set 3',
-    fieldKeyArray: ['MaterialInputs/Sample set 3'],
-    lookup: {
-        displayColumn: 'Name',
-        isPublic: true,
-        keyColumn: 'RowId',
-        multiValued: 'junction',
-        queryName: 'Sample set 3',
-        schemaName: 'samples',
-        table: 'MaterialInputs',
-    },
-    multiValue: false,
-    name: 'MaterialInputs/Sample set 3',
-    required: false,
-    shownInInsertView: true,
-    sortable: true,
-    type: 'Text (String)',
-    userEditable: true,
-    removeFromViews: false,
-});
-
-describe('changeColumn', () => {
-    test('column not found', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const updates = changeColumn(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            'Nonesuch',
-            queryColumn
-        );
-        expect(updates.editorModelChanges).toBe(undefined);
+    const editorModel = new EditorModel({
+        cellMessages: Map<string, CellMessage>({
+            '1-0': 'description 1 message',
+        }),
+        cellValues: Map<string, List<ValueDescriptor>>({
+            '0-0': List<ValueDescriptor>([
+                {
+                    display: 'S-1',
+                    raw: 'S-1',
+                },
+            ]),
+            '0-1': List<ValueDescriptor>([
+                {
+                    display: 'S-2',
+                    raw: 'S-2',
+                },
+            ]),
+            '0-2': List<ValueDescriptor>([
+                {
+                    display: 'S-3',
+                    raw: 'S-3',
+                },
+            ]),
+            '1-0': List<ValueDescriptor>([
+                {
+                    display: 'Description 1',
+                    raw: 'Description 1',
+                },
+            ]),
+            '1-1': List<ValueDescriptor>([
+                {
+                    display: 'Description 2',
+                    raw: 'Description 2',
+                },
+            ]),
+            '1-2': List<ValueDescriptor>([
+                {
+                    display: 'Description 3',
+                    raw: 'Description 3',
+                },
+            ]),
+            '5-0': List<ValueDescriptor>([
+                {
+                    display: 'requirement 1',
+                    raw: 'requirement 1',
+                },
+            ]),
+        }),
+        columns: insertColumnFieldKeys,
+        colCount: insertColumnFieldKeys.size,
+        id: 'insert-samples|samples/sample set 2',
+        isPasting: false,
+        focusColIdx: 1,
+        focusRowIdx: 1,
+        numPastedRows: 0,
+        rowCount: 3,
+        selectedColIdx: 1,
+        selectedRowIdx: 1,
+        selectionCells: Set<string>(),
     });
 
-    test('has values and messages', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        expect(editorModel.cellMessages.size).toBe(1);
+    const dataRows = {
+        '1': {
+            Description: 'S-1 Description',
+        },
+        '2': {
+            Description: 'S-2 Description',
+        },
+    };
 
-        const updates = changeColumn(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            'Description',
-            queryColumn
-        );
+    const dataKeys = ['1', '2'];
 
-        expect(updates.editorModelChanges.cellMessages.size).toBe(0);
-        expect(updates.editorModelChanges.cellValues.get('1-0')).toBeFalsy();
-        expect(updates.editorModelChanges.cellValues.get('1-1')).toBeFalsy();
-        expect(updates.editorModelChanges.cellValues.get('1-2')).toBeFalsy();
+    const queryModel = makeTestQueryModel(
+        new SchemaQuery({
+            schemaName: 'samples',
+            queryName: 'Sample Set 2',
+        }),
+        queryInfo,
+        dataRows,
+        dataKeys,
+        dataKeys.length,
+        editorModel.id
+    );
 
-        const colIndex = queryModel.queryInfo.columns.keySeq().findIndex(column => column === 'description');
-        expect(updates.queryInfo.getColumn('Description')).toBeFalsy();
-        expect(updates.queryInfo.getColumn(queryColumn.fieldKey)).toBeTruthy();
-        const newColIndex = updates.queryInfo.columns
-            .keySeq()
-            .findIndex(column => column === queryColumn.fieldKey.toLowerCase());
-        expect(newColIndex).toBe(colIndex);
-        expect(updates.data.findEntry(rowValues => rowValues.has('Description)'))).toBeFalsy();
-        expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
-    });
-});
-
-describe('addColumns', () => {
-    test('no columns provided', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const updates = addColumns(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            OrderedMap<string, QueryColumn>()
-        );
-        expect(updates.editorModelChanges).toBe(undefined);
-    });
-
-    test('add at beginning', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const updates = addColumns(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            OrderedMap<string, QueryColumn>([[queryColumn.fieldKey, queryColumn]])
-        );
-        expect(updates.editorModelChanges.cellMessages.size).toBe(1);
-        expect(updates.editorModelChanges.cellMessages.has('2-0')).toBe(true);
-        expect(updates.editorModelChanges.cellValues.get('0-0').size).toBe(0);
-        expect(updates.editorModelChanges.cellValues.get('1-0').get(0).display).toBe('S-1');
-        expect(updates.editorModelChanges.cellValues.get('2-0').get(0).display).toBe('Description 1');
-        expect(updates.editorModelChanges.cellValues.get('1-1').get(0).display).toBe('S-2');
-        expect(updates.editorModelChanges.cellValues.get('2-1').get(0).display).toBe('Description 2');
-        expect(updates.queryInfo.getColumnIndex('Description')).toBe(
-            queryModel.queryInfo.getColumnIndex('Description') + 1
-        );
-        expect(updates.queryInfo.getColumnIndex(queryColumn.fieldKey)).toBe(0);
-        expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
+    const queryColumn = new QueryColumn({
+        caption: 'Sample set 3 Parents',
+        conceptURI: null,
+        defaultValue: null,
+        description: 'Contains optional parent entity for this Sample set 3',
+        fieldKey: 'MaterialInputs/Sample set 3',
+        fieldKeyArray: ['MaterialInputs/Sample set 3'],
+        lookup: {
+            displayColumn: 'Name',
+            isPublic: true,
+            keyColumn: 'RowId',
+            multiValued: 'junction',
+            queryName: 'Sample set 3',
+            schemaName: 'samples',
+            table: 'MaterialInputs',
+        },
+        multiValue: false,
+        name: 'MaterialInputs/Sample set 3',
+        required: false,
+        shownInInsertView: true,
+        sortable: true,
+        type: 'Text (String)',
+        userEditable: true,
+        removeFromViews: false,
     });
 
-    test('add at end', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const lastInsertColKey = queryModel.queryInfo.getInsertColumns().last().fieldKey;
-        const updates = addColumns(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            OrderedMap<string, QueryColumn>([[queryColumn.fieldKey, queryColumn]]),
-            lastInsertColKey
-        );
-        expect(updates.editorModelChanges.cellMessages.size).toBe(1);
-        expect(updates.editorModelChanges.cellMessages.has('1-0')).toBe(true);
-        expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
-        expect(updates.editorModelChanges.cellValues.get('1-0').get(0).display).toBe('Description 1');
-        expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('S-2');
-        expect(updates.editorModelChanges.cellValues.get('1-1').get(0).display).toBe('Description 2');
-        expect(updates.queryInfo.getColumnIndex('description')).toBe(
-            queryModel.queryInfo.getColumnIndex('description')
-        );
-        expect(updates.queryInfo.getColumnIndex(queryColumn.fieldKey)).toBe(
-            queryModel.queryInfo.getColumnIndex(lastInsertColKey) + 1
-        );
-        expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
+    describe('addColumns', () => {
+        test('no columns provided', () => {
+            const updates = addColumns(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                OrderedMap<string, QueryColumn>()
+            );
+            expect(updates.editorModelChanges).toBe(undefined);
+        });
+
+        test('add at beginning', () => {
+            const updates = addColumns(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                OrderedMap<string, QueryColumn>([[queryColumn.fieldKey, queryColumn]])
+            );
+            expect(updates.editorModelChanges.cellMessages.size).toBe(1);
+            expect(updates.editorModelChanges.cellMessages.has('2-0')).toBe(true);
+            expect(updates.editorModelChanges.cellValues.get('0-0').size).toBe(0);
+            expect(updates.editorModelChanges.cellValues.get('1-0').get(0).display).toBe('S-1');
+            expect(updates.editorModelChanges.cellValues.get('2-0').get(0).display).toBe('Description 1');
+            expect(updates.editorModelChanges.cellValues.get('1-1').get(0).display).toBe('S-2');
+            expect(updates.editorModelChanges.cellValues.get('2-1').get(0).display).toBe('Description 2');
+            expect(updates.editorModelChanges.columns.get(0)).toEqual(queryColumn.fieldKey);
+            expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size + 1);
+            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
+            expect(updates.queryInfo.getColumnIndex('Description')).toBe(
+                queryModel.queryInfo.getColumnIndex('Description') + 1
+            );
+            expect(updates.queryInfo.getColumnIndex(queryColumn.fieldKey)).toBe(0);
+            expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
+        });
+
+        test('add at end', () => {
+            const lastInsertColKey = queryModel.queryInfo.getInsertColumns().last().fieldKey;
+            const updates = addColumns(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                OrderedMap<string, QueryColumn>([[queryColumn.fieldKey, queryColumn]]),
+                lastInsertColKey
+            );
+            expect(updates.editorModelChanges.cellMessages.size).toBe(1);
+            expect(updates.editorModelChanges.cellMessages.has('1-0')).toBe(true);
+            expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
+            expect(updates.editorModelChanges.cellValues.get('1-0').get(0).display).toBe('Description 1');
+            expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('S-2');
+            expect(updates.editorModelChanges.cellValues.get('1-1').get(0).display).toBe('Description 2');
+            expect(updates.editorModelChanges.columns.get(updates.editorModelChanges.columns.size - 1)).toEqual(
+                queryColumn.fieldKey
+            );
+            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
+            expect(updates.queryInfo.getColumnIndex('description')).toBe(
+                queryModel.queryInfo.getColumnIndex('description')
+            );
+            expect(updates.queryInfo.getColumnIndex(queryColumn.fieldKey)).toBe(
+                queryModel.queryInfo.getColumnIndex(lastInsertColKey) + 1
+            );
+            expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
+        });
+
+        test('add in the middle', () => {
+            const nameColIndex = queryModel.queryInfo.getColumnIndex('name');
+
+            const updates = addColumns(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                OrderedMap<string, QueryColumn>([[queryColumn.fieldKey, queryColumn]]),
+                'Name'
+            );
+
+            expect(updates.editorModelChanges.cellMessages.size).toBe(1);
+            expect(updates.editorModelChanges.cellMessages.has('2-0')).toBe(true);
+            expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
+            expect(updates.editorModelChanges.cellValues.get('2-0').get(0).display).toBe('Description 1');
+            expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('S-2');
+            expect(updates.editorModelChanges.cellValues.get('2-1').get(0).display).toBe('Description 2');
+            expect(updates.editorModelChanges.columns.findIndex(fieldKey => fieldKey === queryColumn.fieldKey)).toEqual(
+                updates.editorModelChanges.columns.findIndex(fieldKey => fieldKey === 'Name') + 1
+            );
+            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
+
+            expect(updates.queryInfo.getColumnIndex('name')).toBe(nameColIndex);
+            expect(updates.queryInfo.getColumnIndex('description')).toBe(
+                queryModel.queryInfo.getColumnIndex('description') + 1
+            );
+            expect(updates.queryInfo.getColumnIndex(queryColumn.fieldKey)).toBe(nameColIndex + 1);
+            expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
+        });
     });
 
-    test('add in the middle', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const nameColIndex = queryModel.queryInfo.getColumnIndex('name');
+    describe('changeColumn', () => {
+        test('column not found', () => {
+            const updates = changeColumn(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                'Nonesuch',
+                queryColumn
+            );
+            expect(updates.editorModelChanges).toBe(undefined);
+        });
 
-        const updates = addColumns(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            OrderedMap<string, QueryColumn>([[queryColumn.fieldKey, queryColumn]]),
-            'Name'
-        );
+        test('has values and messages', () => {
+            expect(editorModel.cellMessages.size).toBe(1);
 
-        expect(updates.editorModelChanges.cellMessages.size).toBe(1);
-        expect(updates.editorModelChanges.cellMessages.has('2-0')).toBe(true);
-        expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
-        expect(updates.editorModelChanges.cellValues.get('2-0').get(0).display).toBe('Description 1');
-        expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('S-2');
-        expect(updates.editorModelChanges.cellValues.get('2-1').get(0).display).toBe('Description 2');
+            const updates = changeColumn(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                'Description',
+                queryColumn
+            );
 
-        expect(updates.queryInfo.getColumnIndex('name')).toBe(nameColIndex);
-        expect(updates.queryInfo.getColumnIndex('description')).toBe(
-            queryModel.queryInfo.getColumnIndex('description') + 1
-        );
-        expect(updates.queryInfo.getColumnIndex(queryColumn.fieldKey)).toBe(nameColIndex + 1);
-        expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
-    });
-});
+            expect(updates.editorModelChanges.cellMessages.size).toBe(0);
+            expect(updates.editorModelChanges.cellValues.get('1-0')).toBeFalsy();
+            expect(updates.editorModelChanges.cellValues.get('1-1')).toBeFalsy();
+            expect(updates.editorModelChanges.cellValues.get('1-2')).toBeFalsy();
+            expect(updates.editorModelChanges.columns.find(fieldKey => fieldKey === 'Description')).toBeUndefined();
+            expect(updates.editorModelChanges.columns.findIndex(fieldKey => fieldKey === queryColumn.fieldKey)).toEqual(
+                editorModel.columns.findIndex(fieldKey => fieldKey === 'Description')
+            );
 
-describe('removeColumn', () => {
-    test('column not found', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const updates = removeColumn(editorModel, queryModel.queryInfo, fromJS(queryModel.rows), 'Modified'); // not an insert column, so cannot be removed
-        expect(updates.editorModelChanges).toBe(undefined);
-    });
-
-    test('first column', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const firstInputColumn = queryModel.queryInfo.getInsertColumns().first();
-        const updates = removeColumn(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            firstInputColumn.fieldKey
-        );
-
-        expect(updates.editorModelChanges.cellMessages.size).toBe(1);
-        expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('Description 1');
-        expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('Description 2');
-        expect(updates.data.find(row => row.has(firstInputColumn.fieldKey))).toBeFalsy();
+            const colIndex = queryModel.queryInfo.columns.keySeq().findIndex(column => column === 'description');
+            expect(updates.queryInfo.getColumn('Description')).toBeFalsy();
+            expect(updates.queryInfo.getColumn(queryColumn.fieldKey)).toBeTruthy();
+            const newColIndex = updates.queryInfo.columns
+                .keySeq()
+                .findIndex(column => column === queryColumn.fieldKey.toLowerCase());
+            expect(newColIndex).toBe(colIndex);
+            expect(updates.data.findEntry(rowValues => rowValues.has('Description)'))).toBeFalsy();
+            expect(updates.data.findEntry(rowValues => rowValues.has(queryColumn.fieldKey))).toBeTruthy();
+        });
     });
 
-    test('last column', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const lastInputColumn = queryModel.queryInfo.getInsertColumns().last();
-        const updates = removeColumn(
-            editorModel,
-            queryModel.queryInfo,
-            fromJS(queryModel.rows),
-            lastInputColumn.fieldKey
-        );
+    describe('removeColumn', () => {
+        test('column not found', () => {
+            const updates = removeColumn(editorModel, queryModel.queryInfo, fromJS(queryModel.rows), 'Modified'); // not an insert column, so cannot be removed
+            expect(updates.editorModelChanges).toBe(undefined);
+        });
 
-        expect(updates.editorModelChanges.cellMessages.size).toBe(1);
-        expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
-        expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('S-2');
-        expect(updates.editorModelChanges.cellValues.has('5-0')).toBe(false);
-        expect(updates.data.find(row => row.has(lastInputColumn.fieldKey))).toBeFalsy();
-    });
+        test('first column', () => {
+            const firstInputColumn = queryModel.queryInfo.getInsertColumns().first();
+            const updates = removeColumn(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                firstInputColumn.fieldKey
+            );
 
-    test('middle column', () => {
-        const editorModel = new EditorModel({ id: queryModel.id }).merge(editableGridWithData) as EditorModel;
-        const updates = removeColumn(editorModel, queryModel.queryInfo, fromJS(queryModel.rows), 'Description');
+            expect(updates.editorModelChanges.cellMessages.size).toBe(1);
+            expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('Description 1');
+            expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('Description 2');
+            expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
+            expect(updates.editorModelChanges.columns.find(fieldKey => fieldKey === firstInputColumn.fieldKey)).toBeUndefined();
+            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
+            expect(updates.data.find(row => row.has(firstInputColumn.fieldKey))).toBeFalsy();
+        });
 
-        expect(updates.editorModelChanges.cellMessages.size).toBe(0);
-        expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
-        expect(updates.editorModelChanges.cellValues.has('1-0')).toBe(false);
-        expect(updates.data.find(row => row.has('Description'))).toBeFalsy();
+        test('last column', () => {
+            const lastInputColumn = queryModel.queryInfo.getInsertColumns().last();
+            const updates = removeColumn(
+                editorModel,
+                queryModel.queryInfo,
+                fromJS(queryModel.rows),
+                lastInputColumn.fieldKey
+            );
+
+            expect(updates.editorModelChanges.cellMessages.size).toBe(1);
+            expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
+            expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('S-2');
+            expect(updates.editorModelChanges.cellValues.has('5-0')).toBe(false);
+            expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
+            expect(updates.editorModelChanges.columns.find(fieldKey => fieldKey === lastInputColumn.fieldKey)).toBeUndefined();
+            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
+            expect(updates.data.find(row => row.has(lastInputColumn.fieldKey))).toBeFalsy();
+        });
+
+        test('middle column', () => {
+            const fieldKey = 'Description';
+            const updates = removeColumn(editorModel, queryModel.queryInfo, fromJS(queryModel.rows), fieldKey);
+
+            expect(updates.editorModelChanges.cellMessages.size).toBe(0);
+            expect(updates.editorModelChanges.cellValues.get('0-0').get(0).display).toBe('S-1');
+            expect(updates.editorModelChanges.cellValues.has('1-0')).toBe(false);
+            expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
+            expect(updates.editorModelChanges.columns.find(fk => fk === fieldKey)).toBeUndefined();
+            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
+            expect(updates.data.find(row => row.has(fieldKey))).toBeFalsy();
+        });
     });
 });
 
@@ -498,7 +523,7 @@ describe('getExportParams', () => {
 });
 
 describe('generateFillSequence', () => {
-    const editorModel = new EditorModel({ id: queryModel.id }).merge({
+    const editorModel = new EditorModel({ id: 'generate|fill|sequence' }).merge({
         cellMessages: Map<string, CellMessage>({
             '1-0': 'description 1 message',
         }),

--- a/packages/components/src/internal/actions.spec.ts
+++ b/packages/components/src/internal/actions.spec.ts
@@ -92,7 +92,6 @@ describe('column mutation actions', () => {
             ]),
         }),
         columns: insertColumnFieldKeys,
-        colCount: insertColumnFieldKeys.size,
         id: 'insert-samples|samples/sample set 2',
         isPasting: false,
         focusColIdx: 1,
@@ -180,7 +179,6 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.cellValues.get('2-1').get(0).display).toBe('Description 2');
             expect(updates.editorModelChanges.columns.get(0)).toEqual(queryColumn.fieldKey);
             expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size + 1);
-            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
             expect(updates.queryInfo.getColumnIndex('Description')).toBe(
                 queryModel.queryInfo.getColumnIndex('Description') + 1
             );
@@ -206,7 +204,6 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.columns.get(updates.editorModelChanges.columns.size - 1)).toEqual(
                 queryColumn.fieldKey
             );
-            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
             expect(updates.queryInfo.getColumnIndex('description')).toBe(
                 queryModel.queryInfo.getColumnIndex('description')
             );
@@ -236,7 +233,6 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.columns.findIndex(fieldKey => fieldKey === queryColumn.fieldKey)).toEqual(
                 updates.editorModelChanges.columns.findIndex(fieldKey => fieldKey === 'Name') + 1
             );
-            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
 
             expect(updates.queryInfo.getColumnIndex('name')).toBe(nameColIndex);
             expect(updates.queryInfo.getColumnIndex('description')).toBe(
@@ -311,7 +307,6 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.cellValues.get('0-1').get(0).display).toBe('Description 2');
             expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
             expect(updates.editorModelChanges.columns.find(fieldKey => fieldKey === firstInputColumn.fieldKey)).toBeUndefined();
-            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
             expect(updates.data.find(row => row.has(firstInputColumn.fieldKey))).toBeFalsy();
         });
 
@@ -330,7 +325,6 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.cellValues.has('5-0')).toBe(false);
             expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
             expect(updates.editorModelChanges.columns.find(fieldKey => fieldKey === lastInputColumn.fieldKey)).toBeUndefined();
-            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
             expect(updates.data.find(row => row.has(lastInputColumn.fieldKey))).toBeFalsy();
         });
 
@@ -343,7 +337,6 @@ describe('column mutation actions', () => {
             expect(updates.editorModelChanges.cellValues.has('1-0')).toBe(false);
             expect(updates.editorModelChanges.columns.size).toEqual(editorModel.columns.size - 1);
             expect(updates.editorModelChanges.columns.find(fk => fk === fieldKey)).toBeUndefined();
-            expect(updates.editorModelChanges.colCount).toEqual(updates.editorModelChanges.columns.size);
             expect(updates.data.find(row => row.has(fieldKey))).toBeFalsy();
         });
     });
@@ -619,7 +612,7 @@ describe('generateFillSequence', () => {
                 },
             ]),
         }),
-        colCount: 5,
+        columns: List(['a', 'b', 'c', 'd', 'e']),
         rowCount: 10,
     }) as EditorModel;
 

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1226,7 +1226,7 @@ function validatePaste(
     ) {
         paste.success = false;
         paste.message = 'Unable to paste. Paste is not supported against multiple selections.';
-    } else if (coordinates.colMax >= model.colCount) {
+    } else if (coordinates.colMax >= model.columns.size) {
         paste.success = false;
         paste.message = 'Unable to paste. Cannot paste columns beyond the columns found in the grid.';
     } else if (coordinates.rowMax - coordinates.rowMin > maxRowPaste) {
@@ -1417,7 +1417,6 @@ export function removeColumn(
     return {
         editorModelChanges: {
             columns,
-            colCount: editorModel.colCount - 1,
             focusColIdx: -1,
             focusRowIdx: -1,
             selectedColIdx: -1,
@@ -1515,7 +1514,6 @@ export function addColumns(
     return {
         editorModelChanges: {
             columns,
-            colCount: editorModel.colCount + queryColumns.size,
             focusColIdx: -1,
             focusRowIdx: -1,
             selectedColIdx: -1,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -1311,11 +1311,8 @@ export function changeColumn(
     // nothing to do if there is no such column
     if (colIndex === -1) return {};
 
-    let newCellMessages = editorModel.cellMessages;
-    let newCellValues = editorModel.cellValues;
-
     // get rid of existing messages and values at the designated index.
-    newCellMessages = newCellMessages.reduce((cellMessages, message, cellKey) => {
+    const newCellMessages = editorModel.cellMessages.reduce((cellMessages, message, cellKey) => {
         const [oldColIdx] = cellKey.split('-').map(v => parseInt(v, 10));
         if (oldColIdx !== colIndex) {
             return cellMessages.set(cellKey, message);
@@ -1324,7 +1321,7 @@ export function changeColumn(
         return cellMessages;
     }, Map<string, CellMessage>());
 
-    newCellValues = newCellValues.reduce((cellValues, value, cellKey) => {
+    const newCellValues = editorModel.cellValues.reduce((cellValues, value, cellKey) => {
         const [oldColIdx] = cellKey.split('-').map(v => parseInt(v, 10));
 
         if (oldColIdx !== colIndex) {
@@ -1385,10 +1382,7 @@ export function removeColumn(
     // nothing to do if there is no such column
     if (deleteIndex === -1) return {};
 
-    let newCellMessages = editorModel.cellMessages;
-    let newCellValues = editorModel.cellValues;
-
-    newCellMessages = newCellMessages.reduce((cellMessages, message, cellKey) => {
+    const newCellMessages = editorModel.cellMessages.reduce((cellMessages, message, cellKey) => {
         const [oldColIdx, oldRowIdx] = cellKey.split('-').map(v => parseInt(v, 10));
         if (oldColIdx > deleteIndex) {
             return cellMessages.set([oldColIdx - 1, oldRowIdx].join('-'), message);
@@ -1399,7 +1393,7 @@ export function removeColumn(
         return cellMessages;
     }, Map<string, CellMessage>());
 
-    newCellValues = newCellValues.reduce((cellValues, value, cellKey) => {
+    const newCellValues = editorModel.cellValues.reduce((cellValues, value, cellKey) => {
         const [oldColIdx, oldRowIdx] = cellKey.split('-').map(v => parseInt(v, 10));
 
         if (oldColIdx > deleteIndex) {
@@ -1470,10 +1464,7 @@ export function addColumns(
 
     if (editorColIndex < 0 || editorColIndex > queryInfo.columns.size) return {};
 
-    let newCellMessages = editorModel.cellMessages;
-    let newCellValues = editorModel.cellValues;
-
-    newCellMessages = newCellMessages.reduce((cellMessages, message, cellKey) => {
+    const newCellMessages = editorModel.cellMessages.reduce((cellMessages, message, cellKey) => {
         const [oldColIdx, oldRowIdx] = cellKey.split('-').map(v => parseInt(v, 10));
         if (oldColIdx >= editorColIndex) {
             return cellMessages.set([oldColIdx + queryColumns.size, oldRowIdx].join('-'), message);
@@ -1484,7 +1475,7 @@ export function addColumns(
         return cellMessages;
     }, Map<string, CellMessage>());
 
-    newCellValues = newCellValues.reduce((cellValues, value, cellKey) => {
+    let newCellValues = editorModel.cellValues.reduce((cellValues, value, cellKey) => {
         const [oldColIdx, oldRowIdx] = cellKey.split('-').map(v => parseInt(v, 10));
 
         if (oldColIdx >= editorColIndex) {
@@ -1495,6 +1486,7 @@ export function addColumns(
 
         return cellValues;
     }, Map<string, List<ValueDescriptor>>());
+
     for (let rowIdx = 0; rowIdx < editorModel.rowCount; rowIdx++) {
         for (let c = 0; c < queryColumns.size; c++) {
             newCellValues = newCellValues.set(genCellKey(editorColIndex + c, rowIdx), List<ValueDescriptor>());

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -1,4 +1,4 @@
-import { fromJS, List, Map, OrderedMap, Record } from 'immutable';
+import { List, Map, OrderedMap, Record } from 'immutable';
 import { AssayDOM } from '@labkey/api';
 
 import { AssayUploadTabs } from '../../constants';
@@ -204,7 +204,7 @@ export class AssayWizardModel
         } else if (this.isGridTab(currentStep)) {
             // need to get the EditorModel for the data to use in the import
             assayData.dataRows = editorModel
-                .getRawDataFromGridData(fromJS(queryModel.rows), fromJS(queryModel.orderedRows), queryModel.queryInfo)
+                .getRawDataFromModel(queryModel)
                 .valueSeq()
                 .map(row => row.filter(v => v !== undefined && v !== null && ('' + v).trim() !== ''))
                 .toList()

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -405,27 +405,13 @@ export class Cell extends React.PureComponent<Props, State> {
             );
         }
 
-        // Some cells have custom displays such as multi value comma separated values like alias so
-        // first check renderer for editable value
-        let renderer;
-        let defaultValue;
-        if (col.columnRenderer) {
-            renderer = getQueryColumnRenderers()[col.columnRenderer.toLowerCase()];
-        }
-
-        if (renderer?.getEditableValue) {
-            defaultValue = renderer.getEditableValue(values);
-        }
-
-        if (defaultValue === undefined) {
-            defaultValue = values.size === 0 ? '' : values.first().display !== undefined ? values.first().display : '';
-        }
-
         return (
             <input
                 autoFocus
                 className="cellular-input"
-                defaultValue={defaultValue}
+                defaultValue={
+                    values.size === 0 ? '' : values.first().display !== undefined ? values.first().display : ''
+                }
                 disabled={this.isReadOnly()}
                 onBlur={this.handleBlur}
                 onChange={this.handleChange}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -439,7 +439,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
     applySelection = (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES): Partial<EditorModel> => {
         const { editorModel } = this.props;
-        const { colCount, rowCount } = editorModel;
+        const { rowCount } = editorModel;
         let selectionCells = Set<string>();
         const hasSelection = editorModel.hasSelection();
         let selectedColIdx = colIdx;
@@ -447,7 +447,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
         switch (selection) {
             case SELECTION_TYPES.ALL:
-                for (let c = 0; c < colCount; c++) {
+                for (let c = 0; c < editorModel.columns.size; c++) {
                     for (let r = 0; r < rowCount; r++) {
                         selectionCells = selectionCells.add(genCellKey(c, r));
                     }
@@ -460,7 +460,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 if (hasSelection) {
                     const upperLeft = [Math.min(selectedColIdx, colIdx), Math.min(selectedRowIdx, rowIdx)];
                     const bottomRight = [Math.max(selectedColIdx, colIdx), Math.max(selectedRowIdx, rowIdx)];
-                    const maxColumn = Math.min(bottomRight[0], colCount - 1);
+                    const maxColumn = Math.min(bottomRight[0], editorModel.columns.size - 1);
                     const maxRow = Math.min(bottomRight[1], rowCount - 1);
 
                     for (let c = upperLeft[0]; c <= maxColumn; c++) {
@@ -488,9 +488,9 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
     selectCell = (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES, resetValue?: boolean): void => {
         const { editorModel, onChange } = this.props;
-        const { cellValues, colCount, focusValue, rowCount } = editorModel;
+        const { cellValues, focusValue, rowCount } = editorModel;
 
-        if (colIdx < 0 || rowIdx < 0 || colIdx >= colCount) {
+        if (colIdx < 0 || rowIdx < 0 || colIdx >= editorModel.columns.size) {
             // out of bounds, do nothing
             return;
         }
@@ -837,7 +837,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                         nextCol = found.colIdx;
                         nextRow = found.rowIdx;
                     } else {
-                        nextCol = editorModel.colCount - 1;
+                        nextCol = editorModel.columns.size - 1;
                         nextRow = rowIdx;
                     }
                 } else {
@@ -868,7 +868,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 break;
 
             case Key.END:
-                nextCol = editorModel.colCount - 1;
+                nextCol = editorModel.columns.size - 1;
                 nextRow = rowIdx;
                 break;
 

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -1,5 +1,5 @@
 import React, { FC, memo, useCallback, useMemo, useState } from 'react';
-import { fromJS, List, Map, OrderedMap } from 'immutable';
+import { fromJS, List, Map } from 'immutable';
 import classNames from 'classnames';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
@@ -16,7 +16,7 @@ import { EditorModel, EditorModelProps } from './models';
 
 import { EditableGrid, SharedEditableGridPanelProps } from './EditableGrid';
 
-import { exportEditedData, getEditorTableData } from './utils';
+import { exportEditedData, getEditorExportData } from './utils';
 
 interface Props extends SharedEditableGridPanelProps {
     editorModel: EditorModel | EditorModel[];
@@ -43,30 +43,16 @@ const exportHandler = (
     extraColumns?: Array<Partial<QueryColumn>>,
     colFilter?: (col: QueryColumn) => boolean
 ): void => {
-    let headings = OrderedMap<string, string>();
-    let editorData = OrderedMap<string, Map<string, any>>();
-    models.forEach((queryModel, idx) => {
-        const [modelHeadings, modelEditorData] = getEditorTableData(
-            editorModels[idx],
-            queryModel,
-            headings,
-            editorData,
-            readOnlyColumns,
-            insertColumns,
-            updateColumns,
-            forUpdate,
-            extraColumns,
-            colFilter,
-            true
-        );
-        headings = modelHeadings;
-        editorData = modelEditorData;
-    });
-
-    const rows = [];
-    editorData.forEach(rowMap => rows.push([...rowMap.toArray().values()]));
-    const exportData = [headings.toArray(), ...rows];
-
+    const exportData = getEditorExportData(
+        editorModels,
+        models,
+        readOnlyColumns,
+        insertColumns,
+        updateColumns,
+        forUpdate,
+        extraColumns,
+        colFilter
+    );
     exportEditedData(exportType, 'data', exportData, models[activeTab]);
 };
 

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
@@ -54,7 +54,7 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
         this.state = {
             isSubmitting: false,
             dataModels: [new QueryModel({ id, schemaQuery: props.queryModel.schemaQuery })],
-            editorModels: [new EditorModel({ id })],
+            editorModels: [new EditorModel({ id, loader: props.loader })],
             error: undefined,
         };
     }
@@ -64,12 +64,10 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
     }
 
     initEditorModel = async (): Promise<void> => {
-        const { queryModel, loader } = this.props;
         const { dataModels, editorModels } = await initEditableGridModels(
             this.state.dataModels,
             this.state.editorModels,
-            queryModel,
-            [loader]
+            this.props.queryModel
         );
         this.setState({ dataModels, editorModels });
     };

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
@@ -102,14 +102,7 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
 
         const gridDataAllTabs = [];
         dataModels.forEach((model, ind) => {
-            const gridData = getUpdatedDataFromEditableGrid(
-                dataModels,
-                editorModels,
-                idField,
-                undefined,
-                selectionData,
-                ind
-            );
+            const gridData = getUpdatedDataFromEditableGrid(dataModels, editorModels, idField, selectionData, ind);
             if (gridData) {
                 gridDataAllTabs.push(gridData);
             }

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
@@ -39,6 +39,7 @@ interface State {
     editorModels: EditorModel[];
     error: string;
     isSubmitting: boolean;
+    loaders: IEditableGridLoader[];
 }
 
 export class EditableGridPanelForUpdate extends React.Component<Props, State> {
@@ -54,8 +55,9 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
         this.state = {
             isSubmitting: false,
             dataModels: [new QueryModel({ id, schemaQuery: props.queryModel.schemaQuery })],
-            editorModels: [new EditorModel({ id, loader: props.loader })],
+            editorModels: [new EditorModel({ id })],
             error: undefined,
+            loaders: [props.loader],
         };
     }
 
@@ -67,6 +69,7 @@ export class EditableGridPanelForUpdate extends React.Component<Props, State> {
         const { dataModels, editorModels } = await initEditableGridModels(
             this.state.dataModels,
             this.state.editorModels,
+            this.state.loaders,
             this.props.queryModel
         );
         this.setState({ dataModels, editorModels });

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
@@ -123,8 +123,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
                     const { dataModels, editorModels } = await initEditableGridModels(
                         editableGridModels.dataModels,
                         editableGridModels.editorModels,
-                        queryModel,
-                        extraExportColumns
+                        queryModel
                     );
                     setEditableGridModels({ dataModels, editorModels });
                 } catch (e) {
@@ -132,7 +131,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
                 }
             })();
         }
-    }, [loaders, queryModel, editableGridModels, extraExportColumns, createNotification]);
+    }, [loaders, queryModel, editableGridModels, createNotification]);
 
     const onGridChange = useCallback(
         (

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
@@ -101,7 +101,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
         const editorModels = [];
         loaders.forEach(loader => {
             dataModels.push(new QueryModel({ id: loader.id, schemaQuery: queryModel.schemaQuery }));
-            editorModels.push(new EditorModel({ id: loader.id }));
+            editorModels.push(new EditorModel({ id: loader.id, loader }));
         });
 
         setIsSubmitting(false);
@@ -117,30 +117,20 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
     }, [loaders, parentDataTypes, queryModel.schemaQuery]);
 
     useEffect(() => {
-        const initEditorModel = async (): Promise<{
-            dataModels: QueryModel[];
-            editorModels: EditorModel[];
-        }> => {
-            return await initEditableGridModels(
-                editableGridModels.dataModels,
-                editableGridModels.editorModels,
-                queryModel,
-                loaders,
-                extraExportColumns
-            );
-        };
-
         if (loaders && editableGridModels?.dataModels?.find(dataModel => dataModel.isLoading)) {
-            initEditorModel()
-                .then(models => {
-                    setEditableGridModels(models);
-                })
-                .catch(error => {
-                    createNotification({
-                        message: error,
-                        alertClass: 'danger',
-                    });
-                });
+            (async () => {
+                try {
+                    const { dataModels, editorModels } = await initEditableGridModels(
+                        editableGridModels.dataModels,
+                        editableGridModels.editorModels,
+                        queryModel,
+                        extraExportColumns
+                    );
+                    setEditableGridModels({ dataModels, editorModels });
+                } catch (e) {
+                    createNotification({ alertClass: 'danger', message: e });
+                }
+            })();
         }
     }, [loaders, queryModel, editableGridModels, extraExportColumns, createNotification]);
 
@@ -349,7 +339,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
             <WizardNavButtons
                 cancel={onCancel}
                 nextStep={onSubmit}
-                finish={true}
+                finish
                 isFinishing={isSubmitting}
                 isFinishingText="Updating..."
                 isFinishedText="Finished Updating"

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
@@ -101,7 +101,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
         const editorModels = [];
         loaders.forEach(loader => {
             dataModels.push(new QueryModel({ id: loader.id, schemaQuery: queryModel.schemaQuery }));
-            editorModels.push(new EditorModel({ id: loader.id, loader }));
+            editorModels.push(new EditorModel({ id: loader.id }));
         });
 
         setIsSubmitting(false);
@@ -123,6 +123,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
                     const { dataModels, editorModels } = await initEditableGridModels(
                         editableGridModels.dataModels,
                         editableGridModels.editorModels,
+                        loaders,
                         queryModel
                     );
                     setEditableGridModels({ dataModels, editorModels });

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdateWithLineage.tsx
@@ -164,7 +164,6 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
                 editableGridModels.dataModels,
                 editableGridModels.editorModels,
                 idField,
-                readOnlyColumns,
                 selectionData,
                 ind
             );
@@ -190,7 +189,7 @@ export const EditableGridPanelForUpdateWithLineage: FC<EditableGridPanelForUpdat
             setIsSubmitting(false);
             onComplete();
         }
-    }, [editableGridModels, idField, onComplete, readOnlyColumns, selectionData, updateAllTabRows]);
+    }, [editableGridModels, idField, onComplete, selectionData, updateAllTabRows]);
 
     const getCurrentTab = useCallback(
         (tabInd: number): number => {

--- a/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.spec.ts
+++ b/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.spec.ts
@@ -67,8 +67,8 @@ describe('getLineageEditorUpdateColumns', () => {
         expect(cols.queryInfoColumns.get('rowid')).toBeDefined();
         expect(cols.queryInfoColumns.get('name')).toBeDefined();
         expect(cols.queryInfoColumns.get('other')).toBeUndefined();
-        expect(cols.queryInfoColumns.get('MaterialInputs/Test1')).toBeDefined();
-        expect(cols.queryInfoColumns.get('DataInputs/Test2')).toBeDefined();
+        expect(cols.queryInfoColumns.get('materialinputs/test1')).toBeDefined();
+        expect(cols.queryInfoColumns.get('datainputs/test2')).toBeDefined();
         expect(cols.columns.size).toBe(3);
         expect(cols.columns.get(0).get('fieldKey')).toBe('name');
         expect(cols.columns.get(1).get('fieldKey')).toBe('DataInputs/Test2');

--- a/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.tsx
+++ b/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.tsx
@@ -37,8 +37,8 @@ export function getLineageEditorUpdateColumns(
                 queryModel.schemaName
             );
 
-            if (!parentColumns[parentCol.fieldKey]) {
-                parentColumns[parentCol.fieldKey] = parentCol;
+            if (!parentColumns[parentCol.fieldKey.toLowerCase()]) {
+                parentColumns[parentCol.fieldKey.toLowerCase()] = parentCol;
                 parentColIndex++;
             }
         });

--- a/packages/components/src/internal/components/editable/models.spec.ts
+++ b/packages/components/src/internal/components/editable/models.spec.ts
@@ -81,24 +81,12 @@ const QUERY_INFO = QueryInfo.fromJSON({
 });
 
 describe('EditorModel', () => {
+    const queryInfo = QueryInfo.fromJSON(sampleSet2QueryInfo);
+
     describe('data validation', () => {
         test('no data', () => {
-            const emptyEditorGridData = {
-                cellMessages: Map<string, CellMessage>(),
-                cellValues: Map<string, List<ValueDescriptor>>(),
-                colCount: 5,
-                id: 'insert-samples|samples/sample set 2',
-                isPasting: false,
-                focusColIdx: -1,
-                focusRowIdx: -1,
-                numPastedRows: 0,
-                rowCount: 0,
-                selectedColIdx: -1,
-                selectedRowIdx: -1,
-                selectionCells: [],
-            };
-            const editorModel = new EditorModel(emptyEditorGridData);
-            const emptyDataModel = makeTestQueryModel(schemaQ, QueryInfo.fromJSON(sampleSet2QueryInfo), {}, [], 0);
+            const editorModel = new EditorModel({ id: 'insert-samples|samples/sample set 2' });
+            const emptyDataModel = makeTestQueryModel(schemaQ, queryInfo, {}, [], 0);
             const { uniqueKeyViolations, missingRequired } = editorModel.validateData(emptyDataModel, 'Name');
             expect(uniqueKeyViolations.isEmpty()).toBe(true);
             expect(missingRequired.isEmpty()).toBe(true);
@@ -107,7 +95,7 @@ describe('EditorModel', () => {
         });
 
         test('valid data', () => {
-            const editableGridData = {
+            const editorModel = new EditorModel({
                 cellMessages: Map<string, CellMessage>({
                     '1-0': 'description 1 message',
                 }),
@@ -159,11 +147,10 @@ describe('EditorModel', () => {
                 selectedColIdx: 1,
                 selectedRowIdx: 1,
                 selectionCells: [],
-            };
-            const editorModel = new EditorModel(editableGridData);
+            });
             const dataModel = makeTestQueryModel(
                 schemaQ,
-                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                queryInfo,
                 {
                     '1': {
                         RequiredData: 'Grid Requirement 1',
@@ -182,7 +169,7 @@ describe('EditorModel', () => {
         });
 
         test('missing required data', () => {
-            const editableGridData = {
+            const editorModel = new EditorModel({
                 cellMessages: Map<string, CellMessage>({
                     '1-0': 'description 1 message',
                 }),
@@ -234,11 +221,10 @@ describe('EditorModel', () => {
                 selectedColIdx: 1,
                 selectedRowIdx: 1,
                 selectionCells: [],
-            };
-            const editorModel = new EditorModel(editableGridData);
+            });
             const dataModel = makeTestQueryModel(
                 schemaQ,
-                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                queryInfo,
                 {
                     '1': {
                         Description: 'grid S-1 Description',
@@ -266,7 +252,7 @@ describe('EditorModel', () => {
         });
 
         test('unique key violations', () => {
-            const editableGridData = {
+            const editorModel = new EditorModel({
                 cellMessages: Map<string, CellMessage>({
                     '1-0': 'description 1 message',
                 }),
@@ -366,11 +352,10 @@ describe('EditorModel', () => {
                 selectedColIdx: 1,
                 selectedRowIdx: 1,
                 selectionCells: [],
-            };
-            const editorModel = new EditorModel(editableGridData);
+            });
             const dataModel = makeTestQueryModel(
                 schemaQ,
-                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                queryInfo,
                 {
                     '1': {},
                     '2': {},
@@ -407,7 +392,7 @@ describe('EditorModel', () => {
         });
 
         test('missing required and unique key violations', () => {
-            const editableGridData = {
+            const editorModel = new EditorModel({
                 cellMessages: Map<string, CellMessage>({
                     '1-0': 'description 1 message',
                 }),
@@ -473,11 +458,10 @@ describe('EditorModel', () => {
                 selectedColIdx: 1,
                 selectedRowIdx: 1,
                 selectionCells: [],
-            };
-            const editorModel = new EditorModel(editableGridData);
+            });
             const dataModel = makeTestQueryModel(
                 schemaQ,
-                QueryInfo.fromJSON(sampleSet2QueryInfo),
+                queryInfo,
                 {
                     '1': {},
                     '2': {},

--- a/packages/components/src/internal/components/editable/models.spec.ts
+++ b/packages/components/src/internal/components/editable/models.spec.ts
@@ -137,7 +137,7 @@ describe('EditorModel', () => {
                         },
                     ]),
                 }),
-                colCount: 5,
+                columns: List(['a', 'b', 'c', 'd', 'e']),
                 id: 'insert-samples|samples/sample set 2',
                 isPasting: false,
                 focusColIdx: 1,
@@ -211,7 +211,7 @@ describe('EditorModel', () => {
                         },
                     ]),
                 }),
-                colCount: 5,
+                columns: List(['a', 'b', 'c', 'd', 'e']),
                 id: 'insert-samples|samples/sample set 2',
                 isPasting: false,
                 focusColIdx: 1,
@@ -342,7 +342,7 @@ describe('EditorModel', () => {
                         },
                     ]),
                 }),
-                colCount: 5,
+                columns: List(['a', 'b', 'c', 'd', 'e']),
                 id: 'insert-samples|samples/sample set 2',
                 isPasting: false,
                 focusColIdx: 1,
@@ -448,7 +448,7 @@ describe('EditorModel', () => {
                     ]),
                     // missing RequiredData for row index 4
                 }),
-                colCount: 5,
+                columns: List(['a', 'b', 'c', 'd', 'e']),
                 id: 'insert-samples|samples/sample set 2',
                 isPasting: false,
                 focusColIdx: 1,
@@ -875,7 +875,7 @@ describe('EditorModel', () => {
         });
 
         test('isInBounds', () => {
-            const model = new EditorModel({ colCount: 1, rowCount: 1 });
+            const model = new EditorModel({ columns: List(['a']), rowCount: 1 });
             expect(model.isInBounds(-1, -1)).toBeFalsy();
             expect(model.isInBounds(0, -1)).toBeFalsy();
             expect(model.isInBounds(-1, 0)).toBeFalsy();

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -93,7 +93,6 @@ export class EditorModel
         focusValue: undefined,
         id: undefined,
         isPasting: false,
-        loader: undefined,
         numPastedRows: 0,
         rowCount: 0,
         selectedColIdx: -1,
@@ -112,7 +111,6 @@ export class EditorModel
     declare focusValue: List<ValueDescriptor>;
     declare id: string;
     declare isPasting: boolean;
-    declare loader: IEditableGridLoader;
     declare numPastedRows: number;
     declare rowCount: number;
     declare selectedColIdx: number;

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -173,8 +173,6 @@ export class EditorModel
         queryModel: QueryModel,
         displayValues?: boolean,
         forUpdate?: boolean,
-        readOnlyColumns?: List<string>,
-        extraColumns?: Array<Partial<QueryColumn>>,
         forExport?: boolean
     ): List<Map<string, any>> {
         return this.getRawDataFromGridData(
@@ -183,8 +181,6 @@ export class EditorModel
             queryModel.queryInfo,
             displayValues,
             forUpdate,
-            readOnlyColumns,
-            extraColumns,
             forExport
         );
     }
@@ -196,24 +192,15 @@ export class EditorModel
         queryInfo: QueryInfo,
         displayValues = true,
         forUpdate = false,
-        readOnlyColumns?: List<string>,
-        extraColumns?: Array<Partial<QueryColumn>>,
         forExport?: boolean
     ): List<Map<string, any>> {
         let rawData = List<Map<string, any>>();
-        let columnMap = this.columns.reduce((map, fieldKey) => {
+        const columnMap = this.columns.reduce((map, fieldKey) => {
             const col = queryInfo.getColumn(fieldKey);
             // Log a warning but still retain the key in the map for column order
             if (!col) console.warn(`Unable to resolve column "${fieldKey}". Cannot retrieve raw data.`);
             return map.set(fieldKey, col);
         }, OrderedMap<string, QueryColumn>());
-
-        extraColumns?.forEach(col => {
-            const column = queryInfo.getColumn(col.fieldKey);
-            if (column && !columnMap.has(column.fieldKey)) {
-                columnMap = columnMap.set(col.fieldKey, column);
-            }
-        });
 
         for (let rn = 0; rn < dataKeys.size; rn++) {
             let row = Map<string, any>();
@@ -254,7 +241,7 @@ export class EditorModel
                                 return arr;
                             }, [])
                         );
-                    } else if (col.lookup.displayColumn == col.lookup.keyColumn) {
+                    } else if (col.lookup.displayColumn === col.lookup.keyColumn) {
                         row = row.set(
                             col.name,
                             values.size === 1 ? quoteValueWithDelimiters(values.first()?.display, ',') : undefined

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -45,7 +45,6 @@ export interface EditorModelProps {
     cellMessages: CellMessages;
     cellValues: CellValues;
     columns: List<string>;
-    colCount: number;
     focusColIdx: number;
     focusRowIdx: number;
     focusValue: List<ValueDescriptor>;
@@ -86,7 +85,6 @@ export class EditorModel
         cellMessages: Map<string, CellMessage>(),
         cellValues: Map<string, List<ValueDescriptor>>(),
         columns: List<string>(),
-        colCount: 0,
         deletedIds: Set<any>(),
         focusColIdx: -1,
         focusRowIdx: -1,
@@ -104,7 +102,6 @@ export class EditorModel
     declare cellMessages: CellMessages;
     declare cellValues: CellValues;
     declare columns: List<string>;
-    declare colCount: number;
     declare deletedIds: Set<any>;
     declare focusColIdx: number;
     declare focusRowIdx: number;
@@ -453,7 +450,7 @@ export class EditorModel
     }
 
     isInBounds(colIdx: number, rowIdx: number): boolean {
-        return colIdx >= 0 && colIdx < this.colCount && rowIdx >= 0 && rowIdx < this.rowCount;
+        return colIdx >= 0 && colIdx < this.columns.size && rowIdx >= 0 && rowIdx < this.rowCount;
     }
 
     inSelection(colIdx: number, rowIdx: number): boolean {

--- a/packages/components/src/internal/components/editable/utils.spec.ts
+++ b/packages/components/src/internal/components/editable/utils.spec.ts
@@ -77,8 +77,7 @@ describe('Editable Grids Utils', () => {
                 '2-2': List([]),
                 '3-1': List([]),
             }),
-            columns: ['SampleID', 'ParticipantID', 'VisitID', 'Date'],
-            colCount: 4,
+            columns: List(['SampleID', 'ParticipantID', 'VisitID', 'Date']),
             id: MODEL_ID_LOADED,
         });
         const extraColumns = [
@@ -128,7 +127,6 @@ describe('Editable Grids Utils', () => {
             expect(models.dataModel.rowsLoadingState).toEqual(LoadingState.LOADED);
             expect(models.editorModel.cellValues.size).toEqual(0);
             expect(models.editorModel.columns.toArray()).toEqual(expectedInsertColumns);
-            expect(models.editorModel.colCount).toEqual(expectedInsertColumns.length);
         });
 
         test('respects loader mode for columns', async () => {
@@ -141,7 +139,6 @@ describe('Editable Grids Utils', () => {
 
             const models = await initEditableGridModel(dataModel, editorModel, loader, dataModel);
             expect(models.editorModel.columns.toArray()).toEqual(expectedUpdateColumns);
-            expect(models.editorModel.colCount).toEqual(expectedUpdateColumns.length);
         });
 
         test('respects loader supplied columns', async () => {

--- a/packages/components/src/internal/components/editable/utils.spec.ts
+++ b/packages/components/src/internal/components/editable/utils.spec.ts
@@ -9,10 +9,11 @@ import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 
 import { QueryInfo } from '../../../public/QueryInfo';
 
+import { QueryColumn } from '../../../public/QueryColumn';
+
 import { EditorMode, EditorModel, IEditableGridLoader, ValueDescriptor } from './models';
 
 import { getEditorExportData, initEditableGridModel } from './utils';
-import { QueryColumn } from '../../../public/QueryColumn';
 
 const MODEL_ID_LOADED = 'loaded';
 

--- a/packages/components/src/internal/components/editable/utils.spec.ts
+++ b/packages/components/src/internal/components/editable/utils.spec.ts
@@ -60,13 +60,13 @@ describe('Editable Grids Utils', () => {
 
         test('defaults to insert columns', async () => {
             const loader = new MockEditableGridLoader(queryInfo);
-            const editorModel = new EditorModel({ loader });
+            const editorModel = new EditorModel({});
             const expectedInsertColumns = queryInfo
                 .getInsertColumns()
                 .map(col => col.fieldKey)
                 .toArray();
 
-            const models = await initEditableGridModel(dataModel, editorModel, dataModel);
+            const models = await initEditableGridModel(dataModel, editorModel, loader, dataModel);
             expect(models.dataModel.queryInfoLoadingState).toEqual(LoadingState.LOADED);
             expect(models.dataModel.rowsLoadingState).toEqual(LoadingState.LOADED);
             expect(models.editorModel.cellValues.size).toEqual(0);
@@ -76,13 +76,13 @@ describe('Editable Grids Utils', () => {
 
         test('respects loader mode for columns', async () => {
             const loader = new MockEditableGridLoader(queryInfo, { mode: EditorMode.Update });
-            const editorModel = new EditorModel({ loader });
+            const editorModel = new EditorModel({});
             const expectedUpdateColumns = queryInfo
                 .getUpdateColumns()
                 .map(col => col.fieldKey)
                 .toArray();
 
-            const models = await initEditableGridModel(dataModel, editorModel, dataModel);
+            const models = await initEditableGridModel(dataModel, editorModel, loader, dataModel);
             expect(models.editorModel.columns.toArray()).toEqual(expectedUpdateColumns);
             expect(models.editorModel.colCount).toEqual(expectedUpdateColumns.length);
         });
@@ -90,9 +90,9 @@ describe('Editable Grids Utils', () => {
         test('respects loader supplied columns', async () => {
             const columns = List([queryInfo.getColumn('SampleID'), queryInfo.getColumn('Date')]);
             const loader = new MockEditableGridLoader(queryInfo, { columns });
-            const editorModel = new EditorModel({ loader });
+            const editorModel = new EditorModel({});
 
-            const models = await initEditableGridModel(dataModel, editorModel, dataModel);
+            const models = await initEditableGridModel(dataModel, editorModel, loader, dataModel);
             expect(models.editorModel.columns.toArray()).toEqual(columns.map(col => col.fieldKey).toArray());
         });
     });

--- a/packages/components/src/internal/components/editable/utils.spec.ts
+++ b/packages/components/src/internal/components/editable/utils.spec.ts
@@ -1,15 +1,39 @@
-import { List, OrderedMap } from 'immutable';
+import { List, Map, OrderedMap } from 'immutable';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { LoadingState } from '../../../public/LoadingState';
 
 import { ASSAY_WIZARD_MODEL } from '../../../test/data/constants';
 
-import { EditorModel } from './models';
+import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 
-import { getEditorTableData } from './utils';
+import { QueryInfo } from '../../../public/QueryInfo';
+
+import { EditorMode, EditorModel, IEditableGridLoader } from './models';
+
+import { getEditorTableData, initEditableGridModel } from './utils';
+import { QueryColumn } from '../../../public/QueryColumn';
 
 const MODEL_ID_LOADED = 'loaded';
+
+class MockEditableGridLoader implements IEditableGridLoader {
+    columns: List<QueryColumn>;
+    id: string;
+    mode = EditorMode.Insert;
+    queryInfo: QueryInfo;
+
+    constructor(queryInfo: QueryInfo, props?: Partial<IEditableGridLoader>) {
+        this.queryInfo = queryInfo;
+        this.columns = props?.columns;
+        this.id = props?.id ?? 'mockEditableGridLoader';
+        this.mode = props?.mode;
+    }
+
+    fetch = jest.fn().mockResolvedValue({
+        data: Map(),
+        dataIds: List(),
+    });
+}
 
 describe('Editable Grids Utils', () => {
     test('getEditorTableData', () => {
@@ -28,5 +52,62 @@ describe('Editable Grids Utils', () => {
         const [headings, rows] = getEditorTableData(editorModel, queryModel, OrderedMap(), OrderedMap());
 
         expect(headings.toArray()).toEqual(['SampleID', 'Participant ID', 'Visit ID', 'Date']);
+    });
+
+    describe('initEditableGridModel', () => {
+        const { queryInfo } = ASSAY_WIZARD_MODEL;
+        const dataModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);
+
+        test('defaults to insert columns', async () => {
+            const loader = new MockEditableGridLoader(queryInfo);
+            const editorModel = new EditorModel({ loader });
+            const expectedInsertColumns = queryInfo
+                .getInsertColumns()
+                .map(col => col.fieldKey)
+                .toArray();
+
+            const models = await initEditableGridModel(dataModel, editorModel, dataModel);
+            expect(models.dataModel.queryInfoLoadingState).toEqual(LoadingState.LOADED);
+            expect(models.dataModel.rowsLoadingState).toEqual(LoadingState.LOADED);
+            expect(models.editorModel.cellValues.size).toEqual(0);
+            expect(models.editorModel.columns.toArray()).toEqual(expectedInsertColumns);
+            expect(models.editorModel.colCount).toEqual(expectedInsertColumns.length);
+        });
+
+        test('respects loader mode for columns', async () => {
+            const loader = new MockEditableGridLoader(queryInfo, { mode: EditorMode.Update });
+            const editorModel = new EditorModel({ loader });
+            const expectedUpdateColumns = queryInfo
+                .getUpdateColumns()
+                .map(col => col.fieldKey)
+                .toArray();
+
+            const models = await initEditableGridModel(dataModel, editorModel, dataModel);
+            expect(models.editorModel.columns.toArray()).toEqual(expectedUpdateColumns);
+            expect(models.editorModel.colCount).toEqual(expectedUpdateColumns.length);
+        });
+
+        test('respects loader supplied columns', async () => {
+            const columns = List([queryInfo.getColumn('SampleID'), queryInfo.getColumn('Date')]);
+            const loader = new MockEditableGridLoader(queryInfo, { columns });
+            const editorModel = new EditorModel({ loader });
+
+            const models = await initEditableGridModel(dataModel, editorModel, dataModel);
+            expect(models.editorModel.columns.toArray()).toEqual(columns.map(col => col.fieldKey).toArray());
+        });
+
+        test('includes extra columns', async () => {
+            const columns = List([queryInfo.getColumn('Date')]);
+            const loader = new MockEditableGridLoader(queryInfo, { columns });
+            const editorModel = new EditorModel({ loader });
+            const extraColumns: Array<Partial<QueryColumn>> = [
+                { fieldKey: 'SampleID' },
+                { fieldKey: 'DoesNotExist' },
+                { fieldKey: 'Date' }, // duplicates are removed
+            ];
+
+            const models = await initEditableGridModel(dataModel, editorModel, dataModel, extraColumns);
+            expect(models.editorModel.columns.toArray()).toEqual(['Date', 'SampleID']);
+        });
     });
 });

--- a/packages/components/src/internal/components/editable/utils.spec.ts
+++ b/packages/components/src/internal/components/editable/utils.spec.ts
@@ -95,19 +95,5 @@ describe('Editable Grids Utils', () => {
             const models = await initEditableGridModel(dataModel, editorModel, dataModel);
             expect(models.editorModel.columns.toArray()).toEqual(columns.map(col => col.fieldKey).toArray());
         });
-
-        test('includes extra columns', async () => {
-            const columns = List([queryInfo.getColumn('Date')]);
-            const loader = new MockEditableGridLoader(queryInfo, { columns });
-            const editorModel = new EditorModel({ loader });
-            const extraColumns: Array<Partial<QueryColumn>> = [
-                { fieldKey: 'SampleID' },
-                { fieldKey: 'DoesNotExist' },
-                { fieldKey: 'Date' }, // duplicates are removed
-            ];
-
-            const models = await initEditableGridModel(dataModel, editorModel, dataModel, extraColumns);
-            expect(models.editorModel.columns.toArray()).toEqual(['Date', 'SampleID']);
-        });
     });
 });

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -89,7 +89,6 @@ export const loadEditorModelData = async (
     return {
         cellValues,
         columns: columns.map(col => col.fieldKey).toList(),
-        colCount: columns.size,
         deletedIds: Set<any>(),
         rowCount: orderedRows.length,
     };

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -31,7 +31,11 @@ export const loadEditorModelData = async (
 ): Promise<Partial<EditorModel>> => {
     const { orderedRows, rows, queryInfo } = queryModelData;
     let columns = editorColumns ?? queryInfo.getInsertColumns();
-    if (extraColumns?.length > 0) columns = columns.push(...extraColumns);
+    extraColumns?.forEach(extraCol => {
+        if (!columns.find(col => col.fieldKey === extraCol.fieldKey)) {
+            columns = columns.push(extraCol);
+        }
+    });
     const lookupValueDescriptors = await getLookupValueDescriptors(
         columns.toArray(),
         fromJS(rows),
@@ -298,7 +302,7 @@ export const getEditorTableData = (
     forExport?: boolean
 ): [Map<string, string>, Map<string, Map<string, any>>] => {
     const tabData = editorModel
-        .getRawDataFromModel(queryModel, true, forUpdate, readOnlyColumns, extraColumns, colFilter, forExport)
+        .getRawDataFromModel(queryModel, true, forUpdate, readOnlyColumns, extraColumns, forExport)
         .toArray();
 
     const columns = editorModel.getColumns(

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -15,7 +15,7 @@ import { EXPORT_TYPES, MODIFICATION_TYPES } from '../../constants';
 
 import { SelectInputOption, SelectInputProps } from '../forms/input/SelectInput';
 
-import { EditorMode, EditorModel, EditorModelProps, ValueDescriptor } from './models';
+import { EditorMode, EditorModel, EditorModelProps, IEditableGridLoader, ValueDescriptor } from './models';
 
 import { CellActions } from './constants';
 
@@ -98,9 +98,9 @@ export const loadEditorModelData = async (
 export const initEditableGridModel = async (
     dataModel: QueryModel,
     editorModel: EditorModel,
+    loader: IEditableGridLoader,
     queryModel: QueryModel
 ): Promise<{ dataModel: QueryModel; editorModel: EditorModel }> => {
-    const { loader } = editorModel;
     const response = await loader.fetch(queryModel);
     const gridData: Partial<QueryModel> = {
         rows: response.data.toJS(),
@@ -136,13 +136,14 @@ export interface EditableGridModels {
 export const initEditableGridModels = async (
     dataModels: QueryModel[],
     editorModels: EditorModel[],
+    loaders: IEditableGridLoader[],
     queryModel: QueryModel
 ): Promise<EditableGridModels> => {
     const updatedDataModels = [];
     const updatedEditorModels = [];
 
     const results = await Promise.all(
-        dataModels.map((dataModel, i) => initEditableGridModel(dataModels[i], editorModels[i], queryModel))
+        dataModels.map((dataModel, i) => initEditableGridModel(dataModels[i], editorModels[i], loaders[i], queryModel))
     );
 
     results.forEach(result => {
@@ -205,9 +206,7 @@ export const getUpdatedDataFromEditableGrid = (
     // to populate the queryInfoForm. If we don't have this data, we came directly to the editable grid
     // using values from the display grid to initialize the editable grid model, so we use that.
     const initData = selectionData ?? fromJS(model.rows);
-    const editorData = editorModel
-        .getRawDataFromModel(model, true, editorModel.loader.mode === EditorMode.Update, readOnlyColumns)
-        .toArray();
+    const editorData = editorModel.getRawDataFromModel(model, true, true, readOnlyColumns).toArray();
 
     return {
         originalRows: model.rows,

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -308,21 +308,23 @@ export const getEditorTableData = (
             if (editableRow.has(col.fieldKey)) {
                 row = row.set(col.fieldKey, editableRow.get(col.fieldKey));
             } else {
-                const datas = queryModel.rows[rowKey]?.[col.fieldKey];
-                if (datas) {
-                    if (Array.isArray(datas)) {
+                const data = queryModel.rows[rowKey]?.[col.fieldKey];
+                if (data) {
+                    if (Array.isArray(data)) {
                         let sep = '';
                         row = row.set(
                             col.fieldKey,
-                            datas.reduce((str, row_) => {
+                            data.reduce((str, row_) => {
                                 str += sep + quoteValueWithDelimiters(row_.displayValue ?? row_.value, ',');
                                 sep = ', ';
                                 return str;
                             }, '')
                         );
                     } else {
-                        row = row.set(col.fieldKey, datas.displayValue ?? datas.value);
+                        row = row.set(col.fieldKey, data.displayValue ?? data.value);
                     }
+                } else {
+                    row = row.set(col.fieldKey, undefined);
                 }
             }
         });

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -406,9 +406,11 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                             const queryModel = new QueryModel({ id: ENTITY_GRID_ID, schemaQuery }).mutate({
                                 queryInfo: this.getGridQueryInfo(),
                             });
-                            const editorModel = new EditorModel({ id: ENTITY_GRID_ID });
-                            const loader = new EntityGridLoader(insertModel, queryModel.queryInfo);
-                            const results = await initEditableGridModel(queryModel, editorModel, queryModel, loader);
+                            const editorModel = new EditorModel({
+                                id: ENTITY_GRID_ID,
+                                loader: new EntityGridLoader(insertModel, queryModel.queryInfo),
+                            });
+                            const results = await initEditableGridModel(queryModel, editorModel, queryModel);
 
                             this.setState({
                                 dataModel: results.dataModel,

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -406,16 +406,13 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                             const queryModel = new QueryModel({ id: ENTITY_GRID_ID, schemaQuery }).mutate({
                                 queryInfo: this.getGridQueryInfo(),
                             });
-                            const editorModel = new EditorModel({
-                                id: ENTITY_GRID_ID,
-                                loader: new EntityGridLoader(insertModel, queryModel.queryInfo),
-                            });
-                            const results = await initEditableGridModel(queryModel, editorModel, queryModel);
-
-                            this.setState({
-                                dataModel: results.dataModel,
-                                editorModel: results.editorModel,
-                            });
+                            const { dataModel, editorModel } = await initEditableGridModel(
+                                queryModel,
+                                new EditorModel({ id: ENTITY_GRID_ID }),
+                                new EntityGridLoader(insertModel, queryModel.queryInfo),
+                                queryModel
+                            );
+                            this.setState({ dataModel, editorModel });
                         }
                     );
                 })

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -768,8 +768,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         const { api, entityDataType, nounPlural } = this.props;
 
         if (!editorModel) {
-            this.setState(() => ({
-                dataModel: dataModel.mutate({
+            this.setState(state => ({
+                dataModel: state.dataModel.mutate({
                     rowsError: 'Grid does not expose an editor. Ensure the grid is properly initialized for editing.',
                 }),
             }));
@@ -779,8 +779,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         const errors = editorModel.getValidationErrors(dataModel, entityDataType.uniqueFieldKey);
         if (errors.length > 0) {
             this.setSubmitting(false);
-            this.setState(() => ({
-                dataModel: dataModel.mutate({ rowsError: errors.join('  ') }),
+            this.setState(state => ({
+                dataModel: state.dataModel.mutate({ rowsError: errors.join('  ') }),
             }));
             return;
         }
@@ -788,15 +788,12 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         this.setSubmitting(true);
 
         let extraColumnsToInclude: QueryColumn[];
-        if (creationType === SampleCreationType.Aliquots) extraColumnsToInclude = this.getAliquotCreationExtraColumns(); // include required sample property fields in post
+        if (creationType === SampleCreationType.Aliquots) {
+            extraColumnsToInclude = this.getAliquotCreationExtraColumns(); // include required sample property fields in post
+        }
 
         try {
-            const response = await insertModel.postEntityGrid(
-                dataModel,
-                editorModel,
-                extraColumnsToInclude,
-                this.isIncludedColumn
-            );
+            const response = await insertModel.postEntityGrid(dataModel, editorModel, extraColumnsToInclude);
 
             this.setSubmitting(false);
 
@@ -811,16 +808,16 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                     response.transactionAuditId
                 );
             } else {
-                this.setState(() => ({
-                    dataModel: dataModel.mutate({
+                this.setState(state => ({
+                    dataModel: state.dataModel.mutate({
                         rowsError: 'Insert response has unexpected format. No "rows" available.',
                     }),
                 }));
             }
         } catch (error) {
             this.setSubmitting(false);
-            this.setState(() => ({
-                dataModel: dataModel.mutate({ rowsError: resolveErrorMessage(error.error, this.props.nounPlural) }),
+            this.setState(state => ({
+                dataModel: state.dataModel.mutate({ rowsError: resolveErrorMessage(error.error, nounPlural) }),
             }));
         }
     };
@@ -891,11 +888,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         return null;
     };
 
-    onTabChange = (tab): void => {
-        if (this.props.onTabChange) {
-            this.props.onTabChange(tab);
-        }
-
+    onTabChange = (tab: number): void => {
+        this.props.onTabChange?.(tab);
         this.setState({ error: undefined });
     };
 

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -36,7 +36,7 @@ import { fetchDomainDetails, getDomainNamePreviews } from '../domainproperties/a
 
 import { SAMPLE_INVENTORY_ITEM_SELECTION_KEY, SAMPLE_STATE_COLUMN_NAME } from '../samples/constants';
 
-import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../settings/actions';
+import { loadNameExpressionOptions } from '../settings/actions';
 
 import { SampleStatusLegend } from '../samples/SampleStatusLegend';
 

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -357,11 +357,10 @@ export class EntityIdCreationModel extends Record({
     postEntityGrid(
         dataModel: QueryModel,
         editorModel: EditorModel,
-        extraColumnsToInclude?: QueryColumn[],
-        colFilter?: (col: QueryColumn) => boolean
+        extraColumnsToInclude?: QueryColumn[]
     ): Promise<InsertRowsResponse> {
         const rows = editorModel
-            .getRawDataFromModel(dataModel, false, false, undefined, undefined, colFilter)
+            .getRawDataFromModel(dataModel, false, false)
             .valueSeq()
             .reduce((rows_, row) => {
                 let map = row.toMap();

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -368,9 +368,6 @@ export function selectRowsDeprecated(userConfig, caller?): Promise<ISelectRowsRe
         function doResolve() {
             if (hasDetails && hasResults) {
                 if (key !== result.key) {
-                    console.warn(
-                        `Mismatched keys between query and model results. query: "${key}", model: "${result.key}".`
-                    );
                     key = result.key; // default to model key
                 }
                 resolve(

--- a/packages/components/src/internal/renderers/AliasRenderer.tsx
+++ b/packages/components/src/internal/renderers/AliasRenderer.tsx
@@ -40,17 +40,6 @@ export class AliasRenderer extends React.Component<Props, State> {
         }, []);
     };
 
-    static getEditableValue = (values: List<ValueDescriptor>): string => {
-        return values.reduce((str, v) => {
-            if (v.display) {
-                if (str) {
-                    return str + ', ' + v.display;
-                }
-                return v.display;
-            } else return str;
-        }, '');
-    };
-
     state: Readonly<State> = { showMore: false };
 
     handleClick = (): void => {


### PR DESCRIPTION
#### Rationale
This PR addresses [Issue 46714](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46714) by persisting the columns being edited to the underlying `EditorModel`. With this it is a logical mapping from the data index to the column index without passing through interstitial layers where the mapping could become misaligned.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1029
* https://github.com/LabKey/biologics/pull/1744
* https://github.com/LabKey/sampleManagement/pull/1403
* https://github.com/LabKey/inventory/pull/616

#### Changes
* Update `addColumns`, `changeColumn`, and `removeColumns` editable grid actions to update the new `columns` array on the `EditorModel`.
* Process directly against `EditorModel.columns` in `EditorModel.getRawDataFromGridData()` rather than relying on all column oriented properties aligning with the initial configuration.
* Introduce `EditorModel.getRawDataFromModel()` as a wrapped replacement for `EditorModel.getRawDataFromGridData()` to reduce redundant processing of the data on a `QueryModel`.
* Remove concept of `getEditableValue` on the renderer for editable grid cells. This pattern is no longer needed.
