### PR TITLE
Lookup Views

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.279.1",
+  "version": "2.280.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.280.0
+*Released*: ? January 2023
+* QueryColumn: Add shownInLookupView
+* QueryInfo: Add getLookupViewColumns
+* QuerySelect
+  * remove previewOptions, we now render additional columns based on the shownInLookupView attribute of QueryColumn
+  * update default option renderer to only render column captions when multiple columns are set to show in lookup views
+* AssayImportPanels: remove showQuerySelectPreviewOptions
+
 ### version 2.279.1
 *Released*: 9 January 2023
 * Issue 47020: Use unique grid id so selections are not shared between FindByIds queries

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.280.0
-*Released*: ? January 2023
+*Released*: 12 January 2023
 * QueryColumn: Add shownInLookupView
 * QueryInfo: Add getLookupViewColumns
 * QuerySelect

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -105,7 +105,6 @@ interface OwnProps {
     runDataPanelTitle?: string;
     runId?: string;
     setIsDirty?: (isDirty: boolean) => void;
-    showQuerySelectPreviewOptions?: boolean;
     showUploadTabs?: boolean;
 }
 
@@ -651,7 +650,6 @@ class AssayImportPanelsBody extends Component<Props, State> {
             maxRows,
             onSave,
             showUploadTabs,
-            showQuerySelectPreviewOptions,
             runDataPanelTitle,
             fileSizeLimits,
             user,
@@ -707,12 +705,10 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 <BatchPropertiesPanel
                     model={model}
                     onChange={this.handleBatchChange}
-                    showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
                 />
                 <RunPropertiesPanel
                     model={model}
                     onChange={this.handleRunChange}
-                    showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
                 />
                 <RunDataPanel
                     acceptedPreviewFileFormats={acceptedPreviewFileFormats}

--- a/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
@@ -19,11 +19,10 @@ import Formsy from 'formsy-react';
 import { QueryFormInputs } from '../forms/QueryFormInputs';
 
 import { AssayPropertiesPanelProps } from './models';
-import { Query } from '@labkey/api';
 import { getContainerFilterForLookups } from '../../query/api';
 
 export const BatchPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
-    const { model, onChange, title = 'Batch Details', showQuerySelectPreviewOptions } = props;
+    const { model, onChange, title = 'Batch Details' } = props;
 
     if (model.batchColumns.size === 0) {
         return null;
@@ -42,7 +41,6 @@ export const BatchPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props =>
                         queryColumns={model.batchColumns}
                         renderFileInputs
                         containerFilter={getContainerFilterForLookups()}
-                        showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
                     />
                 </Formsy>
             </div>

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -30,7 +30,7 @@ import { useServerContext } from '../base/ServerContext';
 import { AssayPropertiesPanelProps } from './models';
 
 export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
-    const { model, onChange, title = 'Run Details', showQuerySelectPreviewOptions } = props;
+    const { model, onChange, title = 'Run Details' } = props;
     const { moduleContext } = useServerContext();
     const nameLabel = useMemo(
         () => (
@@ -85,7 +85,6 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                             queryColumns={model.runColumns}
                             renderFileInputs
                             containerFilter={getContainerFilterForLookups()}
-                            showQuerySelectPreviewOptions={showQuerySelectPreviewOptions}
                         />
                     )}
                 </Formsy>

--- a/packages/components/src/internal/components/assay/models.ts
+++ b/packages/components/src/internal/components/assay/models.ts
@@ -23,7 +23,6 @@ export interface AssayPropertiesPanelProps {
     model: AssayWizardModel;
     onChange: Function;
     title?: string;
-    showQuerySelectPreviewOptions?: boolean;
 }
 
 export class AssayUploadResultModel {

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -61,7 +61,6 @@ export interface QueryFormInputsProps {
     renderFileInputs?: boolean;
     // only used if checkRequiredFields is false, to show * for fields that are originally required
     showLabelAsterisk?: boolean;
-    showQuerySelectPreviewOptions?: boolean;
 }
 
 interface State {
@@ -77,7 +76,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
         allowFieldDisable: false,
         initiallyDisableFields: false,
         disabledFields: List<string>(),
-        showQuerySelectPreviewOptions: false,
     };
 
     private _fieldEnabledCount = 0;
@@ -165,7 +163,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             allowFieldDisable,
             disabledFields,
             renderFieldLabel,
-            showQuerySelectPreviewOptions,
             onAdditionalFormDataChange,
             queryFilters,
         } = this.props;
@@ -257,7 +254,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                         onQSChange={this.onSelectChange}
                                         onToggleDisable={this.onToggleDisable}
                                         placeholder="Select or type to search..."
-                                        previewOptions={col.previewOptions === true || showQuerySelectPreviewOptions}
                                         queryFilters={queryFilter}
                                         renderFieldLabel={renderFieldLabel}
                                         required={col.required}

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -146,7 +146,6 @@ export interface QuerySelectOwnProps extends InheritedSelectInputProps {
     onInitValue?: (value: any, selectedValues: List<any>) => void;
     onQSChange?: QuerySelectChange;
     preLoad?: boolean;
-    previewOptions?: boolean;
     queryFilters?: List<Filter.IFilter>;
     requiredColumns?: string[];
     schemaQuery: SchemaQuery;
@@ -169,7 +168,6 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
         fireQSChangeOnInit: false,
         loadOnFocus: false,
         preLoad: true,
-        previewOptions: false,
         showLoading: true,
     };
 
@@ -307,7 +305,6 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
             onToggleDisable,
             openMenuOnFocus,
             optionRenderer,
-            previewOptions,
             required,
             showLoading,
         } = this.props;
@@ -358,7 +355,7 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
                     onFocus: this.onFocus,
                     openMenuOnFocus,
                     options: undefined, // prevent override
-                    optionRenderer: previewOptions ? this.optionRenderer : optionRenderer,
+                    optionRenderer: optionRenderer ? optionRenderer : this.optionRenderer,
                     selectedOptions: model.getSelectedOptions(),
                     value: getValue(model, this.props), // needed to initialize the Formsy "value" properly
                 }

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -71,11 +71,13 @@ const PreviewOption: FC<any> = props => {
     const { allResults, queryInfo } = model;
 
     if (queryInfo && allResults.size) {
+        const displayColumn = queryInfo.getColumn(model.displayColumn);
+        const columns = [displayColumn].concat(queryInfo.getLookupViewColumns([model.displayColumn]));
         const item = allResults.find(result => value === result.getIn([model.valueColumn, 'value']));
 
         return (
             <>
-                {queryInfo.getDisplayColumns(model.schemaQuery.viewName).map((column, i) => {
+                {columns.map((column, i) => {
                     if (item !== undefined) {
                         let text = resolveDetailFieldValue(item.get(column.name));
                         if (!Utils.isString(text)) {
@@ -84,7 +86,7 @@ const PreviewOption: FC<any> = props => {
 
                         return (
                             <div key={i} className="text__truncate">
-                                <strong>{column.caption}: </strong>
+                                {columns.length > 1 && <strong>{column.caption}: </strong>}
                                 <span>{text}</span>
                             </div>
                         );

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -320,7 +320,6 @@ export function resolveDetailEditRenderer(
                         onBlur={options?.onBlur}
                         onQSChange={options?.onSelectChange}
                         placeholder={options?.placeholder ?? 'Select or type to search...'}
-                        previewOptions={col.previewOptions}
                         required={col.required}
                         schemaQuery={col.lookup.schemaQuery}
                         showLabel={showLabel}

--- a/packages/components/src/internal/components/labels/PrintLabelsModal.tsx
+++ b/packages/components/src/internal/components/labels/PrintLabelsModal.tsx
@@ -221,7 +221,6 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                                 name="label-samples"
                                 onQSChange={this.changeSampleSelection}
                                 placeholder="Select or type to search..."
-                                previewOptions={true}
                                 required={false}
                                 schemaQuery={model.schemaQuery}
                                 queryFilters={List(model.filters)}
@@ -242,7 +241,6 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                             name="label-template"
                             onQSChange={this.changeTemplateSelection}
                             placeholder="Select or type to search..."
-                            previewOptions={true}
                             required={true}
                             schemaQuery={LABEL_TEMPLATE_SQ}
                             displayColumn="name"

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -119,7 +119,7 @@ export class QueryColumn extends Record({
     removeFromViewCustomization: undefined,
     shownInDetailsView: undefined,
     shownInInsertView: undefined,
-    shownInLookupVIew: undefined,
+    shownInLookupView: undefined,
     shownInUpdateView: undefined,
     sortable: true,
     // sqlType: undefined,

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -133,7 +133,6 @@ export class QueryColumn extends Record({
     detailRenderer: undefined,
     helpTipRenderer: undefined,
     inputRenderer: undefined,
-    previewOptions: false,
     removeFromViews: false,
     sorts: undefined,
     units: undefined,
@@ -210,7 +209,6 @@ export class QueryColumn extends Record({
     declare detailRenderer: string;
     declare helpTipRenderer: string;
     declare inputRenderer: string;
-    declare previewOptions: boolean;
     declare sorts: '+' | '-';
     declare removeFromViews: boolean; // strips this column from all ViewInfo definitions
     declare units: string;

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -119,6 +119,7 @@ export class QueryColumn extends Record({
     removeFromViewCustomization: undefined,
     shownInDetailsView: undefined,
     shownInInsertView: undefined,
+    shownInLookupVIew: undefined,
     shownInUpdateView: undefined,
     sortable: true,
     // sqlType: undefined,
@@ -195,6 +196,7 @@ export class QueryColumn extends Record({
     declare removeFromViewCustomization: boolean;
     declare shownInDetailsView: boolean;
     declare shownInInsertView: boolean;
+    declare shownInLookupView: boolean;
     declare shownInUpdateView: boolean;
     declare sortable: boolean;
     // declare sqlType: string;

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -234,8 +234,13 @@ export class QueryInfo extends Record({
         return List<QueryColumn>();
     }
 
-    getLookupViewColumns(): List<QueryColumn> {
-        return this.columns.filter(col => col.shownInLookupView).toList();
+    // Note: Yes, all of the other QueryInfo methods return Immutable lists or related types, but all usages of this
+    // method need arrays, and doing that computation in one area is ideal.
+    getLookupViewColumns(omittedColumns?: string[]): QueryColumn[] {
+        const lcCols = omittedColumns ? omittedColumns.map(c => c.toLowerCase()) : [];
+        return this.columns
+            .filter(col => col.shownInLookupView && lcCols.indexOf(col.fieldKey.toLowerCase()) === -1)
+            .toArray();
     }
 
     getAllColumns(viewName?: string, omittedColumns?: List<string>): List<QueryColumn> {

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -234,6 +234,10 @@ export class QueryInfo extends Record({
         return List<QueryColumn>();
     }
 
+    getLookupViewColumns(): List<QueryColumn> {
+        return this.columns.filter(col => col.shownInLookupView).toList();
+    }
+
     getAllColumns(viewName?: string, omittedColumns?: List<string>): List<QueryColumn> {
         // initialReduction is getDisplayColumns() because they include custom metadata from the view, like alternate
         // column display names (e.g. the Experiment grid overrides Title to "Experiment Title"). See Issue 38186 for


### PR DESCRIPTION
#### Rationale
This PR adds support for the "shownInLookupView" column property (see platform PR).

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1081
* https://github.com/LabKey/labkey-ui-premium/pull/18
* https://github.com/LabKey/platform/pull/3998
* https://github.com/LabKey/biologics/pull/1853
* https://github.com/LabKey/sampleManagement/pull/1533
* https://github.com/LabKey/inventory/pull/686
* https://github.com/LabKey/labbook/pull/377

#### Changes
* QueryColumn: Add shownInLookupView
* QueryInfo: Add getLookupViewColumns
* QuerySelect
  * remove previewOptions, we now render additional columns based on the shownInLookupView attribute of QueryColumn
  * update default option renderer to only render column captions when multiple columns are set to show in lookup views
* AssayImportPanels: remove showQuerySelectPreviewOptions
