### PR TITLE
Issue 46908: Assure that columns added via `addToSystemView` in metadata are carried through to saved views

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.273.1",
+  "version": "2.273.2-viewsWithSystemCols.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.273.2-viewsWithSystemCols.1",
+  "version": "2.273.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.273.2-viewsWithSystemCols.0",
+  "version": "2.273.2-viewsWithSystemCols.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 46908: Assure that columns added via `addToSystemView` in metadata are carried through to saved views
+
 ### version 2.273.1
 *Released*: 19 December 2022
 * Remove premature return from renderLabel in TextInput

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.273.2
+*Released*: 20 December 2022
 * Issue 46908: Assure that columns added via `addToSystemView` in metadata are carried through to saved views
 
 ### version 2.273.1

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -1,6 +1,7 @@
 import { List, Record } from 'immutable';
 import { Filter } from '@labkey/api';
 import { QuerySort } from '../public/QuerySort';
+import { QueryInfo } from '../public/QueryInfo';
 
 function getFiltersFromView(rawViewInfo): List<Filter.IFilter> {
     const filters = List<Filter.IFilter>().asMutable();
@@ -169,6 +170,27 @@ export class ViewInfo extends Record({
                 modifiers.push('shared');
         }
         return modifiers;
+    }
+
+    addSystemViewColumns(queryInfo: QueryInfo) {
+        if (this.isDefault && !this.session) {
+            let columns = this.columns;
+            const columnFieldKeys = this.columns.map(col => {
+                return col.fieldKey.toLowerCase()
+            }).toArray();
+            queryInfo.columns.forEach(queryCol => {
+                if (queryCol.fieldKey && queryCol.addToSystemView && columnFieldKeys.indexOf(queryCol.fieldKey.toLowerCase()) === -1) {
+                    columns = columns.push({
+                        fieldKey: queryCol.fieldKey,
+                        key: queryCol.fieldKey,
+                        name: queryCol.name,
+                        title: queryCol.caption || queryCol.name,
+                    });
+                }
+            });
+            return this.mutate({columns});
+        }
+        return this;
     }
 
     mutate(updates: Partial<ViewInfo>) {

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -820,8 +820,8 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                     return col.fieldKey.toLowerCase()
                 }).toArray();
                 queryInfo.columns.forEach(queryCol => {
-                    if (queryCol.fieldKey && queryCol.addToSystemView && columnFieldKeys.indexOf(queryCol.fieldKey.toLowerCase()) == -1) {
-                        columns = columns.push ({
+                    if (queryCol.fieldKey && queryCol.addToSystemView && columnFieldKeys.indexOf(queryCol.fieldKey.toLowerCase()) === -1) {
+                        columns = columns.push({
                             fieldKey: queryCol.fieldKey,
                             key: queryCol.fieldKey,
                             name: queryCol.name,
@@ -832,7 +832,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 updatedViewInfo = updatedViewInfo.mutate({columns});
             }
             updatedViewInfo = updatedViewInfo.mutate({
-                // update/set sorts and filters to combine view and user defined items
+                // update/set sorts and filters to combine view and user-defined items
                 filters: List(model.filterArray.concat(view.filters.toArray())),
                 sorts: List(model.sorts.concat(view.sorts.toArray())),
             });

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -813,8 +813,25 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
         return new Promise((resolve, reject) => {
             const view = queryInfo?.getView(viewName, true);
-
-            const updatedViewInfo = view.mutate({
+            let updatedViewInfo = view;
+            if (view.isDefault && !view.session) {
+                let columns = view.columns;
+                const columnFieldKeys = view.columns.map(col => {
+                    return col.fieldKey.toLowerCase()
+                }).toArray();
+                queryInfo.columns.forEach(queryCol => {
+                    if (queryCol.fieldKey && queryCol.addToSystemView && columnFieldKeys.indexOf(queryCol.fieldKey.toLowerCase()) == -1) {
+                        columns = columns.push ({
+                            fieldKey: queryCol.fieldKey,
+                            key: queryCol.fieldKey,
+                            name: queryCol.name,
+                            title: queryCol.caption,
+                        });
+                    }
+                });
+                updatedViewInfo = updatedViewInfo.mutate({columns});
+            }
+            updatedViewInfo = updatedViewInfo.mutate({
                 // update/set sorts and filters to combine view and user defined items
                 filters: List(model.filterArray.concat(view.filters.toArray())),
                 sorts: List(model.sorts.concat(view.sorts.toArray())),

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -813,24 +813,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
         return new Promise((resolve, reject) => {
             const view = queryInfo?.getView(viewName, true);
-            let updatedViewInfo = view;
-            if (view.isDefault && !view.session) {
-                let columns = view.columns;
-                const columnFieldKeys = view.columns.map(col => {
-                    return col.fieldKey.toLowerCase()
-                }).toArray();
-                queryInfo.columns.forEach(queryCol => {
-                    if (queryCol.fieldKey && queryCol.addToSystemView && columnFieldKeys.indexOf(queryCol.fieldKey.toLowerCase()) === -1) {
-                        columns = columns.push({
-                            fieldKey: queryCol.fieldKey,
-                            key: queryCol.fieldKey,
-                            name: queryCol.name,
-                            title: queryCol.caption,
-                        });
-                    }
-                });
-                updatedViewInfo = updatedViewInfo.mutate({columns});
-            }
+            let updatedViewInfo = view.addSystemViewColumns(queryInfo);
             updatedViewInfo = updatedViewInfo.mutate({
                 // update/set sorts and filters to combine view and user-defined items
                 filters: List(model.filterArray.concat(view.filters.toArray())),


### PR DESCRIPTION
#### Rationale
We use application metadata to add certain columns to system views (default, details, update). When a user saves a custom view, they expect the columns that are shown in the current grid, which may have been added via this metadata and thus not actually represented in the system view's columns.  This is really only an issue for the default view that has not already been customized as a session view. Here, we assure columns that have come in to the view because of the `addToSystem` view property are added to a saved view when a default view that has been sorted or filtered but has not had other column customizations done to it (and thus been saved as a session view with the full complement of visible columns).

#### Related Pull Requests

- https://github.com/LabKey/biologics/pull/1804
- https://github.com/LabKey/inventory/pull/655
- https://github.com/LabKey/sampleManagement/pull/1479


#### Changes
* Update `onSave` method in `GridPanel` to pick up columns added via `addToSystemView`.
