### PR TITLE
Issue 46841: Require permission/role when creating a new user via app modal

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.268.0",
+  "version": "2.268.0-fb-createUser46841.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.269.0",
+  "version": "2.269.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD December 2022
+* Issue 46841: Require permission/role when creating a new user via app modal
+
 ### version 2.268.0
 *Released*: 8 December 2022
 * Updates for creation of @labkey/premium package

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD December 2022
+### version 2.269.1
+*Released*: 12 December 2022
 * Issue 46841: Require permission/role when creating a new user via app modal
 
 ### version 2.269.0

--- a/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
@@ -41,7 +41,7 @@ describe('<CreateUsersModal/>', () => {
         expect(wrapper.find('SelectInput')).toHaveLength(0);
         expect(wrapper.find('.btn')).toHaveLength(2);
         expect(wrapper.find('.btn-success')).toHaveLength(1);
-        expect(wrapper.find('.btn-success').props().disabled).toBe(false);
+        expect(wrapper.find('.btn-success').props().disabled).toBe(true); // no emailText
         wrapper.unmount();
     });
 
@@ -60,7 +60,7 @@ describe('<CreateUsersModal/>', () => {
         expect(wrapper.find('SelectInput').props().value).toStrictEqual([ROLE_OPTIONS[0].id]);
         expect(wrapper.find('.btn')).toHaveLength(2);
         expect(wrapper.find('.btn-success')).toHaveLength(1);
-        expect(wrapper.find('.btn-success').props().disabled).toBe(false);
+        expect(wrapper.find('.btn-success').props().disabled).toBe(true); // no emailText
         wrapper.unmount();
     });
 
@@ -70,13 +70,27 @@ describe('<CreateUsersModal/>', () => {
         );
 
         const wrapper = mount(component);
+        expect(wrapper.find('.btn-success').props().disabled).toBe(true); // no emailText
+
         wrapper.setState({
             emailText: 'TestEmailText',
             sendEmail: false,
             optionalMessage: 'TestOptionalMessage',
             roles: [ROLE_OPTIONS[1].id],
-            isSubmitting: true,
             error: 'TestError',
+        });
+
+        expect(wrapper.find('.btn-success').props().disabled).toBe(false);
+
+        wrapper.setState({
+            roles: [],
+        });
+
+        expect(wrapper.find('.btn-success').props().disabled).toBe(true); // no roles
+
+        wrapper.setState({
+            isSubmitting: true,
+            roles: [ROLE_OPTIONS[1].id],
         });
 
         expect(wrapper.find('Alert')).toHaveLength(2);
@@ -88,7 +102,7 @@ describe('<CreateUsersModal/>', () => {
         expect(wrapper.find('SelectInput').props().value).toStrictEqual([ROLE_OPTIONS[1].id]);
         expect(wrapper.find('.btn')).toHaveLength(2);
         expect(wrapper.find('.btn-success')).toHaveLength(1);
-        expect(wrapper.find('.btn-success').props().disabled).toBe(true);
+        expect(wrapper.find('.btn-success').props().disabled).toBe(true); // submitting
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Checkbox, FormControl, Modal } from 'react-bootstrap';
+import { FormControl, Modal } from 'react-bootstrap';
 import { Security } from '@labkey/api';
 
 import { UserLimitSettings } from '../permissions/actions';
@@ -122,6 +122,7 @@ export class CreateUsersModal extends React.Component<Props, State> {
                             valueKey="id"
                             onChange={this.handleRoles}
                             clearable={false}
+                            required
                             multiple
                         />
                     </>
@@ -140,23 +141,10 @@ export class CreateUsersModal extends React.Component<Props, State> {
         );
     }
 
-    renderButtons(): ReactNode {
-        return (
-            <WizardNavButtons
-                containerClassName=""
-                cancel={this.props.onCancel}
-                finish={true}
-                finishText="Create Users"
-                isFinishing={this.state.isSubmitting}
-                isFinishingText="Creating Users..."
-                nextStep={this.createUsers}
-            />
-        );
-    }
-
     render(): ReactNode {
         const { show, onCancel } = this.props;
-        const { error } = this.state;
+        const { error, emailText } = this.state;
+        const valid = emailText?.length > 0 && this.getSelectedRoles()?.length > 0; // Issue 46841
 
         return (
             <Modal show={show} onHide={onCancel}>
@@ -167,7 +155,18 @@ export class CreateUsersModal extends React.Component<Props, State> {
                     {this.renderForm()}
                     {error && <Alert style={{ marginTop: '10px' }}>{error}</Alert>}
                 </Modal.Body>
-                <Modal.Footer>{this.renderButtons()}</Modal.Footer>
+                <Modal.Footer>
+                    <WizardNavButtons
+                        containerClassName=""
+                        cancel={this.props.onCancel}
+                        finish={true}
+                        canFinish={valid}
+                        finishText="Create Users"
+                        isFinishing={this.state.isSubmitting}
+                        isFinishingText="Creating Users..."
+                        nextStep={this.createUsers}
+                    />
+                </Modal.Footer>
             </Modal>
         );
     }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46841

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1051
* https://github.com/LabKey/sampleManagement/pull/1454
* https://github.com/LabKey/inventory/pull/641
* https://github.com/LabKey/biologics/pull/1786

#### Changes
* Disabled create user button in CreateUsersModal if no email addresses or roles selected
