### PR TITLE
Update @labkey/build to account for move of eln package into @labkey/premium/eln

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.5.0-fb-elnToPremium.0",
+  "version": "6.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.5.0-fb-elnToPremium.0",
+      "version": "6.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.19.6",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.5.0",
+  "version": "6.5.0-fb-elnToPremium.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.5.0",
+      "version": "6.5.0-fb-elnToPremium.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.19.6",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.5.0",
+  "version": "6.5.0-fb-elnToPremium.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.5.0-fb-elnToPremium.0",
+  "version": "6.6.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,9 +1,9 @@
 # @labkey/build
 
-### version TBD
-*Released*: TBD November 2022
+### version 6.6.0
+*Released*: 12 November 2022
 * webpack updates for `@labkey/premium/eln` package
-  * * move of `@labkey/eln` from labbook module to `@labkey/premium/eln`
+  * move of `@labkey/eln` from labbook module to `@labkey/premium/eln`
 
 ### version 6.5.0
 *Released*: 8 November 2022

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,10 @@
 # @labkey/build
 
+### version TBD
+*Released*: TBD November 2022
+* webpack updates for `@labkey/premium/eln` package
+  * * move of `@labkey/eln` from labbook module to `@labkey/premium/eln`
+
 ### version 6.5.0
 *Released*: 8 November 2022
 * webpack updates for `@labkey/premium` package

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -12,7 +12,6 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 
 const FREEZER_MANAGER_DIRS = ['inventory', 'packages', 'freezermanager', 'src'];
 const WORKFLOW_DIRS = ['sampleManagement', 'packages', 'workflow', 'src'];
-const ELN_DIRS = ['labbook', 'packages', 'eln', 'src'];
 const cwd = path.resolve('./').split(path.sep);
 const lkModule = cwd[cwd.length - 1];
 const isProductionBuild = process.env.NODE_ENV === 'production';
@@ -25,7 +24,6 @@ let labkeyUIComponentsPath = path.resolve('./node_modules/@labkey/components');
 let labkeyUIPremiumPath = path.resolve('./node_modules/@labkey/premium');
 let freezerManagerPath = path.resolve('./node_modules/@labkey/freezermanager');
 let workflowPath = path.resolve('./node_modules/@labkey/workflow');
-let elnPath = path.resolve('./node_modules/@labkey/eln');
 const tsconfigPath = path.resolve('./node_modules/@labkey/build/webpack/tsconfig.json');
 
 if (process.env.LINK) {
@@ -42,13 +40,11 @@ if (process.env.LINK) {
     const lkModulesPath = cwd.slice(0, cwd.lastIndexOf('modules') + 1);
     freezerManagerPath = lkModulesPath.concat(FREEZER_MANAGER_DIRS).join(path.sep);
     workflowPath = lkModulesPath.concat(WORKFLOW_DIRS).join(path.sep);
-    elnPath = lkModulesPath.concat(ELN_DIRS).join(path.sep);
 
     console.log('Using @labkey/components path:', labkeyUIComponentsPath);
     console.log('Using @labkey/premium path:', labkeyUIPremiumPath);
     console.log('Using @labkey/freezermanager path:', freezerManagerPath);
     console.log('Using @labkey/workflow path:', workflowPath);
-    console.log('Using @labkey/eln path:', elnPath);
 }
 
 const watchPort = process.env.WATCH_PORT || 3001;
@@ -168,9 +164,9 @@ const TS_CHECKER_DEV_CONFIG = {
                     "@labkey/components/entities": [labkeyUIComponentsPath + '/entities'],
                     "@labkey/premium": [labkeyUIPremiumPath],
                     "@labkey/premium/assay": [labkeyUIPremiumPath + '/assay'],
+                    "@labkey/premium/eln": [labkeyUIPremiumPath + '/eln'],
                     "@labkey/freezermanager": [freezerManagerPath],
                     "@labkey/workflow": [workflowPath],
-                    "@labkey/eln": [elnPath],
                 }
             }
         },
@@ -185,9 +181,9 @@ const labkeyPackagesDev = process.env.LINK
         '@labkey/components/entities': labkeyUIComponentsPath + '/entities',
         '@labkey/premium': labkeyUIPremiumPath,
         '@labkey/premium/assay': labkeyUIPremiumPath + '/assay',
+        '@labkey/premium/eln': labkeyUIPremiumPath + '/eln',
         '@labkey/freezermanager': freezerManagerPath,
         '@labkey/workflow': workflowPath,
-        '@labkey/eln': elnPath,
     }
     : {};
 
@@ -268,7 +264,6 @@ module.exports = {
             '@labkey/premium-scss': labkeyUIPremiumPath + '/dist/assets/scss/theme',
             '@labkey/freezermanager-scss': freezerManagerPath + '/dist/assets/scss/theme',
             '@labkey/workflow-scss': workflowPath + '/dist/assets/scss/theme',
-            '@labkey/eln-scss': elnPath + '/dist/assets/scss/theme',
         },
         LABKEY_PACKAGES_DEV: {
             ...labkeyPackagesDev,
@@ -278,7 +273,6 @@ module.exports = {
             '@labkey/premium-scss': labkeyUIPremiumPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
             '@labkey/freezermanager-scss': freezerManagerPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
             '@labkey/workflow-scss': workflowPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
-            '@labkey/eln-scss': elnPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
         },
     },
     outputPath: path.resolve('./resources/web/gen'),

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -87,6 +87,7 @@ module.exports = {
         '@labkey/components',
         '@labkey/components/entities',
         '@labkey/premium/assay',
+        '@labkey/premium/eln',
         '@remirror/pm',
         'boostrap-sass',
         'classnames',


### PR DESCRIPTION
#### Rationale
With the move of the eln package to the @labkey/premium package, we need to update a couple of things in the @labkey/build path / alias handling for start-link.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1049
* https://github.com/LabKey/labbook/pull/341
* https://github.com/LabKey/labkey-ui-premium/pull/4
* https://github.com/LabKey/biologics/pull/1783
* https://github.com/LabKey/sampleManagement/pull/1450

#### Changes
* webpack/constants.js update to remove specific path handling for @labkey/eln
* add @labkey/premium/eln to package.config.js "externals"
