### PR TITLE
Issues 46681 an 46023:  various assay bugs

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.268.1-variousAssayBugs.0",
+  "version": "2.268.1-variousAssayBugs.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.268.1-variousAssayBugs.1",
+  "version": "2.268.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.268.0",
+  "version": "2.268.1-variousAssayBugs.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 46681: Don't show the assay button for Aliquots if assays is not enabled
+* Issue 46023: Exclude General assay provider when choosing a speciality assay
+
 ### version 2.268.0
 *Released*: 8 December 2022
 * Updates for creation of @labkey/premium package

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.268.1
+*Released*: 12 December 2022
 * Issue 46681: Don't show the assay button for Aliquots if assays is not enabled
 * Issue 46023: Exclude General assay provider when choosing a speciality assay
 

--- a/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
@@ -79,7 +79,7 @@ describe('SampleAliquotsGridPanel', () => {
         );
         expect(wrapper.find(ResponsiveMenuButtonGroup)).toHaveLength(1);
         const items = wrapper.find(ResponsiveMenuButtonGroup).prop('items');
-        expect(items.length).toBe(3);
+        expect(items.length).toBe(2);
         wrapper.unmount();
     });
 

--- a/packages/components/src/entities/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.tsx
@@ -49,10 +49,12 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
     const metricFeatureArea = 'sampleAliquots';
 
     const moreItems = [];
-    moreItems.push({
-        button: <SamplesAssayButton model={model} providerType={assayProviderType} />,
-        perm: PermissionTypes.Insert,
-    });
+    if (isAssayEnabled(moduleContext)) {
+        moreItems.push({
+            button: <SamplesAssayButton model={model} providerType={assayProviderType}/>,
+            perm: PermissionTypes.Insert,
+        });
+    }
     moreItems.push({
         button: <PicklistButton model={model} user={user} metricFeatureArea={metricFeatureArea} />,
         perm: PermissionTypes.ManagePicklists,

--- a/packages/components/src/internal/components/assay/AssayPicker.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.tsx
@@ -138,7 +138,7 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
                 selectProvider(GENERAL_ASSAY_PROVIDER_NAME);
             } else if (tab_ === AssayPickerTabs.SPECIALTY_ASSAY_TAB) {
                 if (providers.length > 0 && (!provider || provider.name === GENERAL_ASSAY_PROVIDER_NAME)) {
-                    selectProvider(providers[0].name);
+                    selectProvider(providers.filter(p => p.name !== GENERAL_ASSAY_PROVIDER_NAME)[0].name);
                 }
             }
         },

--- a/packages/components/src/internal/components/assay/AssayPicker.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.tsx
@@ -138,7 +138,7 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
                 selectProvider(GENERAL_ASSAY_PROVIDER_NAME);
             } else if (tab_ === AssayPickerTabs.SPECIALTY_ASSAY_TAB) {
                 if (providers.length > 0 && (!provider || provider.name === GENERAL_ASSAY_PROVIDER_NAME)) {
-                    selectProvider(providers.filter(p => p.name !== GENERAL_ASSAY_PROVIDER_NAME)[0].name);
+                    selectProvider(providers.filter(p => p.name !== GENERAL_ASSAY_PROVIDER_NAME)?.[0].name);
                 }
             }
         },


### PR DESCRIPTION
#### Rationale
[Issue 46681](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46681) - Remove assay menu option from aliquots grid if assay is not enable
[Issue 46023](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46023) - Exclude General assay provider when choosing a speciality assay

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/6
- https://github.com/LabKey/platform/pull/3913
- https://github.com/LabKey/biologics/pull/1787
- https://github.com/LabKey/sampleManagement/pull/1455

#### Changes
* Update `SampleAlqiuotsButtons` to exclude assay when not enabled
* Update selection of assay specialty provider to exclude the General assay
