### PR TITLE
View Assay Results report fix for selectionKey when coming from sample > aliquots grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.273.3-fb-assayReportIssueFix.0",
+  "version": "2.273.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.273.3",
+  "version": "2.273.3-fb-assayReportIssueFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,6 +3,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.273.3
 *Released*: 21 December 2022
+* View Assay Results report fix for selectionKey when coming from sample > aliquots grid
+
+### version 2.273.3
+*Released*: 21 December 2022
 * Issue 46923: Use lookup container filter as default in LookupCell
 * Issue 46932: Don't show fields that are not filterable in filter modal
 * Issue 46974: Update delete warning messages to correspond to enabled features

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.273.3
-*Released*: 21 December 2022
+### version 2.273.4
+*Released*: 27 December 2022
 * View Assay Results report fix for selectionKey when coming from sample > aliquots grid
 
 ### version 2.273.3

--- a/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
@@ -17,7 +17,7 @@ import { ManageDropdownButton } from '../internal/components/buttons/ManageDropd
 import { TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT, TEST_LKSM_STARTER_MODULE_CONTEXT } from '../internal/productFixtures';
 
 import { SampleAliquotsGridPanelImpl } from './SampleAliquotsGridPanel';
-import { SampleTypeAppContext } from './SampleTypeAppContext';
+import { SampleTypeAppContext } from '../internal/AppContext';
 
 beforeEach(() => {
     LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };

--- a/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
@@ -31,6 +31,7 @@ describe('SampleAliquotsGridPanel', () => {
     const DEFAULT_PROPS = {
         actions: makeTestActions(jest.fn),
         onSampleChangeInvalidate: jest.fn(),
+        queryModelId: 'model',
         queryModels: {
             model: makeTestQueryModel(SCHEMA_QUERY, new QueryInfo(), {}, [], 0, 'model'),
         },

--- a/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
@@ -16,8 +16,9 @@ import { ManageDropdownButton } from '../internal/components/buttons/ManageDropd
 
 import { TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT, TEST_LKSM_STARTER_MODULE_CONTEXT } from '../internal/productFixtures';
 
-import { SampleAliquotsGridPanelImpl } from './SampleAliquotsGridPanel';
 import { SampleTypeAppContext } from '../internal/AppContext';
+
+import { SampleAliquotsGridPanelImpl } from './SampleAliquotsGridPanel';
 
 beforeEach(() => {
     LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };

--- a/packages/components/src/entities/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.tsx
@@ -51,7 +51,7 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
     const moreItems = [];
     if (isAssayEnabled(moduleContext)) {
         moreItems.push({
-            button: <SamplesAssayButton model={model} providerType={assayProviderType}/>,
+            button: <SamplesAssayButton model={model} providerType={assayProviderType} />,
             perm: PermissionTypes.Insert,
         });
     }
@@ -119,9 +119,9 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
 
 interface Props {
     assayProviderType?: string;
-    queryModelId: string;
     lineageUpdateAllowed: boolean;
     onSampleChangeInvalidate: (schemaQuery: SchemaQuery) => void;
+    queryModelId: string;
     showLabelOption?: boolean;
     user: User;
 }

--- a/packages/components/src/entities/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.tsx
@@ -119,6 +119,7 @@ const AliquotGridButtons: FC<AliquotGridButtonsProps & RequiresModelAndActions> 
 
 interface Props {
     assayProviderType?: string;
+    queryModelId: string;
     lineageUpdateAllowed: boolean;
     onSampleChangeInvalidate: (schemaQuery: SchemaQuery) => void;
     showLabelOption?: boolean;
@@ -126,13 +127,12 @@ interface Props {
 }
 
 export const SampleAliquotsGridPanelImpl: FC<Props & InjectedQueryModels> = memo(props => {
-    const { actions, queryModels, showLabelOption = true, ...buttonProps } = props;
+    const { actions, queryModels, queryModelId, showLabelOption = true, ...buttonProps } = props;
     const [showConfirmDelete, setConfirmDelete] = useState<boolean>(false);
     const [showPrintDialog, setShowPrintDialog] = useState<boolean>(false);
     const { createNotification } = useNotificationsContext();
     const { canPrintLabels, printServiceUrl, labelTemplate } = useLabelPrintingContext();
-
-    const queryModel = queryModels.model;
+    const queryModel = queryModels[queryModelId];
 
     const resetState = useCallback((): void => {
         setConfirmDelete(false);
@@ -227,11 +227,10 @@ export const SampleAliquotsGridPanel: FC<SampleAliquotsGridPanelProps> = props =
         ? [...getOmittedSampleTypeColumns(user), ...omittedColumns]
         : getOmittedSampleTypeColumns(user);
 
-    const queryConfigs = {
-        model: getSampleAliquotsQueryConfig(schemaQuery.getQuery(), sampleLsid, true, rootLsid, omitted),
-    };
+    const queryConfig = getSampleAliquotsQueryConfig(schemaQuery.getQuery(), sampleLsid, true, rootLsid, omitted);
+    const queryConfigs = { [queryConfig.id]: queryConfig };
 
-    return <SampleAliquotsGridPanelWithModel {...props} queryConfigs={queryConfigs} />;
+    return <SampleAliquotsGridPanelWithModel {...props} queryModelId={queryConfig.id} queryConfigs={queryConfigs} />;
 };
 
 SampleAliquotsGridPanel.displayName = 'SampleAliquotsGridPanel';

--- a/packages/components/src/entities/SampleCreatePage.spec.tsx
+++ b/packages/components/src/entities/SampleCreatePage.spec.tsx
@@ -11,7 +11,7 @@ import { BACKGROUND_IMPORT_MIN_FILE_SIZE } from '../internal/components/pipeline
 
 import { SampleCreatePage, SampleCreatePageProps } from './SampleCreatePage';
 import { SampleTypeBasePage } from './SampleTypeBasePage';
-import { SampleTypeAppContext } from './SampleTypeAppContext';
+import { SampleTypeAppContext } from '../internal/AppContext';
 
 function getDefaultProps(): SampleCreatePageProps {
     return {

--- a/packages/components/src/entities/SampleCreatePage.spec.tsx
+++ b/packages/components/src/entities/SampleCreatePage.spec.tsx
@@ -9,9 +9,10 @@ import { createMockWithRouterProps } from '../internal/mockUtils';
 import { ProductMenuModel } from '../internal/components/navigation/model';
 import { BACKGROUND_IMPORT_MIN_FILE_SIZE } from '../internal/components/pipeline/constants';
 
+import { SampleTypeAppContext } from '../internal/AppContext';
+
 import { SampleCreatePage, SampleCreatePageProps } from './SampleCreatePage';
 import { SampleTypeBasePage } from './SampleTypeBasePage';
-import { SampleTypeAppContext } from '../internal/AppContext';
 
 function getDefaultProps(): SampleCreatePageProps {
     return {

--- a/packages/components/src/entities/SampleDetailPage.spec.tsx
+++ b/packages/components/src/entities/SampleDetailPage.spec.tsx
@@ -30,7 +30,7 @@ import { Container } from '../internal/components/base/models/Container';
 import { GENERAL_ASSAY_PROVIDER_NAME } from '../internal/components/assay/constants';
 
 import { SampleDetailPage, SampleDetailPageBody, SampleDetailPageBodyProps } from './SampleDetailPage';
-import { SampleTypeAppContext } from './SampleTypeAppContext';
+import { SampleTypeAppContext } from '../internal/AppContext';
 import { SampleHeader } from './SampleHeader';
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleAliquotsPage } from './SampleAliquotsPage';

--- a/packages/components/src/entities/SampleDetailPage.spec.tsx
+++ b/packages/components/src/entities/SampleDetailPage.spec.tsx
@@ -29,8 +29,9 @@ import { Container } from '../internal/components/base/models/Container';
 
 import { GENERAL_ASSAY_PROVIDER_NAME } from '../internal/components/assay/constants';
 
-import { SampleDetailPage, SampleDetailPageBody, SampleDetailPageBodyProps } from './SampleDetailPage';
 import { SampleTypeAppContext } from '../internal/AppContext';
+
+import { SampleDetailPage, SampleDetailPageBody, SampleDetailPageBodyProps } from './SampleDetailPage';
 import { SampleHeader } from './SampleHeader';
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleAliquotsPage } from './SampleAliquotsPage';

--- a/packages/components/src/entities/SampleOverviewPanel.spec.tsx
+++ b/packages/components/src/entities/SampleOverviewPanel.spec.tsx
@@ -14,6 +14,7 @@ import { TEST_PROJECT_CONTAINER } from '../test/data/constants';
 import { User } from '../internal/components/base/models/User';
 
 import { SampleTypeAppContext } from '../internal/AppContext';
+
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleAliquotsSummary } from './SampleAliquotsSummary';
 import { SampleDetailEditing } from './SampleDetailEditing';

--- a/packages/components/src/entities/SampleOverviewPanel.spec.tsx
+++ b/packages/components/src/entities/SampleOverviewPanel.spec.tsx
@@ -13,7 +13,7 @@ import { TEST_PROJECT_CONTAINER } from '../test/data/constants';
 
 import { User } from '../internal/components/base/models/User';
 
-import { SampleTypeAppContext } from './SampleTypeAppContext';
+import { SampleTypeAppContext } from '../internal/AppContext';
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleAliquotsSummary } from './SampleAliquotsSummary';
 import { SampleDetailEditing } from './SampleDetailEditing';

--- a/packages/components/src/entities/SampleTypeDesignPage.spec.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.spec.tsx
@@ -19,7 +19,7 @@ import { Container } from '../internal/components/base/models/Container';
 
 import { getEntityTestAPIWrapper } from '../internal/components/entities/APIWrapper';
 
-import { SampleTypeAppContext } from './SampleTypeAppContext';
+import { SampleTypeAppContext } from '../internal/AppContext';
 
 import { SampleTypeBasePage } from './SampleTypeBasePage';
 import { SampleTypeDesignPage } from './SampleTypeDesignPage';

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -16,7 +16,7 @@
 import { List, Map, OrderedMap } from 'immutable';
 import { ActionURL, Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
 
-import { EntityDataType, IEntityTypeDetails, IEntityTypeOption, } from '../entities/models';
+import { EntityDataType, IEntityTypeDetails, IEntityTypeOption } from '../entities/models';
 import { deleteEntityType, getEntityTypeOptions, getSelectedItemSamples } from '../entities/actions';
 
 import { Location } from '../../util/URL';
@@ -55,9 +55,10 @@ import { ViewInfo } from '../../ViewInfo';
 
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 
+import { createGridModelId } from '../../models';
+
 import { IS_ALIQUOT_COL, SAMPLE_STATUS_REQUIRED_COLUMNS, SELECTION_KEY_TYPE } from './constants';
 import { FindField, GroupedSampleFields, SampleAliquotsStats, SampleState } from './models';
-import {createGridModelId} from "../../models";
 
 export function initSampleSetSelects(
     isUpdate: boolean,
@@ -258,18 +259,15 @@ export async function getSelectedSampleIdsFromSelectionKey(location: Location): 
         const sampleFieldKey = getLocationQueryVal(location, 'sampleFieldKey');
         const queryName = SCHEMAS.ASSAY_TABLES.RESULTS_QUERYNAME;
         let response;
-        if (isSnapshot)
-            response = await getSnapshotSelections(location.query.selectionKey);
-        else
-            response = await getSelection(location, schemaName, queryName);
+        if (isSnapshot) response = await getSnapshotSelections(location.query.selectionKey);
+        else response = await getSelection(location, schemaName, queryName);
         sampleIds = await getFieldLookupFromSelection(schemaName, queryName, response?.selected, sampleFieldKey);
     } else {
         const picklistName = getLocationQueryVal(location, 'picklistName');
         let response;
         if (isSnapshot && location.query?.selectionKey)
             response = await getSnapshotSelections(location.query.selectionKey);
-        else
-            response = await getSelection(location, SCHEMAS.PICKLIST_TABLES.SCHEMA, picklistName);
+        else response = await getSelection(location, SCHEMAS.PICKLIST_TABLES.SCHEMA, picklistName);
         if (picklistName) {
             sampleIds = await getSelectedPicklistSamples(picklistName, response.selected, false, undefined);
         } else {

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -33,7 +33,12 @@ import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
 import { EXP_TABLES, SCHEMAS } from '../../schemas';
 
-import { getContainerFilter, ISelectRowsResult, selectRowsDeprecated } from '../../query/api';
+import {
+    getContainerFilter,
+    invalidateFullQueryDetailsCache,
+    ISelectRowsResult,
+    selectRowsDeprecated,
+} from '../../query/api';
 
 import { buildURL } from '../../url/AppURL';
 import { SchemaQuery } from '../../../public/SchemaQuery';
@@ -824,8 +829,10 @@ export function getSampleAssayResultViewConfigs(): Promise<SampleAssayResultView
 }
 
 export async function createSessionAssayRunSummaryQuery(sampleIds: number[]): Promise<ISelectRowsResult> {
-    let assayRunsQuery = 'AssayRunsPerSample';
+    // issue with temp table re-use of queryName, invalidate cache to clear any queryDetails for old temp table
+    invalidateFullQueryDetailsCache();
 
+    let assayRunsQuery = 'AssayRunsPerSample';
     if (isProductProjectsEnabled() && !isProjectContainer()) {
         assayRunsQuery = 'AssayRunsPerSampleChildProject';
     }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -52,6 +52,7 @@ import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 
 import { IS_ALIQUOT_COL, SAMPLE_STATUS_REQUIRED_COLUMNS, SELECTION_KEY_TYPE } from './constants';
 import { FindField, GroupedSampleFields, SampleAliquotsStats, SampleState } from './models';
+import {createGridModelId} from "../../models";
 
 export function initSampleSetSelects(
     isUpdate: boolean,
@@ -779,9 +780,11 @@ export function getSampleAliquotsQueryConfig(
     omitCols?: string[]
 ): QueryConfig {
     const omitCol = IS_ALIQUOT_COL;
+    const schemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet);
 
     return {
-        schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet),
+        id: createGridModelId('sample-aliquots-' + sampleLsid, schemaQuery),
+        schemaQuery,
         bindURL: forGridView,
         maxRows: forGridView ? undefined : -1,
         omittedColumns: omitCols ? [...omitCols, omitCol] : [omitCol],


### PR DESCRIPTION
#### Rationale
While selenium tests were being created for the View Assay Results for selected samples report, two issues were found:
- selectionKey not finding schema/query info when coming to report form sample > aliquots grid
- if you select samples > view report and then go back and add data for the selected samples to the assay, going back to the assay report doesn't show new summary columns until page reload

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1064
* https://github.com/LabKey/sampleManagement/pull/1492
* https://github.com/LabKey/inventory/pull/661
* https://github.com/LabKey/biologics/pull/1815

#### Changes
* SampleAliquotsGridPanel fix to use proper grid Id for selectionKey
* add queryDetails invalidate call before creating session/temp query for assay results report
