### PR TITLE
WebDav helper for deleting directories and files: deleteWebDavResource()

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.259.0",
+  "version": "2.259.0-fb-webdavDelete.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.260.0",
+  "version": "2.261.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* WebDav helper for deleting directories and files: deleteWebDavResource()
+* Allow for container GUID to be used instead of containerPath in webdav helpers
+
 ### version 2.259.0
 *Released*: 22 November 2022
 * Update `addColumns`, `changeColumn`, and `removeColumns` editable grid actions to update the new `columns` array on the `EditorModel`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.261.0
+*Released*: 28 November 2022
 * WebDav helper for deleting directories and files: deleteWebDavResource()
 * Allow for container GUID to be used instead of containerPath in webdav helpers
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -124,7 +124,13 @@ import { DEFAULT_FILE } from './internal/components/files/models';
 import { FilesListing } from './internal/components/files/FilesListing';
 import { FilesListingForm } from './internal/components/files/FilesListingForm';
 import { FileAttachmentEntry } from './internal/components/files/FileAttachmentEntry';
-import { createWebDavDirectory, getWebDavFiles, uploadWebDavFile, WebDavFile } from './public/files/WebDav';
+import {
+    createWebDavDirectory,
+    deleteWebDavResource,
+    getWebDavFiles,
+    uploadWebDavFile,
+    WebDavFile,
+} from './public/files/WebDav';
 import { FileTree } from './internal/components/files/FileTree';
 import { Notifications } from './internal/components/notifications/Notifications';
 import { getPipelineActivityData, markAllNotificationsAsRead } from './internal/components/notifications/actions';
@@ -1186,6 +1192,7 @@ export {
     getWebDavFiles,
     uploadWebDavFile,
     createWebDavDirectory,
+    deleteWebDavResource,
     // util functions
     getDateFormat,
     getDisambiguatedSelectInputOptions,

--- a/packages/components/src/public/files/WebDav.ts
+++ b/packages/components/src/public/files/WebDav.ts
@@ -56,7 +56,8 @@ function getWebDavUrl(
     skipAtFiles?: boolean,
     asJSON?: boolean
 ): string {
-    let url = `${ActionURL.getContextPath()}/_webdav${ActionURL.encodePath(containerPath)}`;
+    const containerPath_ = containerPath?.startsWith('/') ? containerPath : '/' + containerPath;
+    let url = `${ActionURL.getContextPath()}/_webdav${ActionURL.encodePath(containerPath_)}`;
 
     if (!skipAtFiles) url += '/' + encodeURIComponent('@files');
     if (directory) url += '/' + encodeURIComponent(directory).replace(/%2F/g, '/');
@@ -147,6 +148,26 @@ export function createWebDavDirectory(
                 () => {
                     console.error('failure creating directory ' + directory);
                     reject(directory);
+                },
+                null,
+                false
+            ),
+        });
+    });
+}
+
+export function deleteWebDavResource(containerPath: string, directoryOrFilePath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        Ajax.request({
+            url: getWebDavUrl(containerPath, directoryOrFilePath),
+            method: 'DELETE',
+            success: Utils.getCallbackWrapper(() => {
+                resolve(directoryOrFilePath);
+            }),
+            failure: Utils.getCallbackWrapper(
+                () => {
+                    console.error('failure deleting resource ' + directoryOrFilePath);
+                    reject(directoryOrFilePath);
                 },
                 null,
                 false


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/SCTx%20CSL/support%20tickets/issues-details.view?issueId=46185

#### Related Pull Requests
* Previous PR with create helper: https://github.com/LabKey/labkey-ui-components/pull/967
* https://github.com/LabKey/tutorialModules/pull/108

#### Changes
* Add webdav helper for deleting directories and files: deleteWebDavResource()
* Allow for container GUID to be used instead of containerPath in webdav helpers
