### PR TITLE
Fix issue related to improper usage of React key prop

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.283.1",
+  "version": "2.283.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,6 +2,10 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.283.1
+*Released*: ?? January 2023
+* Fix issue with react keys in Navigation
+
+### version 2.283.1
 *Released*: 20 January 2023
 * Issue 46344: Display group membership on profile page
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.283.1
+### version 2.283.2
 *Released*: ?? January 2023
 * Fix issue with react keys in Navigation
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.283.2
-*Released*: ?? January 2023
+*Released*: 23 January 2023
 * Fix issue with react keys in Navigation
 
 ### version 2.283.1

--- a/packages/components/src/internal/components/navigation/FolderMenu.tsx
+++ b/packages/components/src/internal/components/navigation/FolderMenu.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo } from 'react';
+import React, { FC, Fragment, memo } from 'react';
 import classNames from 'classnames';
 
 export interface FolderMenuItem {
@@ -22,9 +22,8 @@ export const FolderMenu: FC<FolderMenuProps> = memo(props => {
         <div className="menu-section col-folders">
             <ul>
                 {items.map(item => (
-                    <>
+                    <Fragment key={item.id}>
                         <li
-                            key={item.id}
                             className={classNames({
                                 active: item.id === activeContainerId,
                                 'menu-section-header': item.isTopLevel,
@@ -40,7 +39,7 @@ export const FolderMenu: FC<FolderMenuProps> = memo(props => {
                                 <hr />
                             </li>
                         )}
-                    </>
+                    </Fragment>
                 ))}
             </ul>
         </div>

--- a/packages/components/src/internal/components/navigation/ProductMenu.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.tsx
@@ -255,6 +255,7 @@ export const ProductMenu: FC<ProductMenuProps> = memo(props => {
                 )}
                 {menuModel.isLoaded &&
                     sectionConfigs.map((sectionConfig, i) => (
+                        // eslint-disable-next-line react/no-array-index-key
                         <div key={i} className="menu-section col-product-section">
                             {sectionConfig.entrySeq().map(([key, menuConfig], j) => {
                                 const isLast = i === sectionConfigs.size - 1 && j === sectionConfig.size - 1;

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
@@ -78,7 +78,7 @@ export class ProductMenuSection extends PureComponent<MenuSectionProps> {
         }
 
         return (
-            <ul key={section.key}>
+            <ul>
                 <li className="menu-section-header clickable-item">
                     {headerURL ? <a href={getHref(headerURL)}>{label}</a> : <>{label}</>}
                 </li>
@@ -87,13 +87,9 @@ export class ProductMenuSection extends PureComponent<MenuSectionProps> {
                 </li>
                 {section.items.isEmpty() ? (
                     <>
-                        {config.emptyText && (
-                            <li key="empty" className="empty-section">
-                                {config.emptyText}
-                            </li>
-                        )}
+                        {config.emptyText && <li className="empty-section">{config.emptyText}</li>}
                         {emptyURL && (!config.emptyURLProjectOnly || isProjectContainer(containerPath)) && (
-                            <li key="emptyUrl" className="empty-section-link">
+                            <li className="empty-section-link">
                                 <a href={getHref(emptyURL)}>{config.emptyURLText}</a>
                             </li>
                         )}
@@ -147,7 +143,7 @@ const DashboardSectionHeader: FC<DashboardSectionHeaderProps> = memo(props => {
     const { moduleContext } = useServerContext();
 
     return (
-        <li key="dashbaord" className="menu-section-header clickable-item">
+        <li className="menu-section-header clickable-item">
             <a
                 href={getHref(
                     createProductUrl(

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
@@ -31,9 +31,7 @@ exports[`ProductMenuSection render empty section no text 1`] = `
     }
   }
 >
-  <ul
-    key="samples"
-  >
+  <ul>
     <li
       className="menu-section-header clickable-item"
     >
@@ -89,9 +87,7 @@ exports[`ProductMenuSection render empty section with empty text and create link
     }
   }
 >
-  <ul
-    key="samples"
-  >
+  <ul>
     <li
       className="menu-section-header clickable-item"
     >
@@ -114,7 +110,6 @@ exports[`ProductMenuSection render empty section with empty text and create link
     </li>
     <li
       className="empty-section"
-      key="empty"
     >
       Test empty text
     </li>
@@ -209,9 +204,7 @@ exports[`ProductMenuSection render one column section 1`] = `
     }
   }
 >
-  <ul
-    key="assays"
-  >
+  <ul>
     <li
       className="menu-section-header clickable-item"
     >
@@ -337,9 +330,7 @@ exports[`ProductMenuSection render one-column section 1`] = `
     }
   }
 >
-  <ul
-    key="samples"
-  >
+  <ul>
     <li
       className="menu-section-header clickable-item"
     >
@@ -428,9 +419,7 @@ exports[`ProductMenuSection render section with custom headerURL and headerText 
     }
   }
 >
-  <ul
-    key="samples"
-  >
+  <ul>
     <li
       className="menu-section-header clickable-item"
     >

--- a/packages/components/src/internal/components/productnavigation/ProductAppMenuItem.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductAppMenuItem.tsx
@@ -2,12 +2,12 @@ import React, { FC, memo, useCallback, useState } from 'react';
 import classNames from 'classnames';
 
 interface ProductAppMenuItemProps {
+    disabled?: boolean;
     iconUrl: string;
     iconUrlAlt?: string;
-    title: string;
-    subtitle?: string;
     onClick: () => void;
-    disabled?: boolean;
+    subtitle?: string;
+    title: string;
 }
 
 export const ProductAppMenuItem: FC<ProductAppMenuItemProps> = memo(props => {
@@ -38,7 +38,7 @@ export const ProductAppMenuItem: FC<ProductAppMenuItemProps> = memo(props => {
                     <i className="fa fa-chevron-right" />
                 </div>
             )}
-            <div className={classNames('product-title', { 'no-subtitle': subtitle == undefined })}>{title}</div>
+            <div className={classNames('product-title', { 'no-subtitle': subtitle === undefined })}>{title}</div>
             <div className="product-subtitle">{subtitle}</div>
         </li>
     );

--- a/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
@@ -5,7 +5,7 @@ import { ProductNavigationMenu } from './ProductNavigationMenu';
 
 export const ProductNavigation: FC = memo(() => {
     const [show, setShow] = useState<boolean>(false);
-    const onCloseMenu = useCallback(() => setShow(false), [setShow]);
+    const onCloseMenu = useCallback(() => setShow(false), []);
     const toggleMenu = useCallback(() => {
         setShow(current => !current);
     }, []);

--- a/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
@@ -6,16 +6,19 @@ import { ProductNavigationMenu } from './ProductNavigationMenu';
 export const ProductNavigation: FC = memo(() => {
     const [show, setShow] = useState<boolean>(false);
     const onCloseMenu = useCallback(() => setShow(false), [setShow]);
+    const toggleMenu = useCallback(() => {
+        setShow(current => !current);
+    }, []);
 
     return (
         <DropdownButton
             id="product-navigation-button"
             className="navbar-icon-button-right"
             title={<i className="fa fa-th-large navbar-header-icon" />}
-            onToggle={() => setShow(!show)}
+            onToggle={toggleMenu}
             open={show}
-            noCaret={true}
-            pullRight={true}
+            noCaret
+            pullRight
         >
             {show && <ProductNavigationMenu onCloseMenu={onCloseMenu} />}
         </DropdownButton>


### PR DESCRIPTION
#### Rationale
Opening the nav menu results in an error in the JS console due to all children needing a unique key. This PR addresses that issue, and cleans up usages of the react key prop in the navigation components.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1089
- https://github.com/LabKey/labkey-ui-premium/pull/25
- https://github.com/LabKey/biologics/pull/1880
- https://github.com/LabKey/labbook/pull/397
- https://github.com/LabKey/inventory/pull/701
- https://github.com/LabKey/sampleManagement/pull/1564

#### Changes
- Fix issue with react keys in Navigation
