### PR TITLE
Enable making audit comments for Samples, Sources, and Run deletes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.283.2-fb-deleteComment.4",
+  "version": "2.283.2-fb-deleteComment.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.283.2-fb-deleteComment.6",
+  "version": "2.284.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.283.0",
+  "version": "2.283.0-fb-deleteComment.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.283.2-fb-deleteComment.3",
+  "version": "2.283.2-fb-deleteComment.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.283.0-fb-deleteComment.0",
+  "version": "2.283.0-fb-deleteComment.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.283.2-fb-deleteComment.5",
+  "version": "2.283.2-fb-deleteComment.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Add user audit comments when deleting Samples, Sources, and assays
+
 ### version 2.283.0
 *Released*: 17 January 2023
 * Issue 47066: Adjust timeline to show created date and created by user in timeline's current status, even if detailed audit logging was not on.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,9 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
-* Add user audit comments when deleting Samples, Sources, and assays
+### version 2.284.0
+*Released*: 25 January 2023
+* Enable adding user audit comments when deleting Samples, Sources, and Assays & the associated entity types
 
 ### version 2.283.2
 *Released*: 23 January 2023

--- a/packages/components/src/entities/DeleteConfirmationModal.tsx
+++ b/packages/components/src/entities/DeleteConfirmationModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC, memo, ReactNode, useCallback, useState } from 'react';
 
-import { ConfirmModal, ConfirmModalProps } from '../base/ConfirmModal';
+import { ConfirmModal, ConfirmModalProps } from '../internal/components/base/ConfirmModal';
 
 export interface DeleteConfirmationModalProps extends Omit<ConfirmModalProps, 'onConfirm'> {
     message: ReactNode;
@@ -24,7 +24,7 @@ export const DeleteConfirmationModal: FC<DeleteConfirmationModalProps> = memo(pr
     return (
         <ConfirmModal
             title={title}
-            onConfirm={showDeleteComment ? onConfirmCallback : undefined}
+            onConfirm={onConfirmCallback}
             onCancel={onCancel}
             confirmVariant="danger"
             confirmButtonText={confirmButtonText}
@@ -32,24 +32,26 @@ export const DeleteConfirmationModal: FC<DeleteConfirmationModalProps> = memo(pr
         >
             <span>
                 {message}
-                {showDeleteComment && (
+                {!!onConfirm && (
                     <div className="top-spacing">
                         <div>
                             <strong>Deletion cannot be undone.</strong> Do you want to proceed?
                         </div>
-                        <div className="top-spacing">
-                            <div className="bottom-spacing">
-                                <strong>Reason(s) for deleting</strong>
+                        {showDeleteComment && (
+                            <div className="top-spacing">
+                                <div className="bottom-spacing">
+                                    <strong>Reason(s) for deleting</strong>
+                                </div>
+                                <div>
+                                    <textarea
+                                        className="form-control"
+                                        placeholder="Enter comments (optional)"
+                                        onChange={onCommentChange}
+                                        rows={5}
+                                    />
+                                </div>
                             </div>
-                            <div>
-                                <textarea
-                                    className="form-control"
-                                    placeholder="Enter comments (optional)"
-                                    onChange={onCommentChange}
-                                    rows={5}
-                                />
-                            </div>
-                        </div>
+                        )}
                     </div>
                 )}
             </span>

--- a/packages/components/src/entities/DeleteConfirmationModal.tsx
+++ b/packages/components/src/entities/DeleteConfirmationModal.tsx
@@ -1,16 +1,14 @@
-import React, { FC, memo, ReactNode, useCallback, useState } from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 
 import { ConfirmModal, ConfirmModalProps } from '../internal/components/base/ConfirmModal';
 
 export interface DeleteConfirmationModalProps extends Omit<ConfirmModalProps, 'onConfirm'> {
-    message: ReactNode;
-    onCancel: () => any;
-    onConfirm: (userComment: string) => any;
+    onConfirm?: (userComment: string) => void;
     showDeleteComment?: boolean;
 }
 
 export const DeleteConfirmationModal: FC<DeleteConfirmationModalProps> = memo(props => {
-    const { cancelButtonText, confirmButtonText, message, onCancel, onConfirm, showDeleteComment, title } = props;
+    const { children, onConfirm, showDeleteComment, ...confirmModalProps } = props;
     const [auditUserComment, setAuditUserComment] = useState<string>();
 
     const onConfirmCallback = useCallback(() => {
@@ -22,39 +20,30 @@ export const DeleteConfirmationModal: FC<DeleteConfirmationModalProps> = memo(pr
     }, []);
 
     return (
-        <ConfirmModal
-            title={title}
-            onConfirm={onConfirmCallback}
-            onCancel={onCancel}
-            confirmVariant="danger"
-            confirmButtonText={confirmButtonText}
-            cancelButtonText={cancelButtonText}
-        >
-            <span>
-                {message}
-                {!!onConfirm && (
-                    <div className="top-spacing">
-                        <div>
-                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                        </div>
-                        {showDeleteComment && (
-                            <div className="top-spacing">
-                                <div className="bottom-spacing">
-                                    <strong>Reason(s) for deleting</strong>
-                                </div>
-                                <div>
-                                    <textarea
-                                        className="form-control"
-                                        placeholder="Enter comments (optional)"
-                                        onChange={onCommentChange}
-                                        rows={5}
-                                    />
-                                </div>
-                            </div>
-                        )}
+        <ConfirmModal confirmVariant="danger" {...confirmModalProps} onConfirm={onConfirmCallback}>
+            {children}
+            {!!onConfirm && (
+                <div className="top-spacing">
+                    <div>
+                        <strong>Deletion cannot be undone.</strong> Do you want to proceed?
                     </div>
-                )}
-            </span>
+                    {showDeleteComment && (
+                        <div className="top-spacing">
+                            <div className="bottom-spacing">
+                                <strong>Reason(s) for deleting</strong>
+                            </div>
+                            <div>
+                                <textarea
+                                    className="form-control"
+                                    placeholder="Enter comments (optional)"
+                                    onChange={onCommentChange}
+                                    rows={5}
+                                />
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
         </ConfirmModal>
     );
 });

--- a/packages/components/src/entities/DeleteConfirmationModal.tsx
+++ b/packages/components/src/entities/DeleteConfirmationModal.tsx
@@ -20,7 +20,7 @@ export const DeleteConfirmationModal: FC<DeleteConfirmationModalProps> = memo(pr
     }, []);
 
     return (
-        <ConfirmModal confirmVariant="danger" {...confirmModalProps} onConfirm={onConfirmCallback}>
+        <ConfirmModal confirmVariant="danger" {...confirmModalProps} onConfirm={!!onConfirm ? onConfirmCallback : undefined}>
             {children}
             {!!onConfirm && (
                 <div className="top-spacing">

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -64,7 +64,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
     }
 
     const onConfirm = useCallback(
-        async (rowsToDelete: any[], rowsToKeep: any[]) => {
+        async (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => {
             setNumConfirmed(rowsToDelete.length);
             setShowProgress(true);
             beforeDelete?.();
@@ -76,6 +76,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
                     rows: rowsToDelete,
                     schemaQuery: queryModel.schemaQuery,
                     containerPath,
+                    ['auditUserComment']: userComment,
                 });
                 afterDelete(rowsToKeep);
                 createNotification(deleteSuccessMessage(noun, rowsToDelete.length, undefined));

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -76,7 +76,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
                     rows: rowsToDelete,
                     schemaQuery: queryModel.schemaQuery,
                     containerPath,
-                    ['auditUserComment']: userComment,
+                    auditUserComment: userComment,
                 });
                 afterDelete(rowsToKeep);
                 createNotification(deleteSuccessMessage(noun, rowsToDelete.length, undefined));

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -49,7 +49,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
     let rowIds;
     let numSelected = 0;
     let selectionKey: string;
-    let useSnapshotSelection: boolean = false;
+    let useSnapshotSelection = false;
 
     if (queryModel) {
         if (useSelected) {

--- a/packages/components/src/entities/EntityTypeDeleteConfirmModal.spec.tsx
+++ b/packages/components/src/entities/EntityTypeDeleteConfirmModal.spec.tsx
@@ -66,6 +66,7 @@ describe('EntityTypeDeleteConfirmModal', () => {
                 deleteConfirmationActionName="deleteSampleTypes"
                 onCancel={onCancelFn}
                 onConfirm={onConfirmFn}
+                showDeleteComment
             />
         );
 

--- a/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
@@ -13,6 +13,7 @@ interface Props {
     onCancel: () => any;
     onConfirm: (userComment: string) => any;
     rowId: number;
+    showDeleteComment?: boolean;
     showDependenciesLink?: boolean;
 }
 
@@ -26,10 +27,11 @@ export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
         rowId,
         deleteConfirmationActionName,
         noun,
+        showDeleteComment,
     } = props;
     const [auditUserComment, setAuditUserComment] = useState<string>();
 
-    const onConfirmCallback = useCallback(()=>{
+    const onConfirmCallback = useCallback(() => {
         onConfirm(auditUserComment);
     }, [onConfirm, auditUserComment]);
 
@@ -44,9 +46,7 @@ export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
         if (isSample) {
             params = params.set('sampleOperation', SampleOperation[SampleOperation.Delete]);
         }
-        dependencies = (
-            <a href={buildURL('experiment', deleteConfirmationActionName, params.toJS())}>dependencies</a>
-        );
+        dependencies = <a href={buildURL('experiment', deleteConfirmationActionName, params.toJS())}>dependencies</a>;
     }
 
     return (
@@ -68,13 +68,24 @@ export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
                     </>
                 )}
                 <div className="top-spacing">
-                    <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                     <div>
-                        <label>
-                            <strong>Reason for deleting</strong>
-                            <input type="textarea" placeholder="Enter comments (optional)" value={auditUserComment} onChange={onCommentChange}/>
-                        </label>
+                    <div>
+                        <strong>Deletion cannot be undone.</strong> Do you want to proceed?
                     </div>
+                    {showDeleteComment && (
+                        <div>
+                            <div>
+                                <strong>Reason(s) for deleting</strong>
+                            </div>
+                            <div>
+                                <textarea
+                                    className="form-control"
+                                    placeholder="Enter comments (optional)"
+                                    value={auditUserComment}
+                                    onChange={onCommentChange}
+                                />
+                            </div>
+                        </div>
+                    )}
                 </div>
             </span>
         </ConfirmModal>

--- a/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
@@ -3,10 +3,8 @@ import { Map } from 'immutable';
 
 import { SampleOperation } from '../internal/components/samples/constants';
 import { buildURL } from '../internal/url/AppURL';
-import {
-    DeleteConfirmationModal,
-    DeleteConfirmationModalProps,
-} from '../internal/components/entities/DeleteConfirmationModal';
+
+import { DeleteConfirmationModal, DeleteConfirmationModalProps } from './DeleteConfirmationModal';
 
 interface Props extends Omit<DeleteConfirmationModalProps, 'message'> {
     deleteConfirmationActionName?: string;
@@ -29,7 +27,7 @@ export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
     } = props;
 
     const dependencies = useMemo(() => {
-        if (!showDependenciesLink || !deleteConfirmationActionName) return undefined;
+        if (!showDependenciesLink || !deleteConfirmationActionName) return 'dependencies';
 
         let params = Map<string, string>();
         params = params.set('singleObjectRowId', rowId.toString());

--- a/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
@@ -1,12 +1,11 @@
 import React, { FC, memo, useMemo } from 'react';
-import { Map } from 'immutable';
 
 import { SampleOperation } from '../internal/components/samples/constants';
 import { buildURL } from '../internal/url/AppURL';
 
 import { DeleteConfirmationModal, DeleteConfirmationModalProps } from './DeleteConfirmationModal';
 
-interface Props extends Omit<DeleteConfirmationModalProps, 'message'> {
+interface Props extends DeleteConfirmationModalProps {
     deleteConfirmationActionName?: string;
     isSample?: boolean;
     isShared?: boolean;
@@ -17,53 +16,42 @@ interface Props extends Omit<DeleteConfirmationModalProps, 'message'> {
 
 export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
     const {
+        deleteConfirmationActionName,
         isShared,
         isSample,
-        showDependenciesLink = false,
-        rowId,
-        deleteConfirmationActionName,
         noun,
+        rowId,
+        showDependenciesLink = false,
         ...rest
     } = props;
 
     const dependencies = useMemo(() => {
         if (!showDependenciesLink || !deleteConfirmationActionName) return 'dependencies';
 
-        let params = Map<string, string>();
-        params = params.set('singleObjectRowId', rowId.toString());
+        const params: Record<string, any> = { singleObjectRowId: rowId.toString() };
+
         if (isSample) {
-            params = params.set('sampleOperation', SampleOperation[SampleOperation.Delete]);
+            params.sampleOperation = SampleOperation[SampleOperation.Delete];
         }
 
-        return (
-            <>
-                <a href={buildURL('experiment', deleteConfirmationActionName, params.toJS())}>dependencies</a>
-            </>
-        );
+        return <a href={buildURL('experiment', deleteConfirmationActionName, params)}>dependencies</a>;
     }, [deleteConfirmationActionName, isSample, rowId, showDependenciesLink]);
-
-    const message = useMemo(() => {
-        return (
-            <>
-                The {noun.toLowerCase()} type and all of its {dependencies} will be permanently deleted.
-                {isShared && (
-                    <>
-                        {' '}
-                        Because this is a <strong>shared</strong> {noun.toLowerCase()} type, you may be affecting other
-                        folders.
-                    </>
-                )}
-            </>
-        );
-    }, [dependencies, isShared, noun]);
 
     return (
         <DeleteConfirmationModal
             {...rest}
             cancelButtonText="Cancel"
             confirmButtonText="Yes, Delete"
-            message={message}
             title={`Permanently delete ${isShared ? 'shared ' : ''}${noun.toLowerCase()} type?`}
-        />
+        >
+            The {noun.toLowerCase()} type and all of its {dependencies} will be permanently deleted.
+            {isShared && (
+                <>
+                    {' '}
+                    Because this is a <strong>shared</strong> {noun.toLowerCase()} type, you may be affecting other
+                    folders.
+                </>
+            )}
+        </DeleteConfirmationModal>
     );
 });

--- a/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
@@ -1,66 +1,14 @@
-import React, { FC, memo, ReactNode, useCallback, useMemo, useState } from 'react';
+import React, { FC, memo, useMemo } from 'react';
 import { Map } from 'immutable';
 
 import { SampleOperation } from '../internal/components/samples/constants';
 import { buildURL } from '../internal/url/AppURL';
-import { ConfirmModal, ConfirmModalProps } from '../internal/components/base/ConfirmModal';
+import {
+    DeleteConfirmationModal,
+    DeleteConfirmationModalProps,
+} from '../internal/components/entities/DeleteConfirmationModal';
 
-export interface DeleteConfirmModalProps extends Omit<ConfirmModalProps, 'onConfirm'> {
-    message: ReactNode;
-    onCancel: () => any;
-    onConfirm: (userComment: string) => any;
-    showDeleteComment?: boolean;
-}
-
-export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = memo(props => {
-    const { cancelButtonText, confirmButtonText, message, onCancel, onConfirm, showDeleteComment, title } = props;
-    const [auditUserComment, setAuditUserComment] = useState<string>();
-
-    const onConfirmCallback = useCallback(() => {
-        onConfirm(auditUserComment);
-    }, [onConfirm, auditUserComment]);
-
-    const onCommentChange = useCallback(evt => {
-        setAuditUserComment(evt.target.value);
-    }, []);
-
-    return (
-        <ConfirmModal
-            title={title}
-            onConfirm={showDeleteComment ? onConfirmCallback : undefined}
-            onCancel={onCancel}
-            confirmVariant="danger"
-            confirmButtonText={confirmButtonText}
-            cancelButtonText={cancelButtonText}
-        >
-            <span>
-                {message}
-                {showDeleteComment && (
-                    <div className="top-spacing">
-                        <div>
-                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                        </div>
-                        <div className="top-spacing">
-                            <div className="bottom-spacing">
-                                <strong>Reason(s) for deleting</strong>
-                            </div>
-                            <div>
-                                <textarea
-                                    className="form-control"
-                                    placeholder="Enter comments (optional)"
-                                    onChange={onCommentChange}
-                                    rows={5}
-                                />
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </span>
-        </ConfirmModal>
-    );
-});
-
-interface Props extends Omit<DeleteConfirmModalProps, 'message'> {
+interface Props extends Omit<DeleteConfirmationModalProps, 'message'> {
     deleteConfirmationActionName?: string;
     isSample?: boolean;
     isShared?: boolean;
@@ -112,7 +60,7 @@ export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
     }, [dependencies, isShared, noun]);
 
     return (
-        <DeleteConfirmModal
+        <DeleteConfirmationModal
             {...rest}
             cancelButtonText="Cancel"
             confirmButtonText="Yes, Delete"

--- a/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityTypeDeleteConfirmModal.tsx
@@ -1,34 +1,19 @@
-import React, { FC, memo, useCallback, useState } from 'react';
+import React, { FC, memo, ReactNode, useCallback, useMemo, useState } from 'react';
 import { Map } from 'immutable';
 
 import { SampleOperation } from '../internal/components/samples/constants';
 import { buildURL } from '../internal/url/AppURL';
-import { ConfirmModal } from '../internal/components/base/ConfirmModal';
+import { ConfirmModal, ConfirmModalProps } from '../internal/components/base/ConfirmModal';
 
-interface Props {
-    deleteConfirmationActionName?: string;
-    isSample?: boolean;
-    isShared?: boolean;
-    noun: string;
+export interface DeleteConfirmModalProps extends Omit<ConfirmModalProps, 'onConfirm'> {
+    message: ReactNode;
     onCancel: () => any;
     onConfirm: (userComment: string) => any;
-    rowId: number;
     showDeleteComment?: boolean;
-    showDependenciesLink?: boolean;
 }
 
-export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
-    const {
-        isShared,
-        isSample,
-        onConfirm,
-        onCancel,
-        showDependenciesLink = false,
-        rowId,
-        deleteConfirmationActionName,
-        noun,
-        showDeleteComment,
-    } = props;
+export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = memo(props => {
+    const { cancelButtonText, confirmButtonText, message, onCancel, onConfirm, showDeleteComment, title } = props;
     const [auditUserComment, setAuditUserComment] = useState<string>();
 
     const onConfirmCallback = useCallback(() => {
@@ -39,55 +24,100 @@ export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
         setAuditUserComment(evt.target.value);
     }, []);
 
-    let dependencies = <>dependencies</>;
-    if (showDependenciesLink && deleteConfirmationActionName) {
-        let params = Map<string, string>();
-        params = params.set('singleObjectRowId', rowId.toString());
-        if (isSample) {
-            params = params.set('sampleOperation', SampleOperation[SampleOperation.Delete]);
-        }
-        dependencies = <a href={buildURL('experiment', deleteConfirmationActionName, params.toJS())}>dependencies</a>;
-    }
-
     return (
         <ConfirmModal
-            title={`Permanently delete ${isShared ? 'shared ' : ''}${noun.toLowerCase()} type?`}
-            onConfirm={onConfirmCallback}
+            title={title}
+            onConfirm={showDeleteComment ? onConfirmCallback : undefined}
             onCancel={onCancel}
             confirmVariant="danger"
-            confirmButtonText="Yes, Delete"
-            cancelButtonText="Cancel"
+            confirmButtonText={confirmButtonText}
+            cancelButtonText={cancelButtonText}
         >
             <span>
-                The {noun.toLowerCase()} type and all of its {dependencies} will be permanently deleted.
-                {isShared && (
-                    <>
-                        {' '}
-                        Because this is a <strong>shared</strong> {noun.toLowerCase()} type, you may be affecting
-                        other folders.
-                    </>
-                )}
-                <div className="top-spacing">
-                    <div>
-                        <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                    </div>
-                    {showDeleteComment && (
+                {message}
+                {showDeleteComment && (
+                    <div className="top-spacing">
                         <div>
-                            <div>
+                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
+                        </div>
+                        <div className="top-spacing">
+                            <div className="bottom-spacing">
                                 <strong>Reason(s) for deleting</strong>
                             </div>
                             <div>
                                 <textarea
                                     className="form-control"
                                     placeholder="Enter comments (optional)"
-                                    value={auditUserComment}
                                     onChange={onCommentChange}
+                                    rows={5}
                                 />
                             </div>
                         </div>
-                    )}
-                </div>
+                    </div>
+                )}
             </span>
         </ConfirmModal>
+    );
+});
+
+interface Props extends Omit<DeleteConfirmModalProps, 'message'> {
+    deleteConfirmationActionName?: string;
+    isSample?: boolean;
+    isShared?: boolean;
+    noun: string;
+    rowId: number;
+    showDependenciesLink?: boolean;
+}
+
+export const EntityTypeDeleteConfirmModal: FC<Props> = memo(props => {
+    const {
+        isShared,
+        isSample,
+        showDependenciesLink = false,
+        rowId,
+        deleteConfirmationActionName,
+        noun,
+        ...rest
+    } = props;
+
+    const dependencies = useMemo(() => {
+        if (!showDependenciesLink || !deleteConfirmationActionName) return undefined;
+
+        let params = Map<string, string>();
+        params = params.set('singleObjectRowId', rowId.toString());
+        if (isSample) {
+            params = params.set('sampleOperation', SampleOperation[SampleOperation.Delete]);
+        }
+
+        return (
+            <>
+                <a href={buildURL('experiment', deleteConfirmationActionName, params.toJS())}>dependencies</a>
+            </>
+        );
+    }, [deleteConfirmationActionName, isSample, rowId, showDependenciesLink]);
+
+    const message = useMemo(() => {
+        return (
+            <>
+                The {noun.toLowerCase()} type and all of its {dependencies} will be permanently deleted.
+                {isShared && (
+                    <>
+                        {' '}
+                        Because this is a <strong>shared</strong> {noun.toLowerCase()} type, you may be affecting other
+                        folders.
+                    </>
+                )}
+            </>
+        );
+    }, [dependencies, isShared, noun]);
+
+    return (
+        <DeleteConfirmModal
+            {...rest}
+            cancelButtonText="Cancel"
+            confirmButtonText="Yes, Delete"
+            message={message}
+            title={`Permanently delete ${isShared ? 'shared ' : ''}${noun.toLowerCase()} type?`}
+        />
     );
 });

--- a/packages/components/src/entities/FindSamplesByIdsPageBase.tsx
+++ b/packages/components/src/entities/FindSamplesByIdsPageBase.tsx
@@ -78,9 +78,12 @@ const FindSamplesByIdsTabbedGridPanelImpl: FC<FindSamplesByIdsTabProps> = memo(p
         return models;
     }, [allSamplesModel, sampleGridIds, queryModels]);
 
-    const showViewMenu = useCallback(gridId => {
-        return gridId != allSamplesModel.id
-    }, [allSamplesModel]);
+    const showViewMenu = useCallback(
+        gridId => {
+            return gridId != allSamplesModel.id;
+        },
+        [allSamplesModel]
+    );
 
     return (
         <>
@@ -129,7 +132,10 @@ const FindSamplesByIdsTabbedGridPanel: FC<FindSamplesByIdsTabProps> = memo(props
                     Object.keys(sampleTypesRows).forEach(sampleType => {
                         const sampleSchemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType);
 
-                        const sampleGridId = createGridModelId(TYPE_GRID_PREFIX + allSamplesModel.queryName, sampleSchemaQuery);
+                        const sampleGridId = createGridModelId(
+                            TYPE_GRID_PREFIX + allSamplesModel.queryName,
+                            sampleSchemaQuery
+                        );
 
                         // note: changed to using Name IN clause instead of RowId IN clause so that the filter
                         // will pass through to the Sample Finder via the FindDerivativesButton to match

--- a/packages/components/src/entities/SampleEventListing.tsx
+++ b/packages/components/src/entities/SampleEventListing.tsx
@@ -30,12 +30,12 @@ interface State {
     filterExpanded?: boolean;
     filterStartDate?: any;
     filteredEvents?: TimelineEventModel[];
+    hasDetailedEvents?: boolean;
     includeAssayEvent?: boolean;
     includeJobEvent?: boolean;
     includeSampleEvent?: boolean;
     includeStorageEvent: boolean;
     showRecentFirst?: boolean;
-    hasDetailedEvents?: boolean;
 }
 
 const defaultFilterState: State = {
@@ -520,7 +520,7 @@ export class SampleEventListing extends React.Component<Props, State> {
             return showRecentFirst ? b.eventTimestamp - a.eventTimestamp : a.eventTimestamp - b.eventTimestamp;
         });
 
-        if (!hasDetailedEvents) return <Alert bsStyle="warning">No events available for this sample.</Alert>
+        if (!hasDetailedEvents) return <Alert bsStyle="warning">No events available for this sample.</Alert>;
 
         return (
             <Row>

--- a/packages/components/src/entities/SampleSetDeleteModal.tsx
+++ b/packages/components/src/entities/SampleSetDeleteModal.tsx
@@ -24,12 +24,12 @@ export const SampleSetDeleteModal: FC<Props> = props => {
     const [showProgress, setShowProgress] = useState<boolean>();
     const isShared = containerPath === SHARED_CONTAINER_PATH;
 
-    const onConfirm = useCallback(async () => {
+    const onConfirm = useCallback(async (auditUserComment: string) => {
         beforeDelete?.();
         setShowProgress(true);
 
         try {
-            await deleteSampleSet(rowId, containerPath);
+            await deleteSampleSet(rowId, containerPath, auditUserComment);
             afterDelete?.(true);
             createNotification(deleteSuccessMessage('sample type'));
         } catch (error) {

--- a/packages/components/src/entities/SampleSetDeleteModal.tsx
+++ b/packages/components/src/entities/SampleSetDeleteModal.tsx
@@ -51,6 +51,7 @@ export const SampleSetDeleteModal: FC<Props> = props => {
                     onConfirm={onConfirm}
                     onCancel={onCancel}
                     isShared={isShared}
+                    showDeleteComment
                 />
             )}
             <Progress

--- a/packages/components/src/entities/SampleSetDeleteModal.tsx
+++ b/packages/components/src/entities/SampleSetDeleteModal.tsx
@@ -4,10 +4,11 @@ import { deleteErrorMessage, deleteSuccessMessage } from '../internal/util/messa
 import { useNotificationsContext } from '../internal/components/notifications/NotificationsContext';
 import { SHARED_CONTAINER_PATH } from '../internal/constants';
 
-import { EntityTypeDeleteConfirmModal } from './EntityTypeDeleteConfirmModal';
 import { Progress } from '../internal/components/base/Progress';
 
 import { deleteSampleSet } from '../internal/components/samples/actions';
+
+import { EntityTypeDeleteConfirmModal } from './EntityTypeDeleteConfirmModal';
 
 interface Props {
     afterDelete?: (success: boolean) => void;
@@ -24,22 +25,25 @@ export const SampleSetDeleteModal: FC<Props> = props => {
     const [showProgress, setShowProgress] = useState<boolean>();
     const isShared = containerPath === SHARED_CONTAINER_PATH;
 
-    const onConfirm = useCallback(async (auditUserComment: string) => {
-        beforeDelete?.();
-        setShowProgress(true);
+    const onConfirm = useCallback(
+        async (auditUserComment: string) => {
+            beforeDelete?.();
+            setShowProgress(true);
 
-        try {
-            await deleteSampleSet(rowId, containerPath, auditUserComment);
-            afterDelete?.(true);
-            createNotification(deleteSuccessMessage('sample type'));
-        } catch (error) {
-            afterDelete?.(false);
-            createNotification({
-                alertClass: 'danger',
-                message: deleteErrorMessage('sample type'),
-            });
-        }
-    }, [afterDelete, beforeDelete, containerPath, createNotification, rowId]);
+            try {
+                await deleteSampleSet(rowId, containerPath, auditUserComment);
+                afterDelete?.(true);
+                createNotification(deleteSuccessMessage('sample type'));
+            } catch (error) {
+                afterDelete?.(false);
+                createNotification({
+                    alertClass: 'danger',
+                    message: deleteErrorMessage('sample type'),
+                });
+            }
+        },
+        [afterDelete, beforeDelete, containerPath, createNotification, rowId]
+    );
 
     return (
         <>

--- a/packages/components/src/entities/__snapshots__/SampleEventListing.spec.tsx.snap
+++ b/packages/components/src/entities/__snapshots__/SampleEventListing.spec.tsx.snap
@@ -457,6 +457,7 @@ exports[`<SampleEventListing/> Filter by event type and date 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 547,
@@ -504,6 +505,7 @@ exports[`<SampleEventListing/> Filter by event type and date 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 548,
@@ -551,6 +553,7 @@ exports[`<SampleEventListing/> Filter by event type and date 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 550,
@@ -598,6 +601,7 @@ exports[`<SampleEventListing/> Filter by event type and date 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
             ]
           }
@@ -763,6 +767,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 1549,
@@ -827,6 +832,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 548,
@@ -874,6 +880,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 547,
@@ -921,6 +928,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 546,
@@ -968,6 +976,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 1548,
@@ -1018,6 +1027,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 462023,
@@ -1046,6 +1056,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                   "description": "desc",
                   "modified": "2020-04-05T21:57:36.915-07:00",
                 },
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 544,
@@ -1093,6 +1104,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 462022,
@@ -1129,6 +1141,7 @@ exports[`<SampleEventListing/> Sort by latest 1`] = `
                   "Description": "des",
                   "CreatedBy": "1005",
                 },
+                "userComment": undefined,
               },
             ]
           }
@@ -3619,6 +3632,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 546,
@@ -3666,6 +3680,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 547,
@@ -3713,6 +3728,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 548,
@@ -3760,6 +3776,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 1549,
@@ -3824,6 +3841,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
               Immutable.Record {
                 "rowId": 550,
@@ -3871,6 +3889,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                 ],
                 "oldData": undefined,
                 "newData": undefined,
+                "userComment": undefined,
               },
             ]
           }
@@ -3924,6 +3943,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                   ],
                   "oldData": undefined,
                   "newData": undefined,
+                  "userComment": undefined,
                 },
                 "isCompleted": true,
                 "lastEvent": Immutable.Record {
@@ -3972,6 +3992,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
                   ],
                   "oldData": undefined,
                   "newData": undefined,
+                  "userComment": undefined,
                 },
               },
             ]
@@ -4023,6 +4044,7 @@ exports[`<SampleEventListing/> With selected job that is completed and with filt
               ],
               "oldData": undefined,
               "newData": undefined,
+              "userComment": undefined,
             }
           }
           showRecentFirst={false}

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -68,6 +68,7 @@ import {
     getSamplesCreatedSuccessMessage,
 } from './SampleListingPage';
 import { SampleCreatePage } from './SampleCreatePage';
+import { DeleteConfirmationModal } from './DeleteConfirmationModal';
 
 export {
     createEntityParentKey,
@@ -93,6 +94,7 @@ export {
     AssayResultsForSamplesSubNav,
     CreateSamplesSubMenu,
     CreateSamplesSubMenuBase,
+    DeleteConfirmationModal,
     EntityDeleteModal,
     EntityLineageEditMenuItem,
     EntityTypeDeleteConfirmModal,

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -300,7 +300,10 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 const { column, domain } = sampleColumnData;
                 const samples = await this.props.loadSelectedSamples(location, column);
 
-                const statusConfirmationData = await getSampleOperationConfirmationData(SampleOperation.AddAssayData, samples.keySeq().toArray());
+                const statusConfirmationData = await getSampleOperationConfirmationData(
+                    SampleOperation.AddAssayData,
+                    samples.keySeq().toArray()
+                );
 
                 // Only one sample can be added at batch or run level, so ignore selected samples if multiple are selected.
                 const validSamples = samples.filter((_, key) => statusConfirmationData.isIdAllowed(key)).toOrderedMap();
@@ -702,14 +705,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
                     />
                 )}
                 <Alert bsStyle="warning">{sampleStatusWarning}</Alert>
-                <BatchPropertiesPanel
-                    model={model}
-                    onChange={this.handleBatchChange}
-                />
-                <RunPropertiesPanel
-                    model={model}
-                    onChange={this.handleRunChange}
-                />
+                <BatchPropertiesPanel model={model} onChange={this.handleBatchChange} />
+                <RunPropertiesPanel model={model} onChange={this.handleRunChange} />
                 <RunDataPanel
                     acceptedPreviewFileFormats={acceptedPreviewFileFormats}
                     allowBulkRemove={allowBulkRemove}

--- a/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
@@ -18,8 +18,9 @@ import Formsy from 'formsy-react';
 
 import { QueryFormInputs } from '../forms/QueryFormInputs';
 
-import { AssayPropertiesPanelProps } from './models';
 import { getContainerFilterForLookups } from '../../query/api';
+
+import { AssayPropertiesPanelProps } from './models';
 
 export const BatchPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
     const { model, onChange, title = 'Batch Details' } = props;

--- a/packages/components/src/internal/components/assay/models.ts
+++ b/packages/components/src/internal/components/assay/models.ts
@@ -15,9 +15,10 @@
  */
 import { Draft, immerable, produce } from 'immer';
 
-import { AssayWizardModel } from './AssayWizardModel';
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 import { LoadingState } from '../../../public/LoadingState';
+
+import { AssayWizardModel } from './AssayWizardModel';
 
 export interface AssayPropertiesPanelProps {
     model: AssayWizardModel;

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -224,7 +224,7 @@ class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
         const { detail } = this.state;
         if (!detail) return null;
 
-        const { eventUserId, eventDateFormatted } = detail;
+        const { eventUserId, eventDateFormatted, userComment } = detail;
 
         const rows = [];
         if (eventUserId) {
@@ -233,6 +233,10 @@ class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
 
         if (eventDateFormatted) {
             rows.push({ field: 'Date', value: eventDateFormatted });
+        }
+
+        if (userComment) {
+            rows.push({field: 'User Comment', value: userComment});
         }
 
         return fromJS(rows);

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -23,12 +23,13 @@ import { SelectInput } from '../forms/input/SelectInput';
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 import { useServerContext } from '../base/ServerContext';
 
+import { SCHEMAS } from '../../schemas';
+
 import { getAuditQueries } from './utils';
 import { getAuditDetail } from './actions';
 import { AuditDetailsModel } from './models';
 import { AuditDetails } from './AuditDetails';
 import { AuditQuery, AUDIT_EVENT_TYPE_PARAM, SAMPLE_TIMELINE_AUDIT_QUERY } from './constants';
-import { SCHEMAS } from '../../schemas';
 
 interface BodyProps {
     user: User;
@@ -236,7 +237,7 @@ class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
         }
 
         if (userComment) {
-            rows.push({field: 'User Comment', value: userComment});
+            rows.push({ field: 'User Comment', value: userComment });
         }
 
         return fromJS(rows);

--- a/packages/components/src/internal/components/auditlog/TimelineView.tsx
+++ b/packages/components/src/internal/components/auditlog/TimelineView.tsx
@@ -63,7 +63,10 @@ export class TimelineView extends React.Component<Props, any> {
                 onClick={() => {
                     if (event.rowId) this.selectEvent(event);
                 }}
-                className={classNames({ 'timeline-event-row': event.rowId !== 0, 'timeline-row-selected': eventSelected })}
+                className={classNames({
+                    'timeline-event-row': event.rowId !== 0,
+                    'timeline-row-selected': eventSelected,
+                })}
             >
                 {this.renderTimestampCol(event.timestamp)}
                 {this.renderIconCol(
@@ -217,8 +220,7 @@ export class TimelineView extends React.Component<Props, any> {
             >
                 <tbody>
                     {events.map(event => {
-                        if (event.rowId > 0)
-                            return this.renderRow(event);
+                        if (event.rowId > 0) return this.renderRow(event);
                     })}
                 </tbody>
             </table>

--- a/packages/components/src/internal/components/auditlog/models.ts
+++ b/packages/components/src/internal/components/auditlog/models.ts
@@ -13,7 +13,7 @@ export class AuditDetailsModel extends Record({
     eventDateFormatted: undefined,
     oldData: undefined,
     newData: undefined,
-    userComment: undefined
+    userComment: undefined,
 }) {
     declare rowId?: number;
     declare comment?: string;

--- a/packages/components/src/internal/components/auditlog/models.ts
+++ b/packages/components/src/internal/components/auditlog/models.ts
@@ -13,6 +13,7 @@ export class AuditDetailsModel extends Record({
     eventDateFormatted: undefined,
     oldData: undefined,
     newData: undefined,
+    userComment: undefined
 }) {
     declare rowId?: number;
     declare comment?: string;
@@ -20,6 +21,7 @@ export class AuditDetailsModel extends Record({
     declare eventDateFormatted?: string;
     declare oldData?: Map<string, string>;
     declare newData?: Map<string, string>;
+    declare userComment?: string;
 
     static create(raw: any): AuditDetailsModel {
         return new AuditDetailsModel({
@@ -63,6 +65,7 @@ export class TimelineEventModel extends Record({
     metadata: undefined,
     oldData: undefined,
     newData: undefined,
+    userComment: undefined,
 }) {
     declare rowId?: number;
     declare eventType?: string; // sample, assay, workflow, inventory, etc
@@ -77,6 +80,7 @@ export class TimelineEventModel extends Record({
     declare metadata?: List<Map<string, any>>;
     declare oldData?: Map<string, string>;
     declare newData?: Map<string, string>;
+    declare userComment?: string;
 
     constructor(values?: { [key: string]: any }) {
         super(values);
@@ -102,6 +106,7 @@ export class TimelineEventModel extends Record({
                 : new Date(raw['timestamp']['value']);
         fields.entity = fromJS(raw['entity']);
         fields.entitySeparator = raw['entitySeparator'];
+        fields.userComment = raw['userComment'];
 
         if (raw.metadata) {
             const metaRows = [];
@@ -124,6 +129,7 @@ export class TimelineEventModel extends Record({
             rowId: this.rowId,
             oldData: this.oldData,
             newData: this.newData,
+            userComment: this.userComment,
         });
     }
 

--- a/packages/components/src/internal/components/base/ConfirmModal.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.tsx
@@ -17,7 +17,7 @@ import React, { ReactNode } from 'react';
 import { Button, Modal, Sizes } from 'react-bootstrap';
 import classNames from 'classnames';
 
-interface Props {
+export interface ConfirmModalProps {
     backdrop?: string;
     cancelButtonText?: string;
     confirmButtonText?: string;
@@ -30,7 +30,7 @@ interface Props {
     title?: string;
 }
 
-export class ConfirmModal extends React.PureComponent<Props> {
+export class ConfirmModal extends React.PureComponent<ConfirmModalProps> {
     static defaultProps = {
         show: true,
         title: 'Confirm',

--- a/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
@@ -75,6 +75,6 @@ function fetchDataClassProperties(rowId: number, containerPath?: string): Promis
     });
 }
 
-export function deleteDataClass(rowId: number, containerPath?: string): Promise<any> {
-    return deleteEntityType('deleteDataClass', rowId, containerPath);
+export function deleteDataClass(rowId: number, containerPath?: string, auditUserComment?: string): Promise<any> {
+    return deleteEntityType('deleteDataClass', rowId, containerPath, auditUserComment);
 }

--- a/packages/components/src/internal/components/entities/DeleteConfirmationModal.tsx
+++ b/packages/components/src/internal/components/entities/DeleteConfirmationModal.tsx
@@ -1,0 +1,58 @@
+import React, { FC, memo, ReactNode, useCallback, useState } from 'react';
+
+import { ConfirmModal, ConfirmModalProps } from '../base/ConfirmModal';
+
+export interface DeleteConfirmationModalProps extends Omit<ConfirmModalProps, 'onConfirm'> {
+    message: ReactNode;
+    onCancel: () => any;
+    onConfirm: (userComment: string) => any;
+    showDeleteComment?: boolean;
+}
+
+export const DeleteConfirmationModal: FC<DeleteConfirmationModalProps> = memo(props => {
+    const { cancelButtonText, confirmButtonText, message, onCancel, onConfirm, showDeleteComment, title } = props;
+    const [auditUserComment, setAuditUserComment] = useState<string>();
+
+    const onConfirmCallback = useCallback(() => {
+        onConfirm(auditUserComment);
+    }, [onConfirm, auditUserComment]);
+
+    const onCommentChange = useCallback(evt => {
+        setAuditUserComment(evt.target.value);
+    }, []);
+
+    return (
+        <ConfirmModal
+            title={title}
+            onConfirm={showDeleteComment ? onConfirmCallback : undefined}
+            onCancel={onCancel}
+            confirmVariant="danger"
+            confirmButtonText={confirmButtonText}
+            cancelButtonText={cancelButtonText}
+        >
+            <span>
+                {message}
+                {showDeleteComment && (
+                    <div className="top-spacing">
+                        <div>
+                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
+                        </div>
+                        <div className="top-spacing">
+                            <div className="bottom-spacing">
+                                <strong>Reason(s) for deleting</strong>
+                            </div>
+                            <div>
+                                <textarea
+                                    className="form-control"
+                                    placeholder="Enter comments (optional)"
+                                    onChange={onCommentChange}
+                                    rows={5}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </span>
+        </ConfirmModal>
+    );
+});

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
@@ -21,15 +21,15 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { Alert } from '../base/Alert';
 
-import { DeleteConfirmationHandler, EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
+import { EntityDeleteConfirmHandler, EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
 import { getDeleteConfirmationData } from './actions';
 import { EntityDataType, OperationConfirmationData } from './models';
 
 interface Props {
     entityDataType: EntityDataType;
     getDeletionDescription?: (numToDelete: number) => React.ReactNode;
-    onCancel: () => any;
-    onConfirm: DeleteConfirmationHandler;
+    onCancel: () => void;
+    onConfirm: EntityDeleteConfirmHandler;
     rowIds?: string[];
     selectionKey?: string;
     useSnapshotSelection?: boolean;

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
@@ -25,7 +25,6 @@ import { DeleteConfirmationHandler, EntityDeleteConfirmModalDisplay } from './En
 import { getDeleteConfirmationData } from './actions';
 import { EntityDataType, OperationConfirmationData } from './models';
 
-
 interface Props {
     entityDataType: EntityDataType;
     getDeletionDescription?: (numToDelete: number) => React.ReactNode;
@@ -77,7 +76,12 @@ export class EntityDeleteConfirmModal extends PureComponent<Props, State> {
         const { entityDataType, rowIds, selectionKey, useSnapshotSelection } = this.props;
 
         try {
-            const confirmationData = await getDeleteConfirmationData(entityDataType, rowIds, selectionKey, useSnapshotSelection);
+            const confirmationData = await getDeleteConfirmationData(
+                entityDataType,
+                rowIds,
+                selectionKey,
+                useSnapshotSelection
+            );
             if (this._mounted) {
                 this.setState({ confirmationData, isLoading: false });
             }

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
@@ -21,15 +21,16 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { Alert } from '../base/Alert';
 
-import { EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
+import { DeleteConfirmationHandler, EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
 import { getDeleteConfirmationData } from './actions';
 import { EntityDataType, OperationConfirmationData } from './models';
+
 
 interface Props {
     entityDataType: EntityDataType;
     getDeletionDescription?: (numToDelete: number) => React.ReactNode;
     onCancel: () => any;
-    onConfirm: (rowsToDelete: any[], rowsToKeep: any[]) => any;
+    onConfirm: DeleteConfirmationHandler;
     rowIds?: string[];
     selectionKey?: string;
     useSnapshotSelection?: boolean;

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import React, { PureComponent } from 'react';
+import { Utils } from '@labkey/api';
 
 import { isELNEnabled } from '../../app/utils';
 
@@ -21,8 +22,7 @@ import { capitalizeFirstChar } from '../../util/utils';
 import { HelpLink } from '../../util/helpLinks';
 
 import { EntityDataType, OperationConfirmationData } from './models';
-import { Utils } from '@labkey/api';
-import { DeleteConfirmModal } from '../../../entities/EntityTypeDeleteConfirmModal';
+import { DeleteConfirmationModal } from './DeleteConfirmationModal';
 
 export type DeleteConfirmationHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => any;
 
@@ -152,7 +152,7 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
         const { onCancel } = this.props;
         const confirmProps = this.getConfirmationProperties();
         return (
-            <DeleteConfirmModal
+            <DeleteConfirmationModal
                 title={confirmProps.title}
                 onConfirm={confirmProps.canDelete ? this.onConfirm : undefined}
                 onCancel={onCancel}

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -51,6 +51,10 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
         verb: 'deleted',
     };
 
+    state: Readonly<State> = {
+        userComment: undefined,
+    };
+
     onCommentChange = (evt) => {
         const val = evt.target.value;
         this.setState(() => ({userComment: val}));

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -24,13 +24,20 @@ import { ConfirmModal } from '../base/ConfirmModal';
 import { EntityDataType, OperationConfirmationData } from './models';
 import { Utils } from '@labkey/api';
 
+//TODO change userComment to optional, making required for now to make sure we update the ones we need to.
+export type DeleteConfirmationHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => any;
+
 interface Props {
     confirmationData: OperationConfirmationData;
     entityDataType: EntityDataType;
     getDeletionDescription?: (numToDelete: number) => React.ReactNode;
     onCancel: () => any;
-    onConfirm: (rowsToDelete: any[], rowsToKeep: any[]) => any;
+    onConfirm: DeleteConfirmationHandler;
     verb?: string;
+}
+
+interface State {
+    userComment: string;
 }
 
 /**
@@ -39,9 +46,14 @@ interface Props {
  * within DeleteConfirmationModal, the jest tests do not render the component fully enough to test
  * different confirmation data scenarios.
  */
-export class EntityDeleteConfirmModalDisplay extends PureComponent<Props> {
+export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State> {
     static defaultProps = {
         verb: 'deleted',
+    };
+
+    onCommentChange = (evt) => {
+        const val = evt.target.value;
+        this.setState(() => ({userComment: val}));
     };
 
     getConfirmationProperties(): { canDelete: boolean; message: any; title: string } {
@@ -124,9 +136,15 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props> {
                     </>
                 )}
                 {numCanDelete > 0 && (
-                    <p className="top-spacing">
-                        <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                    </p>
+                    <div className="top-spacing">
+                        <div><strong>Deletion cannot be undone.</strong> Do you want to proceed?</div>
+                        <div>
+                            <label>
+                                <strong>Reason for deleting</strong>
+                                <input type="textarea" placeholder="Enter comments (optional)" onChange={this.onCommentChange}/>
+                            </label>
+                        </div>
+                    </div>
                 )}
             </span>
         );
@@ -144,7 +162,7 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props> {
     }
 
     onConfirm = (): void => {
-        this.props.onConfirm?.(this.props.confirmationData.allowed, this.props.confirmationData.notAllowed);
+        this.props.onConfirm?.(this.props.confirmationData.allowed, this.props.confirmationData.notAllowed, this.state.userComment);
     };
 
     render() {

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -22,7 +22,7 @@ import { capitalizeFirstChar } from '../../util/utils';
 import { HelpLink } from '../../util/helpLinks';
 
 import { EntityDataType, OperationConfirmationData } from './models';
-import { DeleteConfirmationModal } from './DeleteConfirmationModal';
+import { DeleteConfirmationModal } from '../../../entities/DeleteConfirmationModal';
 
 export type DeleteConfirmationHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => any;
 

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -19,12 +19,11 @@ import { isELNEnabled } from '../../app/utils';
 
 import { capitalizeFirstChar } from '../../util/utils';
 import { HelpLink } from '../../util/helpLinks';
-import { ConfirmModal } from '../base/ConfirmModal';
 
 import { EntityDataType, OperationConfirmationData } from './models';
 import { Utils } from '@labkey/api';
+import { DeleteConfirmModal } from '../../../entities/EntityTypeDeleteConfirmModal';
 
-//TODO change userComment to optional, making required for now to make sure we update the ones we need to.
 export type DeleteConfirmationHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => any;
 
 interface Props {
@@ -49,15 +48,6 @@ interface State {
 export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State> {
     static defaultProps = {
         verb: 'deleted',
-    };
-
-    state: Readonly<State> = {
-        userComment: undefined,
-    };
-
-    onCommentChange = (evt) => {
-        const val = evt.target.value;
-        this.setState(() => ({userComment: val}));
     };
 
     getConfirmationProperties(): { canDelete: boolean; message: any; title: string } {
@@ -132,33 +122,14 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
                 );
         }
         const message = (
-            <span>
+            <>
                 {text}
                 {numCannotDelete > 0 && deleteHelpLinkTopic && (
                     <>
                         &nbsp;(<HelpLink topic={deleteHelpLinkTopic}>more info</HelpLink>)
                     </>
                 )}
-                {numCanDelete > 0 && (
-                    <div className="top-spacing">
-                        <div>
-                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
-                        </div>
-                        <div>
-                            <div>
-                                <strong>Reason(s) for deleting</strong>
-                            </div>
-                            <div>
-                                <textarea
-                                    className="form-control"
-                                    placeholder="Enter comments (optional)"
-                                    onChange={this.onCommentChange}
-                                />
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </span>
+            </>
         );
 
         return {
@@ -173,24 +144,23 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
         };
     }
 
-    onConfirm = (): void => {
-        this.props.onConfirm?.(this.props.confirmationData.allowed, this.props.confirmationData.notAllowed, this.state.userComment);
+    onConfirm = (userComment: string): void => {
+        this.props.onConfirm?.(this.props.confirmationData.allowed, this.props.confirmationData.notAllowed, userComment);
     };
 
     render() {
         const { onCancel } = this.props;
         const confirmProps = this.getConfirmationProperties();
         return (
-            <ConfirmModal
+            <DeleteConfirmModal
                 title={confirmProps.title}
                 onConfirm={confirmProps.canDelete ? this.onConfirm : undefined}
                 onCancel={onCancel}
-                confirmVariant="danger"
                 confirmButtonText={confirmProps.canDelete ? 'Yes, Delete' : undefined}
                 cancelButtonText={confirmProps.canDelete ? 'Cancel' : 'Dismiss'}
-            >
-                {confirmProps.message}
-            </ConfirmModal>
+                message={confirmProps.message}
+                showDeleteComment={confirmProps.canDelete}
+            />
         );
     }
 }

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -137,12 +137,20 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
                 )}
                 {numCanDelete > 0 && (
                     <div className="top-spacing">
-                        <div><strong>Deletion cannot be undone.</strong> Do you want to proceed?</div>
                         <div>
-                            <label>
-                                <strong>Reason for deleting</strong>
-                                <input type="textarea" placeholder="Enter comments (optional)" onChange={this.onCommentChange}/>
-                            </label>
+                            <strong>Deletion cannot be undone.</strong> Do you want to proceed?
+                        </div>
+                        <div>
+                            <div>
+                                <strong>Reason(s) for deleting</strong>
+                            </div>
+                            <div>
+                                <textarea
+                                    className="form-control"
+                                    placeholder="Enter comments (optional)"
+                                    onChange={this.onCommentChange}
+                                />
+                            </div>
                         </div>
                     </div>
                 )}

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -21,8 +21,9 @@ import { isELNEnabled } from '../../app/utils';
 import { capitalizeFirstChar } from '../../util/utils';
 import { HelpLink } from '../../util/helpLinks';
 
-import { EntityDataType, OperationConfirmationData } from './models';
 import { DeleteConfirmationModal } from '../../../entities/DeleteConfirmationModal';
+
+import { EntityDataType, OperationConfirmationData } from './models';
 
 export type DeleteConfirmationHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => any;
 
@@ -59,8 +60,7 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
         if (!confirmationData) return undefined;
 
         let _dependencyText;
-        if (Utils.isFunction(dependencyText))
-            _dependencyText = (dependencyText as Function)();
+        if (Utils.isFunction(dependencyText)) _dependencyText = (dependencyText as Function)();
         else {
             _dependencyText = isELNEnabled()
                 ? (dependencyText ? dependencyText + ' or' : '') + ' references in one or more active notebooks'
@@ -145,7 +145,11 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
     }
 
     onConfirm = (userComment: string): void => {
-        this.props.onConfirm?.(this.props.confirmationData.allowed, this.props.confirmationData.notAllowed, userComment);
+        this.props.onConfirm?.(
+            this.props.confirmationData.allowed,
+            this.props.confirmationData.notAllowed,
+            userComment
+        );
     };
 
     render() {

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -25,14 +25,14 @@ import { DeleteConfirmationModal } from '../../../entities/DeleteConfirmationMod
 
 import { EntityDataType, OperationConfirmationData } from './models';
 
-export type DeleteConfirmationHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => any;
+export type EntityDeleteConfirmHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => void;
 
 interface Props {
     confirmationData: OperationConfirmationData;
     entityDataType: EntityDataType;
     getDeletionDescription?: (numToDelete: number) => React.ReactNode;
-    onCancel: () => any;
-    onConfirm: DeleteConfirmationHandler;
+    onCancel: () => void;
+    onConfirm: EntityDeleteConfirmHandler;
     verb?: string;
 }
 
@@ -154,17 +154,19 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
 
     render() {
         const { onCancel } = this.props;
-        const confirmProps = this.getConfirmationProperties();
+        const { canDelete, message, title } = this.getConfirmationProperties();
+
         return (
             <DeleteConfirmationModal
-                title={confirmProps.title}
-                onConfirm={confirmProps.canDelete ? this.onConfirm : undefined}
+                cancelButtonText={canDelete ? 'Cancel' : 'Dismiss'}
+                confirmButtonText={canDelete ? 'Yes, Delete' : undefined}
                 onCancel={onCancel}
-                confirmButtonText={confirmProps.canDelete ? 'Yes, Delete' : undefined}
-                cancelButtonText={confirmProps.canDelete ? 'Cancel' : 'Dismiss'}
-                message={confirmProps.message}
-                showDeleteComment={confirmProps.canDelete}
-            />
+                onConfirm={canDelete ? this.onConfirm : undefined}
+                showDeleteComment={canDelete}
+                title={title}
+            >
+                {message}
+            </DeleteConfirmationModal>
         );
     }
 }

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -565,7 +565,12 @@ export function getEntityTypeData(
     });
 }
 
-export function deleteEntityType(deleteActionName: string, rowId: number, containerPath?: string, auditUserComment?: string): Promise<any> {
+export function deleteEntityType(
+    deleteActionName: string,
+    rowId: number,
+    containerPath?: string,
+    auditUserComment?: string
+): Promise<any> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
             url: buildURL('experiment', deleteActionName + '.api', undefined, { container: containerPath }),

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -565,7 +565,7 @@ export function getEntityTypeData(
     });
 }
 
-export function deleteEntityType(deleteActionName: string, rowId: number, containerPath?: string): Promise<any> {
+export function deleteEntityType(deleteActionName: string, rowId: number, containerPath?: string, auditUserComment?: string): Promise<any> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
             url: buildURL('experiment', deleteActionName + '.api', undefined, { container: containerPath }),
@@ -573,6 +573,7 @@ export function deleteEntityType(deleteActionName: string, rowId: number, contai
             params: {
                 singleObjectRowId: rowId,
                 forceDelete: true,
+                userComment: auditUserComment,
             },
             success: Utils.getCallbackWrapper(response => {
                 resolve(response);

--- a/packages/components/src/internal/components/notifications/ServerActivityList.spec.tsx
+++ b/packages/components/src/internal/components/notifications/ServerActivityList.spec.tsx
@@ -6,7 +6,7 @@ import {
     DONE_NOT_READ,
     IN_PROGRESS,
     UNREAD_WITH_ERROR,
-    UNREAD_WITH_ERROR_HTML
+    UNREAD_WITH_ERROR_HTML,
 } from '../../../test/data/notificationData';
 
 import { ServerActivityList } from './ServerActivityList';
@@ -148,8 +148,10 @@ describe('<ServerActivityList>', () => {
         const errorDetails = item.find('.server-notifications-item-details');
         expect(errorSubject).toHaveLength(1);
         expect(errorDetails).toHaveLength(1);
-        expect(errorSubject.text()).toBe("Sample import failed from file file1.xlsx");
-        expect(errorDetails.text()).toBe("There was a problem creating your data.  Check the existing data for possible duplicates and make sure any referenced data are still valid.");
+        expect(errorSubject.text()).toBe('Sample import failed from file file1.xlsx');
+        expect(errorDetails.text()).toBe(
+            'There was a problem creating your data.  Check the existing data for possible duplicates and make sure any referenced data are still valid.'
+        );
         wrapper.unmount();
     });
 
@@ -176,8 +178,10 @@ describe('<ServerActivityList>', () => {
         const errorDetails = item.find('.server-notifications-item-details');
         expect(errorSubject).toHaveLength(1);
         expect(errorDetails).toHaveLength(1);
-        expect(errorSubject.text()).toBe("Assay import failed from file file1.xlsx");
-        expect(errorDetails.text()).toContain("SampleId: Failed to convert \'SampleId\': Could not translate value: sdfs");
+        expect(errorSubject.text()).toBe('Assay import failed from file file1.xlsx');
+        expect(errorDetails.text()).toContain(
+            "SampleId: Failed to convert 'SampleId': Could not translate value: sdfs"
+        );
         wrapper.unmount();
     });
 
@@ -263,7 +267,12 @@ describe('<ServerActivityList>', () => {
         wrapper.unmount();
     });
 
-    function checkActivityListItem(itemWrapper: ReactWrapper, isComplete: boolean, hasError: boolean, inProgress: boolean): void {
+    function checkActivityListItem(
+        itemWrapper: ReactWrapper,
+        isComplete: boolean,
+        hasError: boolean,
+        inProgress: boolean
+    ): void {
         expect(itemWrapper.find('.is-complete')).toHaveLength(isComplete ? 1 : 0);
         expect(itemWrapper.find('.has-error')).toHaveLength(hasError ? 1 : 0);
         expect(itemWrapper.find('.fa-spinner')).toHaveLength(inProgress ? 1 : 0);

--- a/packages/components/src/internal/components/notifications/ServerActivityList.tsx
+++ b/packages/components/src/internal/components/notifications/ServerActivityList.tsx
@@ -6,17 +6,18 @@ import { formatDateTime, parseDate } from '../../util/Date';
 import { resolveErrorMessage } from '../../util/messaging';
 import { capitalizeFirstChar } from '../../util/utils';
 
-import { ServerActivity, ServerActivityData } from './model';
 import { PIPELINE_MAPPER } from '../../url/URLResolver';
 import { AppURL } from '../../url/AppURL';
+
+import { ServerActivity, ServerActivityData } from './model';
 
 interface Props {
     actionLinkLabel: string;
     maxRows: number;
     noActivityMsg: string;
     onRead: (id: number) => void;
-    onViewClick: () => void;
     onViewAll: () => any;
+    onViewClick: () => void;
     serverActivity: ServerActivity;
     viewAllText: string;
 }
@@ -78,12 +79,13 @@ export class ServerActivityList extends React.PureComponent<Props> {
     renderData(activity: ServerActivityData, key: number): ReactNode {
         const { actionLinkLabel, onViewClick } = this.props;
         const isUnread = activity.isUnread() && !activity.inProgress;
-        let resolvedUrl =  PIPELINE_MAPPER.resolve(
+        const resolvedUrl = PIPELINE_MAPPER.resolve(
             activity.ActionLinkUrl,
-            Map({rowId: activity.RowId, url: activity.ActionLinkUrl }),
+            Map({ rowId: activity.RowId, url: activity.ActionLinkUrl }),
             undefined,
             undefined,
-            undefined);
+            undefined
+        );
 
         return (
             <li
@@ -113,7 +115,10 @@ export class ServerActivityList extends React.PureComponent<Props> {
                 <br />
                 {activity.ActionLinkUrl ? (
                     <span className="server-notifications-link">
-                        <a href={resolvedUrl instanceof AppURL ? resolvedUrl.toHref() : activity.ActionLinkUrl} onClick={onViewClick}>
+                        <a
+                            href={resolvedUrl instanceof AppURL ? resolvedUrl.toHref() : activity.ActionLinkUrl}
+                            onClick={onViewClick}
+                        >
                             {capitalizeFirstChar(activity.ActionLinkText ? activity.ActionLinkText : actionLinkLabel)}
                         </a>
                     </span>

--- a/packages/components/src/internal/components/notifications/ServerNotifications.tsx
+++ b/packages/components/src/internal/components/notifications/ServerNotifications.tsx
@@ -70,7 +70,7 @@ export class ServerNotifications extends React.Component<Props, State> {
     _onViewAll = (): void => {
         this.toggleMenu();
         this.props.onViewAll();
-    }
+    };
 
     render(): ReactNode {
         const { serverActivity, maxRows, onViewAll } = this.props;

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -133,8 +133,8 @@ export function getSampleTypeDetails(
     });
 }
 
-export function deleteSampleSet(rowId: number, containerPath?: string): Promise<any> {
-    return deleteEntityType('deleteSampleTypes', rowId, containerPath);
+export function deleteSampleSet(rowId: number, containerPath?: string, auditUserComment?: string): Promise<any> {
+    return deleteEntityType('deleteSampleTypes', rowId, containerPath, auditUserComment);
 }
 
 /**


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/sampleManagement/issues/1485
[Spec](https://docs.google.com/document/d/1LwKCiLhWoa7xPwyOxBxKN4VGEOCUvw9njdDHHRobKEM/edit#heading=h.rbo1k9dupcqe)
[Github epic](https://github.com/LabKey/sampleManagement/issues/1483)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4037
* https://github.com/LabKey/labkey-ui-components/pull/1087
* https://github.com/LabKey/labkey-ui-premium/pull/21
* https://github.com/LabKey/inventory/pull/698
* https://github.com/LabKey/biologics/pull/1872
* https://github.com/LabKey/sampleManagement/pull/1555
* https://github.com/LabKey/labbook/pull/389

#### Changes
* Modify EntityDeleteModal and EntityTypeDeleteModal to accept a user comment
* Modify AuditLogDetail to show User Comment
