### PR TITLE
@labkey/test: Initialize sessionId when using createRequestContext

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.1.1-fb-test-user-sessions.0",
+  "version": "1.1.2",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.1.1",
+  "version": "1.1.1-fb-test-user-sessions.0",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/releaseNotes/test.md
+++ b/packages/test/releaseNotes/test.md
@@ -1,6 +1,10 @@
 # @labkey/test
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
+### version 1.1.2
+*Released*: 14 December 2022
+* Initialize sessionId for RequestContext created via `createRequestContext()`
+
 ### version 1.1.1
 *Released*: 26 May 2022
 * handle htmlErrors response from CreateNewUsersAction


### PR DESCRIPTION
#### Rationale
When creating a `RequestContext` via `createRequestContext` the incoming context configuration was not being supplied to the underlying request to initialize the context. As a result, the `sessionId` was not being set for any dynamically generated contexts (e.g. when a test creates another user). This fixes that by passing through the supplied context.

#### Changes
* Rename `initCSRF` to `initRequestContext`.
* Pass `requestContext` to `initRequestContext` in `createRequestContext`.
