### PR TITLE
@labkey/premium package move src up to root of repo

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.8.0",
+  "version": "6.8.0-fb-premiumPackageFileMove.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.8.0",
+      "version": "6.8.0-fb-premiumPackageFileMove.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.19.6",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "6.8.0-fb-premiumPackageFileMove.0",
+  "version": "6.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "6.8.0-fb-premiumPackageFileMove.0",
+      "version": "6.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.19.6",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.8.0-fb-premiumPackageFileMove.0",
+  "version": "6.8.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "6.8.0",
+  "version": "6.8.0-fb-premiumPackageFileMove.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
-### version TBD
-*Released*: TBD
+### version 6.8.1
+*Released*: 30 December 2022
 * Update path for premium package src after code move within that repo
 
 ### version 6.8.0

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,9 @@
 # @labkey/build
 
+### version TBD
+*Released*: TBD
+* Update path for premium package src after code move within that repo
+
 ### version 6.8.0
 *Released*: 19 December 2022
 * webpack updates for `@labkey/premium/storage` package

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -33,7 +33,7 @@ if (process.env.LINK) {
     labkeyUIComponentsPath = process.env.LABKEY_UI_COMPONENTS_HOME + '/packages/components/src';
     console.log('Using @labkey/components path:', labkeyUIComponentsPath);
 
-    labkeyUIPremiumPath = process.env.LABKEY_UI_PREMIUM_HOME + '/packages/premium/src';
+    labkeyUIPremiumPath = process.env.LABKEY_UI_PREMIUM_HOME + '/src';
     console.log('Using @labkey/premium path:', labkeyUIPremiumPath);
 }
 


### PR DESCRIPTION
#### Rationale
Since we only have one package in the labkey-ui-premium repo, we can remove the /packages/premium dir and move the content up to the root of the repo.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-premium/pull/13

#### Changes
* @labkey/build update path for premium package src after code move within that repo
