### PR TITLE
Issue 46788: Display folder menu when projects are enabled and available

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.262.0",
+  "version": "2.263.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.263.0
+*Released*: 30 November 2022
+* Fully hide DOM for `FolderMenu` when rendering `NavigationBar` when respecting `!showFolderMenu`.
+* `QuerySelect` skip processing of stale requests.
+* Introduce `setProductProjects` to update moduleContext in React context and global context.
+* Update moduleContext and invalidate query details cache upon creation of the first project.
+
 ### version 2.262.0
 *Released*: 30 November 2022
 * Update `PicklistOverview` to show project column when there are project folders present

--- a/packages/components/src/assay/AssayGridPanel.tsx
+++ b/packages/components/src/assay/AssayGridPanel.tsx
@@ -111,7 +111,7 @@ export const AssayGridButtons: FC<AssayGridButtonsComponentProps> = memo(props =
     if (showQCButton) manageItemCount++;
     const showManageBtn = manageItemCount > 1;
 
-    if (!showImportBtn && manageItemCount == 0 && !showSampleBtn) {
+    if (!showImportBtn && manageItemCount === 0 && !showSampleBtn) {
         return null;
     }
 
@@ -192,7 +192,7 @@ export const AssayGridButtons: FC<AssayGridButtonsComponentProps> = memo(props =
                     metricFeatureArea="assayResultsSampleButton"
                     sampleFinderProps={sampleFinderProps}
                 >
-                    {isWorkflowEnabled() && (
+                    {isWorkflowEnabled(moduleContext) && (
                         <>
                             <MenuItem header>Jobs</MenuItem>
                             <JobsMenuOptionsComponent user={user} model={model} isAssay />
@@ -452,13 +452,14 @@ const AssayGridBody = withQueryModels<AssayGridPanelProps>(AssayGridBodyImpl);
 export const AssayGridPanel: FC<AssayGridPanelProps> = memo(props => {
     const { assayDefinition, filters, queryName, requiredColumns } = props;
     const { protocolSchemaName } = assayDefinition;
+    const { moduleContext } = useServerContext();
     const id = `${protocolSchemaName}.${queryName}`;
     const hasBatchDomain = assayDefinition.getDomainByType(AssayDomainTypes.BATCH).size > 0; // Issue 39412
     const omittedColumns = [];
     if (!hasBatchDomain) {
         omittedColumns.push('Batch');
     }
-    if (!isWorkflowEnabled()) {
+    if (!isWorkflowEnabled(moduleContext)) {
         omittedColumns.push('WorkflowTask');
     }
     const queryConfigs = {

--- a/packages/components/src/assay/AssayRunDetailsPage.tsx
+++ b/packages/components/src/assay/AssayRunDetailsPage.tsx
@@ -68,7 +68,7 @@ const AssayRunDetailsPageBodyImpl: FC<Props & InjectedQueryModels & Notification
 
     const [editingRunDetails, setEditingRunDetails] = useState<boolean>(false);
     const [editingResults, setEditingResults] = useState<boolean>(false);
-    const elnEnabled = isELNEnabled();
+    const elnEnabled = isELNEnabled(moduleContext);
     const subTitle = 'Assay Run Details';
     const resultsFilter = [
         Filter.create('Run/rowId', runId),
@@ -80,7 +80,7 @@ const AssayRunDetailsPageBodyImpl: FC<Props & InjectedQueryModels & Notification
 
     const onQCStateUpdate = useCallback(() => {
         actions.loadModel(model.id);
-    }, [actions]);
+    }, [actions, model.id]);
 
     const onRunDetailUpdate = useCallback(() => {
         actions.loadModel(model.id);
@@ -200,6 +200,7 @@ const AssayRunDetailsPageImpl: FC<Props & InjectedQueryModels> = memo(props => {
         [assayDefinition.protocolSchemaName, runId]
     );
     const { qcEnabledForApp } = useAssayAppContext();
+    const { moduleContext } = useServerContext();
 
     const queryConfigs = useMemo(
         () => ({
@@ -207,14 +208,14 @@ const AssayRunDetailsPageImpl: FC<Props & InjectedQueryModels> = memo(props => {
                 baseFilters: [Filter.create('Replaced', undefined, Filter.Types.NONBLANK)],
                 keyValue: runId,
                 requiredColumns:
-                    qcEnabledForApp && isAssayQCEnabled()
+                    qcEnabledForApp && isAssayQCEnabled(moduleContext)
                         ? RUN_PROPERTIES_REQUIRED_COLUMNS.concat(['LSID', 'QCFlags']).toArray()
                         : RUN_PROPERTIES_REQUIRED_COLUMNS.toArray(),
                 schemaQuery: SchemaQuery.create(assayDefinition.protocolSchemaName, 'Runs'),
-                omittedColumns: isWorkflowEnabled() ? undefined : ['WorkflowTask'],
+                omittedColumns: isWorkflowEnabled(moduleContext) ? undefined : ['WorkflowTask'],
             },
         }),
-        [assayDefinition.protocolSchemaName, runId, id, qcEnabledForApp]
+        [assayDefinition.protocolSchemaName, moduleContext, runId, id, qcEnabledForApp]
     );
 
     return <AssayRunDetailsPageBody {...props} autoLoad key={id} queryConfigs={queryConfigs} />;

--- a/packages/components/src/assay/AssayRunListingPage.tsx
+++ b/packages/components/src/assay/AssayRunListingPage.tsx
@@ -40,7 +40,9 @@ const AssayRunListingPageImpl: FC<CommonPageProps & InjectedAssayModel & Injecte
                 canUpdate={assayProtocol.editableRuns}
                 queryName="Runs"
                 nounPlural="Runs"
-                requiredColumns={isWorkflowEnabled(moduleContext) ? RUN_PROPERTIES_REQUIRED_COLUMNS.toArray() : undefined}
+                requiredColumns={
+                    isWorkflowEnabled(moduleContext) ? RUN_PROPERTIES_REQUIRED_COLUMNS.toArray() : undefined
+                }
             />
         </Page>
     );

--- a/packages/components/src/assay/AssayRunListingPage.tsx
+++ b/packages/components/src/assay/AssayRunListingPage.tsx
@@ -11,6 +11,8 @@ import { isWorkflowEnabled } from '../internal/app/utils';
 
 import { RUN_PROPERTIES_REQUIRED_COLUMNS } from '../internal/components/assay/constants';
 
+import { useServerContext } from '../internal/components/base/ServerContext';
+
 import { AssayHeader } from './AssayHeader';
 import { AssayDesignHeaderButtons } from './AssayButtons';
 import { AssayOverrideBanner } from './AssayOverrideBanner';
@@ -20,7 +22,7 @@ import { assayPage } from './AssayPageHOC';
 
 const AssayRunListingPageImpl: FC<CommonPageProps & InjectedAssayModel & InjectedRouteLeaveProps> = props => {
     const { assayDefinition, assayProtocol, menu, menuInit, navigate, getIsDirty, setIsDirty } = props;
-
+    const { moduleContext } = useServerContext();
     const subTitle = 'Assay Runs';
 
     return (
@@ -38,7 +40,7 @@ const AssayRunListingPageImpl: FC<CommonPageProps & InjectedAssayModel & Injecte
                 canUpdate={assayProtocol.editableRuns}
                 queryName="Runs"
                 nounPlural="Runs"
-                requiredColumns={isWorkflowEnabled() ? RUN_PROPERTIES_REQUIRED_COLUMNS.toArray() : undefined}
+                requiredColumns={isWorkflowEnabled(moduleContext) ? RUN_PROPERTIES_REQUIRED_COLUMNS.toArray() : undefined}
             />
         </Page>
     );

--- a/packages/components/src/entities/AssayResultsForSamplesPage.tsx
+++ b/packages/components/src/entities/AssayResultsForSamplesPage.tsx
@@ -45,17 +45,18 @@ type Props = OwnProps & WithRouterProps & InjectedAssayModel;
 
 const AssayResultsForSamplesImpl: FC<Props & InjectedQueryModels> = memo(props => {
     const { queryModels, actions, sampleIds } = props;
-    const { user } = useServerContext();
+    const { moduleContext, user } = useServerContext();
     const [tabOrder, setTabOrder] = useState<string[]>();
     const [allowViewCustomizationForGridIds, setAllowViewCustomizationForGridIds] = useState<string[]>();
     const allModels = Object.values(queryModels);
     const allLoaded = allModels.every(model => !model.isLoading);
+    const assayEnabled = isAssayEnabled(moduleContext);
 
     useEffect(() => {
-        if (isAssayEnabled() && userCanReadAssays(user)) {
+        if (assayEnabled && userCanReadAssays(user)) {
             actions.loadAllModels(true);
         }
-    }, [actions, user]);
+    }, [actions, assayEnabled, user]);
 
     useEffect(() => {
         // only calculate the tabOrder after all models have loaded and before any
@@ -84,7 +85,7 @@ const AssayResultsForSamplesImpl: FC<Props & InjectedQueryModels> = memo(props =
         setAllowViewCustomizationForGridIds(Object.keys(models).filter(id => id !== summaryGridId));
     }, [allLoaded, tabOrder, allModels]);
 
-    if (!isAssayEnabled()) return <NotFound title={PAGE_TITLE} />;
+    if (!assayEnabled) return <NotFound title={PAGE_TITLE} />;
     if (!userCanReadAssays(user)) return <InsufficientPermissionsPage title={PAGE_TITLE} />;
     if (tabOrder === undefined) return <LoadingPage title={PAGE_TITLE} />;
 

--- a/packages/components/src/entities/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.tsx
@@ -25,6 +25,8 @@ import { useLabelPrintingContext } from '../internal/components/labels/LabelPrin
 import { PrintLabelsModal } from '../internal/components/labels/PrintLabelsModal';
 import { useNotificationsContext } from '../internal/components/notifications/NotificationsContext';
 
+import { useServerContext } from '../internal/components/base/ServerContext';
+
 import { useSampleTypeAppContext } from './SampleTypeAppContext';
 import { EntityDeleteModal } from './EntityDeleteModal';
 import { SamplesAssayButton } from './SamplesAssayButton';
@@ -43,6 +45,7 @@ interface AliquotGridButtonsProps {
 const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> = props => {
     const { afterAction, lineageUpdateAllowed, model, onDelete, user, assayProviderType } = props;
     const { JobsButtonComponent, SampleStorageButtonComponent } = useSampleTypeAppContext();
+    const { moduleContext } = useServerContext();
     const metricFeatureArea = 'sampleAliquots';
 
     const moreItems = [];
@@ -54,7 +57,7 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
         button: <PicklistButton model={model} user={user} metricFeatureArea={metricFeatureArea} />,
         perm: PermissionTypes.ManagePicklists,
     });
-    if (JobsButtonComponent && isWorkflowEnabled()) {
+    if (JobsButtonComponent && isWorkflowEnabled(moduleContext)) {
         moreItems.push({
             button: <JobsButtonComponent model={model} user={user} metricFeatureArea={metricFeatureArea} />,
             perm: PermissionTypes.ManageSampleWorkflows,
@@ -74,7 +77,7 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
             perm: PermissionTypes.EditStorageData,
         });
     }
-    if (isAssayEnabled()) {
+    if (isAssayEnabled(moduleContext)) {
         moreItems.push({
             button: <AssayResultsForSamplesButton user={user} model={model} metricFeatureArea={metricFeatureArea} />,
             perm: PermissionTypes.ReadAssay,

--- a/packages/components/src/entities/SampleHeader.spec.tsx
+++ b/packages/components/src/entities/SampleHeader.spec.tsx
@@ -6,6 +6,7 @@ import { makeTestQueryModel } from '../public/QueryModel/testUtils';
 import { LoadingState } from '../public/LoadingState';
 import { mountWithAppServerContext } from '../internal/testHelpers';
 import { TEST_USER_AUTHOR, TEST_USER_READER } from '../internal/userFixtures';
+
 import { SampleHeaderImpl } from './SampleHeader';
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 
@@ -67,11 +68,7 @@ describe('SampleHeader', () => {
 
     test('empty model as reader', () => {
         const wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl
-                {...DEFAULT_PROPS}
-                user={TEST_USER_READER}
-                sampleModel={EMPTY_MODEL}
-            />,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_READER} sampleModel={EMPTY_MODEL} />,
             {},
             { user: TEST_USER_READER }
         );
@@ -107,11 +104,7 @@ describe('SampleHeader', () => {
 
     test('partial data model as reader', () => {
         const wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl
-                {...DEFAULT_PROPS}
-                user={TEST_USER_READER}
-                sampleModel={PARTIAL_DATA_MODEL}
-            />,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_READER} sampleModel={PARTIAL_DATA_MODEL} />,
             {},
             { user: TEST_USER_READER }
         );
@@ -126,11 +119,7 @@ describe('SampleHeader', () => {
 
     test('CreateSamplesSubMenu permissions', () => {
         let wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl
-                {...DEFAULT_PROPS}
-                user={TEST_USER_READER}
-                sampleModel={DATA_MODEL}
-            />,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_READER} sampleModel={DATA_MODEL} />,
             {},
             { user: TEST_USER_READER }
         );
@@ -138,11 +127,7 @@ describe('SampleHeader', () => {
         wrapper.unmount();
 
         wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl
-                {...DEFAULT_PROPS}
-                user={TEST_USER_AUTHOR}
-                sampleModel={DATA_MODEL}
-            />,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_AUTHOR} sampleModel={DATA_MODEL} />,
             {},
             { user: TEST_USER_AUTHOR }
         );
@@ -152,11 +137,7 @@ describe('SampleHeader', () => {
 
     test('CreateSamplesSubMenu props', () => {
         const wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl
-                {...DEFAULT_PROPS}
-                user={TEST_USER_AUTHOR}
-                sampleModel={DATA_MODEL}
-            />,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_AUTHOR} sampleModel={DATA_MODEL} />,
             {},
             { user: TEST_USER_AUTHOR }
         );

--- a/packages/components/src/entities/SampleHeader.tsx
+++ b/packages/components/src/entities/SampleHeader.tsx
@@ -96,7 +96,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
     const [showPrintDialog, setShowPrintDialog] = useState<boolean>(false);
     const sampleId = useMemo(() => sampleModel.getRowValue('RowId'), [sampleModel]);
     const sampleIds = useMemo(() => [sampleId], [sampleId]);
-    const { user } = useServerContext();
+    const { moduleContext, user } = useServerContext();
 
     const isMedia = queryInfo?.isMedia;
 
@@ -211,7 +211,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
         const color = caseInsensitive(row, 'SampleSet/LabelColor')?.value;
         const labelDisplay = getTitleDisplay(sampleType, hasActiveJob);
         return color ? <ColorIcon label={labelDisplay} useSmall value={color} /> : sampleType;
-    }, [row, subtitle]);
+    }, [hasActiveJob, row, subtitle]);
 
     return (
         <>
@@ -257,7 +257,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                             )}
 
                             {!isMedia &&
-                                isAssayEnabled() &&
+                                isAssayEnabled(moduleContext) &&
                                 (!isCrossFolder || isProjectContainer(sampleContainer?.path)) && (
                                     <RequiresPermission user={user} perms={PermissionTypes.Insert}>
                                         <AssayImportSubMenuItem
@@ -280,7 +280,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                                     />
                                 </RequiresPermission>
                             )}
-                            {isWorkflowEnabled() && (
+                            {isWorkflowEnabled(moduleContext) && (
                                 <RequiresPermission user={user} perms={PermissionTypes.ManageSampleWorkflows}>
                                     <DisableableMenuItem
                                         href={getJobCreationHref(sampleModel, undefined, true)}

--- a/packages/components/src/entities/SampleNav.spec.tsx
+++ b/packages/components/src/entities/SampleNav.spec.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
+import { WithRouterProps } from 'react-router';
 import { ReactWrapper } from 'enzyme';
-
-import { initQueryGridState } from '../internal/global';
 
 import { SubNav } from '../internal/components/navigation/SubNav';
 import { mountWithServerContext } from '../internal/testHelpers';
-import { AppContextProvider } from '../internal/AppContext';
 import { TEST_USER_READER, TEST_USER_STORAGE_EDITOR } from '../internal/userFixtures';
 
 import {
@@ -14,14 +12,21 @@ import {
     TEST_LKSM_STARTER_MODULE_CONTEXT,
 } from '../internal/productFixtures';
 
+import { TEST_PROJECT_CONTAINER } from '../test/data/constants';
+
+import { createMockWithRouterProps } from '../internal/mockUtils';
+
 import { SampleIndexNav } from './SampleNav';
 
-beforeAll(() => {
-    initQueryGridState();
-});
-
 describe('SampleIndexNav', () => {
-    function validateTabText(wrapper: ReactWrapper, showLineage = true, showAssay = true, showWorkflow = true) {
+    function defaultProps(): WithRouterProps {
+        return {
+            ...createMockWithRouterProps(),
+            params: { sampleType: 'test', id: '123' },
+        };
+    }
+
+    function validateTabText(wrapper: ReactWrapper, showLineage = true, showAssay = true, showWorkflow = true): void {
         const subNav = wrapper.find(SubNav);
         const tabs = subNav.prop('tabs').toJS();
         let expectedLength = 3;
@@ -51,96 +56,54 @@ describe('SampleIndexNav', () => {
     }
 
     test('reader', () => {
-        const wrapper = mountWithServerContext(
-            <AppContextProvider initialContext={{}}>
-                <SampleIndexNav
-                    params={{ sampleType: 'test', id: '123' }}
-                    location={undefined}
-                    router={undefined}
-                    routes={undefined}
-                />
-            </AppContextProvider>,
-            { user: TEST_USER_READER }
-        );
+        const wrapper = mountWithServerContext(<SampleIndexNav {...defaultProps()} />, {
+            container: TEST_PROJECT_CONTAINER,
+            user: TEST_USER_READER,
+        });
         validateTabText(wrapper, true, false, false);
     });
 
     test('storage editor', () => {
-        const wrapper = mountWithServerContext(
-            <AppContextProvider initialContext={{}}>
-                <SampleIndexNav
-                    params={{ sampleType: 'test', id: '123' }}
-                    location={undefined}
-                    router={undefined}
-                    routes={undefined}
-                />
-            </AppContextProvider>,
-            { user: TEST_USER_STORAGE_EDITOR }
-        );
+        const wrapper = mountWithServerContext(<SampleIndexNav {...defaultProps()} />, {
+            container: TEST_PROJECT_CONTAINER,
+            user: TEST_USER_STORAGE_EDITOR,
+        });
         validateTabText(wrapper, false, false, false);
     });
 
     test('reader, LKS starter', () => {
-        LABKEY.moduleContext = { ...TEST_LKS_STARTER_MODULE_CONTEXT };
-        const wrapper = mountWithServerContext(
-            <AppContextProvider initialContext={{}}>
-                <SampleIndexNav
-                    params={{ sampleType: 'test', id: '123' }}
-                    location={undefined}
-                    router={undefined}
-                    routes={undefined}
-                />
-            </AppContextProvider>,
-            { user: TEST_USER_READER }
-        );
+        const wrapper = mountWithServerContext(<SampleIndexNav {...defaultProps()} />, {
+            container: TEST_PROJECT_CONTAINER,
+            moduleContext: TEST_LKS_STARTER_MODULE_CONTEXT,
+            user: TEST_USER_READER,
+        });
         validateTabText(wrapper, true, true, false);
     });
 
     test('reader, LKSM starter', () => {
-        LABKEY.moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT };
-        const wrapper = mountWithServerContext(
-            <AppContextProvider initialContext={{}}>
-                <SampleIndexNav
-                    params={{ sampleType: 'test', id: '123' }}
-                    location={undefined}
-                    router={undefined}
-                    routes={undefined}
-                />
-            </AppContextProvider>,
-            { user: TEST_USER_READER }
-        );
+        const wrapper = mountWithServerContext(<SampleIndexNav {...defaultProps()} />, {
+            container: TEST_PROJECT_CONTAINER,
+            moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT,
+            user: TEST_USER_READER,
+        });
         validateTabText(wrapper, true, false, false);
     });
 
     test('reader, LKSM professional', () => {
-        LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
-        const wrapper = mountWithServerContext(
-            <AppContextProvider initialContext={{}}>
-                <SampleIndexNav
-                    params={{ sampleType: 'test', id: '123' }}
-                    location={undefined}
-                    router={undefined}
-                    routes={undefined}
-                />
-            </AppContextProvider>,
-            { user: TEST_USER_READER }
-        );
+        const wrapper = mountWithServerContext(<SampleIndexNav {...defaultProps()} />, {
+            container: TEST_PROJECT_CONTAINER,
+            moduleContext: TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
+            user: TEST_USER_READER,
+        });
         validateTabText(wrapper, true, true, true);
     });
 
     test('LKSM professional, storage editor', () => {
-        LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
-        const wrapper = mountWithServerContext(
-            <AppContextProvider initialContext={{}}>
-                <SampleIndexNav
-                    params={{ sampleType: 'test', id: '123' }}
-                    location={undefined}
-                    router={undefined}
-                    routes={undefined}
-                />
-            </AppContextProvider>,
-            { user: TEST_USER_STORAGE_EDITOR }
-        );
+        const wrapper = mountWithServerContext(<SampleIndexNav {...defaultProps()} />, {
+            container: TEST_PROJECT_CONTAINER,
+            moduleContext: TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
+            user: TEST_USER_STORAGE_EDITOR,
+        });
         validateTabText(wrapper, false, false, true);
     });
 });

--- a/packages/components/src/entities/SampleOverviewPanel.tsx
+++ b/packages/components/src/entities/SampleOverviewPanel.tsx
@@ -12,6 +12,8 @@ import { getContainerFilterForLookups } from '../internal/query/api';
 
 import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 
+import { useServerContext } from '../internal/components/base/ServerContext';
+
 import { SampleAliquotsSummary } from './SampleAliquotsSummary';
 import { SampleDetailEditing } from './SampleDetailEditing';
 
@@ -43,6 +45,7 @@ export const SampleOverviewPanel: FC<Props> = memo(props => {
         noun,
         SampleStorageLocationComponent,
     } = props;
+    const { moduleContext } = useServerContext();
     const { getWorkflowGridQueryConfigs, ReferencingNotebooksComponent, detailRenderer } = useSampleTypeAppContext();
     const [isEditing, setIsEditing] = useState(false);
     const row = useMemo(() => {
@@ -113,7 +116,7 @@ export const SampleOverviewPanel: FC<Props> = memo(props => {
                             />
                         </div>
                     )}
-                    {isELNEnabled() && ReferencingNotebooksComponent && (
+                    {isELNEnabled(moduleContext) && ReferencingNotebooksComponent && (
                         <div className="col-xs-12 col-md-4">
                             <ReferencingNotebooksComponent
                                 label={sampleName}
@@ -141,7 +144,7 @@ export const SampleOverviewPanel: FC<Props> = memo(props => {
                         sampleSet={sampleType}
                     />
                 </div>
-                {isMedia && isELNEnabled() && ReferencingNotebooksComponent && (
+                {isMedia && isELNEnabled(moduleContext) && ReferencingNotebooksComponent && (
                     <div className="col-md-5">
                         <ReferencingNotebooksComponent
                             label={sampleName}

--- a/packages/components/src/entities/SampleTypeListingPage.tsx
+++ b/packages/components/src/entities/SampleTypeListingPage.tsx
@@ -5,6 +5,8 @@
 import React, { FC, memo } from 'react';
 import { PermissionTypes } from '@labkey/api';
 
+import { Button } from 'react-bootstrap';
+
 import { AppURL } from '../internal/url/AppURL';
 import { useServerContext } from '../internal/components/base/ServerContext';
 import { Page } from '../internal/components/base/Page';
@@ -14,16 +16,17 @@ import { RequiresPermission } from '../internal/components/base/Permissions';
 
 import { SampleTypeEmptyAlert } from '../internal/components/samples/SampleEmptyAlert';
 
-import { SampleTypeSummary } from './SampleTypeSummary';
-import { Button } from 'react-bootstrap';
 import { NEW_SAMPLE_TYPE_HREF, SAMPLES_KEY } from '../internal/app/constants';
 import { CommonPageProps } from '../internal/models';
 import { LoadingPage } from '../internal/components/base/LoadingPage';
+
+import { SampleTypeSummary } from './SampleTypeSummary';
+
 import { useSampleTypeAppContext } from './SampleTypeAppContext';
 
 export const SampleTypeListingPage: FC<CommonPageProps> = memo(props => {
     const { menu, navigate } = props;
-    const { user } = useServerContext();
+    const { moduleContext, user } = useServerContext();
     const { sampleTypeListingCaption } = useSampleTypeAppContext();
     const title = 'Sample Types';
 
@@ -40,23 +43,22 @@ export const SampleTypeListingPage: FC<CommonPageProps> = memo(props => {
                 caption={sampleTypeListingCaption}
                 context={
                     <>
-                        {isSampleStatusEnabled() && (
+                        {isSampleStatusEnabled(moduleContext) && (
                             <RequiresPermission perms={PermissionTypes.Admin}>
                                 <a href={AppURL.create('admin', 'settings').toHref()} className="right-spacing">
                                     Manage Sample Statuses
                                 </a>
                             </RequiresPermission>
                         )}
-                        {user.hasDesignSampleTypesPermission() ?
-                            <Button bsStyle="success" href={NEW_SAMPLE_TYPE_HREF.toHref()}>Create Sample Type</Button>
-                            : undefined
-                        }
+                        {user.hasDesignSampleTypesPermission() && (
+                            <Button bsStyle="success" href={NEW_SAMPLE_TYPE_HREF.toHref()}>
+                                Create Sample Type
+                            </Button>
+                        )}
                     </>
                 }
             >
-                {hasSampleTypes && (
-                    <SampleTypeSummary user={user} navigate={navigate}  />
-                )}
+                {hasSampleTypes && <SampleTypeSummary user={user} navigate={navigate} />}
                 {!hasSampleTypes && <SampleTypeEmptyAlert />}
             </Section>
         </Page>

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -22,10 +22,6 @@ import { AssayAppContext } from '../assay';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from './APIWrapper';
 import { NotebookNotificationSettings, NotebookProjectSettings, WorkflowNotificationSettings } from './app/models';
 
-export interface NavigationSettings {
-    showCurrentContainer: boolean;
-}
-
 export interface AdminAppContext {
     NotebookNotificationSettingsComponent: NotebookNotificationSettings;
     NotebookProjectSettingsComponent: NotebookProjectSettings;
@@ -37,7 +33,6 @@ export interface AppContext {
     admin?: AdminAppContext;
     api?: ComponentsAPIWrapper;
     assay?: AssayAppContext;
-    navigation?: NavigationSettings;
     sampleType?: SampleTypeAppContext;
 }
 
@@ -105,8 +100,6 @@ export function AppContextProvider<T>({
         () => ({
             // Provide a default API so that external users don't have to specify it
             api: getDefaultAPIWrapper(),
-            // By default we don't show the container in SubNav, but apps can override this
-            navigation: { showCurrentContainer: false },
             ...initialContext,
         }),
         [initialContext]

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -100,6 +100,7 @@ export enum ProductFeature {
     ELN = 'ELN',
     FreezerManagement = 'FreezerManagement',
     Media = 'Media',
+    Projects = 'Projects',
     SampleManagement = 'SampleManagement',
     Workflow = 'Workflow',
 }

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -50,6 +50,7 @@ import {
     isSampleStatusEnabled,
     isWorkflowEnabled,
     sampleManagerIsPrimaryApp,
+    setProductProjects,
     userCanDesignLocations,
     userCanDesignSourceTypes,
     userCanEditStorageData,
@@ -562,6 +563,16 @@ describe('utils', () => {
         expect(
             isProductNavigationEnabled(BIOLOGICS_APP_PROPERTIES.productId, { biologics: {}, samplemanagement: {} })
         ).toBeTruthy();
+    });
+
+    test('setProductProjects', () => {
+        expect(setProductProjects({}, true)).toEqual({ query: { hasProductProjects: true } });
+        expect(setProductProjects({ query: { hasProductProjects: false } }, true)).toEqual({
+            query: { hasProductProjects: true },
+        });
+        LABKEY.moduleContext = { query: { ken: 'griffey' } };
+        setProductProjects({ query: { hasProductProjects: true } }, false);
+        expect(LABKEY.moduleContext.query).toEqual({ hasProductProjects: false, ken: 'griffey' });
     });
 
     test('hasPremiumModule', () => {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -3,7 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { List, Map } from 'immutable';
-import { ActionURL, getServerContext, PermissionTypes } from '@labkey/api';
+import { ActionURL, LabKey, getServerContext, PermissionTypes } from '@labkey/api';
 
 import { useMemo } from 'react';
 
@@ -47,6 +47,8 @@ import {
     WORKFLOW_HOME_HREF,
     WORKFLOW_KEY,
 } from './constants';
+
+declare var LABKEY: LabKey;
 
 // Type definition not provided for event codes so here we provide our own
 // Source: https://www.iana.org/assignments/websocket/websocket.xml#close-code-number
@@ -169,6 +171,17 @@ export function isProductProjectsEnabled(moduleContext?: ModuleContext): boolean
 
 export function hasProductProjects(moduleContext?: ModuleContext): boolean {
     return resolveModuleContext(moduleContext)?.query?.hasProductProjects === true;
+}
+
+export function setProductProjects(moduleContext: ModuleContext, hasProductProjects: boolean): ModuleContext {
+    // side-effect set global moduleContext
+    if (LABKEY?.moduleContext?.query) {
+        LABKEY.moduleContext.query.hasProductProjects = hasProductProjects;
+    }
+
+    return Object.assign(moduleContext ?? {}, {
+        query: Object.assign(moduleContext?.query ?? {}, { hasProductProjects }),
+    });
 }
 
 export function isSampleManagerEnabled(moduleContext?: ModuleContext): boolean {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -197,7 +197,7 @@ export function isPremiumProductEnabled(moduleContext?: ModuleContext): boolean 
 }
 
 export function isAppHomeFolder(container?: Container): boolean {
-    const folderType = container?.folderType ?? getServerContext()?.container?.folderType;
+    const folderType = (container ?? getServerContext().container).folderType;
     return folderType === SAMPLE_MANAGER_APP_PROPERTIES.name || folderType === BIOLOGICS_APP_PROPERTIES.name;
 }
 

--- a/packages/components/src/internal/components/administration/CreateProjectPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/CreateProjectPage.spec.tsx
@@ -13,8 +13,9 @@ import { createMockWithRouterProps } from '../../mockUtils';
 
 import { AppURL } from '../../url/AppURL';
 
-import { CreateProjectContainer, CreateProjectContainerProps, CreateProjectPage } from './CreateProjectPage';
 import { TEST_LIMS_STARTER_MODULE_CONTEXT } from '../../productFixtures';
+
+import { CreateProjectContainer, CreateProjectContainerProps, CreateProjectPage } from './CreateProjectPage';
 
 describe('CreateProjectPage', () => {
     function getDefaultProps(overrides?: Partial<FolderAPIWrapper>): CreateProjectContainerProps {

--- a/packages/components/src/internal/components/administration/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/administration/CreateProjectPage.tsx
@@ -17,8 +17,9 @@ import { getCurrentAppProperties, hasProductProjects, setProductProjects } from 
 import { useFolderMenuContext } from '../navigation/hooks';
 import { IDNameSettings } from '../settings/NameIdSettings';
 
-import { ProjectProperties } from './ProjectProperties';
 import { invalidateFullQueryDetailsCache } from '../../query/api';
+
+import { ProjectProperties } from './ProjectProperties';
 
 export interface CreateProjectContainerProps {
     api: FolderAPIWrapper;

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { OrderedMap } from 'immutable';
-import { mount } from 'enzyme';
 import { Input, Textarea } from 'formsy-react-components';
 
 import { ASSAY_WIZARD_MODEL } from '../../../test/data/constants';
@@ -14,6 +13,8 @@ import { TextInput } from '../forms/input/TextInput';
 import { DatePickerInput } from '../forms/input/DatePickerInput';
 import { SelectInput } from '../forms/input/SelectInput';
 
+import { mountWithServerContext } from '../../testHelpers';
+
 import { RunPropertiesPanel } from './RunPropertiesPanel';
 import { AssayWizardModel } from './AssayWizardModel';
 
@@ -21,12 +22,11 @@ beforeAll(() => {
     initUnitTestMocks();
 });
 
-describe('<RunPropertiesPanel/>', () => {
+describe('RunPropertiesPanel', () => {
     test('model without run domain fields', () => {
         const model = ASSAY_WIZARD_MODEL.set('runColumns', OrderedMap<string, QueryColumn>()) as AssayWizardModel;
-        const component = <RunPropertiesPanel model={model} onChange={jest.fn} />;
+        const wrapper = mountWithServerContext(<RunPropertiesPanel model={model} onChange={jest.fn} />);
 
-        const wrapper = mount(component);
         expect(wrapper.find('.panel')).toHaveLength(1);
         expect(wrapper.find(Input)).toHaveLength(1); // assay id input always there for run props
         expect(wrapper.find(Textarea)).toHaveLength(1); // comments input always there for run props
@@ -34,9 +34,8 @@ describe('<RunPropertiesPanel/>', () => {
     });
 
     test('check form input types', () => {
-        const component = <RunPropertiesPanel model={ASSAY_WIZARD_MODEL} onChange={jest.fn} />;
+        const wrapper = mountWithServerContext(<RunPropertiesPanel model={ASSAY_WIZARD_MODEL} onChange={jest.fn} />);
 
-        const wrapper = mount(component);
         expect(wrapper.find('.panel')).toHaveLength(1);
         expect(wrapper.find(Input)).toHaveLength(4); // assay id plus 4 TextInputs
         expect(wrapper.find(Textarea)).toHaveLength(2); // comments plus one other multi-line text input

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -25,10 +25,13 @@ import { QueryFormInputs } from '../forms/QueryFormInputs';
 
 import { getContainerFilterForLookups } from '../../query/api';
 
+import { useServerContext } from '../base/ServerContext';
+
 import { AssayPropertiesPanelProps } from './models';
 
 export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
     const { model, onChange, title = 'Run Details', showQuerySelectPreviewOptions } = props;
+    const { moduleContext } = useServerContext();
     const nameLabel = useMemo(
         () => (
             <LabelOverlay
@@ -67,7 +70,7 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                         rows={2}
                         value={model.comment}
                     />
-                    {isWorkflowEnabled() && (
+                    {isWorkflowEnabled(moduleContext) && (
                         <AssayTaskInput
                             assayId={model.assayDef.id}
                             formsy

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -171,6 +171,7 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
         showLoading: true,
     };
 
+    private lastRequest: Record<string, string>;
     private querySelectTimer: number;
 
     constructor(props: QuerySelectOwnProps) {
@@ -208,6 +209,7 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
     };
 
     loadOptions = (input: string): Promise<SelectInputOption[]> => {
+        const request = (this.lastRequest = {});
         clearTimeout(this.querySelectTimer);
 
         // If loadOptions occurs prior to call to "onFocus" then there is no need to "loadOnFocus".
@@ -223,6 +225,10 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
                     const { model } = this.state;
 
                     const data = await model.search(input);
+
+                    // Issue 46816: Skip processing stale requests
+                    if (request !== this.lastRequest) return;
+                    delete this.lastRequest;
 
                     const models = fromJS(data.models[data.key]);
 

--- a/packages/components/src/internal/components/navigation/FolderMenu.spec.tsx
+++ b/packages/components/src/internal/components/navigation/FolderMenu.spec.tsx
@@ -13,10 +13,12 @@ import { AppContext } from '../../AppContext';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { Alert } from '../base/Alert';
 
-import { FolderMenu } from './FolderMenu';
+import { ServerContext } from '../base/ServerContext';
+
+import { FolderMenu, FolderMenuProps } from './FolderMenu';
 
 describe('FolderMenu', () => {
-    function getDefaultProps() {
+    function getDefaultProps(): FolderMenuProps {
         return {
             appProperties: BIOLOGICS_APP_PROPERTIES,
         };
@@ -33,7 +35,7 @@ describe('FolderMenu', () => {
         };
     }
 
-    function getDefaultServerContext() {
+    function getDefaultServerContext(): Partial<ServerContext> {
         return {
             container: TEST_PROJECT_CONTAINER,
         };
@@ -56,6 +58,20 @@ describe('FolderMenu', () => {
         await waitForLifecycle(wrapper);
 
         expect(wrapper.find(Alert).text()).toEqual(`Error: ${expectedError}`);
+    });
+
+    it('does not display when no projects are retrieved', async () => {
+        const wrapper = mountWithAppServerContext(
+            <FolderMenu {...getDefaultProps()} />,
+            getDefaultAppContext({ fetchContainers: jest.fn().mockResolvedValue([TEST_PROJECT_CONTAINER]) }),
+            getDefaultServerContext()
+        );
+
+        // load
+        await waitForLifecycle(wrapper);
+
+        expect(wrapper.find(Dropdown).exists()).toBeFalsy();
+        expect(wrapper.find(MenuItem).exists()).toBeFalsy();
     });
 
     it('loads successfully', async () => {

--- a/packages/components/src/internal/components/navigation/FolderMenu.tsx
+++ b/packages/components/src/internal/components/navigation/FolderMenu.tsx
@@ -32,11 +32,11 @@ function createFolderItem(folder: Container, controllerName: string): FolderMenu
     };
 }
 
-interface Props {
+export interface FolderMenuProps {
     appProperties?: AppProperties;
 }
 
-export const FolderMenu: FC<Props> = memo(({ appProperties }) => {
+export const FolderMenu: FC<FolderMenuProps> = memo(({ appProperties }) => {
     const { controllerName } = appProperties ?? getCurrentAppProperties();
     const [error, setError] = useState<string>();
     const [loading, setLoading] = useState<LoadingState>(LoadingState.INITIALIZED);
@@ -86,7 +86,7 @@ export const FolderMenu: FC<Props> = memo(({ appProperties }) => {
     if (isLoaded && !hasError && items.length === 1) return null;
 
     return (
-        <Dropdown className="nav-folder-menu" id="folder-menu" onToggle={toggleMenu} open={open}>
+        <Dropdown className="nav-folder-menu navbar-item" id="folder-menu" onToggle={toggleMenu} open={open}>
             <Dropdown.Toggle className="nav-folder-menu__button" title={container.title}>
                 {container.title}
             </Dropdown.Toggle>

--- a/packages/components/src/internal/components/navigation/FolderMenu.tsx
+++ b/packages/components/src/internal/components/navigation/FolderMenu.tsx
@@ -36,8 +36,7 @@ export interface FolderMenuProps {
     appProperties?: AppProperties;
 }
 
-export const FolderMenu: FC<FolderMenuProps> = memo(({ appProperties }) => {
-    const { controllerName } = appProperties ?? getCurrentAppProperties();
+export const FolderMenu: FC<FolderMenuProps> = memo(({ appProperties = getCurrentAppProperties() }) => {
     const [error, setError] = useState<string>();
     const [loading, setLoading] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [open, setOpen] = useState(false);
@@ -64,19 +63,19 @@ export const FolderMenu: FC<FolderMenuProps> = memo(({ appProperties }) => {
                 if (topLevelFolderIdx > -1) {
                     // Remove top-level folder from array as it is always displayed as the first menu item
                     const topLevelFolder = folders.splice(topLevelFolderIdx, 1)[0];
-                    items_.push(createFolderItem(topLevelFolder, controllerName));
+                    items_.push(createFolderItem(topLevelFolder, appProperties?.controllerName));
                 }
 
                 // Issue 45805: sort folders by title as server-side sorting is insufficient
                 folders.sort(naturalSortByProperty('title'));
-                setItems(items_.concat(folders.map(folder => createFolderItem(folder, controllerName))));
+                setItems(items_.concat(folders.map(folder => createFolderItem(folder, appProperties?.controllerName))));
             } catch (e) {
                 setError(`Error: ${resolveErrorMessage(e)}`);
             }
 
             setLoading(LoadingState.LOADED);
         })();
-    }, [api, container, controllerName]);
+    }, [api, container, appProperties?.controllerName]);
 
     const toggleMenu = useCallback(() => {
         setOpen(open_ => !open_);

--- a/packages/components/src/internal/components/navigation/NavigationBar.spec.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.spec.tsx
@@ -35,10 +35,6 @@ import { NavigationBar } from './NavigationBar';
 import { UserMenu } from './UserMenu';
 import { ProductMenu } from './ProductMenu';
 
-beforeEach(() => {
-    LABKEY.devMode = false;
-});
-
 describe('NavigationBar', () => {
     const productMenuModel = new ProductMenuModel({
         productIds: ['testNavBar'],

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -96,19 +96,15 @@ export const NavigationBar: FC<Props> = memo(props => {
     const _showNotifications = showNotifications !== false && !!notificationsConfig && !!user && !user.isGuest;
     const _showProductNav = showProductNav !== false && shouldShowProductNavigation(user, moduleContext);
     const hasSubNav = Children.count(children) > 0;
-    const className = classNames('app-navigation', { 'with-sub-nav': hasSubNav });
+
     return (
-        <div className={className}>
+        <div className={classNames('app-navigation', { 'with-sub-nav': hasSubNav })}>
             <nav className="main-nav navbar navbar-container test-loc-nav-header">
                 <div className="container">
                     <div className="row">
                         <div className="navbar-left col-xs-8 col-md-7">
                             <span className="navbar-item pull-left">{brand}</span>
-                            {showFolderMenu && (
-                                <span className="navbar-item">
-                                    <FolderMenu key={folderMenuContext.key} />
-                                </span>
-                            )}
+                            {showFolderMenu && <FolderMenu key={folderMenuContext.key} />}
                             {showNavMenu && !!model && (
                                 <span className="navbar-item">
                                     <ProductMenu model={model} sectionConfigs={menuSectionConfigs} />

--- a/packages/components/src/internal/components/navigation/SubNav.tsx
+++ b/packages/components/src/internal/components/navigation/SubNav.tsx
@@ -17,8 +17,9 @@ import React, { FC, useRef, useState, useCallback, useEffect, memo } from 'react
 import { List } from 'immutable';
 import { Button } from 'react-bootstrap';
 
-import { useAppContext } from '../../AppContext';
 import { useServerContext } from '../base/ServerContext';
+
+import { hasPremiumModule, hasProductProjects } from '../../app/utils';
 
 import NavItem, { ParentNavItem } from './NavItem';
 import { ITab, SubNavGlobalContext } from './types';
@@ -31,8 +32,8 @@ interface Props {
 
 export const SubNav: FC<Props> = ({ noun, tabs }) => {
     const scrollable = useRef<HTMLDivElement>();
-    const { navigation } = useAppContext();
-    const { container } = useServerContext();
+    const { container, moduleContext } = useServerContext();
+    const showCurrentContainer = hasPremiumModule(moduleContext) && !hasProductProjects(moduleContext);
     const [isScrollable, setIsScrollable] = useState<boolean>(false);
     const scroll = useCallback(offset => {
         scrollable.current.scrollLeft = scrollable.current.scrollLeft + offset;
@@ -110,7 +111,7 @@ export const SubNav: FC<Props> = ({ noun, tabs }) => {
                     </div>
                 )}
 
-                {navigation.showCurrentContainer && (
+                {showCurrentContainer && (
                     <div className="container-nav">
                         <span className="fa fa-folder-open" />
                         <span className="container-nav__name" title={container.name}>

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -55,6 +55,7 @@ export const PrefixDescription: FC = memo(() => {
 
 export const IDNameSettings: FC = memo(() => {
     const [prefix, setPrefix] = useState<string>();
+    const { moduleContext } = useServerContext();
 
     const onPrefixChange = useCallback(evt => {
         setPrefix(evt.target.value);
@@ -75,7 +76,7 @@ export const IDNameSettings: FC = memo(() => {
                 </Col>
             </FormGroup>
 
-            {biologicsIsPrimaryApp() && (
+            {biologicsIsPrimaryApp(moduleContext) && (
                 <FormGroup controlId="id-name-prop-prefix">
                     <Col componentClass={ControlLabel} xs={12} sm={2} className="text-left">
                         ID/Name Prefix

--- a/packages/components/src/internal/productFixtures.ts
+++ b/packages/components/src/internal/productFixtures.ts
@@ -1,4 +1,9 @@
-import { FREEZER_MANAGER_APP_PROPERTIES, ProductFeature, SAMPLE_MANAGER_APP_PROPERTIES } from './app/constants';
+import {
+    BIOLOGICS_APP_PROPERTIES,
+    FREEZER_MANAGER_APP_PROPERTIES,
+    ProductFeature,
+    SAMPLE_MANAGER_APP_PROPERTIES,
+} from './app/constants';
 
 export const TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT = {
     api: {
@@ -42,5 +47,27 @@ export const TEST_LKS_STARTER_MODULE_CONTEXT = {
     },
     core: {
         productFeatures: [ProductFeature.Assay],
+    },
+};
+
+export const TEST_LIMS_STARTER_MODULE_CONTEXT = {
+    biologics: {
+        productId: BIOLOGICS_APP_PROPERTIES.productId,
+    },
+    core: {
+        productFeatures: [
+            ProductFeature.Assay,
+            ProductFeature.ELN,
+            ProductFeature.FreezerManagement,
+            ProductFeature.Projects,
+            ProductFeature.SampleManagement,
+            ProductFeature.Workflow,
+        ],
+    },
+    inventory: {
+        productId: FREEZER_MANAGER_APP_PROPERTIES.productId,
+    },
+    samplemanagement: {
+        productId: SAMPLE_MANAGER_APP_PROPERTIES.productId,
     },
 };

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -501,10 +501,11 @@ describe('GridTitle', () => {
     }
 
     test('no title, no view', () => {
-        const tree = renderer
-            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} />)
-            .toJSON();
-        expect(tree).toBeNull();
+        const wrapper = mountWithServerContext(
+            <GridTitle model={model} actions={actions} allowSelections allowViewCustomization={false} />
+        );
+        expect(wrapper.exists('.view-header')).toBeFalsy();
+        wrapper.unmount();
     });
 
     test('title, no view', () => {
@@ -542,7 +543,7 @@ describe('GridTitle', () => {
         ) as QueryInfo;
         const model = makeTestQueryModel(SCHEMA_QUERY, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization />,
             { user: TEST_USER_PROJECT_ADMIN }
         );
         validate(wrapper, testTitle, true, true, true, false);
@@ -572,7 +573,7 @@ describe('GridTitle', () => {
         ) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization />,
             { user: TEST_USER_PROJECT_ADMIN }
         );
         validate(wrapper, 'No Extra Column', true, true, false, false);
@@ -587,7 +588,7 @@ describe('GridTitle', () => {
         ) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization />,
             { user: TEST_USER_READER }
         );
         validate(wrapper, testTitle + ' - No Extra Column', true, true, false, false);
@@ -601,7 +602,7 @@ describe('GridTitle', () => {
             .setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization={true} />,
+            <GridTitle {...GRID_TITLE_PROPS} model={model} allowViewCustomization />,
             { user: TEST_USER_READER }
         );
         validate(wrapper, testTitle, true, true, false, true);
@@ -615,7 +616,7 @@ describe('GridTitle', () => {
             .setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(
-            <GridTitle actions={actions} allowSelections={true} model={model} allowViewCustomization={true} />,
+            <GridTitle actions={actions} allowSelections model={model} allowViewCustomization />,
             { user: TEST_USER_READER }
         );
         validate(wrapper, 'EditedDefault ViewUndoSave', true, true, false, true);
@@ -626,9 +627,10 @@ describe('GridTitle', () => {
         const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
-        const tree = renderer
-            .create(<GridTitle model={model} actions={actions} allowSelections={true} allowViewCustomization={false} />)
-            .toJSON();
-        expect(tree).toBeNull();
+        const wrapper = mountWithServerContext(
+            <GridTitle model={model} actions={actions} allowSelections allowViewCustomization={false} />
+        );
+        expect(wrapper.exists('.view-header')).toBeFalsy();
+        wrapper.unmount();
     });
 });

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -320,9 +320,9 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
         onRevertView?.();
     }, [model, onRevertView, actions, allowSelections]);
 
-    const _onSaveCurrentView = (): void => {
+    const _onSaveCurrentView = useCallback((): void => {
         onSaveView(user?.isAdmin);
-    };
+    }, [onSaveView, user]);
 
     if (!displayTitle && (!allowViewCustomization || (!isEdited && !isUpdated))) {
         return null;


### PR DESCRIPTION
#### Rationale
This addresses part of [Issue 46788](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46788) to ensure the folder menu appears whenever the projects feature is enabled and projects are available to choose from. Specifically, this separates the logics of `NavigationBar.showFolderMenu`, an application controlled prop, from the rendering of the folder menu, which is now solely responsible for determining if projects are available.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1036
* https://github.com/LabKey/inventory/pull/621
* https://github.com/LabKey/biologics/pull/1750
* https://github.com/LabKey/sampleManagement/pull/1413

#### Changes
* Fully hide DOM for `FolderMenu` when rendering `NavigationBar` when respecting `!showFolderMenu`.
* Address [Issue 46816](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46816) by having `QuerySelect` skip processing of stale requests.
* Introduce `setProductProjects` to update moduleContext in React context and global context.
* Update moduleContext and invalidate query details cache upon creation of the first project.