### PR TITLE
Add samples to storage in the order they are in grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.266.1",
+  "version": "2.267.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.265.0",
+  "version": "2.266.0-fb-orderedStorage.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.266.0",
+  "version": "2.267.0-fb-orderedStorage.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.XX
 *Released*: XX December 2022
 * Add samples to storage in the order they are in grid
-    * TODO
+    * added getOrderedSelectedMappedKeys util to get remapped ordered selections from grid
+    * modify getSelectedPicklistSamples to return ordered samples from selected ids
 
 ### version 2.265.0
 *Released*: 1 December 2022

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.XX
+*Released*: XX December 2022
+* Add samples to storage in the order they are in grid
+    * TODO
+
 ### version 2.265.0
 *Released*: 1 December 2022
 * AssayProtocolModel: Add hasBatchFields

--- a/packages/components/src/entities/PicklistOverview.tsx
+++ b/packages/components/src/entities/PicklistOverview.tsx
@@ -37,11 +37,13 @@ import { Picklist, PICKLIST_SAMPLES_FILTER } from '../internal/components/pickli
 import { deletePicklists, updatePicklist } from '../internal/components/picklist/actions';
 import { SamplesEditableGridProps } from '../internal/sampleModels';
 
+import { hasProductProjects } from '../internal/app/utils';
+
+import { useServerContext } from '../internal/components/base/ServerContext';
+
 import { PicklistGridButtons } from './PicklistGridButtons';
 import { PicklistDeleteConfirm } from './PicklistDeleteConfirm';
 import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
-import { hasProductProjects } from '../internal/app/utils';
-import { useServerContext } from '../internal/components/base/ServerContext';
 
 const PICKLIST_ITEMS_ID_PREFIX = 'picklist-items-';
 const PICKLIST_PER_SAMPLE_TYPE_ID_PREFIX = 'picklist-per-sample-type-';

--- a/packages/components/src/entities/PicklistOverview.tsx
+++ b/packages/components/src/entities/PicklistOverview.tsx
@@ -308,7 +308,7 @@ export const PicklistOverview: FC<OwnProps> = memo(props => {
             const omittedColumns = [];
             const { moduleContext } = useServerContext();
             if (!hasProductProjects(moduleContext)) {
-                omittedColumns.push('SampleID/SampleSet_Folder');
+                omittedColumns.push('SampleID/Folder');
             }
             configs[gridId] = {
                 id: gridId,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1488,7 +1488,13 @@ export type { UsersLoader } from './internal/components/forms/actions';
 export type { LineageGroupingOptions } from './internal/components/lineage/types';
 export type { AnnouncementModel, ThreadActions } from './internal/announcements/model';
 export type { AnnouncementsAPIWrapper } from './internal/announcements/APIWrapper';
-export type { AdminAppContext, AppContext, AssayAppContext, ExtendableAppContext, SampleTypeAppContext } from './internal/AppContext';
+export type {
+    AdminAppContext,
+    AppContext,
+    AssayAppContext,
+    ExtendableAppContext,
+    SampleTypeAppContext,
+} from './internal/AppContext';
 export type { WithAdminAppContext } from './internal/components/administration/useAdminAppContext';
 export type { ThreadBlockProps } from './internal/announcements/ThreadBlock';
 export type { ThreadEditorProps } from './internal/announcements/ThreadEditor';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -173,6 +173,7 @@ import { ValueList } from './internal/components/base/ValueList';
 import { EditorModel } from './internal/components/editable/models';
 import {
     clearSelected,
+    getOrderedSelectedMappedKeys,
     getSelected,
     getSelectedData,
     getSelection,
@@ -545,7 +546,7 @@ import { PicklistCreationMenuItem } from './internal/components/picklist/Picklis
 import { PicklistButton } from './internal/components/picklist/PicklistButton';
 
 import { AddToPicklistMenuItem } from './internal/components/picklist/AddToPicklistMenuItem';
-import { getSelectedPicklistSamples } from './internal/components/picklist/actions';
+import { getSelectedPicklistSamples, getOrderedSelectedPicklistSamples } from './internal/components/picklist/actions';
 import { BarTenderSettingsForm } from './internal/components/labels/BarTenderSettingsForm';
 import { PrintLabelsModal } from './internal/components/labels/PrintLabelsModal';
 import { BarTenderConfiguration } from './internal/components/labels/models';
@@ -826,6 +827,7 @@ export {
     createGridModelId,
     clearSelected,
     // grid functions
+    getOrderedSelectedMappedKeys,
     getSelected,
     getSelectedData,
     getSelection,
@@ -967,6 +969,7 @@ export {
     PicklistButton,
     PicklistCreationMenuItem,
     Picklist,
+    getOrderedSelectedPicklistSamples,
     getSelectedPicklistSamples,
     // data class and sample type related items
     ALIQUOT_FILTER_MODE,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -687,10 +687,10 @@ interface RemappedKeyValues {
  */
 export function getOrderedSelectedMappedKeys(
     fromColumn: string,
-    toColumn?: string,
-    schemaName?: string,
-    queryName?: string,
-    selections?: string[],
+    toColumn: string,
+    schemaName: string,
+    queryName: string,
+    selections: string[],
     sortString?: string,
     queryParameters?: Record<string, any>,
     viewName?: string
@@ -708,20 +708,14 @@ export function getOrderedSelectedMappedKeys(
         )
             .then(response => {
                 const { data, dataIds } = response;
-                const toIds = [];
-                const fromIds = [];
                 const values = [];
                 data.forEach(row => {
                     const rowData = row.toJS();
-                    fromIds.push(caseInsensitive(rowData, fromColumn)?.value);
-                    if (toColumn) toIds.push(caseInsensitive(rowData, toColumn)?.value);
-                });
-
-                fromIds.forEach((rowId, ind) => {
-                    const orderNum = dataIds.indexOf(rowId + '');
-                    const to = toColumn ? toIds[ind] : undefined;
+                    const from = caseInsensitive(rowData, fromColumn)?.value;
+                    const to = toColumn ? caseInsensitive(rowData, toColumn)?.value : null;
+                    const orderNum = dataIds.indexOf(from + '');
                     values.push({
-                        from: rowId,
+                        from,
                         to,
                         orderNum,
                     });

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -668,8 +668,8 @@ export function getSelectedData(
 }
 
 interface RemappedKeyValues {
-    mapFromValues: any[],
-    mapToValues: any[]
+    mapFromValues: any[];
+    mapToValues: any[];
 }
 
 /**
@@ -685,12 +685,16 @@ interface RemappedKeyValues {
  * @param queryParameters
  * @param viewName
  */
-export function getOrderedSelectedMappedKeys(fromColumn: string, toColumn?: string, schemaName?: string,
-                                             queryName?: string,
-                                             selections?: string[],
-                                             sortString?: string,
-                                             queryParameters?: Record<string, any>,
-                                             viewName?: string,): Promise<RemappedKeyValues> {
+export function getOrderedSelectedMappedKeys(
+    fromColumn: string,
+    toColumn?: string,
+    schemaName?: string,
+    queryName?: string,
+    selections?: string[],
+    sortString?: string,
+    queryParameters?: Record<string, any>,
+    viewName?: string
+): Promise<RemappedKeyValues> {
     return new Promise((resolve, reject) => {
         getSelectedData(
             schemaName,
@@ -701,41 +705,41 @@ export function getOrderedSelectedMappedKeys(fromColumn: string, toColumn?: stri
             queryParameters,
             viewName,
             fromColumn
-        ).then(response => {
-            const { data, dataIds } = response;
-            const toIds = [];
-            const fromIds = [];
-            const values = [];
-            data.forEach(row => {
-                const rowData = row.toJS();
-                fromIds.push(caseInsensitive(rowData, fromColumn)?.value);
-                if (toColumn)
-                    toIds.push(caseInsensitive(rowData, toColumn)?.value);
-            });
-
-            fromIds.forEach((rowId, ind) => {
-                const orderNum = dataIds.indexOf(rowId + '');
-                const to = toColumn ? toIds[ind] : undefined;
-                values.push({
-                    from: rowId,
-                    to,
-                    orderNum
+        )
+            .then(response => {
+                const { data, dataIds } = response;
+                const toIds = [];
+                const fromIds = [];
+                const values = [];
+                data.forEach(row => {
+                    const rowData = row.toJS();
+                    fromIds.push(caseInsensitive(rowData, fromColumn)?.value);
+                    if (toColumn) toIds.push(caseInsensitive(rowData, toColumn)?.value);
                 });
-            });
 
-            const mapFromValues = [];
-            const mapToValues = [];
-            values.sort((a, b) => a.orderNum - b.orderNum);
-            values.forEach(value => {
-                mapToValues.push(value.to);
-                mapFromValues.push(value.from);
-            });
+                fromIds.forEach((rowId, ind) => {
+                    const orderNum = dataIds.indexOf(rowId + '');
+                    const to = toColumn ? toIds[ind] : undefined;
+                    values.push({
+                        from: rowId,
+                        to,
+                        orderNum,
+                    });
+                });
 
-            resolve({
-                mapToValues,
-                mapFromValues
-            });
-        })
+                const mapFromValues = [];
+                const mapToValues = [];
+                values.sort((a, b) => a.orderNum - b.orderNum);
+                values.forEach(value => {
+                    mapToValues.push(value.to);
+                    mapFromValues.push(value.from);
+                });
+
+                resolve({
+                    mapToValues,
+                    mapFromValues,
+                });
+            })
             .catch(reason => {
                 console.error(reason);
                 reject(reason);

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -13,14 +13,15 @@ import { AppURL, buildURL, createProductUrlFromParts } from '../../url/AppURL';
 import { fetchListDesign, getListIdFromDomainId } from '../domainproperties/list/actions';
 
 import { PICKLIST_KEY } from '../../app/constants';
-import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
 
 import { isProductProjectsEnabled } from '../../app/utils';
 
-import { Picklist, PICKLIST_KEY_COLUMN, PICKLIST_SAMPLE_ID_COLUMN } from './models';
 import { SCHEMAS } from '../../schemas';
 import { OperationConfirmationData } from '../entities/models';
 import { caseInsensitive } from '../../util/utils';
+
+import { Picklist, PICKLIST_KEY_COLUMN, PICKLIST_SAMPLE_ID_COLUMN } from './models';
+import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
 
 export function getPicklistsForInsert(): Promise<Picklist[]> {
     return new Promise((resolve, reject) => {
@@ -201,7 +202,15 @@ export function getPicklistSamples(listName: string): Promise<Set<string>> {
 
 export function getOrderedSelectedPicklistSamples(queryModel: QueryModel, saveSnapshot?: boolean): Promise<number[]> {
     const { queryName, queryParameters, selections, sortString, viewName, selectionKey } = queryModel;
-    return getSelectedPicklistSamples(queryName, Array.of(...selections), saveSnapshot, selectionKey, sortString, queryParameters, viewName)
+    return getSelectedPicklistSamples(
+        queryName,
+        Array.of(...selections),
+        saveSnapshot,
+        selectionKey,
+        sortString,
+        queryParameters,
+        viewName
+    );
 }
 
 export function getSelectedPicklistSamples(
@@ -211,7 +220,7 @@ export function getSelectedPicklistSamples(
     selectionKey?: string,
     sorts?: string,
     queryParameters?: Record<string, any>,
-    viewName?: string,
+    viewName?: string
 ): Promise<number[]> {
     return new Promise((resolve, reject) => {
         getOrderedSelectedMappedKeys(
@@ -223,17 +232,19 @@ export function getSelectedPicklistSamples(
             sorts,
             queryParameters,
             viewName
-        ).then((result) => {
-            const rowIds = result.mapFromValues;
-            const sampleIds = result.mapToValues;
-            if (saveSnapshot) {
-                setSnapshotSelections(selectionKey, rowIds);
-            }
-            resolve(sampleIds);
-        }).catch((reason) => {
-            console.error(reason);
-            reject(reason);
-        })
+        )
+            .then(result => {
+                const rowIds = result.mapFromValues;
+                const sampleIds = result.mapToValues;
+                if (saveSnapshot) {
+                    setSnapshotSelections(selectionKey, rowIds);
+                }
+                resolve(sampleIds);
+            })
+            .catch(reason => {
+                console.error(reason);
+                reject(reason);
+            });
     });
 }
 
@@ -309,7 +320,16 @@ export interface PicklistDeletionData {
 export function getPicklistDeleteData(model: QueryModel, user: User): Promise<PicklistDeletionData> {
     return new Promise((resolve, reject) => {
         const columnString = 'Name,listId,category,createdBy';
-        getSelectedData(model.schemaName, model.queryName, [...model.selections], columnString, undefined, undefined, undefined, 'ListId')
+        getSelectedData(
+            model.schemaName,
+            model.queryName,
+            [...model.selections],
+            columnString,
+            undefined,
+            undefined,
+            undefined,
+            'ListId'
+        )
             .then(response => {
                 const { data } = response;
                 let numNotDeletable = 0;
@@ -446,10 +466,10 @@ export const getPicklistFromId = async (listId: number, loadSampleTypes = true):
                 .filter(value => !!value),
         });
         picklist = picklist.mutate({
-            hasMedia: !!Object.values(listSampleTypeData.models[listSampleTypeData.key])
-                .find(row => caseInsensitive(row, 'Category')?.value === 'media')
+            hasMedia: !!Object.values(listSampleTypeData.models[listSampleTypeData.key]).find(
+                row => caseInsensitive(row, 'Category')?.value === 'media'
+            ),
         });
-
     }
 
     return picklist;

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -250,7 +250,7 @@ export async function getSelectedSampleIdsFromSelectionKey(location: Location): 
     let sampleIds;
 
     if (getLocationQueryVal(location, 'selectionKeyType') === SAMPLE_INVENTORY_ITEM_SELECTION_KEY) {
-        const response = await getSnapshotSelections(key);
+        const response = await getSnapshotSelections(key);// ordered ? is this still needed
         sampleIds = await getSelectedItemSamples(response.selected);
     } else if (getLocationQueryVal(location, 'isAssay')) {
         const schemaName = getLocationQueryVal(location, 'assayProtocol');

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -250,7 +250,7 @@ export async function getSelectedSampleIdsFromSelectionKey(location: Location): 
     let sampleIds;
 
     if (getLocationQueryVal(location, 'selectionKeyType') === SAMPLE_INVENTORY_ITEM_SELECTION_KEY) {
-        const response = await getSnapshotSelections(key);// ordered ? is this still needed
+        const response = await getSnapshotSelections(key);
         sampleIds = await getSelectedItemSamples(response.selected);
     } else if (getLocationQueryVal(location, 'isAssay')) {
         const schemaName = getLocationQueryVal(location, 'assayProtocol');

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -205,7 +205,6 @@ export interface SampleGridButtonProps {
     createBtnParentType?: string;
     excludeAddButton?: boolean;
     excludedMenuKeys?: SamplesEditButtonSections[];
-    hasOrdinal?: boolean;
     includesMedia?: boolean;
     initAliquotMode?: ALIQUOT_FILTER_MODE;
     metricFeatureArea?: string;


### PR DESCRIPTION
#### Rationale
When adding samples to storage, user had to manually adjust each sample's assigned location in freezer location, because the ordering of the selected samples are not carried through. With this PR, samples are assigned to storage location in the same order that they are from the source grid. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1041
* https://github.com/LabKey/platform/pull/3892
* https://github.com/LabKey/inventory/pull/632
* https://github.com/LabKey/sampleManagement/pull/1430
* https://github.com/LabKey/biologics/pull/1767

#### Changes
* added getOrderedSelectedMappedKeys util to get remapped ordered selections from grid
* modify getSelectedPicklistSamples to return ordered samples from selected ids
