### PR TITLE
Issue 46767: DatePicker valid dates start at year 1000

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.276.0-fb-datePicker46767.0",
+  "version": "2.276.0-fb-datePicker46767.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.276.0",
+  "version": "2.276.0-fb-datePicker46767.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.276.0-fb-datePicker46767.1",
+  "version": "2.276.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD January 2023
+### version 2.276.1
+*Released*: 3 January 2023
 * Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))
   * update `parseDate` to add an optional minDate param for valid dates for DatePicker selected date
 * Issue 46839: Allow click on search input icon for grid panel to apply search value

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD January 2023
+* Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))
+
 ### version 2.276.0
 *Released*: 3 January 2023
 * App header Projects and Menu misc fixes

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD January 2023
 * Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))
   * update `parseDate` to add an optional minDate param for valid dates for DatePicker selected date
+* Issue 46839: Allow click on search input icon for grid panel to apply search value
 
 ### version 2.276.0
 *Released*: 3 January 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD January 2023
 * Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))
+  * update `parseDate` to add an optional minDate param for valid dates for DatePicker selected date
 
 ### version 2.276.0
 *Released*: 3 January 2023

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -104,7 +104,9 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
         // Issue 45140: props.value is the original formatted date, so pass the date format
         // to parseDate when getting the initial value.
         const dateFormat = props.initValueFormatted ? this.getDateFormat() : undefined;
-        return props.value ? parseDate(props.value, dateFormat) : undefined;
+
+        // Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))
+        return props.value ? parseDate(props.value, dateFormat, new Date('1000-01-01')) : undefined;
     }
 
     onChange = (date: Date): void => {

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -224,5 +224,12 @@ describe('Date Utilities', () => {
             expect(parseDate('22/04/11', 'yy/MM/dd').toString()).toContain('Apr 11 2022');
             expect(parseDate('22/04/11', 'YY/MM/DD').toString()).toContain('Apr 11 2022');
         });
+
+        test('minDate', () => {
+            expect(parseDate('0218-11-18', undefined).toString()).toContain('0218');
+            expect(parseDate('0218-11-18', undefined, new Date('1000-01-01'))).toBe(null);
+            expect(parseDate('0218-11-18 00:00', 'yyyy-MM-dd HH:ss').toString()).toContain('0218');
+            expect(parseDate('0218-11-18 00:00', 'yyyy-MM-dd HH:ss', new Date('1000-01-01'))).toBe(null);
+        });
     });
 });

--- a/packages/components/src/public/QueryModel/SearchBox.tsx
+++ b/packages/components/src/public/QueryModel/SearchBox.tsx
@@ -32,6 +32,10 @@ export const SearchBox: FC<Props> = memo(props => {
         [onSearch, searchValue]
     );
 
+    const onIconClick = useCallback(() => {
+        onSearch(searchValue);
+    }, [onSearch, searchValue]);
+
     const removeSearch = useCallback(() => {
         onSearch('');
         setSearchValue('');
@@ -41,7 +45,7 @@ export const SearchBox: FC<Props> = memo(props => {
         <form className="grid-panel__search-form" onSubmit={onSubmit}>
             <div className="form-group">
                 <span className="grid-panel__input-group input-group">
-                    <span className="input-group-addon">
+                    <span className="input-group-addon" onClick={onIconClick}>
                         <i className="fa fa-search" />
                     </span>
                     <input

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -59,7 +59,7 @@
 }
 .grid-panel__menu-toggle {
     color: $light-gray;
-    fontSize: 12px;
+    font-size: 12px;
 }
 
 .grid-panel__search-form {
@@ -68,10 +68,11 @@
 
     .input-group-addon {
         background-color: inherit;
-    }
 
-    .grid-panel__search-input {
-        padding: 7px 22px;
+        &:hover {
+            cursor: pointer;
+            background-color: $light-gray;
+        }
     }
 }
 


### PR DESCRIPTION
#### Rationale
Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1072
* https://github.com/LabKey/sampleManagement/pull/1510
* https://github.com/LabKey/inventory/pull/671
* https://github.com/LabKey/biologics/pull/1833

#### Changes
* update parseDate to add a minDate param for valid dates for DatePicker selected date
