### PR TITLE
Issue 46788: remove ID/Name settings from project creation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.263.0-fb-idname-46788.0",
+  "version": "2.263.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.263.0",
+  "version": "2.263.0-fb-idname-46788.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.263.1
+*Released*: 2 December 2022
+* Remove ID/Name Settings from `CreateProjectPage`.
+* Coalesce usage of `IDNameHelpTip` and `PrefixDescription` now that they are no longer utilized separately.
+
 ### version 2.263.0
 *Released*: 30 November 2022
 * Fully hide DOM for `FolderMenu` when rendering `NavigationBar` when respecting `!showFolderMenu`.

--- a/packages/components/src/internal/components/administration/CreateProjectPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/CreateProjectPage.spec.tsx
@@ -56,10 +56,8 @@ describe('CreateProjectPage', () => {
         await waitForLifecycle(wrapper);
 
         expect(createProject).toHaveBeenCalledWith({
-            allowUserSpecifiedNames: true,
             name: '',
             nameAsTitle: true,
-            prefix: '',
             title: null,
         });
         expect(onCreated).toHaveBeenCalledWith(project);

--- a/packages/components/src/internal/components/administration/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/administration/CreateProjectPage.tsx
@@ -15,7 +15,6 @@ import { AppURL } from '../../url/AppURL';
 import { getCurrentAppProperties, hasProductProjects, setProductProjects } from '../../app/utils';
 
 import { useFolderMenuContext } from '../navigation/hooks';
-import { IDNameSettings } from '../settings/NameIdSettings';
 
 import { invalidateFullQueryDetailsCache } from '../../query/api';
 
@@ -40,10 +39,8 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
 
             const formData = new FormData(evt.target);
             const options: ProjectSettingsOptions = {
-                allowUserSpecifiedNames: !!formData.get('allowUserSpecifiedNames'),
                 name: formData.get('name') as string,
                 nameAsTitle: !!formData.get('nameAsTitle'),
-                prefix: formData.get('prefix') as string,
                 title: formData.get('title') as string,
             };
 
@@ -73,10 +70,6 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                             <div className="form-subtitle">Project Properties</div>
 
                             <ProjectProperties autoFocus />
-
-                            <div className="form-subtitle">ID/Name Settings</div>
-
-                            <IDNameSettings />
 
                             {/* Dummy submit button so browsers trigger onSubmit with enter key */}
                             <button type="submit" className="dummy-input" tabIndex={-1} />

--- a/packages/components/src/internal/components/settings/NameIdSettings.spec.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.spec.tsx
@@ -9,7 +9,7 @@ import { ConfirmModal } from '../base/ConfirmModal';
 
 import { BIOLOGICS_APP_PROPERTIES, SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
-import { IDNameHelpTip, NameIdSettingsForm, PrefixDescription } from './NameIdSettings';
+import { NameIdSettingsForm } from './NameIdSettings';
 
 describe('NameIdSettings', () => {
     let DEFAULT_PROPS;
@@ -42,8 +42,6 @@ describe('NameIdSettings', () => {
         expect(wrapper.find('.name-id-setting__setting-section')).toHaveLength(2);
         expect(wrapper.find('.name-id-setting__prefix-field')).toHaveLength(1);
         expect(wrapper.find(Checkbox)).toHaveLength(1);
-        expect(wrapper.find(IDNameHelpTip)).toHaveLength(1);
-        expect(wrapper.find(PrefixDescription)).toHaveLength(1);
         expect(wrapper.find(FormControl)).toHaveLength(1);
         expect(DEFAULT_PROPS.loadNameExpressionOptions).toHaveBeenCalled();
     });
@@ -104,8 +102,6 @@ describe('NameIdSettings', () => {
         expect(wrapper.find('.name-id-setting__setting-section')).toHaveLength(1);
         expect(wrapper.find('.name-id-setting__prefix-field')).toHaveLength(0);
         expect(wrapper.find(Checkbox)).toHaveLength(1);
-        expect(wrapper.find(IDNameHelpTip)).toHaveLength(1);
-        expect(wrapper.find(PrefixDescription)).toHaveLength(0);
         expect(wrapper.find(FormControl)).toHaveLength(0);
     });
 });

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -1,7 +1,7 @@
-import React, { FC, memo, useCallback, useEffect, useReducer, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useReducer } from 'react';
 
 import { PermissionTypes } from '@labkey/api';
-import { Button, Checkbox, Col, ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
+import { Button, Checkbox, FormControl } from 'react-bootstrap';
 
 import { biologicsIsPrimaryApp, sampleManagerIsPrimaryApp } from '../../app/utils';
 
@@ -20,88 +20,6 @@ import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
 
 const TITLE = 'ID/Name Settings';
-
-// exported for jest testing
-export const IDNameHelpTip: FC = memo(() => {
-    const { moduleContext } = useServerContext();
-
-    return (
-        <LabelHelpTip title="User Defined ID/Names">
-            <p>
-                When users are not permitted to create their own IDs/Names, the ID/Name field will be hidden during
-                creation and update of rows, and when accessing the design of a new or existing Sample Type or{' '}
-                {sampleManagerIsPrimaryApp(moduleContext) ? 'Source Type' : 'Data Class'}.
-            </p>
-            <p>
-                Additionally, attempting to import data and update existing rows during file import will result in an
-                error if a new ID/Name is encountered.
-            </p>
-        </LabelHelpTip>
-    );
-});
-
-// exported for jest testing
-export const PrefixDescription: FC = memo(() => {
-    const { moduleContext } = useServerContext();
-
-    return (
-        <div>
-            Enter a prefix to be applied to all Sample Types and{' '}
-            {sampleManagerIsPrimaryApp(moduleContext) ? 'Source Types' : 'Data Classes (e.g., CellLine, Construct)'}.
-            Prefixes generally are 2-3 characters long but will not be limited.
-        </div>
-    );
-});
-
-export const IDNameSettings: FC = memo(() => {
-    const [prefix, setPrefix] = useState<string>();
-    const { moduleContext } = useServerContext();
-
-    const onPrefixChange = useCallback(evt => {
-        setPrefix(evt.target.value);
-    }, []);
-
-    return (
-        <div className="id-name-settings">
-            <FormGroup controlId="id-name-prop-user-names">
-                <Col componentClass={ControlLabel} xs={12} sm={2} className="text-left">
-                    User-defined IDs/Names
-                    <IDNameHelpTip />
-                </Col>
-
-                <Col sm={10} md={5}>
-                    <Checkbox defaultChecked name="allowUserSpecifiedNames">
-                        Allow users to create/import their own IDs/Names
-                    </Checkbox>
-                </Col>
-            </FormGroup>
-
-            {biologicsIsPrimaryApp(moduleContext) && (
-                <FormGroup controlId="id-name-prop-prefix">
-                    <Col componentClass={ControlLabel} xs={12} sm={2} className="text-left">
-                        ID/Name Prefix
-                        <LabelHelpTip title="ID/Name Prefix">
-                            <PrefixDescription />
-                        </LabelHelpTip>
-                    </Col>
-
-                    <Col sm={10} md={5}>
-                        <FormControl
-                            autoComplete="off"
-                            name="prefix"
-                            onChange={onPrefixChange}
-                            placeholder="Enter Prefix"
-                            type="text"
-                        />
-                        <span className="help-block">
-                            Example: {prefix}Blood-${'{'}GenId{'}'}
-                        </span>
-                    </Col>
-                </FormGroup>
-            )}
-        </div>
-    );
-});
 
 interface NameIdSettingsFormProps extends InjectedRouteLeaveProps {
     loadNameExpressionOptions: () => Promise<{ allowUserSpecifiedNames: boolean; prefix: string }>;
@@ -235,7 +153,18 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                 checked={allowUserSpecifiedNames}
                             >
                                 Allow users to create/import their own IDs/Names
-                                <IDNameHelpTip />
+                                <LabelHelpTip title="User Defined ID/Names">
+                                    <p>
+                                        When users are not permitted to create their own IDs/Names, the ID/Name field
+                                        will be hidden during creation and update of rows, and when accessing the design
+                                        of a new or existing Sample Type or{' '}
+                                        {sampleManagerIsPrimaryApp(moduleContext) ? 'Source Type' : 'Data Class'}.
+                                    </p>
+                                    <p>
+                                        Additionally, attempting to import data and update existing rows during file
+                                        import will result in an error if a new ID/Name is encountered.
+                                    </p>
+                                </LabelHelpTip>
                             </Checkbox>
                         </form>
                     )}
@@ -244,7 +173,13 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                 {biologicsIsPrimaryApp(moduleContext) && (
                     <div className="name-id-setting__setting-section">
                         <div className="list__bold-text margin-bottom margin-top">ID/Name Prefix</div>
-                        <PrefixDescription />
+                        <div>
+                            Enter a prefix to be applied to all Sample Types and{' '}
+                            {sampleManagerIsPrimaryApp(moduleContext)
+                                ? 'Source Types'
+                                : 'Data Classes (e.g., CellLine, Construct)'}
+                            . Prefixes generally are 2-3 characters long but will not be limited.
+                        </div>
 
                         {loading && <LoadingSpinner />}
                         {!loading && (


### PR DESCRIPTION
#### Rationale
This addresses [Issue 46788](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46788) by removing the capability to configure the ID/Name settings from the project creation page.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1040
* https://github.com/LabKey/biologics/pull/1766
* https://github.com/LabKey/sampleManagement/pull/1429
* https://github.com/LabKey/platform/pull/3893

#### Changes
* Remove ID/Name Settings from `CreateProjectPage`.
* Coalesce usage of `IDNameHelpTip` and `PrefixDescription` now that they are no longer utilized separately.
