### PR TITLE
webpack updates for `@labkey/premium/storage` package

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.7.0",
+  "version": "6.7.0-fb-fmToPremium.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.7.0",
+      "version": "6.7.0-fb-fmToPremium.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.19.6",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.7.0-fb-fmToPremium.0",
+  "version": "6.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.7.0-fb-fmToPremium.0",
+      "version": "6.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.19.6",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.7.0-fb-fmToPremium.0",
+  "version": "6.8.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.7.0",
+  "version": "6.7.0-fb-fmToPremium.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,10 @@
 # @labkey/build
 
+### version TBD
+*Released*: TBD December 2022
+* webpack updates for `@labkey/premium/storage` package
+  * move of `@labkey/freezermanager` from inventory module to `@labkey/premium/storage`
+
 ### version 6.7.0
 *Released*: 16 December 2022
 * webpack updates for `@labkey/premium/workflow` package

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
-### version TBD
-*Released*: TBD December 2022
+### version 6.8.0
+*Released*: 19 December 2022
 * webpack updates for `@labkey/premium/storage` package
   * move of `@labkey/freezermanager` from inventory module to `@labkey/premium/storage`
 

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -10,7 +10,6 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
-const FREEZER_MANAGER_DIRS = ['inventory', 'packages', 'freezermanager', 'src'];
 const cwd = path.resolve('./').split(path.sep);
 const lkModule = cwd[cwd.length - 1];
 const isProductionBuild = process.env.NODE_ENV === 'production';
@@ -21,7 +20,6 @@ const isProductionBuild = process.env.NODE_ENV === 'production';
 // NOTE: the LABKEY_UI_COMPONENTS_HOME and LABKEY_UI_PREMIUM_HOME environment variable must be set for this to work.
 let labkeyUIComponentsPath = path.resolve('./node_modules/@labkey/components');
 let labkeyUIPremiumPath = path.resolve('./node_modules/@labkey/premium');
-let freezerManagerPath = path.resolve('./node_modules/@labkey/freezermanager');
 const tsconfigPath = path.resolve('./node_modules/@labkey/build/webpack/tsconfig.json');
 
 if (process.env.LINK) {
@@ -33,14 +31,10 @@ if (process.env.LINK) {
     }
 
     labkeyUIComponentsPath = process.env.LABKEY_UI_COMPONENTS_HOME + '/packages/components/src';
-    labkeyUIPremiumPath = process.env.LABKEY_UI_PREMIUM_HOME + '/packages/premium/src';
-    // lastIndexOf just in case someone is weird and has their LKS deployment under a directory named modules.
-    const lkModulesPath = cwd.slice(0, cwd.lastIndexOf('modules') + 1);
-    freezerManagerPath = lkModulesPath.concat(FREEZER_MANAGER_DIRS).join(path.sep);
-
     console.log('Using @labkey/components path:', labkeyUIComponentsPath);
+
+    labkeyUIPremiumPath = process.env.LABKEY_UI_PREMIUM_HOME + '/packages/premium/src';
     console.log('Using @labkey/premium path:', labkeyUIPremiumPath);
-    console.log('Using @labkey/freezermanager path:', freezerManagerPath);
 }
 
 const watchPort = process.env.WATCH_PORT || 3001;
@@ -162,7 +156,7 @@ const TS_CHECKER_DEV_CONFIG = {
                     "@labkey/premium/assay": [labkeyUIPremiumPath + '/assay'],
                     "@labkey/premium/eln": [labkeyUIPremiumPath + '/eln'],
                     "@labkey/premium/workflow": [labkeyUIPremiumPath + '/workflow'],
-                    "@labkey/freezermanager": [freezerManagerPath],
+                    "@labkey/premium/storage": [labkeyUIPremiumPath + '/storage'],
                 }
             }
         },
@@ -179,7 +173,7 @@ const labkeyPackagesDev = process.env.LINK
         '@labkey/premium/assay': labkeyUIPremiumPath + '/assay',
         '@labkey/premium/eln': labkeyUIPremiumPath + '/eln',
         '@labkey/premium/workflow': labkeyUIPremiumPath + '/workflow',
-        '@labkey/freezermanager': freezerManagerPath,
+        '@labkey/premium/storage': labkeyUIPremiumPath + '/storage',
     }
     : {};
 
@@ -187,7 +181,6 @@ module.exports = {
     lkModule,
     labkeyUIComponentsPath,
     labkeyUIPremiumPath,
-    freezerManagerPath,
     tsconfigPath,
     watchPort,
     TS_CHECKER_CONFIG,
@@ -257,7 +250,6 @@ module.exports = {
             '@labkey/components-scss': labkeyUIComponentsPath + '/dist/assets/scss/theme',
             '@labkey/components-app-scss': labkeyUIComponentsPath + '/dist/assets/scss/theme/app',
             '@labkey/premium-scss': labkeyUIPremiumPath + '/dist/assets/scss/theme',
-            '@labkey/freezermanager-scss': freezerManagerPath + '/dist/assets/scss/theme',
         },
         LABKEY_PACKAGES_DEV: {
             ...labkeyPackagesDev,
@@ -265,7 +257,6 @@ module.exports = {
             '@labkey/components-scss': labkeyUIComponentsPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
             '@labkey/components-app-scss': labkeyUIComponentsPath + (process.env.LINK ? '/theme/app' : '/dist/assets/scss/theme/app'),
             '@labkey/premium-scss': labkeyUIPremiumPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
-            '@labkey/freezermanager-scss': freezerManagerPath + (process.env.LINK ? '/theme' : '/dist/assets/scss/theme'),
         },
     },
     outputPath: path.resolve('./resources/web/gen'),

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -89,6 +89,7 @@ module.exports = {
         '@labkey/premium/assay',
         '@labkey/premium/eln',
         '@labkey/premium/workflow',
+        '@labkey/premium/storage',
         '@remirror/pm',
         'boostrap-sass',
         'classnames',


### PR DESCRIPTION
#### Rationale
Next up in the move of npm packages to @labkey/premium is the freezermanager package. This PR updates the @labkey/build package paths for the freezermanager (now named storage) src code when using `npm run start-link`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-premium/pull/10

#### Changes
* move of `@labkey/freezermanager` from inventory module to `@labkey/premium/storage
