### PR TITLE
Simplify SamplesDeriveButton, consolidate props

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.285.0",
+  "version": "2.285.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.285.1
+*Released*: 27 January 2023
+- `waitForLifeCycle` now supports `ShallowWrapper` components (and can be used with `shallow()`)
+- `EntityFieldFilterModal` update unit tests to match expected behavior and remove test-specific workarounds from component.
+- Wrap `CreateSamplesSubMenuBaseImpl` with `withRouterProps` to support in-app navigation.
+- Rename `SamplesDeriveButtonBase` to `SamplesDeriveButton`.
+- Remove redundant prop declarations for `CreateSamplesSubMenuBaseProps` and `CreateSamplesSubMenuProps` and `SamplesDeriveButtonProps`
+
 ### version 2.285.0
 *Released*: 27 January 2023
 * Add `help` prop to `SelectInput` and render without colliding with error message rendering.

--- a/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
+++ b/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
@@ -6,7 +6,7 @@ import { SchemaQuery } from '../public/SchemaQuery';
 import { QueryModel } from '../public/QueryModel/QueryModel';
 import { MenuOption, SubMenu } from '../internal/components/menus/SubMenu';
 import { AppURL } from '../internal/url/AppURL';
-import { SAMPLES_KEY, SOURCES_KEY } from '../internal/app/constants';
+import { SOURCES_KEY } from '../internal/app/constants';
 import { SCHEMAS } from '../internal/schemas';
 import { getCrossFolderSelectionResult } from '../internal/components/entities/actions';
 import { EntityCrossProjectSelectionConfirmModal } from '../internal/components/entities/EntityCrossProjectSelectionConfirmModal';
@@ -26,6 +26,8 @@ import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 import { caseInsensitive } from '../internal/util/utils';
 
 import { isProjectContainer } from '../internal/app/utils';
+
+import { CrossFolderSelectionResult } from '../internal/components/entities/models';
 
 import { SampleCreationTypeModal } from './SampleCreationTypeModal';
 
@@ -80,7 +82,7 @@ const CreateSamplesSubMenuBaseImpl: FC<CreateSamplesSubMenuBaseProps & WithRoute
 
     const [sampleCreationURL, setSampleCreationURL] = useState<string | AppURL>();
     const [selectedOption, setSelectedOption] = useState<string>();
-    const [crossFolderSelectionResult, setCrossFolderSelectionResult] = useState(undefined);
+    const [crossFolderSelectionResult, setCrossFolderSelectionResult] = useState<CrossFolderSelectionResult>();
     const [selectionsAreSet, setSelectionsAreSet] = useState<boolean>(false);
     const [selectionData, setSelectionData] = useState<Map<any, any>>();
     const allowCrossFolderDerive = !isProjectContainer(); // Issue 46853: LKSM/LKB Projects: should allow derivation of samples within projects when parent/source is in Home
@@ -287,7 +289,6 @@ const CreateSamplesSubMenuBaseImpl: FC<CreateSamplesSubMenuBaseProps & WithRoute
             <SubMenu
                 currentMenuChoice={menuCurrentChoice}
                 extractCurrentMenuChoice={false}
-                key={SAMPLES_KEY}
                 options={
                     getOptions
                         ? getOptions(

--- a/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
+++ b/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
@@ -1,5 +1,6 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { List } from 'immutable';
+import { withRouter, WithRouterProps } from 'react-router';
 
 import { SchemaQuery } from '../public/SchemaQuery';
 import { QueryModel } from '../public/QueryModel/QueryModel';
@@ -28,7 +29,7 @@ import { isProjectContainer } from '../internal/app/utils';
 
 import { SampleCreationTypeModal } from './SampleCreationTypeModal';
 
-interface CreateSamplesSubMenuProps {
+export interface CreateSamplesSubMenuBaseProps {
     allowPooledSamples?: boolean;
     currentProductId?: string;
     getOptions: (useOnClick: boolean, disabledMsg: string, itemActionFn: (key: string) => any) => List<MenuOption>;
@@ -37,7 +38,6 @@ interface CreateSamplesSubMenuProps {
     maxParentPerSample: number;
     menuCurrentChoice?: string;
     menuText?: string;
-    navigate: (url: string | AppURL) => any;
     parentKey?: string;
     parentQueryModel?: QueryModel;
     parentType?: string;
@@ -56,7 +56,7 @@ interface CreateSamplesSubMenuProps {
     targetProductId?: string;
 }
 
-export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(props => {
+const CreateSamplesSubMenuBaseImpl: FC<CreateSamplesSubMenuBaseProps & WithRouterProps> = memo(props => {
     const {
         allowPooledSamples = true,
         menuCurrentChoice,
@@ -64,7 +64,6 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
         parentType,
         parentKey,
         parentQueryModel,
-        navigate,
         getOptions,
         maxParentPerSample,
         sampleWizardURL,
@@ -76,6 +75,7 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
         selectionNoun = 'sample',
         selectionNounPlural = 'samples',
         skipCrossFolderCheck,
+        router,
     } = props;
 
     const [sampleCreationURL, setSampleCreationURL] = useState<string | AppURL>();
@@ -213,19 +213,14 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
             return onSampleCreationMenuSelect(key);
         },
         [
-            sampleWizardURL,
-            useOnClick,
-            parentKey,
-            currentProductId,
-            targetProductId,
-            selectionKey,
-            menuText,
-            selectedType,
             parentQueryModel,
             selectedQuantity,
             selectingSampleParents,
             skipCrossFolderCheck,
+            allowCrossFolderDerive,
+            onSampleCreationMenuSelect,
             useSnapshotSelection,
+            selectedType,
         ]
     );
 
@@ -243,12 +238,12 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
                 );
             }
             if (sampleCreationURL instanceof AppURL) {
-                navigate(sampleCreationURL.addParams({ creationType, numPerParent }));
+                router.push(sampleCreationURL.addParams({ creationType, numPerParent }).toString());
             } else {
                 window.location.href = sampleCreationURL + `&creationType=${creationType}&numPerParent=${numPerParent}`;
             }
         },
-        [navigate, sampleCreationURL, parentQueryModel?.selectionKey, selectionData]
+        [router, sampleCreationURL, parentQueryModel?.selectionKey, selectionData]
     );
 
     const dismissCrossFolderError = useCallback(() => {
@@ -336,3 +331,5 @@ export const CreateSamplesSubMenuBase: FC<CreateSamplesSubMenuProps> = memo(prop
         </>
     );
 });
+
+export const CreateSamplesSubMenuBase = withRouter<CreateSamplesSubMenuBaseProps>(CreateSamplesSubMenuBaseImpl);

--- a/packages/components/src/entities/SampleHeader.tsx
+++ b/packages/components/src/entities/SampleHeader.tsx
@@ -36,7 +36,7 @@ import { PrintLabelsModal } from '../internal/components/labels/PrintLabelsModal
 
 import { invalidateLineageResults } from '../internal/components/lineage/actions';
 
-import { isAssayEnabled, isProjectContainer, isWorkflowEnabled } from '../internal/app/utils';
+import { isAssayEnabled, isWorkflowEnabled } from '../internal/app/utils';
 
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 import { AssayImportSubMenuItem } from './AssayImportSubMenuItem';
@@ -248,7 +248,6 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                                             selectedQueryInfo={sampleModel.queryInfo}
                                             parentType={SAMPLES_KEY}
                                             parentKey={parent}
-                                            navigate={navigate}
                                         />
                                     )}
                                 </RequiresPermission>

--- a/packages/components/src/entities/SamplesDeriveButton.spec.tsx
+++ b/packages/components/src/entities/SamplesDeriveButton.spec.tsx
@@ -10,11 +10,11 @@ import { TEST_USER_EDITOR, TEST_USER_READER } from '../internal/userFixtures';
 
 import { DisableableButton } from '../internal/components/buttons/DisableableButton';
 
-import { SamplesDeriveButtonBase, SamplesDeriveButtonBaseProps } from './SamplesDeriveButtonBase';
+import { SamplesDeriveButton, SamplesDeriveButtonProps } from './SamplesDeriveButton';
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 
-describe('SamplesDeriveButtonBase', () => {
-    function defaultProps(): SamplesDeriveButtonBaseProps {
+describe('SamplesDeriveButton', () => {
+    function defaultProps(): SamplesDeriveButtonProps {
         return {
             model: makeTestQueryModel(SchemaQuery.create('schema', 'query')),
             isSelectingSamples: jest.fn().mockReturnValue(true),
@@ -28,7 +28,7 @@ describe('SamplesDeriveButtonBase', () => {
     }
 
     test('default props', () => {
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButton {...defaultProps()} />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper);
@@ -37,7 +37,7 @@ describe('SamplesDeriveButtonBase', () => {
     });
 
     test('asSubMenu', () => {
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} asSubMenu />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButton {...defaultProps()} asSubMenu />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper, true, true);
@@ -46,7 +46,7 @@ describe('SamplesDeriveButtonBase', () => {
     });
 
     test('reader', () => {
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButton {...defaultProps()} />, {
             user: TEST_USER_READER,
         });
         validate(wrapper, false);
@@ -58,7 +58,7 @@ describe('SamplesDeriveButtonBase', () => {
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
             selections: new Set(Array.from(Array(1001).keys()).map(key => key + '')),
         });
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} model={model} />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButton {...defaultProps()} model={model} />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper, false, false, true);

--- a/packages/components/src/entities/SamplesDeriveButton.tsx
+++ b/packages/components/src/entities/SamplesDeriveButton.tsx
@@ -10,7 +10,7 @@ import { DisableableButton } from '../internal/components/buttons/DisableableBut
 
 import { CreateSamplesSubMenu, CreateSamplesSubMenuProps } from './CreateSamplesSubMenu';
 
-export interface SamplesDeriveButtonBaseProps
+export interface SamplesDeriveButtonProps
     extends Omit<
         CreateSamplesSubMenuProps,
         'id' | 'menuText' | 'parentQueryModel' | 'selectedQueryInfo' | 'selectedType' | 'subMenuText'
@@ -19,7 +19,7 @@ export interface SamplesDeriveButtonBaseProps
     model: QueryModel;
 }
 
-export const SamplesDeriveButtonBase: FC<SamplesDeriveButtonBaseProps> = memo(props => {
+export const SamplesDeriveButton: FC<SamplesDeriveButtonProps> = memo(props => {
     const { model, asSubMenu, ...createSampleMenuProps } = props;
 
     const selectedCount = model?.selections?.size ?? -1;

--- a/packages/components/src/entities/SamplesDeriveButtonBase.spec.tsx
+++ b/packages/components/src/entities/SamplesDeriveButtonBase.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { DropdownButton } from 'react-bootstrap';
 import { ReactWrapper } from 'enzyme';
 
-import { ProductMenuModel } from '../internal/components/navigation/model';
 import { makeTestQueryModel } from '../public/QueryModel/testUtils';
 import { SchemaQuery } from '../public/SchemaQuery';
 import { mountWithServerContext } from '../internal/testHelpers';
@@ -11,21 +10,16 @@ import { TEST_USER_EDITOR, TEST_USER_READER } from '../internal/userFixtures';
 
 import { DisableableButton } from '../internal/components/buttons/DisableableButton';
 
-import { SamplesDeriveButtonBase } from './SamplesDeriveButtonBase';
+import { SamplesDeriveButtonBase, SamplesDeriveButtonBaseProps } from './SamplesDeriveButtonBase';
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 
 describe('SamplesDeriveButtonBase', () => {
-    const DEFAULT_PROPS = {
-        menu: new ProductMenuModel(),
-        user: TEST_USER_EDITOR,
-        model: makeTestQueryModel(SchemaQuery.create('schema', 'query')),
-        navigate: jest.fn(),
-        goBack: jest.fn(),
-        menuInit: jest.fn(),
-        menuInvalidate: jest.fn(),
-        setReloadRequired: jest.fn(),
-        isSelectingSamples: () => true,
-    };
+    function defaultProps(): SamplesDeriveButtonBaseProps {
+        return {
+            model: makeTestQueryModel(SchemaQuery.create('schema', 'query')),
+            isSelectingSamples: jest.fn().mockReturnValue(true),
+        };
+    }
 
     function validate(wrapper: ReactWrapper, rendered = true, asSubMenu = false, disabled = false): void {
         expect(wrapper.find(DropdownButton)).toHaveLength(rendered && !asSubMenu && !disabled ? 1 : 0);
@@ -34,7 +28,7 @@ describe('SamplesDeriveButtonBase', () => {
     }
 
     test('default props', () => {
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper);
@@ -43,7 +37,7 @@ describe('SamplesDeriveButtonBase', () => {
     });
 
     test('asSubMenu', () => {
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...DEFAULT_PROPS} asSubMenu />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} asSubMenu />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper, true, true);
@@ -52,7 +46,7 @@ describe('SamplesDeriveButtonBase', () => {
     });
 
     test('reader', () => {
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} />, {
             user: TEST_USER_READER,
         });
         validate(wrapper, false);
@@ -64,7 +58,7 @@ describe('SamplesDeriveButtonBase', () => {
         const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
             selections: new Set(Array.from(Array(1001).keys()).map(key => key + '')),
         });
-        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...DEFAULT_PROPS} model={model} />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButtonBase {...defaultProps()} model={model} />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper, false, false, true);

--- a/packages/components/src/entities/SamplesDeriveButtonBase.tsx
+++ b/packages/components/src/entities/SamplesDeriveButtonBase.tsx
@@ -10,12 +10,16 @@ import { DisableableButton } from '../internal/components/buttons/DisableableBut
 
 import { CreateSamplesSubMenu, CreateSamplesSubMenuProps } from './CreateSamplesSubMenu';
 
-interface Props extends Pick<CreateSamplesSubMenuProps, 'currentProductId' | 'isSelectingSamples' | 'targetProductId'> {
+export interface SamplesDeriveButtonBaseProps
+    extends Omit<
+        CreateSamplesSubMenuProps,
+        'id' | 'menuText' | 'parentQueryModel' | 'selectedQueryInfo' | 'selectedType' | 'subMenuText'
+    > {
     asSubMenu?: boolean;
     model: QueryModel;
 }
 
-export const SamplesDeriveButtonBase: FC<Props> = memo(props => {
+export const SamplesDeriveButtonBase: FC<SamplesDeriveButtonBaseProps> = memo(props => {
     const { model, asSubMenu, ...createSampleMenuProps } = props;
 
     const selectedCount = model?.selections?.size ?? -1;

--- a/packages/components/src/entities/SamplesDeriveButtonBase.tsx
+++ b/packages/components/src/entities/SamplesDeriveButtonBase.tsx
@@ -1,56 +1,22 @@
 import React, { FC, memo } from 'react';
 import { PermissionTypes } from '@labkey/api';
 
-import { SchemaQuery } from '../public/SchemaQuery';
 import { QueryModel } from '../public/QueryModel/QueryModel';
 import { RequiresPermission } from '../internal/components/base/Permissions';
 import { ResponsiveMenuButton } from '../internal/components/buttons/ResponsiveMenuButton';
-import { AppURL } from '../internal/url/AppURL';
 import { SampleCreationType } from '../internal/components/samples/models';
 import { MAX_EDITABLE_GRID_ROWS } from '../internal/constants';
 import { DisableableButton } from '../internal/components/buttons/DisableableButton';
 
-import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
+import { CreateSamplesSubMenu, CreateSamplesSubMenuProps } from './CreateSamplesSubMenu';
 
-interface Props {
+interface Props extends Pick<CreateSamplesSubMenuProps, 'currentProductId' | 'isSelectingSamples' | 'targetProductId'> {
     asSubMenu?: boolean;
-    currentProductId?: string;
-    isSelectingSamples?: (schemaQuery: SchemaQuery) => boolean;
     model: QueryModel;
-    navigate: (url: string | AppURL) => any;
-    targetProductId?: string;
 }
 
 export const SamplesDeriveButtonBase: FC<Props> = memo(props => {
-    const { model, asSubMenu } = props;
-
-    const items = (
-        <>
-            <CreateSamplesSubMenu
-                {...props}
-                id="aliquot-samples-menu-item"
-                parentQueryModel={model}
-                selectedQueryInfo={model.queryInfo}
-                selectedType={SampleCreationType.Aliquots}
-                subMenuText="Aliquot Selected"
-            />
-            <CreateSamplesSubMenu
-                {...props}
-                id="derive-samples-menu-item"
-                menuText="Derive from Selected"
-                parentQueryModel={model}
-                selectedType={SampleCreationType.Derivatives}
-            />
-            <CreateSamplesSubMenu
-                {...props}
-                id="pool-samples-menu-item"
-                parentQueryModel={model}
-                selectedQueryInfo={model.queryInfo}
-                selectedType={SampleCreationType.PooledSamples}
-                subMenuText="Pool Selected"
-            />
-        </>
-    );
+    const { model, asSubMenu, ...createSampleMenuProps } = props;
 
     const selectedCount = model?.selections?.size ?? -1;
     if (!asSubMenu && selectedCount > MAX_EDITABLE_GRID_ROWS) {
@@ -70,7 +36,38 @@ export const SamplesDeriveButtonBase: FC<Props> = memo(props => {
 
     return (
         <RequiresPermission permissionCheck="any" perms={PermissionTypes.Insert}>
-            <ResponsiveMenuButton id="samples-derive-menu" text="Derive" items={items} asSubMenu={asSubMenu} />
+            <ResponsiveMenuButton
+                id="samples-derive-menu"
+                text="Derive"
+                items={
+                    <>
+                        <CreateSamplesSubMenu
+                            {...createSampleMenuProps}
+                            id="aliquot-samples-menu-item"
+                            parentQueryModel={model}
+                            selectedQueryInfo={model.queryInfo}
+                            selectedType={SampleCreationType.Aliquots}
+                            subMenuText="Aliquot Selected"
+                        />
+                        <CreateSamplesSubMenu
+                            {...createSampleMenuProps}
+                            id="derive-samples-menu-item"
+                            menuText="Derive from Selected"
+                            parentQueryModel={model}
+                            selectedType={SampleCreationType.Derivatives}
+                        />
+                        <CreateSamplesSubMenu
+                            {...createSampleMenuProps}
+                            id="pool-samples-menu-item"
+                            parentQueryModel={model}
+                            selectedQueryInfo={model.queryInfo}
+                            selectedType={SampleCreationType.PooledSamples}
+                            subMenuText="Pool Selected"
+                        />
+                    </>
+                }
+                asSubMenu={asSubMenu}
+            />
         </RequiresPermission>
     );
 });

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -2,7 +2,7 @@ import React, { FC, memo, useCallback, useMemo, useState } from 'react';
 import { MenuItem } from 'react-bootstrap';
 import { PermissionTypes } from '@labkey/api';
 
-import { EntityDataType } from '../internal/components/entities/models';
+import { CrossFolderSelectionResult, EntityDataType } from '../internal/components/entities/models';
 
 import { RequiresModelAndActions } from '../public/QueryModel/withQueryModels';
 
@@ -54,8 +54,7 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
         currentProductId,
         targetProductId,
     } = props;
-    const [crossFolderSelectionResult, setCrossFolderSelectionResult] = useState(undefined);
-
+    const [crossFolderSelectionResult, setCrossFolderSelectionResult] = useState<CrossFolderSelectionResult>();
     const { user, moduleContext } = useServerContext();
 
     const handleMenuClick = useCallback(
@@ -78,11 +77,11 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
 
     const onToggleEditWithGridUpdate = useCallback(() => {
         handleMenuClick(toggleEditWithGridUpdate, 'Cannot Edit Samples');
-    }, [toggleEditWithGridUpdate]);
+    }, [handleMenuClick, toggleEditWithGridUpdate]);
 
     const onShowBulkUpdate = useCallback(() => {
         handleMenuClick(showBulkUpdate, 'Cannot Edit Samples');
-    }, [showBulkUpdate]);
+    }, [handleMenuClick, showBulkUpdate]);
 
     const dismissCrossFolderError = useCallback(() => {
         setCrossFolderSelectionResult(undefined);
@@ -163,18 +162,16 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
                         {user.canUpdate && parentEntityDataTypes?.length > 0 && <MenuItem divider />}
                         {!combineParentTypes &&
                             user.canUpdate &&
-                            parentEntityDataTypes.map(parentEntityDataType => {
-                                return (
-                                    <EntityLineageEditMenuItem
-                                        key={parentEntityDataType.nounSingular}
-                                        childEntityDataType={SampleTypeDataType}
-                                        parentEntityDataTypes={[parentEntityDataType]}
-                                        queryModel={model}
-                                        onSuccess={afterSampleActionComplete}
-                                        handleClick={handleMenuClick}
-                                    />
-                                );
-                            })}
+                            parentEntityDataTypes.map(parentEntityDataType => (
+                                <EntityLineageEditMenuItem
+                                    key={parentEntityDataType.nounSingular}
+                                    childEntityDataType={SampleTypeDataType}
+                                    parentEntityDataTypes={[parentEntityDataType]}
+                                    queryModel={model}
+                                    onSuccess={afterSampleActionComplete}
+                                    handleClick={handleMenuClick}
+                                />
+                            ))}
                         {combineParentTypes && user.canUpdate && (
                             <EntityLineageEditMenuItem
                                 childEntityDataType={SampleTypeDataType}

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -24,7 +24,7 @@ import { SampleDetailEditing } from './SampleDetailEditing';
 import { SampleLineageGraph } from './SampleLineageGraph';
 import { SampleHeader } from './SampleHeader';
 import { SampleSetDeleteModal } from './SampleSetDeleteModal';
-import { SamplesDeriveButtonBase } from './SamplesDeriveButtonBase';
+import { SamplesDeriveButton } from './SamplesDeriveButton';
 import { SamplesEditButton } from './SamplesEditButton';
 import { SampleAliquotDetailHeader } from './SampleAliquotDetailHeader';
 import { SampleCreationTypeModal } from './SampleCreationTypeModal';
@@ -136,7 +136,7 @@ export {
     SampleTypeInsightsPanel,
     SampleTypeTemplateDownloadRenderer,
     SamplesAssayButton,
-    SamplesDeriveButtonBase,
+    SamplesDeriveButton,
     SamplesEditButton,
     SamplesTabbedGridPanel,
 };

--- a/packages/components/src/internal/testHelpers.tsx
+++ b/packages/components/src/internal/testHelpers.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactElement, useMemo } from 'react';
 import { act } from 'react-dom/test-utils';
 import { Map } from 'immutable';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import { mount, MountRendererProps, ReactWrapper } from 'enzyme';
+import { mount, MountRendererProps, ReactWrapper, ShallowWrapper } from 'enzyme';
 import { LabKey, Query } from '@labkey/api';
 
 import { RowsResponse, bindColumnRenderers } from '../public/QueryModel/QueryModelLoader';
@@ -252,10 +252,10 @@ export const sleep = (ms = 0): Promise<void> => {
  *      await waitForLifecycle(wrapper);
  *      // Items have been loaded and rendered
  *      expect(wrapper.find('.item').length).toEqual(4);
- * @param wrapper: enzyme ReactWrapper
+ * @param wrapper: enzyme ReactWrapper or ShallowWrapper
  * @param ms: the amount of time (in ms) to sleep
  */
-export const waitForLifecycle = (wrapper: ReactWrapper, ms?: number): Promise<undefined> => {
+export const waitForLifecycle = (wrapper: ReactWrapper | ShallowWrapper, ms?: number): Promise<undefined> => {
     // Wrap in react-dom/utils act so we don't get errors in our test logs
     return act(async () => {
         await sleep(ms);


### PR DESCRIPTION
#### Rationale
A collection of improvements found while shoring up unit tests in our client-side applications.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1091
- https://github.com/LabKey/labkey-ui-premium/pull/29
- https://github.com/LabKey/biologics/pull/1888
- https://github.com/LabKey/sampleManagement/pull/1572
- https://github.com/LabKey/inventory/pull/705

#### Changes
- `waitForLifeCycle` now supports `ShallowWrapper` components (and can be used with `shallow()`)
- `EntityFieldFilterModal` update unit tests to match expected behavior and remove test-specific workarounds from component. Introduce loading state.
- Wrap `CreateSamplesSubMenuBaseImpl` with `withRouterProps` to support in-app navigation.
- Rename `SamplesDeriveButtonBase` to `SamplesDeriveButton`.
- Remove redundant prop declarations for `CreateSamplesSubMenuBaseProps` and `CreateSamplesSubMenuProps` and `SamplesDeriveButtonProps`
