### PR TITLE
Updates for form consistency in apps: textarea resize vertically only

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.263.0",
+  "version": "2.263.0-fb-textAreaResizing.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.261.2",
+  "version": "2.261.2-fb-textAreaResizing.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.263.0-fb-textAreaResizing.0",
+  "version": "2.264.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.261.1",
+  "version": "2.261.1-fb-textAreaResizing.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Updates for form consistency in apps: textarea resizing
+  * only allow for vertical resizing, not horizontal
+
 ### version 2.261.1
 *Released*: 29 November 2022
 * Various projects container filtering fixes

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.264.0
+*Released*: 1 December 2022
 * Updates for form consistency in apps: textarea resizing
   * only allow for vertical resizing, not horizontal
 

--- a/packages/components/src/assay/AssayQCModal.tsx
+++ b/packages/components/src/assay/AssayQCModal.tsx
@@ -111,7 +111,6 @@ export class AssayQCModal extends PureComponent<Props, AssayQCState> {
                             <div className="col-sm-9">
                                 <FormControl
                                     componentClass="textarea"
-                                    className="textarea-noresize"
                                     value={comment}
                                     onChange={this.updateComment}
                                 />

--- a/packages/components/src/assay/AssayQCModal.tsx
+++ b/packages/components/src/assay/AssayQCModal.tsx
@@ -109,11 +109,7 @@ export class AssayQCModal extends PureComponent<Props, AssayQCState> {
                             <label className="control-label col-sm-3 text-left">Comment{requireComment && ' *'}</label>
 
                             <div className="col-sm-9">
-                                <FormControl
-                                    componentClass="textarea"
-                                    value={comment}
-                                    onChange={this.updateComment}
-                                />
+                                <FormControl componentClass="textarea" value={comment} onChange={this.updateComment} />
                             </div>
                         </div>
 

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -175,7 +175,7 @@ export const EditInlineField: FC<Props> = memo(props => {
                     <textarea
                         autoFocus
                         className="form-control"
-                        cols={50}
+                        cols={100}
                         defaultValue={_value}
                         onBlur={onBlur}
                         onFocus={onTextAreaFocus}

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.spec.tsx
@@ -63,7 +63,7 @@ describe('NameAndLinkingOptions', () => {
         // Description
         let formField = wrapper.find({
             id: createFormInputId(DOMAIN_FIELD_DESCRIPTION, 1, 1),
-            className: 'form-control textarea-noresize form-control',
+            className: 'form-control',
         });
         expect(formField.length).toEqual(1);
         expect(formField.props().value).toEqual(_description);

--- a/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameAndLinkingOptions.tsx
@@ -79,7 +79,6 @@ export class NameAndLinkingOptions extends PureComponent<NameAndLinkingProps> {
                         <div className="domain-field-label">Description</div>
                         <FormControl
                             componentClass="textarea"
-                            className="form-control textarea-noresize"
                             rows={4}
                             value={field.description || ''}
                             id={createFormInputId(DOMAIN_FIELD_DESCRIPTION, domainIndex, index)}

--- a/packages/components/src/internal/components/domainproperties/TextChoiceAddValuesModal.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceAddValuesModal.tsx
@@ -8,10 +8,10 @@ import { getValidValuesFromArray } from './models';
 
 interface Props {
     fieldName: string;
-    onCancel: () => void;
-    onApply: (values: string[]) => void;
     initialValueCount?: number;
     maxValueCount?: number;
+    onApply: (values: string[]) => void;
+    onCancel: () => void;
 }
 
 export const TextChoiceAddValuesModal: FC<Props> = memo(props => {

--- a/packages/components/src/internal/components/domainproperties/TextChoiceAddValuesModal.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceAddValuesModal.tsx
@@ -49,7 +49,7 @@ export const TextChoiceAddValuesModal: FC<Props> = memo(props => {
                 <textarea
                     rows={8}
                     cols={50}
-                    className="textarea-fullwidth textarea-noresize"
+                    className="form-control textarea-fullwidth"
                     placeholder="Enter new values..."
                     onChange={onChange}
                     value={valueStr}

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
@@ -1447,7 +1447,6 @@ exports[`DomainRow Sample Field 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-0"
@@ -1457,7 +1456,7 @@ exports[`DomainRow Sample Field 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-0"
                                                           name="domainpropertiesrow-description"
@@ -3466,7 +3465,6 @@ exports[`DomainRow client side warning on field 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-1"
@@ -3476,7 +3474,7 @@ exports[`DomainRow client side warning on field 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"
@@ -5383,7 +5381,6 @@ exports[`DomainRow date time field 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-0"
@@ -5393,7 +5390,7 @@ exports[`DomainRow date time field 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-0"
                                                           name="domainpropertiesrow-description"
@@ -7419,7 +7416,6 @@ exports[`DomainRow decimal field 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-2"
@@ -7429,7 +7425,7 @@ exports[`DomainRow decimal field 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-2"
                                                           name="domainpropertiesrow-description"
@@ -9255,7 +9251,6 @@ exports[`DomainRow participant id field 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-0"
@@ -9265,7 +9260,7 @@ exports[`DomainRow participant id field 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-0"
                                                           name="domainpropertiesrow-description"
@@ -11314,7 +11309,6 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-1"
@@ -11324,7 +11318,7 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"
@@ -13322,7 +13316,6 @@ exports[`DomainRow string field test 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-1"
@@ -13332,7 +13325,7 @@ exports[`DomainRow string field test 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"
@@ -15472,7 +15465,6 @@ exports[`DomainRow with empty domain form 1`] = `
                                                       </div>
                                                       <FormControl
                                                         bsClass="form-control"
-                                                        className="form-control textarea-noresize"
                                                         componentClass="textarea"
                                                         disabled={false}
                                                         id="domainpropertiesrow-description-1-1"
@@ -15482,7 +15474,7 @@ exports[`DomainRow with empty domain form 1`] = `
                                                         value=""
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize form-control"
+                                                          className="form-control"
                                                           disabled={false}
                                                           id="domainpropertiesrow-description-1-1"
                                                           name="domainpropertiesrow-description"

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/NameAndLinkingOptions.spec.tsx.snap
@@ -149,7 +149,6 @@ exports[`NameAndLinkingOptions Name and Linking options 1`] = `
             </div>
             <FormControl
               bsClass="form-control"
-              className="form-control textarea-noresize"
               componentClass="textarea"
               disabled={false}
               id="domainpropertiesrow-description-1-1"
@@ -159,7 +158,7 @@ exports[`NameAndLinkingOptions Name and Linking options 1`] = `
               value="This is a description"
             >
               <textarea
-                className="form-control textarea-noresize form-control"
+                className="form-control"
                 disabled={false}
                 id="domainpropertiesrow-description-1-1"
                 name="domainpropertiesrow-description"

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -85,7 +85,7 @@ export function DescriptionInput(props: InputProps) {
             helpTipBody={<p>A short description for this assay design.</p>}
         >
             <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id={FORM_IDS.ASSAY_DESCRIPTION}
                 value={props.model.description || ''}
                 onChange={props.onChange}

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
@@ -1438,7 +1438,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
                                                         className="col-lg-10 col-xs-9"
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize"
+                                                          className="form-control"
                                                           id="assay-design-description"
                                                           onChange={[Function]}
                                                           value=""
@@ -7202,7 +7202,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                         className="col-lg-10 col-xs-9"
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize"
+                                                          className="form-control"
                                                           id="assay-design-description"
                                                           onChange={[Function]}
                                                           value="My assay protocol for you all to use."
@@ -12372,7 +12372,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-0"
@@ -12382,7 +12381,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-0"
                                                                                               name="domainpropertiesrow-description"
@@ -14239,7 +14238,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-1"
@@ -14249,7 +14247,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-1"
                                                                                               name="domainpropertiesrow-description"
@@ -16060,7 +16058,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-2"
@@ -16070,7 +16067,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-2"
                                                                                               name="domainpropertiesrow-description"
@@ -18161,7 +18158,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
                                                         className="col-lg-8 col-xs-9"
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize"
+                                                          className="form-control"
                                                           id="assay-design-description"
                                                           onChange={[Function]}
                                                           value=""
@@ -21786,7 +21783,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain for new assay 1`] = `
                                                         className="col-lg-8 col-xs-9"
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize"
+                                                          className="form-control"
                                                           id="assay-design-description"
                                                           onChange={[Function]}
                                                           value=""
@@ -26950,7 +26947,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                         className="col-lg-8 col-xs-9"
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize"
+                                                          className="form-control"
                                                           id="assay-design-description"
                                                           onChange={[Function]}
                                                           value="My assay protocol for you all to use."
@@ -31535,7 +31532,6 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-0"
@@ -31545,7 +31541,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-0"
                                                                                               name="domainpropertiesrow-description"
@@ -33414,7 +33410,6 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-1"
@@ -33424,7 +33419,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-1"
                                                                                               name="domainpropertiesrow-description"
@@ -35247,7 +35242,6 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-2"
@@ -35257,7 +35251,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-2"
                                                                                               name="domainpropertiesrow-description"
@@ -39507,7 +39501,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                         className="col-lg-8 col-xs-9"
                                                       >
                                                         <textarea
-                                                          className="form-control textarea-noresize"
+                                                          className="form-control"
                                                           id="assay-design-description"
                                                           onChange={[Function]}
                                                           value="My assay protocol for you all to use."
@@ -45158,7 +45152,6 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-0"
@@ -45168,7 +45161,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-0"
                                                                                               name="domainpropertiesrow-description"
@@ -47037,7 +47030,6 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-1"
@@ -47047,7 +47039,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-1"
                                                                                               name="domainpropertiesrow-description"
@@ -48870,7 +48862,6 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-1-2"
@@ -48880,7 +48871,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-1-2"
                                                                                               name="domainpropertiesrow-description"

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
@@ -828,7 +828,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                             className="col-lg-10 col-xs-9"
                           >
                             <textarea
-                              className="form-control textarea-noresize"
+                              className="form-control"
                               id="assay-design-description"
                               onChange={[Function]}
                               value=""
@@ -2124,7 +2124,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                           className="col-lg-8 col-xs-9"
                                         >
                                           <textarea
-                                            className="form-control textarea-noresize"
+                                            className="form-control"
                                             id="assay-design-description"
                                             onChange={[Function]}
                                             value=""
@@ -3451,7 +3451,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                           className="col-lg-8 col-xs-9"
                                         >
                                           <textarea
-                                            className="form-control textarea-noresize"
+                                            className="form-control"
                                             id="assay-design-description"
                                             onChange={[Function]}
                                             value=""
@@ -4304,7 +4304,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                           className="col-lg-8 col-xs-9"
                                         >
                                           <textarea
-                                            className="form-control textarea-noresize"
+                                            className="form-control"
                                             id="assay-design-description"
                                             onChange={[Function]}
                                             value="test description for this assay"
@@ -5517,7 +5517,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                           className="col-lg-10 col-xs-9"
                                         >
                                           <textarea
-                                            className="form-control textarea-noresize"
+                                            className="form-control"
                                             id="assay-design-description"
                                             onChange={[Function]}
                                             value=""

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -118,7 +118,7 @@ exports[`DataClassDesigner custom properties 1`] = `
               className="col-xs-10"
             >
               <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="entity-description"
                 onChange={[Function]}
                 value=""
@@ -459,7 +459,7 @@ exports[`DataClassDesigner default properties 1`] = `
               className="col-xs-10"
             >
               <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="entity-description"
                 onChange={[Function]}
                 value=""
@@ -3346,7 +3346,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                               className="col-xs-10"
                                             >
                                               <textarea
-                                                className="form-control textarea-noresize"
+                                                className="form-control"
                                                 id="entity-description"
                                                 onChange={[Function]}
                                                 value="with a description"
@@ -20610,7 +20610,6 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-0"
@@ -20620,7 +20619,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-0"
                                                                                               name="domainpropertiesrow-description"
@@ -22553,7 +22552,6 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-1"
@@ -22563,7 +22561,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-1"
                                                                                               name="domainpropertiesrow-description"
@@ -24410,7 +24408,6 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-2"
@@ -24420,7 +24417,7 @@ exports[`DataClassDesigner initModel 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-2"
                                                                                               name="domainpropertiesrow-description"

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassPropertiesPanel.spec.tsx.snap
@@ -113,7 +113,7 @@ exports[`DataClassPropertiesPanel custom properties 1`] = `
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""
@@ -263,7 +263,7 @@ exports[`DataClassPropertiesPanel default properties 1`] = `
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanelFormElements.tsx
@@ -53,12 +53,7 @@ export class DescriptionInput extends React.PureComponent<BasicPropertiesInputsP
                 </Col>
 
                 <Col xs={7}>
-                    <textarea
-                        className="form-control"
-                        id="description"
-                        value={value}
-                        onChange={onInputChange}
-                    />
+                    <textarea className="form-control" id="description" value={value} onChange={onInputChange} />
                 </Col>
 
                 <Col xs={1} />

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanelFormElements.tsx
@@ -54,7 +54,7 @@ export class DescriptionInput extends React.PureComponent<BasicPropertiesInputsP
 
                 <Col xs={7}>
                     <textarea
-                        className="form-control textarea-noresize"
+                        className="form-control"
                         id="description"
                         value={value}
                         onChange={onInputChange}

--- a/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
@@ -165,7 +165,7 @@ exports[`Dataset Properties Panel Edit existing dataset 1`] = `
               className="col-xs-7"
             >
               <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="description"
                 onChange={[Function]}
                 value="This is the first dataset"
@@ -787,7 +787,7 @@ exports[`Dataset Properties Panel New dataset 1`] = `
               className="col-xs-7"
             >
               <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="description"
                 onChange={[Function]}
                 value=""

--- a/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
@@ -91,7 +91,7 @@ export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, a
                     </Col>
                     <Col xs={10}>
                         <textarea
-                            className="form-control textarea-noresize"
+                            className="form-control"
                             id={ENTITY_FORM_IDS.DESCRIPTION}
                             onChange={onFormChange}
                             value={getEntityDescriptionValue(formValues, data)}

--- a/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
@@ -20,19 +20,19 @@ import {
 import { ENTITY_FORM_IDS } from './constants';
 
 export interface EntityDetailsProps {
-    noun: string;
-    onFormChange: (evt: any) => any;
-    warning?: string;
-    formValues?: IEntityDetails;
     data?: Map<string, any>;
+    formValues?: IEntityDetails;
+    nameExpressionGenIdProps?: NameExpressionGenIdProps;
     nameExpressionInfoUrl?: string;
     nameExpressionPlaceholder?: string;
-    nameReadOnly?: boolean;
-    showPreviewName?: boolean;
-    previewName?: string;
     namePreviewsLoading?: boolean;
+    nameReadOnly?: boolean;
+    noun: string;
+    onFormChange: (evt: any) => any;
     onNameFieldHover?: () => any;
-    nameExpressionGenIdProps?: NameExpressionGenIdProps;
+    previewName?: string;
+    showPreviewName?: boolean;
+    warning?: string;
 }
 
 export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, any> {
@@ -66,10 +66,7 @@ export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, a
             <Form>
                 <Row className="margin-bottom margin-top">
                     <Col xs={2}>
-                        <DomainFieldLabel
-                            label="Name"
-                            required={true}
-                        />
+                        <DomainFieldLabel label="Name" required={true} />
                     </Col>
                     <Col xs={10}>
                         <FormControl

--- a/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`<EntityDetailsForm/> default properties 1`] = `
       className="col-xs-10"
     >
       <textarea
-        className="form-control textarea-noresize"
+        className="form-control"
         id="entity-description"
         onChange={[MockFunction]}
         value=""
@@ -162,7 +162,7 @@ exports[`<EntityDetailsForm/> initial data 1`] = `
       className="col-xs-10"
     >
       <textarea
-        className="form-control textarea-noresize"
+        className="form-control"
         id="entity-description"
         onChange={[MockFunction]}
         value="Test Entity Description"
@@ -268,7 +268,7 @@ exports[`<EntityDetailsForm/> nameExpression properties 1`] = `
       className="col-xs-10"
     >
       <textarea
-        className="form-control textarea-noresize"
+        className="form-control"
         id="entity-description"
         onChange={[MockFunction]}
         value=""
@@ -375,7 +375,7 @@ exports[`<EntityDetailsForm/> with formValues 1`] = `
       className="col-xs-10"
     >
       <textarea
-        className="form-control textarea-noresize"
+        className="form-control"
         id="entity-description"
         onChange={[MockFunction]}
         value="Test Entity Description"
@@ -573,7 +573,7 @@ exports[`<EntityDetailsForm/> with previewName 1`] = `
               className="col-xs-10"
             >
               <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="entity-description"
                 onChange={[MockFunction]}
                 value="Test Entity Description"

--- a/packages/components/src/internal/components/domainproperties/list/ListPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListPropertiesPanelFormElements.tsx
@@ -43,7 +43,7 @@ export const DescriptionInput: FC<BasicPropertiesInputsProps> = memo(({ model, o
 
         <Col xs={9} lg={8}>
             <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="description"
                 value={model.description === null ? '' : model.description}
                 onChange={onInputChange}

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListDesignerPanels.spec.tsx.snap
@@ -12151,7 +12151,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                     className="col-lg-8 col-xs-9"
                                                   >
                                                     <textarea
-                                                      className="form-control textarea-noresize"
+                                                      className="form-control"
                                                       id="description"
                                                       onChange={[Function]}
                                                       value=""
@@ -20733,7 +20733,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-0"
@@ -20743,7 +20742,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-0"
                                                                                               name="domainpropertiesrow-description"
@@ -22715,7 +22714,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-1"
@@ -22725,7 +22723,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-1"
                                                                                               name="domainpropertiesrow-description"
@@ -24708,7 +24706,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-2"
@@ -24718,7 +24715,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-2"
                                                                                               name="domainpropertiesrow-description"
@@ -27017,7 +27014,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-3"
@@ -27027,7 +27023,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-3"
                                                                                               name="domainpropertiesrow-description"
@@ -29326,7 +29322,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-4"
@@ -29336,7 +29331,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-4"
                                                                                               name="domainpropertiesrow-description"
@@ -31319,7 +31314,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-5"
@@ -31329,7 +31323,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-5"
                                                                                               name="domainpropertiesrow-description"
@@ -33114,7 +33108,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-6"
@@ -33124,7 +33117,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-6"
                                                                                               name="domainpropertiesrow-description"
@@ -35337,7 +35330,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-7"
@@ -35347,7 +35339,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-7"
                                                                                               name="domainpropertiesrow-description"
@@ -37330,7 +37322,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-8"
@@ -37340,7 +37331,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-8"
                                                                                               name="domainpropertiesrow-description"
@@ -39323,7 +39314,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-9"
@@ -39333,7 +39323,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-9"
                                                                                               name="domainpropertiesrow-description"
@@ -41316,7 +41306,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-10"
@@ -41326,7 +41315,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-10"
                                                                                               name="domainpropertiesrow-description"
@@ -43179,7 +43168,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-11"
@@ -43189,7 +43177,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-11"
                                                                                               name="domainpropertiesrow-description"
@@ -44997,7 +44985,6 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-12"
@@ -45007,7 +44994,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-12"
                                                                                               name="domainpropertiesrow-description"
@@ -45852,7 +45839,7 @@ exports[`ListDesignerPanel new list 1`] = `
                 className="col-lg-8 col-xs-9"
               >
                 <textarea
-                  className="form-control textarea-noresize"
+                  className="form-control"
                   id="description"
                   onChange={[Function]}
                   value=""

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanel.spec.tsx.snap
@@ -115,7 +115,7 @@ exports[`ListPropertiesPanel existing list 1`] = `
             className="col-lg-8 col-xs-9"
           >
             <textarea
-              className="form-control textarea-noresize"
+              className="form-control"
               id="description"
               onChange={[Function]}
               value=""
@@ -321,7 +321,7 @@ exports[`ListPropertiesPanel list with error 1`] = `
             className="col-lg-8 col-xs-9"
           >
             <textarea
-              className="form-control textarea-noresize"
+              className="form-control"
               id="description"
               onChange={[Function]}
               value=""
@@ -514,7 +514,7 @@ exports[`ListPropertiesPanel new list 1`] = `
             className="col-lg-8 col-xs-9"
           >
             <textarea
-              className="form-control textarea-noresize"
+              className="form-control"
               id="description"
               onChange={[Function]}
               value=""

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanelFormElements.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanelFormElements.spec.tsx.snap
@@ -192,7 +192,7 @@ exports[`BasicPropertiesFields existing list, existing properties 1`] = `
       className="col-lg-8 col-xs-9"
     >
       <textarea
-        className="form-control textarea-noresize"
+        className="form-control"
         id="description"
         onChange={[MockFunction]}
         value=""
@@ -269,7 +269,7 @@ exports[`BasicPropertiesFields new list, default properties 1`] = `
       className="col-lg-8 col-xs-9"
     >
       <textarea
-        className="form-control textarea-noresize"
+        className="form-control"
         id="description"
         onChange={[MockFunction]}
         value=""

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -118,7 +118,7 @@ exports[`SampleTypeDesigner custom properties 1`] = `
               className="col-xs-10"
             >
               <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="entity-description"
                 onChange={[Function]}
                 value=""
@@ -464,7 +464,7 @@ exports[`SampleTypeDesigner default properties 1`] = `
               className="col-xs-10"
             >
               <textarea
-                className="form-control textarea-noresize"
+                className="form-control"
                 id="entity-description"
                 onChange={[Function]}
                 value=""
@@ -2200,7 +2200,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                               className="col-xs-10"
                                             >
                                               <textarea
-                                                className="form-control textarea-noresize"
+                                                className="form-control"
                                                 id="entity-description"
                                                 onChange={[Function]}
                                                 value=""
@@ -4803,7 +4803,6 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                                           </div>
                                                                                           <FormControl
                                                                                             bsClass="form-control"
-                                                                                            className="form-control textarea-noresize"
                                                                                             componentClass="textarea"
                                                                                             disabled={false}
                                                                                             id="domainpropertiesrow-description-0-0"
@@ -4813,7 +4812,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
                                                                                             value=""
                                                                                           >
                                                                                             <textarea
-                                                                                              className="form-control textarea-noresize form-control"
+                                                                                              className="form-control"
                                                                                               disabled={false}
                                                                                               id="domainpropertiesrow-description-0-0"
                                                                                               name="domainpropertiesrow-description"

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -102,7 +102,7 @@ exports[`<SampleTypePropertiesPanel/> appPropertiesOnly 1`] = `
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""
@@ -340,7 +340,7 @@ exports[`<SampleTypePropertiesPanel/> default props 1`] = `
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""
@@ -528,7 +528,7 @@ exports[`<SampleTypePropertiesPanel/> include dataclass and use custom labels 1`
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""
@@ -759,7 +759,7 @@ exports[`<SampleTypePropertiesPanel/> includeMetricUnitProperty 1`] = `
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""
@@ -1037,7 +1037,7 @@ exports[`<SampleTypePropertiesPanel/> metricUnitOptions 1`] = `
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""
@@ -1427,7 +1427,7 @@ exports[`<SampleTypePropertiesPanel/> nameExpressionInfoUrl 1`] = `
           className="col-xs-10"
         >
           <textarea
-            className="form-control textarea-noresize"
+            className="form-control"
             id="entity-description"
             onChange={[Function]}
             value=""
@@ -2067,7 +2067,7 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                                 className="col-xs-10"
                               >
                                 <textarea
-                                  className="form-control textarea-noresize"
+                                  className="form-control"
                                   id="entity-description"
                                   onChange={[Function]}
                                   value=""

--- a/packages/components/src/internal/components/domainproperties/validation/RangeValidationOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/validation/RangeValidationOptions.tsx
@@ -50,7 +50,7 @@ export class RangeValidationOptions extends PureComponent<RangeValidationOptions
                     <div>
                         <FormControl
                             componentClass="textarea"
-                            className="domain-validation-textarea"
+                            className="textarea-fullwidth"
                             rows={3}
                             id={createFormInputId(name, domainIndex, validatorIndex)}
                             name={createFormInputName(name)}

--- a/packages/components/src/internal/components/domainproperties/validation/RegexValidationOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/validation/RegexValidationOptions.tsx
@@ -64,7 +64,7 @@ export class RegexValidationOptions extends React.PureComponent<RegexValidationO
                     <div>
                         <FormControl
                             componentClass="textarea"
-                            className="domain-validation-textarea"
+                            className="textarea-fullwidth"
                             rows={3}
                             id={createFormInputId(name, domainIndex, validatorIndex)}
                             name={createFormInputName(name)}

--- a/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RangeValidationOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RangeValidationOptions.spec.tsx.snap
@@ -534,7 +534,7 @@ exports[`RangeValidationOptions Range Validator - expanded 1`] = `
               <div>
                 <FormControl
                   bsClass="form-control"
-                  className="domain-validation-textarea"
+                  className="textarea-fullwidth"
                   componentClass="textarea"
                   id="domainpropertiesrow-description-1-0"
                   name="domainpropertiesrow-description"
@@ -543,7 +543,7 @@ exports[`RangeValidationOptions Range Validator - expanded 1`] = `
                   value="This is a range validator"
                 >
                   <textarea
-                    className="domain-validation-textarea form-control"
+                    className="textarea-fullwidth form-control"
                     id="domainpropertiesrow-description-1-0"
                     name="domainpropertiesrow-description"
                     onChange={[Function]}
@@ -588,7 +588,7 @@ exports[`RangeValidationOptions Range Validator - expanded 1`] = `
               <div>
                 <FormControl
                   bsClass="form-control"
-                  className="domain-validation-textarea"
+                  className="textarea-fullwidth"
                   componentClass="textarea"
                   id="domainpropertiesrow-errorMessage-1-0"
                   name="domainpropertiesrow-errorMessage"
@@ -597,7 +597,7 @@ exports[`RangeValidationOptions Range Validator - expanded 1`] = `
                   value="Range validation failed"
                 >
                   <textarea
-                    className="domain-validation-textarea form-control"
+                    className="textarea-fullwidth form-control"
                     id="domainpropertiesrow-errorMessage-1-0"
                     name="domainpropertiesrow-errorMessage"
                     onChange={[Function]}

--- a/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RegexValidationOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/validation/__snapshots__/RegexValidationOptions.spec.tsx.snap
@@ -176,7 +176,7 @@ exports[`RegexValidationOptions Regex Validator - expanded 1`] = `
               <div>
                 <FormControl
                   bsClass="form-control"
-                  className="domain-validation-textarea"
+                  className="textarea-fullwidth"
                   componentClass="textarea"
                   id="domainpropertiesrow-expression-1-0"
                   name="domainpropertiesrow-expression"
@@ -185,7 +185,7 @@ exports[`RegexValidationOptions Regex Validator - expanded 1`] = `
                   value="$[abc]"
                 >
                   <textarea
-                    className="domain-validation-textarea form-control"
+                    className="textarea-fullwidth form-control"
                     id="domainpropertiesrow-expression-1-0"
                     name="domainpropertiesrow-expression"
                     onChange={[Function]}
@@ -230,7 +230,7 @@ exports[`RegexValidationOptions Regex Validator - expanded 1`] = `
               <div>
                 <FormControl
                   bsClass="form-control"
-                  className="domain-validation-textarea"
+                  className="textarea-fullwidth"
                   componentClass="textarea"
                   id="domainpropertiesrow-description-1-0"
                   name="domainpropertiesrow-description"
@@ -239,7 +239,7 @@ exports[`RegexValidationOptions Regex Validator - expanded 1`] = `
                   value="This is my validator description"
                 >
                   <textarea
-                    className="domain-validation-textarea form-control"
+                    className="textarea-fullwidth form-control"
                     id="domainpropertiesrow-description-1-0"
                     name="domainpropertiesrow-description"
                     onChange={[Function]}
@@ -311,7 +311,7 @@ exports[`RegexValidationOptions Regex Validator - expanded 1`] = `
               <div>
                 <FormControl
                   bsClass="form-control"
-                  className="domain-validation-textarea"
+                  className="textarea-fullwidth"
                   componentClass="textarea"
                   id="domainpropertiesrow-errorMessage-1-0"
                   name="domainpropertiesrow-errorMessage"
@@ -320,7 +320,7 @@ exports[`RegexValidationOptions Regex Validator - expanded 1`] = `
                   value="Test Validation Failure"
                 >
                   <textarea
-                    className="domain-validation-textarea form-control"
+                    className="textarea-fullwidth form-control"
                     id="domainpropertiesrow-errorMessage-1-0"
                     name="domainpropertiesrow-errorMessage"
                     onChange={[Function]}

--- a/packages/components/src/internal/components/samples/DiscardConsumedSamplesPanel.tsx
+++ b/packages/components/src/internal/components/samples/DiscardConsumedSamplesPanel.tsx
@@ -2,10 +2,10 @@ import React, { FC, memo } from 'react';
 import { Col, Row } from 'react-bootstrap';
 
 interface Props {
-    shouldDiscard: boolean;
-    onCommentChange: (event) => any;
-    toggleShouldDiscard: () => any;
     discardTitle?: string;
+    onCommentChange: (event) => any;
+    shouldDiscard: boolean;
+    toggleShouldDiscard: () => any;
 }
 
 export const DISCARD_CONSUMED_CHECKBOX_FIELD = 'discardcheckbox';

--- a/packages/components/src/internal/components/samples/DiscardConsumedSamplesPanel.tsx
+++ b/packages/components/src/internal/components/samples/DiscardConsumedSamplesPanel.tsx
@@ -37,7 +37,7 @@ export const DiscardConsumedSamplesPanel: FC<Props> = memo(props => {
             <div className="form-group">
                 <div className="storage-item-data">Reason for discarding</div>
                 <textarea
-                    className="form-control textarea-noresize"
+                    className="form-control"
                     id={DISCARD_CONSUMED_COMMENT_FIELD}
                     name={DISCARD_CONSUMED_COMMENT_FIELD}
                     placeholder="Enter comments (optional)"

--- a/packages/components/src/internal/components/search/FindByIdsModal.tsx
+++ b/packages/components/src/internal/components/search/FindByIdsModal.tsx
@@ -12,8 +12,8 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 // exported for Jest testing
 export const FindFieldOption: FC<{
-    field: FindField;
     checked: boolean;
+    field: FindField;
     onFieldChange: (field: FindField) => void;
 }> = memo(({ field, checked, onFieldChange }) => {
     const onChange = useCallback(
@@ -38,12 +38,12 @@ export const FindFieldOption: FC<{
 
 interface Props {
     api?: ComponentsAPIWrapper;
-    show: boolean;
+    initialField?: FindField;
+    nounPlural: string;
     onCancel: () => void;
     onFind: (sessionKey: string) => void;
-    nounPlural: string;
-    initialField?: FindField;
     sessionKey?: string; // when defined, ids entered will be added to the existing ones in session
+    show: boolean;
 }
 
 export const FindByIdsModal: FC<Props> = memo(props => {

--- a/packages/components/src/internal/components/search/FindByIdsModal.tsx
+++ b/packages/components/src/internal/components/search/FindByIdsModal.tsx
@@ -114,7 +114,7 @@ export const FindByIdsModal: FC<Props> = memo(props => {
                 <textarea
                     rows={8}
                     cols={50}
-                    className="textarea-fullwidth textarea-noresize"
+                    className="form-control textarea-fullwidth"
                     placeholder={`List ${fieldType.nounPlural} here`}
                     onChange={onIdTextChange}
                     value={idString}

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -97,7 +97,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
                 </div>
                 <FormControl
                     componentClass="textarea"
-                    className="form-control create-users-textarea"
+                    className="form-control"
                     id="create-users-email-input"
                     rows={5}
                     value={emailText || ''}
@@ -129,7 +129,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
                 <div className="create-users-label-bottom">Optional message to send to new users:</div>
                 <FormControl
                     componentClass="textarea"
-                    className="form-control create-users-textarea"
+                    className="form-control"
                     id="create-users-optionalMessage-input"
                     rows={5}
                     value={optionalMessage || ''}

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -572,11 +572,6 @@
   border: 1px solid $gray-border;
 }
 
-.domain-validation-textarea {
-  resize: none;
-  width: 100%
-}
-
 .domain-validation-failOnMatch-row {
   margin-top: -14px;
 }

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -215,9 +215,9 @@ div.react-datepicker__current-month {
     font-size: 13px;
 }
 
-.textarea-noresize {
-    resize: none;
-    padding-bottom: 2%;
+textarea.form-control {
+    resize: vertical;
+    min-height: 54px;
 }
 
 .textarea-fullwidth {

--- a/packages/components/src/theme/user.scss
+++ b/packages/components/src/theme/user.scss
@@ -13,10 +13,6 @@
   padding-top: 10px;
 }
 
-.create-users-textarea {
-  resize: none;
-}
-
 .user-avatar {
     width: 32px;
     border-radius: 50%;


### PR DESCRIPTION
#### Rationale
Per the app consistency epic's form consistency spec, we want to prevent the textarea inputs in the app from being resized in a way that makes them "expand out" beyond their containing element. To accomplish this, we are using the css for "resize: vertical" to only allow for vertical resizing of this input type.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1039
* https://github.com/LabKey/platform/pull/3885
* https://github.com/LabKey/sampleManagement/pull/1420
* https://github.com/LabKey/inventory/pull/625
* https://github.com/LabKey/biologics/pull/1757
* https://github.com/LabKey/provenance/pull/135
* https://github.com/LabKey/labbook/pull/329

#### Changes
* remove textarea-noresize and update CSS for textarea.form-control directly
