### PR TITLE
Synchronize the creation of the Label templates list

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.275.0-23-1-fb-fixLabelTable.1",
+  "version": "2.275.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.275.0-23-1-fb-fixLabelTable.0",
+  "version": "2.275.0-23-1-fb-fixLabelTable.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.275.0",
+  "version": "2.275.0-23-1-fb-fixLabelTable.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.275.TBD
-*Released*: TBD
+### version 2.275.1
+*Released*: 06 January 2023
 * Fix race condition that causes LabelTemplates table creation to fail
 
 ### version 2.275.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.275.TBD
+*Released*: TBD
+* Fix race condition that causes LabelTemplates table creation to fail
+
 ### version 2.275.0
 *Released*: 29 December 2022
 * Add support for tracking and using multiple BarTender Label templates

--- a/packages/components/src/internal/components/labels/APIWrapper.ts
+++ b/packages/components/src/internal/components/labels/APIWrapper.ts
@@ -1,4 +1,4 @@
-import { ActionURL, Ajax, Domain, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Utils } from '@labkey/api';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { getQueryModelExportParams } from '../../../public/QueryModel/utils';
@@ -23,44 +23,17 @@ function handleBarTenderConfigurationResponse(response: any): BarTenderConfigura
 
 function createLabelTemplateList(): Promise<DomainDesign> {
     return new Promise((resolve, reject) => {
-        Domain.create({
-            kind: 'IntList',
-            domainDesign: {
-                name: LABEL_TEMPLATES_LIST_NAME,
-                description: 'Set of label templates available to print.',
-                fields: [
-                    {
-                        name: 'rowId',
-                        rangeURI: 'int',
-                    },
-                    {
-                        name: 'name',
-                        rangeURI: 'string',
-                        required: true,
-                        description: 'Display name for template',
-                    },
-                    {
-                        name: 'description',
-                        rangeURI: 'string',
-                    },
-                    {
-                        name: 'path',
-                        rangeURI: 'string',
-                        required: true,
-                        description: "Label template's relative location for print service",
-                    },
-                ],
+        Ajax.request({
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'ensureLabelTemplateList.api', undefined, {
+                returnUrl: false,
+            }),
+            method: 'POST',
+            success: () => {
+                resolve(undefined);
             },
-            options: {
-                keyName: 'rowId',
-                keyType: 'AutoIncrementInteger',
-            },
-            success: response => {
-                resolve(DomainDesign.create(response));
-            },
-            failure: response => {
-                reject(response);
-            },
+            failure: reason => {
+                reject(reason);
+            }
         });
     });
 }

--- a/packages/components/src/internal/components/labels/APIWrapper.ts
+++ b/packages/components/src/internal/components/labels/APIWrapper.ts
@@ -21,7 +21,7 @@ function handleBarTenderConfigurationResponse(response: any): BarTenderConfigura
     return new BarTenderConfiguration(btConfiguration);
 }
 
-function createLabelTemplateList(): Promise<DomainDesign> {
+function createLabelTemplateList(): Promise<LabelTemplate[]> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'ensureLabelTemplateList.api', undefined, {
@@ -29,7 +29,7 @@ function createLabelTemplateList(): Promise<DomainDesign> {
             }),
             method: 'POST',
             success: () => {
-                resolve(undefined);
+                resolve([]);
             },
             failure: reason => {
                 reject(reason);
@@ -175,7 +175,7 @@ export class LabelPrintingServerAPIWrapper implements LabelPrintingAPIWrapper {
 
                         // try to create list
                         createLabelTemplateList()
-                            .then(() => resolve([]))
+                            .then(result => resolve(result))
                             .catch(createReason => {
                                 console.error(createReason);
                                 resolve(undefined);

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
@@ -288,7 +288,7 @@ export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props
             api.labelprinting
                 .ensureLabelTemplatesList(user)
                 .then(labelTemplates => {
-                    setTemplates(labelTemplates);
+                    setTemplates(labelTemplates ?? []);
                     if (newLabelTemplate)
                         setSelected(labelTemplates.findIndex(template => template.rowId === newLabelTemplate));
                 })
@@ -325,7 +325,7 @@ export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props
         [queryLabelTemplates, setIsDirty]
     );
 
-    const template = templates.length === 0 ? null : templates[selected];
+    const template = !templates.length ? null : templates[selected];
 
     return (
         <div className="panel panel-default label-templates-container">


### PR DESCRIPTION
#### Rationale
Fix tests failing due to multiple requests to create the labels list. https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerCPostgres/2202697?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1076
* https://github.com/LabKey/sampleManagement/pull/1522
* https://github.com/LabKey/inventory/pull/680
* https://github.com/LabKey/biologics/pull/1843


#### Changes
* Changed to use a server side api to create the Labels list 