### PR TITLE
Refactor SchemaQuery

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.289.0",
+  "version": "2.290.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.290.0
 *Released*: 2 February 2023
-* SchemaQuery: Convert to vanilla class, remove getQuery, getSchema, getView
+* SchemaQuery: Convert to vanilla class, remove getQuery, getSchema, getView, create
+  * Use new SchemaQuery(schemaName, queryName, viewName) instead of SchemaQuery.create
 * Remove unused resolveSchemaQuery
 
 ### version 2.289.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.290.0
+*Released*: 2 February 2023
+* SchemaQuery: remove getQuery, getSchema, getView
+* Remove unused resolveSchemaQuery
+
 ### version 2.289.0
 *Released*: 2 February 2023
 * Update links from users to display user detail data via modal for those who have permission

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.290.0
 *Released*: 2 February 2023
-* SchemaQuery: remove getQuery, getSchema, getView
+* SchemaQuery: Convert to vanilla class, remove getQuery, getSchema, getView
 * Remove unused resolveSchemaQuery
 
 ### version 2.289.0

--- a/packages/components/src/entities/AssayImportSubMenuItem.spec.tsx
+++ b/packages/components/src/entities/AssayImportSubMenuItem.spec.tsx
@@ -59,7 +59,7 @@ describe('AssayImportSubMenuItem', () => {
     });
 
     test('requireSelection with too few selected', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ selections: new Set() });
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({ selections: new Set() });
         const wrapper = mount(
             <AssayImportSubMenuItemImpl {...DEFAULT_PROPS} requireSelection={true} queryModel={model} />
         );
@@ -78,7 +78,7 @@ describe('AssayImportSubMenuItem', () => {
     });
 
     test('requireSelection with proper number selected', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             selections: new Set(['test']),
         });
         const wrapper = mount(

--- a/packages/components/src/entities/CreateSamplesSubMenu.spec.tsx
+++ b/packages/components/src/entities/CreateSamplesSubMenu.spec.tsx
@@ -155,7 +155,7 @@ describe('CreateSamplesSubMenu', () => {
                 selectedQueryInfo={
                     new QueryInfo({
                         schemaName: 'samples',
-                        schemaQuery: SchemaQuery.create('samples', 'Other'),
+                        schemaQuery: new SchemaQuery('samples', 'Other'),
                     })
                 }
             />
@@ -185,7 +185,7 @@ describe('CreateSamplesSubMenu', () => {
     });
 
     test('useOnClick for parentQueryModel with selection', async () => {
-        const model = makeTestQueryModel(SchemaQuery.create('samples', 'Test')).mutate({ selections: new Set('1') });
+        const model = makeTestQueryModel(new SchemaQuery('samples', 'Test')).mutate({ selections: new Set('1') });
         const wrapper = mountWithAppServerContext(
             <CreateSamplesSubMenu {...defaultProps()} parentQueryModel={model} isSelectingSamples={() => true} />
         );
@@ -214,7 +214,7 @@ describe('CreateSamplesSubMenu', () => {
     });
 
     test('use href for parentQueryModel with non sample or source schema', async () => {
-        const model = makeTestQueryModel(SchemaQuery.create('other', 'Test')).mutate({ selections: new Set('1') });
+        const model = makeTestQueryModel(new SchemaQuery('other', 'Test')).mutate({ selections: new Set('1') });
         const wrapper = mountWithAppServerContext(
             <CreateSamplesSubMenu {...defaultProps()} parentQueryModel={model} />
         );
@@ -230,7 +230,7 @@ describe('CreateSamplesSubMenu', () => {
         for (var i = 0; i < MAX_PARENTS_PER_SAMPLE + 1; i++) {
             selections.add('' + i);
         }
-        const model = makeTestQueryModel(SchemaQuery.create('samples', 'Test')).mutate({ selections });
+        const model = makeTestQueryModel(new SchemaQuery('samples', 'Test')).mutate({ selections });
         const wrapper = mountWithAppServerContext(
             <CreateSamplesSubMenu
                 {...defaultProps()}

--- a/packages/components/src/entities/EntityFieldFilterModal.spec.tsx
+++ b/packages/components/src/entities/EntityFieldFilterModal.spec.tsx
@@ -62,7 +62,7 @@ describe('EntityFieldFilterModal', () => {
                     jsonType: 'boolean',
                 },
             ],
-            schemaQuery: SchemaQuery.create('TestSchema', 'samplesetallfieldtypes'),
+            schemaQuery: new SchemaQuery('TestSchema', 'samplesetallfieldtypes'),
             index: 1,
         },
     ];

--- a/packages/components/src/entities/EntityLineageEditMenuItem.spec.tsx
+++ b/packages/components/src/entities/EntityLineageEditMenuItem.spec.tsx
@@ -28,7 +28,7 @@ describe('EntityLineageEditMenuItem', () => {
     });
 
     test('multiple selections', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'q'));
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'q'));
         queryModel.mutate({ selections: new Set<string>(['1', '2']) });
         const wrapper = mount(
             <EntityLineageEditMenuItem
@@ -43,7 +43,7 @@ describe('EntityLineageEditMenuItem', () => {
     });
 
     test('single selection', () => {
-        let queryModel = makeTestQueryModel(SchemaQuery.create('test', 'q'));
+        let queryModel = makeTestQueryModel(new SchemaQuery('test', 'q'));
         queryModel = queryModel.mutate({ selections: new Set<string>(['1']) });
         const wrapper = mount(
             <EntityLineageEditMenuItem

--- a/packages/components/src/entities/EntityLineageEditModal.spec.tsx
+++ b/packages/components/src/entities/EntityLineageEditModal.spec.tsx
@@ -19,7 +19,7 @@ import { DataClassDataType, SampleTypeDataType } from '../internal/components/en
 import { ParentEntityEditPanel } from './ParentEntityEditPanel';
 import { OperationConfirmationData } from '../internal/components/entities/models';
 
-const SQ = SchemaQuery.create('schema', 'query');
+const SQ = new SchemaQuery('schema', 'query');
 const MODEL = makeTestQueryModel(SQ).mutate({
     selections: new Set(['1', '2', '3']),
 });

--- a/packages/components/src/entities/FindSamplesByIdsPageBase.tsx
+++ b/packages/components/src/entities/FindSamplesByIdsPageBase.tsx
@@ -130,7 +130,7 @@ const FindSamplesByIdsTabbedGridPanel: FC<FindSamplesByIdsTabProps> = memo(props
             .then(sampleTypesRows => {
                 if (sampleTypesRows) {
                     Object.keys(sampleTypesRows).forEach(sampleType => {
-                        const sampleSchemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType);
+                        const sampleSchemaQuery = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType);
 
                         const sampleGridId = createGridModelId(
                             TYPE_GRID_PREFIX + allSamplesModel.queryName,
@@ -237,7 +237,7 @@ const FindSamplesByIdsPageBaseImpl: FC<Props> = memo(props => {
                 setMissingIds(missingIds);
                 setIds(ids);
                 if (queryName) {
-                    listSchemaQuery = SchemaQuery.create(SCHEMAS.EXP_TABLES.SCHEMA, queryName);
+                    listSchemaQuery = new SchemaQuery(SCHEMAS.EXP_TABLES.SCHEMA, queryName);
                     // add model twice, one used for header, one for tabbed grid, so that header doesn't reload when switching tabs
 
                     const listId = createGridModelId('find-samples-by-id', listSchemaQuery);

--- a/packages/components/src/entities/FindSamplesByidHeaderPanel.spec.tsx
+++ b/packages/components/src/entities/FindSamplesByidHeaderPanel.spec.tsx
@@ -54,7 +54,7 @@ describe('getFindIdCountsByTypeMessage', () => {
 
 describe('FindSamplesByIdHeaderPanel', () => {
     test('loading', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
 
         const wrapper = mount(
             <FindSamplesByIdHeaderPanel
@@ -96,7 +96,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
     });
 
     test('list model loading', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
 
         const wrapper = mount(
             <FindSamplesByIdHeaderPanel
@@ -113,7 +113,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
     });
 
     test('no ids', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'), new QueryInfo(), {}, [], 0);
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'), new QueryInfo(), {}, [], 0);
 
         const wrapper = mount(
             <FindSamplesByIdHeaderPanel
@@ -134,7 +134,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
     });
 
     test('with error', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'), new QueryInfo(), {}, [], 0);
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'), new QueryInfo(), {}, [], 0);
 
         const wrapper = mount(
             <FindSamplesByIdHeaderPanel
@@ -158,7 +158,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
 
     test('found multiple samples', () => {
         const queryModel = makeTestQueryModel(
-            SchemaQuery.create('test', 'query'),
+            new SchemaQuery('test', 'query'),
             new QueryInfo(),
             { 1: {}, 2: {} },
             ['1', '2'],
@@ -194,7 +194,7 @@ describe('FindSamplesByIdHeaderPanel', () => {
 
     test('custom workWithSamplesMsg', () => {
         const queryModel = makeTestQueryModel(
-            SchemaQuery.create('test', 'query'),
+            new SchemaQuery('test', 'query'),
             new QueryInfo(),
             { 1: {}, 2: {} },
             ['1', '2'],

--- a/packages/components/src/entities/GridAliquotViewSelector.spec.tsx
+++ b/packages/components/src/entities/GridAliquotViewSelector.spec.tsx
@@ -25,7 +25,7 @@ describe('<GridAliquotViewSelector/>', () => {
 
     test('experimental flag disabled', () => {
         LABKEY.moduleContext = { samplemanagement: { 'experimental-sample-aliquot-selector': false } };
-        const model = makeTestQueryModel(SchemaQuery.create('a', 'b'));
+        const model = makeTestQueryModel(new SchemaQuery('a', 'b'));
         const component = <GridAliquotViewSelector queryModel={model} />;
         const tree = renderer.create(component).toJSON();
         expect(tree).toBe(null);
@@ -52,7 +52,7 @@ describe('<GridAliquotViewSelector/>', () => {
     }
 
     test('with queryModel, without filter', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('a', 'b'));
+        const model = makeTestQueryModel(new SchemaQuery('a', 'b'));
 
         const component = <GridAliquotViewSelector queryModel={model} />;
         const wrapper = mount(component);
@@ -63,7 +63,7 @@ describe('<GridAliquotViewSelector/>', () => {
     });
 
     test('with queryModel, filtered to aliquots only', () => {
-        let model = makeTestQueryModel(SchemaQuery.create('a', 'b'));
+        let model = makeTestQueryModel(new SchemaQuery('a', 'b'));
         model = model.mutate({
             filterArray: [Filter.create(IS_ALIQUOT_COL, true)],
         });
@@ -76,7 +76,7 @@ describe('<GridAliquotViewSelector/>', () => {
     });
 
     test('with queryModel, filtered to samples only', () => {
-        let model = makeTestQueryModel(SchemaQuery.create('a', 'b'));
+        let model = makeTestQueryModel(new SchemaQuery('a', 'b'));
         model = model.mutate({
             filterArray: [Filter.create(IS_ALIQUOT_COL, false)],
         });

--- a/packages/components/src/entities/ParentEntityEditPanel.spec.tsx
+++ b/packages/components/src/entities/ParentEntityEditPanel.spec.tsx
@@ -24,7 +24,7 @@ beforeAll(() => {
 });
 
 describe('ParentEntityEditPanel', () => {
-    const schemaQuery = SchemaQuery.create('samples', 'example');
+    const schemaQuery = new SchemaQuery('samples', 'example');
     const queryInfo = QueryInfo.create({
         schemaName: schemaQuery.schemaName,
         queryName: schemaQuery.queryName,

--- a/packages/components/src/entities/PicklistDeleteConfirm.spec.tsx
+++ b/packages/components/src/entities/PicklistDeleteConfirm.spec.tsx
@@ -373,7 +373,7 @@ describe('PicklistDeleteConfirm', () => {
     });
 
     test('with model selections', async () => {
-        let model = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        let model = makeTestQueryModel(new SchemaQuery('test', 'query'));
         model = model.mutate({ selections: new Set(['1', '2']) });
         const wrapper = mount(
             <PicklistDeleteConfirm
@@ -407,7 +407,7 @@ describe('PicklistDeleteConfirm', () => {
     });
 
     test('with model selections, none deletable', async () => {
-        let model = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        let model = makeTestQueryModel(new SchemaQuery('test', 'query'));
         model = model.mutate({ selections: new Set(['1', '2']) });
         const wrapper = mount(
             <PicklistDeleteConfirm

--- a/packages/components/src/entities/PicklistOverview.spec.tsx
+++ b/packages/components/src/entities/PicklistOverview.spec.tsx
@@ -228,7 +228,7 @@ describe('PicklistOverviewImpl', () => {
         navigate: jest.fn,
         loadPicklist: jest.fn,
         queryModels: {
-            model: makeTestQueryModel(SchemaQuery.create('schema', 'query')),
+            model: makeTestQueryModel(new SchemaQuery('schema', 'query')),
         },
         actions: makeTestActions(),
     };

--- a/packages/components/src/entities/PicklistOverview.tsx
+++ b/packages/components/src/entities/PicklistOverview.tsx
@@ -304,7 +304,7 @@ export const PicklistOverview: FC<OwnProps> = memo(props => {
             configs[gridId] = {
                 id: gridId,
                 title: 'All Samples',
-                schemaQuery: SchemaQuery.create(SCHEMAS.PICKLIST_TABLES.SCHEMA, picklist.name),
+                schemaQuery: new SchemaQuery(SCHEMAS.PICKLIST_TABLES.SCHEMA, picklist.name),
                 // For picklists, we get sample-related things via a lookup through SampleID.
                 requiredColumns: [
                     'Created',
@@ -321,7 +321,7 @@ export const PicklistOverview: FC<OwnProps> = memo(props => {
                 configs[id] = {
                     id,
                     title: sampleType,
-                    schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType),
+                    schemaQuery: new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType),
                     requiredColumns: SAMPLE_STATUS_REQUIRED_COLUMNS.concat(
                         samplesEditableGridProps?.samplesGridRequiredColumns ?? []
                     ),

--- a/packages/components/src/entities/RemoveFromPicklistButton.spec.tsx
+++ b/packages/components/src/entities/RemoveFromPicklistButton.spec.tsx
@@ -36,7 +36,7 @@ describe('RemoveFromPicklistButton', () => {
     const DEFAULT_PROPS = {
         user: TEST_USER_EDITOR,
         afterSampleActionComplete: jest.fn,
-        model: makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        model: makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             rowCount: 2,
             selections: new Set(['1', '2']),
         }),

--- a/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.spec.tsx
@@ -25,7 +25,7 @@ beforeEach(() => {
 });
 
 describe('SampleAliquotsGridPanel', () => {
-    const SCHEMA_QUERY = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'SampleTypeName');
+    const SCHEMA_QUERY = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'SampleTypeName');
     const DEFAULT_CONTEXT = { user: TEST_USER_EDITOR };
     const SAMPLE_TYPE_APP_CONTEXT = {} as SampleTypeAppContext;
 

--- a/packages/components/src/entities/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.tsx
@@ -226,7 +226,7 @@ export const SampleAliquotsGridPanel: FC<SampleAliquotsGridPanelProps> = props =
         ? [...getOmittedSampleTypeColumns(user), ...omittedColumns]
         : getOmittedSampleTypeColumns(user);
 
-    const queryConfig = getSampleAliquotsQueryConfig(schemaQuery.getQuery(), sampleLsid, true, rootLsid, omitted);
+    const queryConfig = getSampleAliquotsQueryConfig(schemaQuery.queryName, sampleLsid, true, rootLsid, omitted);
     const queryConfigs = { [queryConfig.id]: queryConfig };
 
     return <SampleAliquotsGridPanelWithModel {...props} queryModelId={queryConfig.id} queryConfigs={queryConfigs} />;

--- a/packages/components/src/entities/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotsSummary.spec.tsx
@@ -12,7 +12,7 @@ const DEFAULT_PROPS = {
     queryModels: {},
     actions: makeTestActions(),
     hideAssayData: true,
-    aliquotJobsQueryConfig: { schemaQuery: SchemaQuery.create('test', 'query') },
+    aliquotJobsQueryConfig: { schemaQuery: new SchemaQuery('test', 'query') },
 };
 
 const noAliquotVolume = {
@@ -35,7 +35,7 @@ const zeroAliquotVolume = {
 
 function getQueryModelFromRows(rows) {
     return makeTestQueryModel(
-        SchemaQuery.create('schema', 'query'),
+        new SchemaQuery('schema', 'query'),
         undefined,
         rows,
         Object.keys(rows),
@@ -93,7 +93,7 @@ describe('<SampleAliquotsSummaryWithModels/>', () => {
                 sampleLsid="S-20200404-1"
                 sampleSet="dirt"
                 sampleRow={noAliquotVolume}
-                aliquotsModel={makeTestQueryModel(SchemaQuery.create('schema', 'query'))}
+                aliquotsModel={makeTestQueryModel(new SchemaQuery('schema', 'query'))}
                 jobsModel={undefined}
             />
         );

--- a/packages/components/src/entities/SampleAssayDetail.spec.tsx
+++ b/packages/components/src/entities/SampleAssayDetail.spec.tsx
@@ -39,7 +39,7 @@ const assayModel = new AssayStateModel({
     ],
     definitionsLoadingState: LoadingState.LOADED,
 });
-const SQ = SchemaQuery.create('schema', 'query');
+const SQ = new SchemaQuery('schema', 'query');
 const modelLoadedNoRows = makeTestQueryModel(SQ, new QueryInfo(), {}, [], 0).mutate({
     queryInfoLoadingState: LoadingState.LOADED,
     rowsLoadingState: LoadingState.LOADED,
@@ -78,14 +78,14 @@ describe('SampleAssayDetailButtons', () => {
     });
 
     test('currentAssayHref undefined', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'Other Assay' });
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({ title: 'Other Assay' });
         const wrapper = mount(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} user={TEST_USER_AUTHOR} />);
         validate(wrapper);
         wrapper.unmount();
     });
 
     test('multiple menu items', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({ title: 'NAb Assay' });
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({ title: 'NAb Assay' });
         const wrapper = mount(<SampleAssayDetailButtons {...DEFAULT_PROPS} model={model} user={TEST_USER_AUTHOR} />);
         validate(wrapper, 2);
         expect(wrapper.find(SplitButton).prop('href')).toBe('test2');
@@ -162,7 +162,7 @@ describe('getSampleAssayDetailEmptyText', () => {
 
 const SUMMARY_GRID_ID = 'assay-detail:assayruncount:1';
 const SUMMARY_GRID_MODEL = makeTestQueryModel(
-    SchemaQuery.create('exp', 'AssayRunsPerSample'),
+    new SchemaQuery('exp', 'AssayRunsPerSample'),
     new QueryInfo(),
     { 1: { RowId: { value: 1 }, Name: { value: 'Name1' } } },
     ['1'],

--- a/packages/components/src/entities/SampleCreatePage.tsx
+++ b/packages/components/src/entities/SampleCreatePage.tsx
@@ -76,7 +76,7 @@ export const SampleCreatePage: FC<SampleCreatePageProps> = memo(props => {
                 // so we need to reload the queryInfo for the sample type.
                 // N.B.  We could call getDomainDetails for the sample type and see if there is an options.autoLinkTargetContainerId and
                 // clear the cache only then, but the minor optimization doesn't seem worth it.
-                invalidateQueryDetailsCache(SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, targetSampleTypeName));
+                invalidateQueryDetailsCache(new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, targetSampleTypeName));
             }
             onSampleChange();
 

--- a/packages/components/src/entities/SampleDeleteMenuItem.spec.tsx
+++ b/packages/components/src/entities/SampleDeleteMenuItem.spec.tsx
@@ -34,14 +34,14 @@ describe('SampleDeleteMenuItem', () => {
     });
 
     test('click menu item with no selection', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
         const wrapper = mountWithAppServerContext(<SampleDeleteMenuItem queryModel={queryModel} />);
         validate(wrapper);
         wrapper.unmount();
     });
 
     test('click menu item', () => {
-        let queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        let queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
         queryModel = queryModel.mutate({ rowCount: 2, selections: new Set(['1', '2']) });
         const wrapper = mountWithAppServerContext(<SampleDeleteMenuItem queryModel={queryModel} />);
         validate(wrapper, 1);

--- a/packages/components/src/entities/SampleDetailEditing.tsx
+++ b/packages/components/src/entities/SampleDetailEditing.tsx
@@ -103,7 +103,7 @@ class SampleDetailEditingImpl extends PureComponent<Props & NotificationsContext
         const rootLsid = model.getRowValue('RootMaterialLSID');
 
         return {
-            schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet, ViewInfo.DETAIL_NAME),
+            schemaQuery: new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet, ViewInfo.DETAIL_NAME),
             baseFilters: [Filter.create('lsid', rootLsid)],
             requiredColumns: ['Name', 'Description', ...SAMPLE_STATUS_REQUIRED_COLUMNS],
             omittedColumns: [IS_ALIQUOT_COL],

--- a/packages/components/src/entities/SampleDetailPage.spec.tsx
+++ b/packages/components/src/entities/SampleDetailPage.spec.tsx
@@ -42,7 +42,7 @@ import { SampleAssayDetail } from './SampleAssayDetail';
 import { SampleLineagePage, SampleLineagePanel } from './SampleLineagePage';
 
 const QUERY_MODEL = makeTestQueryModel(
-    SchemaQuery.create('schema', 'query'),
+    new SchemaQuery('schema', 'query'),
     new QueryInfo(),
     {
         1: {
@@ -60,7 +60,7 @@ const QUERY_MODEL = makeTestQueryModel(
 ).mutate({ queryInfoLoadingState: LoadingState.LOADED, rowsLoadingState: LoadingState.LOADED });
 
 const CHILD_SAMPLE_QUERY_MODEL = makeTestQueryModel(
-    SchemaQuery.create('schema', 'query'),
+    new SchemaQuery('schema', 'query'),
     new QueryInfo(),
     {
         1: {
@@ -161,7 +161,7 @@ describe('SampleDetailPage', () => {
     });
 
     test('NotFound', async () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('schema', 'query'), new QueryInfo(), {}, [], 0).mutate(
+        const queryModel = makeTestQueryModel(new SchemaQuery('schema', 'query'), new QueryInfo(), {}, [], 0).mutate(
             { queryInfoLoadingState: LoadingState.LOADED, rowsLoadingState: LoadingState.LOADED }
         );
         const wrapper = mountWithAppServerContext(

--- a/packages/components/src/entities/SampleDetailPage.tsx
+++ b/packages/components/src/entities/SampleDetailPage.tsx
@@ -201,7 +201,7 @@ export const SampleDetailPage: FC<SampleDetailPageProps> = props => {
     const { params, requiredColumns, sampleType } = props;
     const { id } = params;
     const sampleType_ = sampleType ?? params.sampleType;
-    const schemaQuery = useMemo(() => SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType_), [sampleType_]);
+    const schemaQuery = useMemo(() => new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType_), [sampleType_]);
     const modelId = useMemo(() => createGridModelId('sample-detail', schemaQuery, id), [id, schemaQuery]);
 
     const queryConfigs: QueryConfigMap = useMemo(

--- a/packages/components/src/entities/SampleFinderSection.spec.tsx
+++ b/packages/components/src/entities/SampleFinderSection.spec.tsx
@@ -30,7 +30,7 @@ describe('SampleFinderSection', () => {
                     TestTypeDataType,
                     {
                         ...TestTypeDataType,
-                        typeListingSchemaQuery: SchemaQuery.create('TestClasses', 'query2'),
+                        typeListingSchemaQuery: new SchemaQuery('TestClasses', 'query2'),
                         nounSingular: 'Other',
                         nounAsParentSingular: 'Other Parent',
                     },
@@ -57,7 +57,7 @@ describe('SampleFinderSection', () => {
                     TestTypeDataType,
                     {
                         ...TestTypeDataType,
-                        typeListingSchemaQuery: SchemaQuery.create('TestClasses', 'query2'),
+                        typeListingSchemaQuery: new SchemaQuery('TestClasses', 'query2'),
                         nounSingular: 'Other',
                         nounAsParentSingular: 'Other Parent',
                     },

--- a/packages/components/src/entities/SampleFinderSection.tsx
+++ b/packages/components/src/entities/SampleFinderSection.tsx
@@ -283,7 +283,7 @@ const SampleFinderSectionImpl: FC<Props & InjectedAssayModel> = memo(props => {
                 newFilterCards.push({
                     schemaQuery: isAssay
                         ? entityDataType.getInstanceSchemaQuery(queryName)
-                        : SchemaQuery.create(schemaName, queryLabels[queryName]),
+                        : new SchemaQuery(schemaName, queryLabels[queryName]),
                     filterArray: dataTypeFilters[queryName],
                     entityDataType: chosenEntityType,
                     dataTypeDisplayName: queryLabels[queryName],

--- a/packages/components/src/entities/SampleHeader.spec.tsx
+++ b/packages/components/src/entities/SampleHeader.spec.tsx
@@ -11,7 +11,7 @@ import { SampleHeaderImpl } from './SampleHeader';
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 
 describe('SampleHeader', () => {
-    const SQ = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'TestSampleType');
+    const SQ = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'TestSampleType');
 
     const EMPTY_MODEL = makeTestQueryModel(SQ, undefined, {}, [], 0, 'empty-model').mutate({
         queryInfoLoadingState: LoadingState.LOADED,

--- a/packages/components/src/entities/SampleListingPage.spec.tsx
+++ b/packages/components/src/entities/SampleListingPage.spec.tsx
@@ -51,7 +51,7 @@ import { SampleTypeInsightsPanel } from './SampleTypeInsightsPanel';
 import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SampleSetDeleteModal } from './SampleSetDeleteModal';
 
-const SQ = SchemaQuery.create('schema', 'query');
+const SQ = new SchemaQuery('schema', 'query');
 
 beforeAll(() => {
     initBrowserHistoryState();

--- a/packages/components/src/entities/SampleListingPage.tsx
+++ b/packages/components/src/entities/SampleListingPage.tsx
@@ -91,7 +91,7 @@ export const SamplesImportSuccessMessage: FC<SamplesImportSuccessMessageProps> =
         try {
             selectGridIdsFromTransactionId(
                 sampleListingGridId,
-                SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType),
+                new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType),
                 transactionAuditId,
                 SAMPLES_KEY,
                 actions
@@ -321,9 +321,9 @@ export const SampleListingPageBody: FC<SampleListingPageBodyProps> = props => {
             setShowPrintDialog(false);
             createNotification(
                 'Successfully printed ' +
-                    numLabels +
-                    (numSamples === 0 ? ' blank ' : '') +
-                    (numLabels > 1 ? ' labels.' : ' label.')
+                numLabels +
+                (numSamples === 0 ? ' blank ' : '') +
+                (numLabels > 1 ? ' labels.' : ' label.')
             );
         },
         [createNotification]
@@ -458,7 +458,7 @@ const SampleListingPageWithQueryModels = withRouteLeave(withQueryModels(SampleLi
 export const SampleListingPage: FC<CommonPageProps & WithRouterProps> = props => {
     const { params, location } = props;
     const { sampleType } = params;
-    const listSchemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType);
+    const listSchemaQuery = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType);
     const sampleListModelId = createGridModelId(SAMPLES_LISTING_GRID_ID, listSchemaQuery);
     const key = sampleType + (location.query?.importInProgress ? '-importing' : ''); // Issue 43154
     const { samplesGridRequiredColumns } = useSampleTypeAppContext();

--- a/packages/components/src/entities/SampleListingPage.tsx
+++ b/packages/components/src/entities/SampleListingPage.tsx
@@ -161,7 +161,7 @@ export const SampleListingPageBody: FC<SampleListingPageBodyProps> = props => {
         if (!isLoaded) return;
 
         const { createdSampleCount, importFile, importedSampleCount, transactionAuditId } = props.location?.query;
-        const _sampleType = listModel.schemaQuery.getQuery();
+        const _sampleType = listModel.schemaQuery.queryName;
 
         if (transactionAuditId) {
             const createdCount = parseInt(createdSampleCount, 10);

--- a/packages/components/src/entities/SampleOverviewPanel.spec.tsx
+++ b/packages/components/src/entities/SampleOverviewPanel.spec.tsx
@@ -19,7 +19,7 @@ import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleAliquotsSummary } from './SampleAliquotsSummary';
 import { SampleDetailEditing } from './SampleDetailEditing';
 
-const SQ = SchemaQuery.create('schema', 'query');
+const SQ = new SchemaQuery('schema', 'query');
 const ROW = {
     Folder: { value: TEST_PROJECT_CONTAINER.id },
     RowId: { value: 1 },

--- a/packages/components/src/entities/SampleTypeDesignPage.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.tsx
@@ -99,7 +99,7 @@ export const SampleTypeDesignPage: FC<Props> = memo(props => {
         return query;
     }, [isMedia, params, routes]);
 
-    const schemaQuery = useMemo(() => SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, queryName), [queryName]);
+    const schemaQuery = useMemo(() => new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, queryName), [queryName]);
 
     const init = async () => {
         if (queryName) {

--- a/packages/components/src/entities/SampleTypeInsightsPanel.spec.tsx
+++ b/packages/components/src/entities/SampleTypeInsightsPanel.spec.tsx
@@ -14,7 +14,7 @@ import { LabelHelpTip } from '../internal/components/base/LabelHelpTip';
 import { INSIGHTS_MODEL_ID, SampleTypeInsightsPanelImpl, STATUS_COUNTS_MODEL_ID } from './SampleTypeInsightsPanel';
 
 describe('SampleTypeInsightsPanel', () => {
-    const SQ = SchemaQuery.create('schema', 'query');
+    const SQ = new SchemaQuery('schema', 'query');
     const MODEL_NO_ROWS = makeTestQueryModel(SQ, new QueryInfo(), {}, [], 0).mutate({
         queryInfoLoadingState: LoadingState.LOADED,
         rowsLoadingState: LoadingState.LOADED,

--- a/packages/components/src/entities/SampleTypeTemplateDownloadRenderer.tsx
+++ b/packages/components/src/entities/SampleTypeTemplateDownloadRenderer.tsx
@@ -21,7 +21,7 @@ interface Props {
 export class SampleTypeTemplateDownloadRenderer extends React.PureComponent<Props> {
     onDownload = () => {
         const { row, excludeColumns } = this.props;
-        const schemaQuery = SchemaQuery.create(
+        const schemaQuery = new SchemaQuery(
             SCHEMAS.SAMPLE_SETS.SCHEMA,
             row.getIn(['Name', 'value']) ?? row.getIn(['name', 'value'])
         );

--- a/packages/components/src/entities/SamplesAddButton.spec.tsx
+++ b/packages/components/src/entities/SamplesAddButton.spec.tsx
@@ -15,7 +15,7 @@ import { SamplesAddButton } from './SamplesAddButton';
 describe('SamplesAddButton', () => {
     const DEFAULT_PROPS = {
         model: makeTestQueryModel(
-            SchemaQuery.create('schema', 'query'),
+            new SchemaQuery('schema', 'query'),
             QueryInfo.create({ importUrl: 'testimporturl', insertUrl: 'testinserturl' })
         ),
     };
@@ -81,7 +81,7 @@ describe('SamplesAddButton', () => {
 
     test('not showInsertNewButton on queryInfo', () => {
         const model = makeTestQueryModel(
-            SchemaQuery.create('schema', 'query'),
+            new SchemaQuery('schema', 'query'),
             QueryInfo.create({ importUrl: 'testimporturl', insertUrl: 'testinserturl', showInsertNewButton: false })
         );
         const wrapper = mountWithServerContext(<SamplesAddButton {...DEFAULT_PROPS} model={model} />, {
@@ -93,7 +93,7 @@ describe('SamplesAddButton', () => {
 
     test('no importUrl on queryInfo', () => {
         const model = makeTestQueryModel(
-            SchemaQuery.create('schema', 'query'),
+            new SchemaQuery('schema', 'query'),
             QueryInfo.create({ importUrl: undefined, insertUrl: 'testinserturl' })
         );
         const wrapper = mountWithServerContext(<SamplesAddButton {...DEFAULT_PROPS} model={model} />, {
@@ -105,7 +105,7 @@ describe('SamplesAddButton', () => {
 
     test('asSubMenu', () => {
         const model = makeTestQueryModel(
-            SchemaQuery.create('schema', 'query'),
+            new SchemaQuery('schema', 'query'),
             QueryInfo.create({ importUrl: undefined, insertUrl: 'testinserturl' })
         );
         const wrapper = mountWithServerContext(<SamplesAddButton {...DEFAULT_PROPS} model={model} asSubMenu />, {

--- a/packages/components/src/entities/SamplesAssayButton.spec.tsx
+++ b/packages/components/src/entities/SamplesAssayButton.spec.tsx
@@ -55,7 +55,7 @@ describe('SamplesAssayButton', () => {
 
     test('not isSamplesSchema', () => {
         const model = makeTestQueryModel(
-            SchemaQuery.create('schema', 'query'),
+            new SchemaQuery('schema', 'query'),
             QueryInfo.create({ importUrl: 'testimporturl', insertUrl: 'testinserturl' })
         ).mutate({ selections: new Set(['1']) });
         const wrapper = mountWithServerContext(<SamplesAssayButtonImpl {...DEFAULT_PROPS} model={model} />, {

--- a/packages/components/src/entities/SamplesBulkUpdateForm.spec.tsx
+++ b/packages/components/src/entities/SamplesBulkUpdateForm.spec.tsx
@@ -76,7 +76,7 @@ describe('SamplesBulkUpdateForm', () => {
     const samplesSelection = fromJS(['1', '2', '3']);
 
     const DEFAULT_PROPS = {
-        queryModel: makeTestQueryModel(SchemaQuery.create('schema', 'query'), QUERY_INFO).mutate({
+        queryModel: makeTestQueryModel(new SchemaQuery('schema', 'query'), QUERY_INFO).mutate({
             urlPrefix: 'Sample1',
             selections: new Set(['1', '2', '3']),
         }),

--- a/packages/components/src/entities/SamplesCreatedSuccessMessage.tsx
+++ b/packages/components/src/entities/SamplesCreatedSuccessMessage.tsx
@@ -18,7 +18,7 @@ async function selectSamplesAndAddToStorage(
     sampleListingGridId: string,
     actions: Actions
 ): Promise<AppURL> {
-    const schemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, targetSampleTypeName);
+    const schemaQuery = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, targetSampleTypeName);
 
     const selected = await selectGridIdsFromTransactionId(
         sampleListingGridId,
@@ -85,7 +85,7 @@ const SamplesCreatedSuccessMessageImpl: FC<SamplesCreatedSuccessMessageProps & W
         try {
             selectGridIdsFromTransactionId(
                 sampleListingGridId,
-                SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType),
+                new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType),
                 transactionAuditId,
                 SAMPLES_KEY,
                 actions

--- a/packages/components/src/entities/SamplesDeriveButton.spec.tsx
+++ b/packages/components/src/entities/SamplesDeriveButton.spec.tsx
@@ -16,7 +16,7 @@ import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 describe('SamplesDeriveButton', () => {
     function defaultProps(): SamplesDeriveButtonProps {
         return {
-            model: makeTestQueryModel(SchemaQuery.create('schema', 'query')),
+            model: makeTestQueryModel(new SchemaQuery('schema', 'query')),
             isSelectingSamples: jest.fn().mockReturnValue(true),
         };
     }
@@ -55,7 +55,7 @@ describe('SamplesDeriveButton', () => {
     });
 
     test('over max selections', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             selections: new Set(Array.from(Array(1001).keys()).map(key => key + '')),
         });
         const wrapper = mountWithServerContext(<SamplesDeriveButton {...defaultProps()} model={model} />, {

--- a/packages/components/src/entities/SamplesEditButton.spec.tsx
+++ b/packages/components/src/entities/SamplesEditButton.spec.tsx
@@ -30,7 +30,7 @@ describe('SamplesEditButton', () => {
         showInsertNewButton: true,
         importUrl: 'test',
         importUrlDisabled: false,
-        schemaQuery: SchemaQuery.create('schema', 'query'),
+        schemaQuery: new SchemaQuery('schema', 'query'),
     });
 
     function validate(
@@ -52,7 +52,7 @@ describe('SamplesEditButton', () => {
 
     const DEFAULT_PROPS = {
         parentEntityDataTypes: [DataClassDataType, SampleTypeDataType],
-        model: makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+        model: makeTestQueryModel(new SchemaQuery('schema', 'query'), queryInfo).mutate({
             queryInfoLoadingState: LoadingState.LOADED,
             rowsLoadingState: LoadingState.LOADED,
         }),
@@ -67,7 +67,7 @@ describe('SamplesEditButton', () => {
 
     test('loading', () => {
         const wrapper = mountWithServerContext(
-            <SamplesEditButton {...DEFAULT_PROPS} model={makeTestQueryModel(SchemaQuery.create('schema', 'query'))} />,
+            <SamplesEditButton {...DEFAULT_PROPS} model={makeTestQueryModel(new SchemaQuery('schema', 'query'))} />,
             { user: TEST_USER_EDITOR }
         );
         validate(wrapper, false);
@@ -115,7 +115,7 @@ describe('SamplesEditButton', () => {
 
     test('not showImportDataButton', () => {
         const queryInfo2 = new QueryInfo({ showInsertNewButton: false });
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo2).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query'), queryInfo2).mutate({
             queryInfoLoadingState: LoadingState.LOADED,
             rowsLoadingState: LoadingState.LOADED,
         });

--- a/packages/components/src/entities/SamplesEditableGrid.tsx
+++ b/packages/components/src/entities/SamplesEditableGrid.tsx
@@ -56,7 +56,7 @@ const SAMPLES_EDIT_GRID_ID = 'update-samples-grid';
 const SAMPLES_STORAGE_EDIT_GRID_ID = 'update-samples-storage-grid';
 const SAMPLES_LINEAGE_EDIT_GRID_ID = 'update-samples-lineage-grid';
 
-const INVENTORY_ITEM_QS = SchemaQuery.create('inventory', 'item');
+const INVENTORY_ITEM_QS = new SchemaQuery('inventory', 'item');
 
 interface State {
     consumedStatusIds: number[];

--- a/packages/components/src/entities/SamplesTabbedGridPanel.spec.tsx
+++ b/packages/components/src/entities/SamplesTabbedGridPanel.spec.tsx
@@ -17,7 +17,7 @@ import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 import { SamplesBulkUpdateForm } from './SamplesBulkUpdateForm';
 import { SamplesEditableGrid } from './SamplesEditableGrid';
 
-const SQ = SchemaQuery.create('schema', 'query');
+const SQ = new SchemaQuery('schema', 'query');
 const QI = QueryInfo.create({ title: 'Test title' });
 
 const QM1 = makeTestQueryModel(SQ, QI);

--- a/packages/components/src/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/entities/SingleParentEntityPanel.tsx
@@ -108,7 +108,7 @@ class SingleParentEntity extends PureComponent<SingleParentEntityProps> {
         let parentSchemaQuery;
         if (chosenType && parentTypeOptions) {
             // use the detail view, so we get all parents, even if the default view has been filtered
-            parentSchemaQuery = SchemaQuery.create(chosenType.schema, chosenType.query, ViewInfo.DETAIL_NAME);
+            parentSchemaQuery = new SchemaQuery(chosenType.schema, chosenType.query, ViewInfo.DETAIL_NAME);
         }
 
         let value = chosenValue ?? undefined;
@@ -277,7 +277,7 @@ export const SingleParentEntityPanel: FC<Props> = memo(props => {
                 baseFilters: parentLSIDs?.length > 0 ? [Filter.create('LSID', parentLSIDs, Filter.Types.IN)] : [],
                 bindURL: false,
                 containerPath,
-                schemaQuery: SchemaQuery.create(chosenType.schema, chosenType.query, ViewInfo.DETAIL_NAME),
+                schemaQuery: new SchemaQuery(chosenType.schema, chosenType.query, ViewInfo.DETAIL_NAME),
                 omittedColumns: ['Run'],
                 requiredColumns: ['Name'],
             },

--- a/packages/components/src/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
+++ b/packages/components/src/entities/__snapshots__/ParentEntityEditPanel.spec.tsx.snap
@@ -6,9 +6,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
   cancelText="Cancel"
   childNounSingular="Testing"
   childSchemaQuery={
-    Immutable.Record {
-      "schemaName": "samples",
+    SchemaQuery {
       "queryName": "example",
+      "schemaName": "samples",
       "viewName": undefined,
     }
   }
@@ -28,9 +28,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
         "inputTypeValueField": "rowId",
         "insertColumnNamePrefix": "DataInputs/",
         "instanceSchemaName": "exp.data",
-        "listingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "listingSchemaQuery": SchemaQuery {
           "queryName": "Data",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "nounAsParentPlural": "Data Types",
@@ -40,9 +40,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
         "operationConfirmationControllerName": "experiment",
         "typeIcon": "source_type",
-        "typeListingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "typeListingSchemaQuery": SchemaQuery {
           "queryName": "DataClasses",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "typeNounAsParentSingular": "Data Type",
@@ -136,9 +136,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                       "inputTypeValueField": "rowId",
                       "insertColumnNamePrefix": "DataInputs/",
                       "instanceSchemaName": "exp.data",
-                      "listingSchemaQuery": Immutable.Record {
-                        "schemaName": "exp",
+                      "listingSchemaQuery": SchemaQuery {
                         "queryName": "Data",
+                        "schemaName": "exp",
                         "viewName": undefined,
                       },
                       "nounAsParentPlural": "Data Types",
@@ -148,9 +148,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                       "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                       "operationConfirmationControllerName": "experiment",
                       "typeIcon": "source_type",
-                      "typeListingSchemaQuery": Immutable.Record {
-                        "schemaName": "exp",
+                      "typeListingSchemaQuery": SchemaQuery {
                         "queryName": "DataClasses",
+                        "schemaName": "exp",
                         "viewName": undefined,
                       },
                       "typeNounAsParentSingular": "Data Type",
@@ -182,9 +182,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                         "inputTypeValueField": "rowId",
                         "insertColumnNamePrefix": "DataInputs/",
                         "instanceSchemaName": "exp.data",
-                        "listingSchemaQuery": Immutable.Record {
-                          "schemaName": "exp",
+                        "listingSchemaQuery": SchemaQuery {
                           "queryName": "Data",
+                          "schemaName": "exp",
                           "viewName": undefined,
                         },
                         "nounAsParentPlural": "Data Types",
@@ -194,9 +194,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                         "operationConfirmationControllerName": "experiment",
                         "typeIcon": "source_type",
-                        "typeListingSchemaQuery": Immutable.Record {
-                          "schemaName": "exp",
+                        "typeListingSchemaQuery": SchemaQuery {
                           "queryName": "DataClasses",
+                          "schemaName": "exp",
                           "viewName": undefined,
                         },
                         "typeNounAsParentSingular": "Data Type",
@@ -242,9 +242,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                           "inputTypeValueField": "rowId",
                           "insertColumnNamePrefix": "DataInputs/",
                           "instanceSchemaName": "exp.data",
-                          "listingSchemaQuery": Immutable.Record {
-                            "schemaName": "exp",
+                          "listingSchemaQuery": SchemaQuery {
                             "queryName": "Data",
+                            "schemaName": "exp",
                             "viewName": undefined,
                           },
                           "nounAsParentPlural": "Data Types",
@@ -254,9 +254,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                           "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                           "operationConfirmationControllerName": "experiment",
                           "typeIcon": "source_type",
-                          "typeListingSchemaQuery": Immutable.Record {
-                            "schemaName": "exp",
+                          "typeListingSchemaQuery": SchemaQuery {
                             "queryName": "DataClasses",
+                            "schemaName": "exp",
                             "viewName": undefined,
                           },
                           "typeNounAsParentSingular": "Data Type",
@@ -316,9 +316,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                             "inputTypeValueField": "rowId",
                             "insertColumnNamePrefix": "DataInputs/",
                             "instanceSchemaName": "exp.data",
-                            "listingSchemaQuery": Immutable.Record {
-                              "schemaName": "exp",
+                            "listingSchemaQuery": SchemaQuery {
                               "queryName": "Data",
+                              "schemaName": "exp",
                               "viewName": undefined,
                             },
                             "nounAsParentPlural": "Data Types",
@@ -328,9 +328,9 @@ exports[`ParentEntityEditPanel editing, no data 1`] = `
                             "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                             "operationConfirmationControllerName": "experiment",
                             "typeIcon": "source_type",
-                            "typeListingSchemaQuery": Immutable.Record {
-                              "schemaName": "exp",
+                            "typeListingSchemaQuery": SchemaQuery {
                               "queryName": "DataClasses",
+                              "schemaName": "exp",
                               "viewName": undefined,
                             },
                             "typeNounAsParentSingular": "Data Type",
@@ -4799,9 +4799,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
   cancelText="Cancel"
   childNounSingular="Testing"
   childSchemaQuery={
-    Immutable.Record {
-      "schemaName": "samples",
+    SchemaQuery {
       "queryName": "example",
+      "schemaName": "samples",
       "viewName": undefined,
     }
   }
@@ -4821,9 +4821,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
         "inputTypeValueField": "rowId",
         "insertColumnNamePrefix": "DataInputs/",
         "instanceSchemaName": "exp.data",
-        "listingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "listingSchemaQuery": SchemaQuery {
           "queryName": "Data",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "nounAsParentPlural": "Data Types",
@@ -4833,9 +4833,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
         "operationConfirmationControllerName": "experiment",
         "typeIcon": "source_type",
-        "typeListingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "typeListingSchemaQuery": SchemaQuery {
           "queryName": "DataClasses",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "typeNounAsParentSingular": "Data Type",
@@ -4939,9 +4939,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                       "inputTypeValueField": "rowId",
                       "insertColumnNamePrefix": "DataInputs/",
                       "instanceSchemaName": "exp.data",
-                      "listingSchemaQuery": Immutable.Record {
-                        "schemaName": "exp",
+                      "listingSchemaQuery": SchemaQuery {
                         "queryName": "Data",
+                        "schemaName": "exp",
                         "viewName": undefined,
                       },
                       "nounAsParentPlural": "Data Types",
@@ -4951,9 +4951,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                       "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                       "operationConfirmationControllerName": "experiment",
                       "typeIcon": "source_type",
-                      "typeListingSchemaQuery": Immutable.Record {
-                        "schemaName": "exp",
+                      "typeListingSchemaQuery": SchemaQuery {
                         "queryName": "DataClasses",
+                        "schemaName": "exp",
                         "viewName": undefined,
                       },
                       "typeNounAsParentSingular": "Data Type",
@@ -4985,9 +4985,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                         "inputTypeValueField": "rowId",
                         "insertColumnNamePrefix": "DataInputs/",
                         "instanceSchemaName": "exp.data",
-                        "listingSchemaQuery": Immutable.Record {
-                          "schemaName": "exp",
+                        "listingSchemaQuery": SchemaQuery {
                           "queryName": "Data",
+                          "schemaName": "exp",
                           "viewName": undefined,
                         },
                         "nounAsParentPlural": "Data Types",
@@ -4997,9 +4997,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                         "operationConfirmationControllerName": "experiment",
                         "typeIcon": "source_type",
-                        "typeListingSchemaQuery": Immutable.Record {
-                          "schemaName": "exp",
+                        "typeListingSchemaQuery": SchemaQuery {
                           "queryName": "DataClasses",
+                          "schemaName": "exp",
                           "viewName": undefined,
                         },
                         "typeNounAsParentSingular": "Data Type",
@@ -5045,9 +5045,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                           "inputTypeValueField": "rowId",
                           "insertColumnNamePrefix": "DataInputs/",
                           "instanceSchemaName": "exp.data",
-                          "listingSchemaQuery": Immutable.Record {
-                            "schemaName": "exp",
+                          "listingSchemaQuery": SchemaQuery {
                             "queryName": "Data",
+                            "schemaName": "exp",
                             "viewName": undefined,
                           },
                           "nounAsParentPlural": "Data Types",
@@ -5057,9 +5057,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                           "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                           "operationConfirmationControllerName": "experiment",
                           "typeIcon": "source_type",
-                          "typeListingSchemaQuery": Immutable.Record {
-                            "schemaName": "exp",
+                          "typeListingSchemaQuery": SchemaQuery {
                             "queryName": "DataClasses",
+                            "schemaName": "exp",
                             "viewName": undefined,
                           },
                           "typeNounAsParentSingular": "Data Type",
@@ -5119,9 +5119,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                             "inputTypeValueField": "rowId",
                             "insertColumnNamePrefix": "DataInputs/",
                             "instanceSchemaName": "exp.data",
-                            "listingSchemaQuery": Immutable.Record {
-                              "schemaName": "exp",
+                            "listingSchemaQuery": SchemaQuery {
                               "queryName": "Data",
+                              "schemaName": "exp",
                               "viewName": undefined,
                             },
                             "nounAsParentPlural": "Data Types",
@@ -5131,9 +5131,9 @@ exports[`ParentEntityEditPanel error state 1`] = `
                             "operationConfirmationActionName": "getDataOperationConfirmationData.api",
                             "operationConfirmationControllerName": "experiment",
                             "typeIcon": "source_type",
-                            "typeListingSchemaQuery": Immutable.Record {
-                              "schemaName": "exp",
+                            "typeListingSchemaQuery": SchemaQuery {
                               "queryName": "DataClasses",
+                              "schemaName": "exp",
                               "viewName": undefined,
                             },
                             "typeNounAsParentSingular": "Data Type",
@@ -5203,9 +5203,9 @@ exports[`ParentEntityEditPanel loading state 1`] = `
   cancelText="Cancel"
   childNounSingular="Testing"
   childSchemaQuery={
-    Immutable.Record {
-      "schemaName": "samples",
+    SchemaQuery {
       "queryName": "example",
+      "schemaName": "samples",
       "viewName": undefined,
     }
   }
@@ -5225,9 +5225,9 @@ exports[`ParentEntityEditPanel loading state 1`] = `
         "inputTypeValueField": "rowId",
         "insertColumnNamePrefix": "DataInputs/",
         "instanceSchemaName": "exp.data",
-        "listingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "listingSchemaQuery": SchemaQuery {
           "queryName": "Data",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "nounAsParentPlural": "Data Types",
@@ -5237,9 +5237,9 @@ exports[`ParentEntityEditPanel loading state 1`] = `
         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
         "operationConfirmationControllerName": "experiment",
         "typeIcon": "source_type",
-        "typeListingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "typeListingSchemaQuery": SchemaQuery {
           "queryName": "DataClasses",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "typeNounAsParentSingular": "Data Type",

--- a/packages/components/src/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -18,9 +18,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
       "inputTypeValueField": "rowId",
       "insertColumnNamePrefix": "DataInputs/",
       "instanceSchemaName": "exp.data",
-      "listingSchemaQuery": Immutable.Record {
-        "schemaName": "exp",
+      "listingSchemaQuery": SchemaQuery {
         "queryName": "Data",
+        "schemaName": "exp",
         "viewName": undefined,
       },
       "nounAsParentPlural": "Data Types",
@@ -30,9 +30,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
       "operationConfirmationActionName": "getDataOperationConfirmationData.api",
       "operationConfirmationControllerName": "experiment",
       "typeIcon": "source_type",
-      "typeListingSchemaQuery": Immutable.Record {
-        "schemaName": "exp",
+      "typeListingSchemaQuery": SchemaQuery {
         "queryName": "DataClasses",
+        "schemaName": "exp",
         "viewName": undefined,
       },
       "typeNounAsParentSingular": "Data Type",
@@ -88,9 +88,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
         "inputTypeValueField": "rowId",
         "insertColumnNamePrefix": "DataInputs/",
         "instanceSchemaName": "exp.data",
-        "listingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "listingSchemaQuery": SchemaQuery {
           "queryName": "Data",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "nounAsParentPlural": "Data Types",
@@ -100,9 +100,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
         "operationConfirmationControllerName": "experiment",
         "typeIcon": "source_type",
-        "typeListingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "typeListingSchemaQuery": SchemaQuery {
           "queryName": "DataClasses",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "typeNounAsParentSingular": "Data Type",
@@ -172,9 +172,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
           "inputTypeValueField": "rowId",
           "insertColumnNamePrefix": "DataInputs/",
           "instanceSchemaName": "exp.data",
-          "listingSchemaQuery": Immutable.Record {
-            "schemaName": "exp",
+          "listingSchemaQuery": SchemaQuery {
             "queryName": "Data",
+            "schemaName": "exp",
             "viewName": undefined,
           },
           "nounAsParentPlural": "Data Types",
@@ -184,9 +184,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
           "operationConfirmationActionName": "getDataOperationConfirmationData.api",
           "operationConfirmationControllerName": "experiment",
           "typeIcon": "source_type",
-          "typeListingSchemaQuery": Immutable.Record {
-            "schemaName": "exp",
+          "typeListingSchemaQuery": SchemaQuery {
             "queryName": "DataClasses",
+            "schemaName": "exp",
             "viewName": undefined,
           },
           "typeNounAsParentSingular": "Data Type",
@@ -270,9 +270,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
             "inputTypeValueField": "rowId",
             "insertColumnNamePrefix": "DataInputs/",
             "instanceSchemaName": "exp.data",
-            "listingSchemaQuery": Immutable.Record {
-              "schemaName": "exp",
+            "listingSchemaQuery": SchemaQuery {
               "queryName": "Data",
+              "schemaName": "exp",
               "viewName": undefined,
             },
             "nounAsParentPlural": "Data Types",
@@ -282,9 +282,9 @@ exports[`<SingleParentEntityPanel> empty state editing 1`] = `
             "operationConfirmationActionName": "getDataOperationConfirmationData.api",
             "operationConfirmationControllerName": "experiment",
             "typeIcon": "source_type",
-            "typeListingSchemaQuery": Immutable.Record {
-              "schemaName": "exp",
+            "typeListingSchemaQuery": SchemaQuery {
               "queryName": "DataClasses",
+              "schemaName": "exp",
               "viewName": undefined,
             },
             "typeNounAsParentSingular": "Data Type",
@@ -5310,9 +5310,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
       "inputTypeValueField": "rowId",
       "insertColumnNamePrefix": "DataInputs/",
       "instanceSchemaName": "exp.data",
-      "listingSchemaQuery": Immutable.Record {
-        "schemaName": "exp",
+      "listingSchemaQuery": SchemaQuery {
         "queryName": "Data",
+        "schemaName": "exp",
         "viewName": undefined,
       },
       "nounAsParentPlural": "Data Types",
@@ -5322,9 +5322,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
       "operationConfirmationActionName": "getDataOperationConfirmationData.api",
       "operationConfirmationControllerName": "experiment",
       "typeIcon": "source_type",
-      "typeListingSchemaQuery": Immutable.Record {
-        "schemaName": "exp",
+      "typeListingSchemaQuery": SchemaQuery {
         "queryName": "DataClasses",
+        "schemaName": "exp",
         "viewName": undefined,
       },
       "typeNounAsParentSingular": "Data Type",
@@ -5380,9 +5380,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
         "inputTypeValueField": "rowId",
         "insertColumnNamePrefix": "DataInputs/",
         "instanceSchemaName": "exp.data",
-        "listingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "listingSchemaQuery": SchemaQuery {
           "queryName": "Data",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "nounAsParentPlural": "Data Types",
@@ -5392,9 +5392,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
         "operationConfirmationControllerName": "experiment",
         "typeIcon": "source_type",
-        "typeListingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "typeListingSchemaQuery": SchemaQuery {
           "queryName": "DataClasses",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "typeNounAsParentSingular": "Data Type",
@@ -5464,9 +5464,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
           "inputTypeValueField": "rowId",
           "insertColumnNamePrefix": "DataInputs/",
           "instanceSchemaName": "exp.data",
-          "listingSchemaQuery": Immutable.Record {
-            "schemaName": "exp",
+          "listingSchemaQuery": SchemaQuery {
             "queryName": "Data",
+            "schemaName": "exp",
             "viewName": undefined,
           },
           "nounAsParentPlural": "Data Types",
@@ -5476,9 +5476,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
           "operationConfirmationActionName": "getDataOperationConfirmationData.api",
           "operationConfirmationControllerName": "experiment",
           "typeIcon": "source_type",
-          "typeListingSchemaQuery": Immutable.Record {
-            "schemaName": "exp",
+          "typeListingSchemaQuery": SchemaQuery {
             "queryName": "DataClasses",
+            "schemaName": "exp",
             "viewName": undefined,
           },
           "typeNounAsParentSingular": "Data Type",
@@ -5562,9 +5562,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
             "inputTypeValueField": "rowId",
             "insertColumnNamePrefix": "DataInputs/",
             "instanceSchemaName": "exp.data",
-            "listingSchemaQuery": Immutable.Record {
-              "schemaName": "exp",
+            "listingSchemaQuery": SchemaQuery {
               "queryName": "Data",
+              "schemaName": "exp",
               "viewName": undefined,
             },
             "nounAsParentPlural": "Data Types",
@@ -5574,9 +5574,9 @@ exports[`<SingleParentEntityPanel> empty state not editing 1`] = `
             "operationConfirmationActionName": "getDataOperationConfirmationData.api",
             "operationConfirmationControllerName": "experiment",
             "typeIcon": "source_type",
-            "typeListingSchemaQuery": Immutable.Record {
-              "schemaName": "exp",
+            "typeListingSchemaQuery": SchemaQuery {
               "queryName": "DataClasses",
+              "schemaName": "exp",
               "viewName": undefined,
             },
             "typeNounAsParentSingular": "Data Type",
@@ -5682,9 +5682,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
       "inputTypeValueField": "rowId",
       "insertColumnNamePrefix": "DataInputs/",
       "instanceSchemaName": "exp.data",
-      "listingSchemaQuery": Immutable.Record {
-        "schemaName": "exp",
+      "listingSchemaQuery": SchemaQuery {
         "queryName": "Data",
+        "schemaName": "exp",
         "viewName": undefined,
       },
       "nounAsParentPlural": "Data Types",
@@ -5694,9 +5694,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
       "operationConfirmationActionName": "getDataOperationConfirmationData.api",
       "operationConfirmationControllerName": "experiment",
       "typeIcon": "source_type",
-      "typeListingSchemaQuery": Immutable.Record {
-        "schemaName": "exp",
+      "typeListingSchemaQuery": SchemaQuery {
         "queryName": "DataClasses",
+        "schemaName": "exp",
         "viewName": undefined,
       },
       "typeNounAsParentSingular": "Data Type",
@@ -5781,9 +5781,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
         "inputTypeValueField": "rowId",
         "insertColumnNamePrefix": "DataInputs/",
         "instanceSchemaName": "exp.data",
-        "listingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "listingSchemaQuery": SchemaQuery {
           "queryName": "Data",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "nounAsParentPlural": "Data Types",
@@ -5793,9 +5793,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
         "operationConfirmationActionName": "getDataOperationConfirmationData.api",
         "operationConfirmationControllerName": "experiment",
         "typeIcon": "source_type",
-        "typeListingSchemaQuery": Immutable.Record {
-          "schemaName": "exp",
+        "typeListingSchemaQuery": SchemaQuery {
           "queryName": "DataClasses",
+          "schemaName": "exp",
           "viewName": undefined,
         },
         "typeNounAsParentSingular": "Data Type",
@@ -5884,9 +5884,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
           "requiredColumns": [
             "Name",
           ],
-          "schemaQuery": Immutable.Record {
-            "schemaName": "exp.data",
+          "schemaQuery": SchemaQuery {
             "queryName": "Second Source",
+            "schemaName": "exp.data",
             "viewName": "~~DETAILS~~",
           },
         },
@@ -5939,9 +5939,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
           "inputTypeValueField": "rowId",
           "insertColumnNamePrefix": "DataInputs/",
           "instanceSchemaName": "exp.data",
-          "listingSchemaQuery": Immutable.Record {
-            "schemaName": "exp",
+          "listingSchemaQuery": SchemaQuery {
             "queryName": "Data",
+            "schemaName": "exp",
             "viewName": undefined,
           },
           "nounAsParentPlural": "Data Types",
@@ -5951,9 +5951,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
           "operationConfirmationActionName": "getDataOperationConfirmationData.api",
           "operationConfirmationControllerName": "experiment",
           "typeIcon": "source_type",
-          "typeListingSchemaQuery": Immutable.Record {
-            "schemaName": "exp",
+          "typeListingSchemaQuery": SchemaQuery {
             "queryName": "DataClasses",
+            "schemaName": "exp",
             "viewName": undefined,
           },
           "typeNounAsParentSingular": "Data Type",
@@ -6042,9 +6042,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             "requiredColumns": [
               "Name",
             ],
-            "schemaQuery": Immutable.Record {
-              "schemaName": "exp.data",
+            "schemaQuery": SchemaQuery {
               "queryName": "Second Source",
+              "schemaName": "exp.data",
               "viewName": "~~DETAILS~~",
             },
           },
@@ -6111,9 +6111,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             "inputTypeValueField": "rowId",
             "insertColumnNamePrefix": "DataInputs/",
             "instanceSchemaName": "exp.data",
-            "listingSchemaQuery": Immutable.Record {
-              "schemaName": "exp",
+            "listingSchemaQuery": SchemaQuery {
               "queryName": "Data",
+              "schemaName": "exp",
               "viewName": undefined,
             },
             "nounAsParentPlural": "Data Types",
@@ -6123,9 +6123,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             "operationConfirmationActionName": "getDataOperationConfirmationData.api",
             "operationConfirmationControllerName": "experiment",
             "typeIcon": "source_type",
-            "typeListingSchemaQuery": Immutable.Record {
-              "schemaName": "exp",
+            "typeListingSchemaQuery": SchemaQuery {
               "queryName": "DataClasses",
+              "schemaName": "exp",
               "viewName": undefined,
             },
             "typeNounAsParentSingular": "Data Type",
@@ -6235,9 +6235,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
               "rows": undefined,
               "rowsError": undefined,
               "rowsLoadingState": "INITIALIZED",
-              "schemaQuery": Immutable.Record {
-                "schemaName": "exp.data",
+              "schemaQuery": SchemaQuery {
                 "queryName": "Second Source",
+                "schemaName": "exp.data",
                 "viewName": "~~DETAILS~~",
               },
               "selectedReportId": undefined,
@@ -6370,9 +6370,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                 "rows": undefined,
                 "rowsError": undefined,
                 "rowsLoadingState": "INITIALIZED",
-                "schemaQuery": Immutable.Record {
-                  "schemaName": "exp.data",
+                "schemaQuery": SchemaQuery {
                   "queryName": "Second Source",
+                  "schemaName": "exp.data",
                   "viewName": "~~DETAILS~~",
                 },
                 "selectedReportId": undefined,
@@ -6486,9 +6486,9 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                     "rows": undefined,
                     "rowsError": undefined,
                     "rowsLoadingState": "INITIALIZED",
-                    "schemaQuery": Immutable.Record {
-                      "schemaName": "exp.data",
+                    "schemaQuery": SchemaQuery {
                       "queryName": "Second Source",
+                      "schemaName": "exp.data",
                       "viewName": "~~DETAILS~~",
                     },
                     "selectedReportId": undefined,

--- a/packages/components/src/entities/utils.spec.tsx
+++ b/packages/components/src/entities/utils.spec.tsx
@@ -393,10 +393,10 @@ describe('getSampleTypeTemplateUrl', () => {
 
 describe('createEntityParentKey', () => {
     test('without id', () => {
-        expect(createEntityParentKey(SchemaQuery.create('schema', 'query'))).toBe('schema:query');
+        expect(createEntityParentKey(new SchemaQuery('schema', 'query'))).toBe('schema:query');
     });
     test('with id', () => {
-        expect(createEntityParentKey(SchemaQuery.create('schema', 'query'), 'id')).toBe('schema:query:id');
+        expect(createEntityParentKey(new SchemaQuery('schema', 'query'), 'id')).toBe('schema:query:id');
     });
 });
 
@@ -914,7 +914,7 @@ describe('getUpdatedLineageRowsForBulkEdit', () => {
 
 describe('getImportItemsForAssayDefinitions', () => {
     test('empty list', () => {
-        const sampleModel = makeTestQueryModel(SchemaQuery.create('samples', 'samples'));
+        const sampleModel = makeTestQueryModel(new SchemaQuery('samples', 'samples'));
         const items = getImportItemsForAssayDefinitions(new AssayStateModel(), sampleModel);
         expect(items.size).toBe(0);
     });
@@ -924,13 +924,13 @@ describe('getImportItemsForAssayDefinitions', () => {
         let queryInfo = QueryInfo.create(sampleSet2QueryInfo);
 
         // with a query name that DOES NOT match the assay def sampleColumn lookup
-        queryInfo = queryInfo.set('schemaQuery', SchemaQuery.create('samples', 'Sample set 1')) as QueryInfo;
+        queryInfo = queryInfo.set('schemaQuery', new SchemaQuery('samples', 'Sample set 1')) as QueryInfo;
         let sampleModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);
         let items = getImportItemsForAssayDefinitions(assayStateModel, sampleModel);
         expect(items.size).toBe(0);
 
         // with a query name that DOES match the assay def sampleColumn lookup
-        queryInfo = queryInfo.set('schemaQuery', SchemaQuery.create('samples', 'Sample set 10')) as QueryInfo;
+        queryInfo = queryInfo.set('schemaQuery', new SchemaQuery('samples', 'Sample set 10')) as QueryInfo;
         sampleModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);
         items = getImportItemsForAssayDefinitions(assayStateModel, sampleModel);
         expect(items.size).toBe(1);
@@ -1051,7 +1051,7 @@ describe('getSamplesAssayGridQueryConfigs', () => {
 });
 
 describe('getJobCreationHref', () => {
-    const schemaQuery = SchemaQuery.create('s', 'q');
+    const schemaQuery = new SchemaQuery('s', 'q');
     const queryInfo = new QueryInfo({ pkCols: List(['pk']), schemaQuery });
     const modelId = 'id';
     const queryModel = makeTestQueryModel(schemaQuery, queryInfo, undefined, undefined, undefined, modelId);

--- a/packages/components/src/entities/utils.tsx
+++ b/packages/components/src/entities/utils.tsx
@@ -196,14 +196,14 @@ export const getSampleTypeTemplateUrl = (
 
     return ActionURL.buildURL('query', 'ExportExcelTemplate', null, {
         ...exportConfig,
-        schemaName: schemaQuery.getSchema(),
-        'query.queryName': schemaQuery.getQuery(),
+        schemaName: schemaQuery.schemaName,
+        'query.queryName': schemaQuery.queryName,
         headerType: 'DisplayFieldKey',
         excludeColumn: excludeColumns
             ? excludeColumns.concat(queryInfo.getFileColumnFieldKeys())
             : queryInfo.getFileColumnFieldKeys(),
         includeColumn: extraColumns,
-        filenamePrefix: schemaQuery.getQuery(),
+        filenamePrefix: schemaQuery.queryName,
     });
 };
 

--- a/packages/components/src/entities/utils.tsx
+++ b/packages/components/src/entities/utils.tsx
@@ -387,7 +387,7 @@ export async function getSamplesAssayGridQueryConfigs(
         if (activeModules?.indexOf(config.moduleName) > -1) {
             const baseConfig = {
                 title: config.title,
-                schemaQuery: SchemaQuery.create(config.schemaName, config.queryName, config.viewName),
+                schemaQuery: new SchemaQuery(config.schemaName, config.queryName, config.viewName),
                 containerFilter: config.containerFilter,
             };
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -33,7 +33,6 @@ import {
     encodePart,
     getSchemaQuery,
     resolveKey,
-    resolveSchemaQuery,
     SchemaQuery,
 } from './public/SchemaQuery';
 import { insertColumnFilter, QueryColumn, QueryLookup } from './public/QueryColumn';
@@ -1346,7 +1345,6 @@ export {
     LoadingState,
     SCHEMAS,
     getSchemaQuery,
-    resolveSchemaQuery,
     insertColumnFilter,
     EXPORT_TYPES,
     SELECTION_KEY_TYPE,

--- a/packages/components/src/internal/AssayDefinitionModel.spec.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.spec.ts
@@ -35,9 +35,9 @@ describe('AssayDefinitionModel', () => {
 
     test('hasLookup()', () => {
         const modelWithSampleId = AssayDefinitionModel.create(assayDefJSON);
-        expect(modelWithSampleId.hasLookup(SchemaQuery.create('samples', 'Samples'))).toBeTruthy();
-        expect(modelWithSampleId.hasLookup(SchemaQuery.create('study', 'Study'))).toBeTruthy();
-        expect(modelWithSampleId.hasLookup(SchemaQuery.create('study', 'Other'))).toBeFalsy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('samples', 'Samples'))).toBeTruthy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Study'))).toBeTruthy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Other'))).toBeFalsy();
     });
 
     test('getSampleColumnFieldKeys()', () => {

--- a/packages/components/src/internal/actions.spec.ts
+++ b/packages/components/src/internal/actions.spec.ts
@@ -349,7 +349,7 @@ describe('column mutation actions', () => {
 describe('getExportParams', () => {
     const schemaName = 'test';
     const queryName = 'query';
-    const schemaQuery = SchemaQuery.create(schemaName, queryName);
+    const schemaQuery = new SchemaQuery(schemaName, queryName);
     test('no options or advanced options', () => {
         expect(getExportParams(EXPORT_TYPES.TSV, schemaQuery)).toStrictEqual({
             schemaName,
@@ -359,7 +359,7 @@ describe('getExportParams', () => {
     });
 
     test('with schema view', () => {
-        expect(getExportParams(EXPORT_TYPES.TSV, SchemaQuery.create(schemaName, queryName, 'testView'))).toStrictEqual({
+        expect(getExportParams(EXPORT_TYPES.TSV, new SchemaQuery(schemaName, queryName, 'testView'))).toStrictEqual({
             schemaName,
             'query.queryName': queryName,
             'query.showRows': ['ALL'],

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -120,8 +120,8 @@ export function selectGridIdsFromTransactionId(
                         selected,
                         undefined,
                         true,
-                        schemaQuery.getSchema(),
-                        schemaQuery.getQuery()
+                        schemaQuery.schemaName,
+                        schemaQuery.queryName
                     )
                         .then(response => {
                             actions.replaceSelections(modelId, selected);
@@ -754,8 +754,8 @@ export function fetchCharts(schemaQuery: SchemaQuery, containerPath?: string): P
                 'study-reports',
                 'getReportInfos.api',
                 {
-                    schemaName: schemaQuery.getSchema(),
-                    queryName: schemaQuery.getQuery(),
+                    schemaName: schemaQuery.schemaName,
+                    queryName: schemaQuery.queryName,
                 },
                 {
                     container: containerPath,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -599,7 +599,7 @@ export function getSelection(location: any, schemaName?: string, queryName?: str
             }
             if (!schemaQuery) {
                 if (schemaName && queryName) {
-                    schemaQuery = SchemaQuery.create(schemaName, queryName);
+                    schemaQuery = new SchemaQuery(schemaName, queryName);
                 }
             }
 

--- a/packages/components/src/internal/components/PreviewGrid.spec.tsx
+++ b/packages/components/src/internal/components/PreviewGrid.spec.tsx
@@ -13,7 +13,7 @@ beforeAll(() => {
     registerDefaultURLMappers();
 });
 
-const SQ = SchemaQuery.create('exp.data', 'mixtures', '~~default~~');
+const SQ = new SchemaQuery('exp.data', 'mixtures', '~~default~~');
 
 describe('PreviewGrid render', () => {
     test('PreviewGrid loading', () => {

--- a/packages/components/src/internal/components/administration/ProjectManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/ProjectManagementPage.tsx
@@ -25,7 +25,7 @@ export const ProjectManagementPage: FC = memo(() => {
     const queryConfig: QueryConfig = useMemo(
         () => ({
             bindURL: true,
-            schemaQuery: SchemaQuery.create('core', 'ProjectManagement'),
+            schemaQuery: new SchemaQuery('core', 'ProjectManagement'),
         }),
         []
     );

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -143,7 +143,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
 
     constructor(props: Props) {
         super(props);
-        const schemaQuery = SchemaQuery.create(props.assayDefinition.protocolSchemaName, 'Data');
+        const schemaQuery = new SchemaQuery(props.assayDefinition.protocolSchemaName, 'Data');
         this.state = {
             dataModel: new QueryModel({ id: DATA_GRID_ID, schemaQuery }),
             editorModel: new EditorModel({ id: DATA_GRID_ID }),
@@ -174,7 +174,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 {
                     id: BATCH_PROPERTIES_GRID_ID,
                     keyValue: batchId,
-                    schemaQuery: SchemaQuery.create(assayDefinition.protocolSchemaName, 'Batches'),
+                    schemaQuery: new SchemaQuery(assayDefinition.protocolSchemaName, 'Batches'),
                     requiredColumns: SCHEMAS.CBMB.concat('Name', 'RowId').toArray(),
                 },
                 true
@@ -773,7 +773,7 @@ const AssayImportPanelsBodyImpl: FC<OwnProps & WithFormStepsProps> = props => {
     const { container, user } = useServerContext();
     const key = [runId, assayDefinition.protocolSchemaName].join('|');
     const schemaQuery = useMemo(
-        () => SchemaQuery.create(assayDefinition.protocolSchemaName, 'Runs'),
+        () => new SchemaQuery(assayDefinition.protocolSchemaName, 'Runs'),
         [assayDefinition.protocolSchemaName]
     );
     const queryConfigs: QueryConfigMap = useMemo(

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -155,7 +155,7 @@ class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
             actions.addModel(
                 {
                     id,
-                    schemaQuery: SchemaQuery.create(SCHEMAS.AUDIT_TABLES.SCHEMA, selected),
+                    schemaQuery: new SchemaQuery(SCHEMAS.AUDIT_TABLES.SCHEMA, selected),
                     containerFilter: this.containerFilter,
                     bindURL: isFirstModel,
                 },

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButton.spec.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButton.spec.tsx
@@ -14,7 +14,7 @@ import { SubMenuItem } from '../menus/SubMenuItem';
 import { ResponsiveMenuButton } from './ResponsiveMenuButton';
 
 describe('ResponsiveMenuButton', () => {
-    const items = <PicklistButton model={makeTestQueryModel(SchemaQuery.create('s', 'q'))} user={TEST_USER_READER} />;
+    const items = <PicklistButton model={makeTestQueryModel(new SchemaQuery('s', 'q'))} user={TEST_USER_READER} />;
     const DEFAULT_PROPS = {
         id: 'test-id',
         items,

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.spec.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.spec.tsx
@@ -14,7 +14,7 @@ import { mountWithServerContext } from '../../testHelpers';
 import { ResponsiveMenuButtonGroup } from './ResponsiveMenuButtonGroup';
 
 describe('ResponsiveMenuButtonGroup', () => {
-    const model = makeTestQueryModel(SchemaQuery.create('s', 'q'));
+    const model = makeTestQueryModel(new SchemaQuery('s', 'q'));
     const DEFAULT_PROPS = {
         items: [
             { button: <PicklistButton model={model} user={TEST_USER_READER} />, perm: PermissionTypes.ManagePicklists },

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -1111,8 +1111,8 @@ export function getDomainNamePreviews(
         return Domain.getDomainNamePreviews({
             containerPath,
             domainId,
-            queryName: schemaQuery?.getQuery(),
-            schemaName: schemaQuery?.getSchema(),
+            queryName: schemaQuery?.queryName,
+            schemaName: schemaQuery?.schemaName,
             success: response => {
                 resolve(response['previews']);
             },

--- a/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.spec.ts
+++ b/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.spec.ts
@@ -12,7 +12,7 @@ import { getLineageEditorUpdateColumns } from './LineageEditableGridLoaderFromSe
 
 describe('getLineageEditorUpdateColumns', () => {
     const MODEL = makeTestQueryModel(
-        SchemaQuery.create('schema', 'query'),
+        new SchemaQuery('schema', 'query'),
         QueryInfo.fromJSON({
             columns: [
                 { fieldKey: 'rowId' },

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -104,7 +104,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
                 queryFilters={queryFilters}
                 multiple={isMultiple}
                 // use detail view to assure we get values that may have been filtered out in the default view
-                schemaQuery={SchemaQuery.create(
+                schemaQuery={new SchemaQuery(
                     lookup.schemaQuery.schemaName,
                     lookup.schemaQuery.queryName,
                     ViewInfo.DETAIL_NAME

--- a/packages/components/src/internal/components/entities/AssayResultsForSamplesButton.spec.tsx
+++ b/packages/components/src/internal/components/entities/AssayResultsForSamplesButton.spec.tsx
@@ -10,7 +10,7 @@ import { TEST_USER_READER, TEST_USER_STORAGE_EDITOR } from '../../userFixtures';
 
 import { AssayResultsForSamplesMenuItem } from './AssayResultsForSamplesButton';
 
-const MODEL = makeTestQueryModel(SchemaQuery.create('samples', 'query'), new QueryInfo());
+const MODEL = makeTestQueryModel(new SchemaQuery('samples', 'query'), new QueryInfo());
 
 describe('AssayResultsForSamplesButton', () => {
     const DEFAULT_PROPS = {

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -395,7 +395,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                 });
             }
 
-            getQueryDetails(schemaQuery.toJS())
+            getQueryDetails(schemaQuery)
                 .then(originalQueryInfo => {
                     this.setState(
                         () => ({ insertModel, originalQueryInfo }),

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -1038,7 +1038,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         // Issue 45483: allowed creation types in bulk insert modal to be based on if sample parent types exist and based on the creation type for the page
         const numSampleParentTypes = insertModel.entityParents
             ?.get(SCHEMAS.EXP_TABLES.SAMPLE_SETS.queryName)
-            ?.filter(parentType => isSamplesSchema(SchemaQuery.create(parentType.schema, parentType.query))).size;
+            ?.filter(parentType => isSamplesSchema(new SchemaQuery(parentType.schema, parentType.query))).size;
         const bulkCreationTypeOptions = getBulkCreationTypeOptions(numSampleParentTypes > 0, creationType);
 
         return (

--- a/packages/components/src/internal/components/entities/FindDerivativesButton.spec.tsx
+++ b/packages/components/src/internal/components/entities/FindDerivativesButton.spec.tsx
@@ -74,7 +74,7 @@ const QUERY_INFO = QueryInfo.fromJSON({
         },
     ],
 });
-const MODEL = makeTestQueryModel(SchemaQuery.create('samples', 'query', VIEW_NAME), QUERY_INFO).mutate({
+const MODEL = makeTestQueryModel(new SchemaQuery('samples', 'query', VIEW_NAME), QUERY_INFO).mutate({
     baseFilters: [Filter.create('a', null, Filter.Types.ISBLANK)],
     filterArray: [Filter.create('b', null, Filter.Types.ISBLANK)],
 });
@@ -184,7 +184,7 @@ describe('getSessionSearchFilterProps', () => {
 
     test('baseFilter, with baseModel for sample type', () => {
         const baseModel = MODEL.mutate({
-            schemaQuery: SchemaQuery.create('samples', 'query2'),
+            schemaQuery: new SchemaQuery('samples', 'query2'),
         });
         const props = getSessionSearchFilterProps(SampleTypeDataType, MODEL, [], SampleTypeDataType, baseModel, [
             Filter.create('a', 'Something'),
@@ -198,7 +198,7 @@ describe('getSessionSearchFilterProps', () => {
 
     test('baseFilter, with baseModel for data class', () => {
         const baseModel = MODEL.mutate({
-            schemaQuery: SchemaQuery.create('exp.data', 'query3'),
+            schemaQuery: new SchemaQuery('exp.data', 'query3'),
         });
         const props = getSessionSearchFilterProps(SampleTypeDataType, MODEL, [], DataClassDataType, baseModel, [
             Filter.create('a', 'Something'),

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -334,8 +334,8 @@ function resolveEntityParentTypeFromIds(
     return List<EntityParentType>([
         EntityParentType.create({
             index: 1,
-            schema: schemaQuery.getSchema(),
-            query: schemaQuery.getQuery(),
+            schema: schemaQuery.schemaName,
+            query: schemaQuery.queryName,
             value: data,
             isAliquotParent,
         }),
@@ -601,11 +601,11 @@ export function handleEntityFileImport(
     saveToPipeline?: boolean
 ): Promise<any> {
     return new Promise((resolve, reject) => {
-        const { schemaQuery } = queryInfo;
+        const { schemaName, queryName } = queryInfo.schemaQuery;
 
         return importData({
-            schemaName: schemaQuery.getSchema(),
-            queryName: schemaQuery.getQuery(),
+            schemaName,
+            queryName,
             file,
             importUrl: ActionURL.buildURL(importFileController ?? 'experiment', importAction, null, {
                 ...importParameters,

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -296,7 +296,7 @@ async function initParents(
             filterArray.push(opFilter);
         }
 
-        return getSelectedParents(SchemaQuery.create(schema, query), filterArray, isAliquotParent);
+        return getSelectedParents(new SchemaQuery(schema, query), filterArray, isAliquotParent);
     } else if (isAliquotParent && targetQueryName) {
         return List<EntityParentType>([
             EntityParentType.create({

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -44,7 +44,7 @@ export const AssayResultDataType: EntityDataType = {
     instanceSchemaName: undefined,
     supportHasNoValueInQuery: true,
     getInstanceSchemaQuery: (assayName: string) => {
-        return SchemaQuery.create('assay.General.' + assayName, 'data');
+        return new SchemaQuery('assay.General.' + assayName, 'data');
     },
     getInstanceDataType: (schemaQuery: SchemaQuery) => {
         return schemaQuery.schemaName.replace('assay.General.', '');

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -243,7 +243,7 @@ export class EntityIdCreationModel extends Record({
                     throw new Error('Invalid inputColumn fieldKey. "' + fieldKey[0] + '"');
                 }
 
-                return SchemaQuery.create(decodePart(schemaName), decodePart(fieldKey[1]));
+                return new SchemaQuery(decodePart(schemaName), decodePart(fieldKey[1]));
             }
 
             throw new Error('invalid inputColumn fieldKey length.');
@@ -353,7 +353,7 @@ export class EntityIdCreationModel extends Record({
 
     getSchemaQuery(): SchemaQuery {
         const entityTypeName = this.getTargetEntityTypeValue();
-        return entityTypeName ? SchemaQuery.create(this.entityDataType.instanceSchemaName, entityTypeName) : undefined;
+        return entityTypeName ? new SchemaQuery(this.entityDataType.instanceSchemaName, entityTypeName) : undefined;
     }
 
     postEntityGrid(

--- a/packages/components/src/internal/components/forms/QueryFormInputs.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.spec.tsx
@@ -40,10 +40,7 @@ beforeAll(() => {
     initUnitTestMocks();
 });
 
-const SCHEMA_QUERY = new SchemaQuery({
-    schemaName: 'assay.General.GPAT 1',
-    queryName: 'Data',
-});
+const SCHEMA_QUERY = new SchemaQuery( 'assay.General.GPAT 1', 'Data');
 
 describe('QueryFormInputs', () => {
     test('default properties with queryInfo', () => {

--- a/packages/components/src/internal/components/forms/QueryInfoForm.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.spec.tsx
@@ -34,10 +34,7 @@ beforeAll(() => {
     initUnitTestMocks();
 });
 
-const schemaQuery = new SchemaQuery({
-    schemaName: 'exp.data',
-    queryName: 'Mixtures',
-});
+const schemaQuery = new SchemaQuery('exp.data', 'Mixtures');
 
 describe('QueryInfoForm', () => {
     test('default props', () => {

--- a/packages/components/src/internal/components/forms/input/AssayTaskInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AssayTaskInput.tsx
@@ -26,7 +26,7 @@ async function loadInputOptions(assayId: number): Promise<InputOption[]> {
             Filter.create('Status/Value', 'In Progress'),
         ],
         maxRows: -1,
-        schemaQuery: SchemaQuery.create('samplemanagement', 'Tasks', ViewInfo.DETAIL_NAME),
+        schemaQuery: new SchemaQuery('samplemanagement', 'Tasks', ViewInfo.DETAIL_NAME),
     });
     const taskOptions: InputOption[] = [];
 

--- a/packages/components/src/internal/components/labels/PrintLabelsModal.spec.tsx
+++ b/packages/components/src/internal/components/labels/PrintLabelsModal.spec.tsx
@@ -38,12 +38,12 @@ describe('<PrintLabelsModal/>', () => {
     beforeAll(() => {
         actions = makeTestActions();
         queryModels = {
-            sampleModel: makeTestQueryModel(SchemaQuery.create(TEST_SCHEMA, TEST_QUERY), QueryInfo.create({})).mutate({
+            sampleModel: makeTestQueryModel(new SchemaQuery(TEST_SCHEMA, TEST_QUERY), QueryInfo.create({})).mutate({
                 queryInfoLoadingState: LoadingState.LOADED,
                 rowsLoadingState: LoadingState.LOADED,
             }),
             singleSampleModel: makeTestQueryModel(
-                SchemaQuery.create(TEST_SCHEMA, TEST_QUERY),
+                new SchemaQuery(TEST_SCHEMA, TEST_QUERY),
                 QueryInfo.create({})
             ).mutate({
                 queryInfoLoadingState: LoadingState.LOADED,

--- a/packages/components/src/internal/components/labels/constants.ts
+++ b/packages/components/src/internal/components/labels/constants.ts
@@ -5,4 +5,4 @@ export const LABEL_NOT_FOUND_ERROR =
     "The supplied label template contains an error or was not found. Please check the template, filename, and the BarTender service's configured path.";
 export const BARTENDER_CONFIGURATION_TITLE = 'BarTender Web Service Configuration';
 export const LABEL_TEMPLATES_LIST_NAME = 'LabelTemplates';
-export const LABEL_TEMPLATE_SQ = SchemaQuery.create('lists', LABEL_TEMPLATES_LIST_NAME);
+export const LABEL_TEMPLATE_SQ = new SchemaQuery('lists', LABEL_TEMPLATES_LIST_NAME);

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -100,7 +100,7 @@ function fetchNodeMetadata(lineage: LineageResult): Array<Promise<ISelectRowsRes
     // keys cannot be filtered upon and thus are also not supported.
     return lineage.nodes
         .filter(n => n.schemaName !== undefined && n.queryName !== undefined && n.pkFilters.length === 1)
-        .groupBy(n => SchemaQuery.create(n.schemaName, n.queryName))
+        .groupBy(n => new SchemaQuery(n.schemaName, n.queryName))
         .map((nodes, schemaQuery) => {
             const node = nodes.first();
             const { fieldKey } = node.pkFilters[0];

--- a/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
@@ -46,7 +46,7 @@ export const LineageDetail: FC<LineageDetailProps> = memo(({ item }) => {
                 baseFilters: item.pkFilters.map(pkFilter => Filter.create(pkFilter.fieldKey, pkFilter.value)),
                 containerPath: item.container,
                 // Issue 45028: Display details view columns in lineage
-                schemaQuery: SchemaQuery.create(item.schemaName, item.queryName, ViewInfo.DETAIL_NAME),
+                schemaQuery: new SchemaQuery(item.schemaName, item.queryName, ViewInfo.DETAIL_NAME),
                 // Must specify '*' columns be requested to resolve "properties" columns
                 requiredColumns: ['*'],
             },

--- a/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
+++ b/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
@@ -87,7 +87,7 @@ export const QueryDetailPage: FC<WithRouterProps> = memo(({ params }) => {
                 bindURL: true,
                 keyValue: id,
                 requiredColumns: SCHEMAS.CBMB.toArray(),
-                schemaQuery: SchemaQuery.create(schema, query),
+                schemaQuery: new SchemaQuery(schema, query),
             },
         }),
         [modelId]

--- a/packages/components/src/internal/components/listing/pages/QueryListingPage.tsx
+++ b/packages/components/src/internal/components/listing/pages/QueryListingPage.tsx
@@ -46,7 +46,7 @@ export const QueryListingPage: FC<WithRouterProps> = ({ params }) => {
     const modelId = `q.${schema}.${query}`;
     const queryConfigs = useMemo(
         () => ({
-            [modelId]: { bindURL: true, schemaQuery: SchemaQuery.create(schema, query) },
+            [modelId]: { bindURL: true, schemaQuery: new SchemaQuery(schema, query) },
         }),
         [modelId]
     );

--- a/packages/components/src/internal/components/menus/SelectionMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/menus/SelectionMenuItem.spec.tsx
@@ -26,7 +26,7 @@ import { SelectionMenuItem } from './SelectionMenuItem';
 describe('SelectionMenuItem', () => {
     test('without selections', () => {
         const text = 'Menu Item Text';
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             rowCount: 3,
             selections: new Set(),
         });
@@ -42,7 +42,7 @@ describe('SelectionMenuItem', () => {
 
     test('with selections', () => {
         const text = 'Menu Item Text';
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             rowCount: 3,
             selections: new Set(['1', '2']),
         });
@@ -58,7 +58,7 @@ describe('SelectionMenuItem', () => {
 
     test('with maxSelection but not too many', () => {
         const text = 'Menu Item Text';
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             rowCount: 5,
             selections: new Set(['1', '2', '3']),
         });
@@ -75,7 +75,7 @@ describe('SelectionMenuItem', () => {
 
     test('with maxSelection too many', () => {
         const text = 'Menu Item Text';
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             rowCount: 5,
             selections: new Set(['1', '2', '3']),
         });
@@ -92,7 +92,7 @@ describe('SelectionMenuItem', () => {
 
     test('with href', () => {
         const text = 'Menu Item Text';
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             rowCount: 5,
             selections: new Set(['1', '2', '3']),
         });

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.spec.tsx
@@ -22,8 +22,8 @@ beforeAll(() => {
 describe('AddToPicklistMenuItem', () => {
     const text = 'Picklist Testing';
 
-    const queryModelWithoutSelections = makeTestQueryModel(SchemaQuery.create('test', 'query'));
-    let queryModelWithSelections = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+    const queryModelWithoutSelections = makeTestQueryModel(new SchemaQuery('test', 'query'));
+    let queryModelWithSelections = makeTestQueryModel(new SchemaQuery('test', 'query'));
     queryModelWithSelections = queryModelWithSelections.mutate({
         rowCount: 2,
         selections: new Set(['1', '2']),
@@ -87,7 +87,7 @@ describe('AddToPicklistMenuItem', () => {
         );
         validateMenuItemClick(wrapper, false);
 
-        wrapper.setProps({ queryModel: makeTestQueryModel(SchemaQuery.create('test', 'query')) });
+        wrapper.setProps({ queryModel: makeTestQueryModel(new SchemaQuery('test', 'query')) });
         validateMenuItemClick(wrapper, false);
 
         wrapper.setProps({ queryModel: queryModelWithSelections });
@@ -110,7 +110,7 @@ describe('AddToPicklistMenuItem', () => {
     });
 
     test('sample with status', () => {
-        let model = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        let model = makeTestQueryModel(new SchemaQuery('test', 'query'));
         model = model.mutate({
             rows: {
                 '1': {

--- a/packages/components/src/internal/components/picklist/PicklistButton.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistButton.spec.tsx
@@ -15,7 +15,7 @@ import { AddToPicklistMenuItem } from './AddToPicklistMenuItem';
 
 describe('PicklistButton', () => {
     test('with model no selections', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
         const featureArea = 'featureArea';
         const wrapper = mountWithServerContext(
             <PicklistButton model={queryModel} user={TEST_USER_EDITOR} metricFeatureArea={featureArea} />,
@@ -34,7 +34,7 @@ describe('PicklistButton', () => {
     });
 
     test('asSubMenu', () => {
-        const queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
         const featureArea = 'featureArea';
         const wrapper = mountWithServerContext(
             <PicklistButton model={queryModel} user={TEST_USER_EDITOR} metricFeatureArea={featureArea} asSubMenu />,
@@ -45,7 +45,7 @@ describe('PicklistButton', () => {
     });
 
     test('with model and selections', () => {
-        let queryModel = makeTestQueryModel(SchemaQuery.create('test', 'query'));
+        let queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
         queryModel = queryModel.mutate({ selections: new Set(['1', '2']) });
         const wrapper = mountWithServerContext(<PicklistButton model={queryModel} user={TEST_USER_EDITOR} />, {
             user: TEST_USER_EDITOR,

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -276,7 +276,7 @@ export function addSamplesToPicklist(
                 });
                 if (rows.size > 0) {
                     insertRows({
-                        schemaQuery: SchemaQuery.create('lists', listName),
+                        schemaQuery: new SchemaQuery('lists', listName),
                         rows,
                     })
                         .then(response => {
@@ -287,7 +287,7 @@ export function addSamplesToPicklist(
                     resolve(
                         new InsertRowsResponse({
                             rows: [],
-                            schemaQuery: SchemaQuery.create('lists', listName),
+                            schemaQuery: new SchemaQuery('lists', listName),
                             error: undefined,
                             transactionAuditId: undefined,
                         })
@@ -409,7 +409,7 @@ export const removeSamplesFromPicklist = async (picklist: Picklist, selectionMod
             resolve(0);
         } else {
             deleteRows({
-                schemaQuery: SchemaQuery.create(SCHEMAS.PICKLIST_TABLES.SCHEMA, picklist.name),
+                schemaQuery: new SchemaQuery(SCHEMAS.PICKLIST_TABLES.SCHEMA, picklist.name),
                 rows,
             })
                 .then(response => {

--- a/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
+++ b/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
@@ -49,7 +49,7 @@ export class PipelineJobsPageImpl extends React.PureComponent<Props & InjectedQu
 
         const queryConfig = {
             id: gridId,
-            schemaQuery: SchemaQuery.create('pipeline', 'job'),
+            schemaQuery: new SchemaQuery('pipeline', 'job'),
             baseFilters,
             sorts: [new QuerySort({ fieldKey: 'Created', dir: '-' })],
             requiredColumns: ['Provider'],

--- a/packages/components/src/internal/components/report-list/ReportList.tsx
+++ b/packages/components/src/internal/components/report-list/ReportList.tsx
@@ -125,7 +125,7 @@ class UnsupportedReportBody extends PureComponent<ReportConsumer> {
 class GridReportBody extends PureComponent<ReportConsumer> {
     render() {
         const { schemaName, queryName, viewName, runUrl, appUrl } = this.props.report;
-        const schemaQuery = SchemaQuery.create(schemaName, queryName, viewName);
+        const schemaQuery = new SchemaQuery(schemaName, queryName, viewName);
 
         return (
             <div className="report-list__grid-preview">

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -27,7 +27,7 @@ import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 import { SampleState } from './models';
 
 const TITLE = 'Manage Sample Statuses';
-const STATE_TYPE_SQ = SchemaQuery.create('exp', 'SampleStateType');
+const STATE_TYPE_SQ = new SchemaQuery('exp', 'SampleStateType');
 const DEFAULT_TYPE_OPTIONS = [{ value: 'Available' }, { value: 'Consumed' }, { value: 'Locked' }];
 const NEW_STATUS_INDEX = -1;
 const SAMPLE_STATUS_LOCKED_TITLE = 'Sample Status Locked';

--- a/packages/components/src/internal/components/samples/SampleStatusLegend.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusLegend.spec.tsx
@@ -11,7 +11,7 @@ import { SampleStatusLegendImpl } from './SampleStatusLegend';
 import { SampleStatusTag } from './SampleStatusTag';
 
 describe('SampleStatusLegend', () => {
-    const SQ = SchemaQuery.create('schema', 'query');
+    const SQ = new SchemaQuery('schema', 'query');
     const MODEL_NO_ROWS = makeTestQueryModel(SQ, new QueryInfo(), {}, [], 0).mutate({
         queryInfoLoadingState: LoadingState.LOADED,
         rowsLoadingState: LoadingState.LOADED,

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -190,7 +190,7 @@ export function loadSelectedSamples(location: Location, sampleColumn: QueryColum
     // If the "workflowJobId" URL parameter is specified, then fetch the samples associated with the workflow job.
     if (location?.query?.workflowJobId) {
         return fetchSamples(
-            SchemaQuery.create('sampleManagement', 'inputSamples'),
+            new SchemaQuery('sampleManagement', 'inputSamples'),
             sampleColumn,
             [
                 Filter.create('ApplicationType', 'ExperimentRun'),
@@ -280,7 +280,7 @@ export async function getSelectedSampleIdsFromSelectionKey(location: Location): 
 
 export function getGroupedSampleDomainFields(sampleType: string): Promise<GroupedSampleFields> {
     return new Promise((resolve, reject) => {
-        getSampleTypeDetails(SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType))
+        getSampleTypeDetails(new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType))
             .then(sampleTypeDomain => {
                 const metaFields = [],
                     independentFields = [],
@@ -712,7 +712,7 @@ export function createQueryConfigFilteredBySample(
             model.createSampleFilter(sampleColumns, value, singleFilter, whereClausePart, useLsid, singleFilterValue),
         ],
         omittedColumns: omitSampleCols ? sampleColumns.toArray() : undefined,
-        schemaQuery: SchemaQuery.create(model.protocolSchemaName, 'Data'),
+        schemaQuery: new SchemaQuery(model.protocolSchemaName, 'Data'),
         title: model.name,
         urlPrefix: model.name,
     };
@@ -783,7 +783,7 @@ export function getSampleAliquotsQueryConfig(
     omitCols?: string[]
 ): QueryConfig {
     const omitCol = IS_ALIQUOT_COL;
-    const schemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet);
+    const schemaQuery = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleSet);
 
     return {
         id: createGridModelId('sample-aliquots-' + sampleLsid, schemaQuery),

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -119,8 +119,8 @@ export function getSampleTypeDetails(
         return Domain.getDomainDetails({
             containerPath,
             domainId,
-            queryName: query ? query.getQuery() : undefined,
-            schemaName: query ? query.getSchema() : undefined,
+            queryName: query ? query.queryName : undefined,
+            schemaName: query ? query.schemaName : undefined,
             domainKind: query === undefined && domainId === undefined ? 'SampleSet' : undefined,
             success: response => {
                 resolve(DomainDetails.create(Map(response)));

--- a/packages/components/src/internal/components/samples/utils.spec.tsx
+++ b/packages/components/src/internal/components/samples/utils.spec.tsx
@@ -275,19 +275,19 @@ describe('isSamplesSchema', () => {
     });
 
     test('sample set', () => {
-        expect(isSamplesSchema(SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'test'))).toBeTruthy();
-        expect(isSamplesSchema(SchemaQuery.create('Samples', 'test'))).toBeTruthy();
+        expect(isSamplesSchema(new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'test'))).toBeTruthy();
+        expect(isSamplesSchema(new SchemaQuery('Samples', 'test'))).toBeTruthy();
     });
 
     test('exp.materials', () => {
-        expect(isSamplesSchema(SchemaQuery.create('EXP', 'materials'))).toBeTruthy();
+        expect(isSamplesSchema(new SchemaQuery('EXP', 'materials'))).toBeTruthy();
         expect(isSamplesSchema(SCHEMAS.EXP_TABLES.MATERIALS)).toBeTruthy();
     });
 
     test('source samples', () => {
         expect(isSamplesSchema(SCHEMAS.SAMPLE_MANAGEMENT.SOURCE_SAMPLES)).toBeTruthy();
-        expect(isSamplesSchema(SchemaQuery.create('sampleManagement', 'SourceSamples'))).toBeTruthy();
-        expect(isSamplesSchema(SchemaQuery.create('sampleManagement', 'Jobs'))).toBeFalsy();
+        expect(isSamplesSchema(new SchemaQuery('sampleManagement', 'SourceSamples'))).toBeTruthy();
+        expect(isSamplesSchema(new SchemaQuery('sampleManagement', 'Jobs'))).toBeFalsy();
     });
 });
 
@@ -326,7 +326,7 @@ describe('getSampleStatus', () => {
     });
 });
 
-const TEST_SQ = SchemaQuery.create('schema', 'query');
+const TEST_SQ = new SchemaQuery('schema', 'query');
 const TEST_QUERY_INFO = new QueryInfo({ schemaQuery: TEST_SQ });
 const TEST_MODEL = makeTestQueryModel(TEST_SQ, TEST_QUERY_INFO).mutate({ id: 'model-id' });
 

--- a/packages/components/src/internal/components/search/FilterCards.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterCards.spec.tsx
@@ -34,7 +34,7 @@ describe('FilterCard', () => {
             <FilterCard
                 dataTypeDisplayName="Parent"
                 entityDataType={TestTypeDataType}
-                schemaQuery={SchemaQuery.create('testSample', 'parent')}
+                schemaQuery={new SchemaQuery('testSample', 'parent')}
                 filterArray={[]}
                 onAdd={jest.fn}
                 onEdit={jest.fn}
@@ -73,7 +73,7 @@ describe('FilterCard', () => {
         const wrapper = mount(
             <FilterCard
                 entityDataType={TestTypeDataType}
-                schemaQuery={SchemaQuery.create('testSample', 'parent')}
+                schemaQuery={new SchemaQuery('testSample', 'parent')}
                 filterArray={[filter1, filter2]}
                 onAdd={jest.fn}
                 onEdit={jest.fn}

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -78,7 +78,7 @@ test('getFinderStartText', () => {
                 TestTypeDataType,
                 {
                     ...TestTypeDataType,
-                    typeListingSchemaQuery: SchemaQuery.create('TestClasses', 'query2'),
+                    typeListingSchemaQuery: new SchemaQuery('TestClasses', 'query2'),
                     nounAsParentSingular: 'Other Parents',
                 },
             ],
@@ -91,7 +91,7 @@ test('getFinderStartText', () => {
                 TestTypeDataType,
                 {
                     ...TestTypeDataType,
-                    typeListingSchemaQuery: SchemaQuery.create('TestClasses', 'query2'),
+                    typeListingSchemaQuery: new SchemaQuery('TestClasses', 'query2'),
                     nounAsParentSingular: 'Other Parents',
                 },
             ],
@@ -156,7 +156,7 @@ describe('getFinderViewColumnsConfig', () => {
         }),
     });
     const model = makeTestQueryModel(
-        SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Test', SAMPLE_FINDER_VIEW_NAME),
+        new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Test', SAMPLE_FINDER_VIEW_NAME),
         queryInfo,
         {},
         [],
@@ -240,7 +240,7 @@ describe('getFinderViewColumnsConfig', () => {
             }),
         });
         const model = makeTestQueryModel(
-            SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Test', SAMPLE_FINDER_VIEW_NAME),
+            new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Test', SAMPLE_FINDER_VIEW_NAME),
             queryInfo,
             {},
             [],
@@ -261,7 +261,7 @@ describe('getFinderViewColumnsConfig', () => {
 });
 
 const assay1 = 'assay1';
-const assay1SchemaQuery = SchemaQuery.create('assay.general.' + assay1, 'data');
+const assay1SchemaQuery = new SchemaQuery('assay.general.' + assay1, 'data');
 
 const AssayColumnInFilter = Filter.create(
     'RowId',
@@ -292,7 +292,7 @@ describe('getAssayFilter', () => {
         expect(
             getAssayFilter({
                 entityDataType: AssayResultDataType,
-                schemaQuery: SchemaQuery.create('assay.general.' + assay1, 'data'),
+                schemaQuery: new SchemaQuery('assay.general.' + assay1, 'data'),
                 filterArray: [cardFilter],
                 targetColumnFieldKey: 'SampleId',
                 selectColumnFieldKey: 'RowId',
@@ -310,7 +310,7 @@ describe('getAssayFilter', () => {
         expect(
             getAssayFilter({
                 entityDataType: AssayResultDataType,
-                schemaQuery: SchemaQuery.create('assay.general.' + assay1, 'data'),
+                schemaQuery: new SchemaQuery('assay.general.' + assay1, 'data'),
                 filterArray: [AssayNotInFilterField],
             })
         ).toEqual(AssayNotInFilter);
@@ -331,7 +331,7 @@ describe('getSampleFinderCommonConfigs', () => {
                 [
                     {
                         entityDataType: TestTypeDataType,
-                        schemaQuery: SchemaQuery.create('Samples', 'TestQuery'),
+                        schemaQuery: new SchemaQuery('Samples', 'TestQuery'),
                     },
                 ],
                 false
@@ -354,7 +354,7 @@ describe('getSampleFinderCommonConfigs', () => {
                 [
                     {
                         entityDataType: AssayResultDataType,
-                        schemaQuery: SchemaQuery.create('assay.general.' + assay1, 'data'),
+                        schemaQuery: new SchemaQuery('assay.general.' + assay1, 'data'),
                     },
                 ],
                 false
@@ -371,7 +371,7 @@ describe('getSampleFinderCommonConfigs', () => {
                 [
                     {
                         entityDataType: TestTypeDataType,
-                        schemaQuery: SchemaQuery.create('Samples', 'TestQuery'),
+                        schemaQuery: new SchemaQuery('Samples', 'TestQuery'),
                     },
                 ],
                 true
@@ -401,11 +401,11 @@ describe('getSampleFinderCommonConfigs', () => {
                 [
                     {
                         entityDataType: TestTypeDataType,
-                        schemaQuery: SchemaQuery.create('Samples', 'TestQuery'),
+                        schemaQuery: new SchemaQuery('Samples', 'TestQuery'),
                     },
                     {
                         entityDataType: TestTypeDataType,
-                        schemaQuery: SchemaQuery.create('Samples', 'TestQuery2'),
+                        schemaQuery: new SchemaQuery('Samples', 'TestQuery2'),
                         filterArray: [cardFilter],
                     },
                 ],
@@ -446,7 +446,7 @@ describe('getSampleFinderCommonConfigs', () => {
                 [
                     {
                         entityDataType: AssayResultDataType,
-                        schemaQuery: SchemaQuery.create('assay.general.' + assay1, 'data'),
+                        schemaQuery: new SchemaQuery('assay.general.' + assay1, 'data'),
                         filterArray: [cardFilter],
                         targetColumnFieldKey: 'SampleId',
                         selectColumnFieldKey: 'RowId',
@@ -466,7 +466,7 @@ describe('getSampleFinderCommonConfigs', () => {
                 [
                     {
                         entityDataType: AssayResultDataType,
-                        schemaQuery: SchemaQuery.create('assay.general.' + assay1, 'data'),
+                        schemaQuery: new SchemaQuery('assay.general.' + assay1, 'data'),
                         filterArray: [AssayNotInFilterField],
                     },
                 ],
@@ -491,7 +491,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|exp/materials': {
                 id: 'uuid-1-testId|exp/materials',
                 title: 'All Samples',
-                schemaQuery: SchemaQuery.create(
+                schemaQuery: new SchemaQuery(
                     SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
                     SCHEMAS.EXP_TABLES.MATERIALS.queryName,
                     SAMPLE_FINDER_VIEW_NAME
@@ -511,7 +511,7 @@ describe('getSampleFinderQueryConfigs', () => {
                 [
                     {
                         entityDataType: TestTypeDataType,
-                        schemaQuery: SchemaQuery.create('Samples', 'TestQuery'),
+                        schemaQuery: new SchemaQuery('Samples', 'TestQuery'),
                     },
                 ],
                 'testId'
@@ -520,7 +520,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|exp/materials': {
                 id: 'uuid-1-testId|exp/materials',
                 title: 'All Samples',
-                schemaQuery: SchemaQuery.create(
+                schemaQuery: new SchemaQuery(
                     SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
                     SCHEMAS.EXP_TABLES.MATERIALS.queryName,
                     SAMPLE_FINDER_VIEW_NAME
@@ -545,7 +545,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|exp/materials': {
                 id: 'uuid-1-testId|exp/materials',
                 title: 'All Samples',
-                schemaQuery: SchemaQuery.create(
+                schemaQuery: new SchemaQuery(
                     SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
                     SCHEMAS.EXP_TABLES.MATERIALS.queryName,
                     SAMPLE_FINDER_VIEW_NAME
@@ -557,7 +557,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|samples/Sample Type 1': {
                 id: 'uuid-1-testId|samples/Sample Type 1',
                 title: 'Sample Type 1',
-                schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 1', SAMPLE_FINDER_VIEW_NAME),
+                schemaQuery: new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 1', SAMPLE_FINDER_VIEW_NAME),
                 omittedColumns: ['checkedOutBy'],
                 baseFilters: [],
                 requiredColumns: SAMPLE_STATUS_REQUIRED_COLUMNS,
@@ -565,7 +565,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|samples/Sample Type 2': {
                 id: 'uuid-1-testId|samples/Sample Type 2',
                 title: 'Sample Type 2',
-                schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 2', SAMPLE_FINDER_VIEW_NAME),
+                schemaQuery: new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 2', SAMPLE_FINDER_VIEW_NAME),
                 omittedColumns: ['checkedOutBy'],
                 baseFilters: [],
                 requiredColumns: SAMPLE_STATUS_REQUIRED_COLUMNS,
@@ -577,7 +577,7 @@ describe('getSampleFinderQueryConfigs', () => {
         const cards = [
             {
                 entityDataType: TestTypeDataType,
-                schemaQuery: SchemaQuery.create('Samples', 'TestQuery'),
+                schemaQuery: new SchemaQuery('Samples', 'TestQuery'),
             },
         ];
         expect(
@@ -586,7 +586,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|exp/materials': {
                 id: 'uuid-1-testId|exp/materials',
                 title: 'All Samples',
-                schemaQuery: SchemaQuery.create(
+                schemaQuery: new SchemaQuery(
                     SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
                     SCHEMAS.EXP_TABLES.MATERIALS.queryName,
                     SAMPLE_FINDER_VIEW_NAME
@@ -604,7 +604,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|samples/Sample Type 1': {
                 id: 'uuid-1-testId|samples/Sample Type 1',
                 title: 'Sample Type 1',
-                schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 1', SAMPLE_FINDER_VIEW_NAME),
+                schemaQuery: new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 1', SAMPLE_FINDER_VIEW_NAME),
                 omittedColumns: ['checkedOutBy'],
                 baseFilters: [
                     Filter.create(
@@ -618,7 +618,7 @@ describe('getSampleFinderQueryConfigs', () => {
             'uuid-1-testId|samples/Sample Type 2': {
                 id: 'uuid-1-testId|samples/Sample Type 2',
                 title: 'Sample Type 2',
-                schemaQuery: SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 2', SAMPLE_FINDER_VIEW_NAME),
+                schemaQuery: new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, 'Sample Type 2', SAMPLE_FINDER_VIEW_NAME),
                 omittedColumns: ['checkedOutBy'],
                 baseFilters: [
                     Filter.create(
@@ -699,7 +699,7 @@ const badBetweenFilter = {
 const card = {
     entityDataType: TestTypeDataType,
     filterArray: [anyValueFilter, stringBetweenFilter],
-    schemaQuery: SchemaQuery.create('TestSchema', 'samples1'),
+    schemaQuery: new SchemaQuery('TestSchema', 'samples1'),
     index: 1,
 };
 
@@ -716,7 +716,7 @@ const cardJSON =
 const cardWithEntityTypeFilter = {
     entityDataType: TestTypeDataTypeWithEntityFilter,
     filterArray: [anyValueFilter, stringBetweenFilter],
-    schemaQuery: SchemaQuery.create('TestSchema', 'samples1'),
+    schemaQuery: new SchemaQuery('TestSchema', 'samples1'),
     index: 1,
 };
 
@@ -1324,8 +1324,8 @@ describe('getLabKeySql', () => {
     });
 });
 
-const schemaQuery = SchemaQuery.create('Test', 'SampleA');
-const schemaQueryWithSpace = SchemaQuery.create('Test', 'Sample Type A');
+const schemaQuery = new SchemaQuery('Test', 'SampleA');
+const schemaQueryWithSpace = new SchemaQuery('Test', 'Sample Type A');
 
 describe('getExpDescendantOfSelectClause', () => {
     test('empty', () => {
@@ -1388,7 +1388,7 @@ describe('getSampleFinderColumnNames', () => {
             getSampleFinderColumnNames([
                 {
                     entityDataType: SampleTypeDataType,
-                    schemaQuery: SchemaQuery.create('test', 'query'),
+                    schemaQuery: new SchemaQuery('test', 'query'),
                     filterArray: [
                         {
                             fieldKey: 'IntValue',
@@ -1407,7 +1407,7 @@ describe('getSampleFinderColumnNames', () => {
             getSampleFinderColumnNames([
                 {
                     entityDataType: SampleTypeDataType,
-                    schemaQuery: SchemaQuery.create('test', 'query'),
+                    schemaQuery: new SchemaQuery('test', 'query'),
                     dataTypeDisplayName: 'Test Samples',
                     filterArray: [],
                 },
@@ -1423,7 +1423,7 @@ describe('getSampleFinderColumnNames', () => {
             getSampleFinderColumnNames([
                 {
                     entityDataType: SampleTypeDataType,
-                    schemaQuery: SchemaQuery.create('test', 'query'),
+                    schemaQuery: new SchemaQuery('test', 'query'),
                     dataTypeDisplayName: 'Test Samples',
                     filterArray: [
                         {
@@ -1448,7 +1448,7 @@ describe('getSampleFinderColumnNames', () => {
             getSampleFinderColumnNames([
                 {
                     entityDataType: AssayResultDataType,
-                    schemaQuery: SchemaQuery.create('test', 'query'),
+                    schemaQuery: new SchemaQuery('test', 'query'),
                     dataTypeDisplayName: 'Test Assays',
                     filterArray: [
                         {

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -291,7 +291,7 @@ export function getSampleFinderQueryConfigs(
         [allSamplesKey]: {
             id: allSamplesKey,
             title: 'All Samples',
-            schemaQuery: SchemaQuery.create(
+            schemaQuery: new SchemaQuery(
                 SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
                 SCHEMAS.EXP_TABLES.MATERIALS.queryName,
                 SAMPLE_FINDER_VIEW_NAME
@@ -306,7 +306,7 @@ export function getSampleFinderQueryConfigs(
 
         for (const name of sampleTypeNames) {
             const id = getSampleFinderConfigId(finderId, 'samples/' + name);
-            const schemaQuery = SchemaQuery.create(SCHEMAS.SAMPLE_SETS.SCHEMA, name, SAMPLE_FINDER_VIEW_NAME);
+            const schemaQuery = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, name, SAMPLE_FINDER_VIEW_NAME);
 
             configs[id] = {
                 id,

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1011,7 +1011,7 @@ export function selectDistinctRows(options: Query.SelectDistinctOptions): Promis
 
 export function loadQueries(schemaQueries: SchemaQuery[]): Promise<QueryInfo[]> {
     return Promise.all(
-        schemaQueries.map(sq => getQueryDetails({ schemaName: sq.getSchema(), queryName: sq.getQuery() }))
+        schemaQueries.map(sq => getQueryDetails({ schemaName: sq.schemaName, queryName: sq.queryName }))
     );
 }
 
@@ -1041,11 +1041,8 @@ export async function loadQueriesFromTable(
     containerFilter?: Query.ContainerFilter,
     filters?: Filter.IFilter[]
 ): Promise<QueryInfo[]> {
-    const info = await getQueryDetails({
-        queryName: tableSchemaQuery.getQuery(),
-        schemaName: tableSchemaQuery.getSchema(),
-    });
-
+    const { schemaName, queryName, viewName } = tableSchemaQuery;
+    const info = await getQueryDetails({ queryName, schemaName });
     const queryNameField = info.getColumn(tableFieldKey);
 
     if (queryNameField) {
@@ -1058,17 +1055,17 @@ export async function loadQueriesFromTable(
                 .add(queryNameField.name)
                 .join(','),
             filterArray: filters,
-            queryName: tableSchemaQuery.getQuery(),
-            schemaName: tableSchemaQuery.getSchema(),
-            viewName: tableSchemaQuery.getView(),
+            queryName,
+            schemaName,
+            viewName,
         });
 
         const schemaQueries: SchemaQuery[] = Object.values(models[key])
             .map(row => caseInsensitive(row, queryNameField.name)?.value)
-            .filter(queryName => queryName !== undefined)
-            .map(queryName => SchemaQuery.create(targetSchemaName, queryName));
+            .filter(query => query !== undefined)
+            .map(query => SchemaQuery.create(targetSchemaName, query));
 
-        return await loadQueries(schemaQueries);
+        return loadQueries(schemaQueries);
     }
 
     return [];

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -59,7 +59,7 @@ export interface GetQueryDetailsOptions {
 
 export function getQueryDetails(options: GetQueryDetailsOptions): Promise<QueryInfo> {
     const { containerPath, queryName, schemaName, viewName, fk, lookup } = options;
-    const schemaQuery = SchemaQuery.create(schemaName, queryName, viewName);
+    const schemaQuery = new SchemaQuery(schemaName, queryName, viewName);
     const key = getQueryDetailsCacheKey(schemaQuery, containerPath, fk);
 
     if (!queryDetailsCache[key]) {
@@ -111,7 +111,7 @@ export function applyQueryMetadata(rawQueryInfo: any, schemaName?: string, query
     const _queryName = queryName ?? rawQueryInfo?.name;
 
     if (rawQueryInfo && _schemaName && _queryName) {
-        const schemaQuery = SchemaQuery.create(_schemaName, _queryName);
+        const schemaQuery = new SchemaQuery(_schemaName, _queryName);
 
         let columns = OrderedMap<string, QueryColumn>();
         rawQueryInfo.columns.forEach(rawColumn => {
@@ -370,7 +370,7 @@ export function selectRowsDeprecated(userConfig, caller?): Promise<ISelectRowsRe
     return new Promise((resolve, reject) => {
         let schemaQuery, key;
         if (userConfig.queryName) {
-            schemaQuery = SchemaQuery.create(userConfig.schemaName, userConfig.queryName, userConfig.viewName);
+            schemaQuery = new SchemaQuery(userConfig.schemaName, userConfig.queryName, userConfig.viewName);
             key = schemaQuery.getKey();
         }
 
@@ -418,7 +418,7 @@ export function selectRowsDeprecated(userConfig, caller?): Promise<ISelectRowsRe
                         let resultSchemaQuery: SchemaQuery;
 
                         if (saveInSession) {
-                            resultSchemaQuery = SchemaQuery.create(userConfig.schemaName, json.queryName);
+                            resultSchemaQuery = new SchemaQuery(userConfig.schemaName, json.queryName);
                             key = resultSchemaQuery.getKey();
                         } else {
                             resultSchemaQuery = schemaQuery;
@@ -1063,7 +1063,7 @@ export async function loadQueriesFromTable(
         const schemaQueries: SchemaQuery[] = Object.values(models[key])
             .map(row => caseInsensitive(row, queryNameField.name)?.value)
             .filter(query => query !== undefined)
-            .map(query => SchemaQuery.create(targetSchemaName, query));
+            .map(query => new SchemaQuery(targetSchemaName, query));
 
         return loadQueries(schemaQueries);
     }

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -66,7 +66,7 @@ describe('HeaderCellDropdown', () => {
             title: 'Column',
             raw: QueryColumn.create({ fieldKey: 'column', sortable: true, filterable: true }),
         }),
-        model: makeTestQueryModel(SchemaQuery.create('schema', 'query')),
+        model: makeTestQueryModel(new SchemaQuery('schema', 'query')),
         handleSort: jest.fn,
         handleFilter: jest.fn,
     };
@@ -270,7 +270,7 @@ describe('HeaderCellDropdown', () => {
     });
 
     test('isSortAsc', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             sorts: [new QuerySort({ fieldKey: 'column', dir: '' })],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
@@ -295,7 +295,7 @@ describe('HeaderCellDropdown', () => {
         const view = ViewInfo.create({ sort: [sortObj] });
         const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query'), queryInfo).mutate({
             sorts: [],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
@@ -316,7 +316,7 @@ describe('HeaderCellDropdown', () => {
     });
 
     test('isSortDesc', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             sorts: [new QuerySort({ fieldKey: 'column', dir: '-' })],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
@@ -341,7 +341,7 @@ describe('HeaderCellDropdown', () => {
         const view = ViewInfo.create({ sort: [sortObj] });
         const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query'), queryInfo).mutate({
             sorts: [],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
@@ -362,7 +362,7 @@ describe('HeaderCellDropdown', () => {
     });
 
     test('one colFilters', () => {
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query')).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
             filterArray: [Filter.create('column', 'value', Filter.Types.EQUALS)],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
@@ -381,7 +381,7 @@ describe('HeaderCellDropdown', () => {
         const view = ViewInfo.create({ filter: [filterObj] });
         const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query'), queryInfo).mutate({
             filterArray: [],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);
@@ -400,7 +400,7 @@ describe('HeaderCellDropdown', () => {
         const view = ViewInfo.create({ filter: [filterObj] });
         const queryInfo = QueryInfo.create({ views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }) });
 
-        const model = makeTestQueryModel(SchemaQuery.create('schema', 'query'), queryInfo).mutate({
+        const model = makeTestQueryModel(new SchemaQuery('schema', 'query'), queryInfo).mutate({
             filterArray: [Filter.create('column', 'value', Filter.Types.EQUALS)],
         });
         const wrapper = mount(<HeaderCellDropdown {...DEFAULT_PROPS} model={model} />);

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -25,8 +25,8 @@ export const CBMB = List<string>(['Created', 'CreatedBy', 'Modified', 'ModifiedB
 // ASSAY
 const ASSAY_SCHEMA = 'assay';
 export const ASSAY_TABLES = {
-    ASSAY_LIST: SchemaQuery.create(ASSAY_SCHEMA, 'AssayList'),
-    ASSAY_DETAILS_SQ: SchemaQuery.create(ASSAY_SCHEMA, 'AssayList', ViewInfo.DETAIL_NAME),
+    ASSAY_LIST: new SchemaQuery(ASSAY_SCHEMA, 'AssayList'),
+    ASSAY_DETAILS_SQ: new SchemaQuery(ASSAY_SCHEMA, 'AssayList', ViewInfo.DETAIL_NAME),
     SCHEMA: ASSAY_SCHEMA,
     RESULTS_QUERYNAME: 'Data',
 };
@@ -34,51 +34,51 @@ export const ASSAY_TABLES = {
 // EXP
 const EXP_SCHEMA = 'exp';
 export const EXP_TABLES = {
-    ASSAY_RUNS: SchemaQuery.create(EXP_SCHEMA, 'AssayRuns'),
-    DATA: SchemaQuery.create(EXP_SCHEMA, 'Data'),
-    DATA_CLASSES: SchemaQuery.create(EXP_SCHEMA, 'DataClasses'),
-    DATA_CLASS_CATEGORY_TYPE: SchemaQuery.create(EXP_SCHEMA, 'DataClassCategoryType'),
-    MATERIALS: SchemaQuery.create(EXP_SCHEMA, 'Materials'),
-    PROTOCOLS: SchemaQuery.create(EXP_SCHEMA, 'Protocols'),
+    ASSAY_RUNS: new SchemaQuery(EXP_SCHEMA, 'AssayRuns'),
+    DATA: new SchemaQuery(EXP_SCHEMA, 'Data'),
+    DATA_CLASSES: new SchemaQuery(EXP_SCHEMA, 'DataClasses'),
+    DATA_CLASS_CATEGORY_TYPE: new SchemaQuery(EXP_SCHEMA, 'DataClassCategoryType'),
+    MATERIALS: new SchemaQuery(EXP_SCHEMA, 'Materials'),
+    PROTOCOLS: new SchemaQuery(EXP_SCHEMA, 'Protocols'),
     SCHEMA: EXP_SCHEMA,
-    SAMPLE_SETS: SchemaQuery.create(EXP_SCHEMA, 'SampleSets'),
-    SAMPLE_SETS_DETAILS: SchemaQuery.create(EXP_SCHEMA, 'SampleSets', ViewInfo.DETAIL_NAME),
-    SAMPLE_STATUS: SchemaQuery.create(EXP_SCHEMA, 'SampleStatus'),
+    SAMPLE_SETS: new SchemaQuery(EXP_SCHEMA, 'SampleSets'),
+    SAMPLE_SETS_DETAILS: new SchemaQuery(EXP_SCHEMA, 'SampleSets', ViewInfo.DETAIL_NAME),
+    SAMPLE_STATUS: new SchemaQuery(EXP_SCHEMA, 'SampleStatus'),
 };
 
 // CORE
 const CORE_SCHEMA = 'core';
 export const CORE_TABLES = {
     SCHEMA: CORE_SCHEMA,
-    DATA_STATES: SchemaQuery.create(CORE_SCHEMA, 'DataStates'),
-    USERS: SchemaQuery.create(CORE_SCHEMA, 'Users'),
+    DATA_STATES: new SchemaQuery(CORE_SCHEMA, 'DataStates'),
+    USERS: new SchemaQuery(CORE_SCHEMA, 'Users'),
 };
 
 // DATA CLASSES
 const DATA_CLASS_SCHEMA = 'exp.data';
 export const DATA_CLASSES = {
     SCHEMA: DATA_CLASS_SCHEMA,
-    CELL_LINE: SchemaQuery.create(DATA_CLASS_SCHEMA, 'CellLine'),
-    CONSTRUCT: SchemaQuery.create(DATA_CLASS_SCHEMA, 'Construct'),
-    EXPRESSION_SYSTEM: SchemaQuery.create(DATA_CLASS_SCHEMA, 'ExpressionSystem'),
-    MOLECULE: SchemaQuery.create(DATA_CLASS_SCHEMA, 'Molecule'),
-    MOLECULE_SET: SchemaQuery.create(DATA_CLASS_SCHEMA, 'MoleculeSet'),
-    MOLECULAR_SPECIES: SchemaQuery.create(DATA_CLASS_SCHEMA, 'MolecularSpecies'),
-    MOLECULAR_SPECIES_SEQ: SchemaQuery.create(DATA_CLASS_SCHEMA, 'MolecularSpeciesSequence'),
-    NUC_SEQUENCE: SchemaQuery.create(DATA_CLASS_SCHEMA, 'NucSequence'),
-    PROTEIN_SEQUENCE: SchemaQuery.create(DATA_CLASS_SCHEMA, 'ProtSequence'),
-    VECTOR: SchemaQuery.create(DATA_CLASS_SCHEMA, 'Vector'),
+    CELL_LINE: new SchemaQuery(DATA_CLASS_SCHEMA, 'CellLine'),
+    CONSTRUCT: new SchemaQuery(DATA_CLASS_SCHEMA, 'Construct'),
+    EXPRESSION_SYSTEM: new SchemaQuery(DATA_CLASS_SCHEMA, 'ExpressionSystem'),
+    MOLECULE: new SchemaQuery(DATA_CLASS_SCHEMA, 'Molecule'),
+    MOLECULE_SET: new SchemaQuery(DATA_CLASS_SCHEMA, 'MoleculeSet'),
+    MOLECULAR_SPECIES: new SchemaQuery(DATA_CLASS_SCHEMA, 'MolecularSpecies'),
+    MOLECULAR_SPECIES_SEQ: new SchemaQuery(DATA_CLASS_SCHEMA, 'MolecularSpeciesSequence'),
+    NUC_SEQUENCE: new SchemaQuery(DATA_CLASS_SCHEMA, 'NucSequence'),
+    PROTEIN_SEQUENCE: new SchemaQuery(DATA_CLASS_SCHEMA, 'ProtSequence'),
+    VECTOR: new SchemaQuery(DATA_CLASS_SCHEMA, 'Vector'),
 
-    INGREDIENTS: SchemaQuery.create(DATA_CLASS_SCHEMA, 'Ingredients'),
-    MIXTURES: SchemaQuery.create(DATA_CLASS_SCHEMA, 'Mixtures'),
+    INGREDIENTS: new SchemaQuery(DATA_CLASS_SCHEMA, 'Ingredients'),
+    MIXTURES: new SchemaQuery(DATA_CLASS_SCHEMA, 'Mixtures'),
 };
 
 // INVENTORY
 const INVENTORY_SCHEMA = 'inventory';
 export const INVENTORY = {
     SCHEMA: INVENTORY_SCHEMA,
-    ITEMS: SchemaQuery.create(INVENTORY_SCHEMA, 'Item'),
-    SAMPLE_ITEMS: SchemaQuery.create(INVENTORY_SCHEMA, 'SampleItems'),
+    ITEMS: new SchemaQuery(INVENTORY_SCHEMA, 'Item'),
+    SAMPLE_ITEMS: new SchemaQuery(INVENTORY_SCHEMA, 'SampleItems'),
     CHECKED_OUT_BY_FIELD: 'checkedOutBy',
     INVENTORY_COLS: [
         'LabelColor',
@@ -102,36 +102,36 @@ export const INVENTORY = {
 const SAMPLE_SET_SCHEMA = 'samples';
 export const SAMPLE_SETS = {
     SCHEMA: SAMPLE_SET_SCHEMA,
-    EXPRESSION_SYSTEM: SchemaQuery.create(SAMPLE_SET_SCHEMA, 'ExpressionSystemSamples'),
-    MIXTURE_BATCHES: SchemaQuery.create(SAMPLE_SET_SCHEMA, 'MixtureBatches'),
-    RAW_MATERIALS: SchemaQuery.create(SAMPLE_SET_SCHEMA, 'RawMaterials'),
-    SAMPLES: SchemaQuery.create(SAMPLE_SET_SCHEMA, 'Samples'),
+    EXPRESSION_SYSTEM: new SchemaQuery(SAMPLE_SET_SCHEMA, 'ExpressionSystemSamples'),
+    MIXTURE_BATCHES: new SchemaQuery(SAMPLE_SET_SCHEMA, 'MixtureBatches'),
+    RAW_MATERIALS: new SchemaQuery(SAMPLE_SET_SCHEMA, 'RawMaterials'),
+    SAMPLES: new SchemaQuery(SAMPLE_SET_SCHEMA, 'Samples'),
 };
 
 // SAMPLE MANAGEMENT
 const SAMPLE_MANAGEMENT_SCHEMA = 'samplemanagement';
 export const SAMPLE_MANAGEMENT = {
     SCHEMA: SAMPLE_MANAGEMENT_SCHEMA,
-    SAMPLE_TYPE_INSIGHTS: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'SampleTypeInsights'),
-    SAMPLE_STATUS_COUNTS: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'SampleStatusCounts'),
-    SOURCE_SAMPLES: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'SourceSamples'),
-    INPUT_SAMPLES_SQ: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'InputSamples'),
-    JOBS: SchemaQuery.create(SAMPLE_MANAGEMENT_SCHEMA, 'Jobs'),
+    SAMPLE_TYPE_INSIGHTS: new SchemaQuery(SAMPLE_MANAGEMENT_SCHEMA, 'SampleTypeInsights'),
+    SAMPLE_STATUS_COUNTS: new SchemaQuery(SAMPLE_MANAGEMENT_SCHEMA, 'SampleStatusCounts'),
+    SOURCE_SAMPLES: new SchemaQuery(SAMPLE_MANAGEMENT_SCHEMA, 'SourceSamples'),
+    INPUT_SAMPLES_SQ: new SchemaQuery(SAMPLE_MANAGEMENT_SCHEMA, 'InputSamples'),
+    JOBS: new SchemaQuery(SAMPLE_MANAGEMENT_SCHEMA, 'Jobs'),
 };
 
 // STUDY
 const STUDY_SCHEMA = 'study';
 export const STUDY_TABLES = {
     SCHEMA: STUDY_SCHEMA,
-    COHORT: SchemaQuery.create(STUDY_SCHEMA, 'Cohort'),
+    COHORT: new SchemaQuery(STUDY_SCHEMA, 'Cohort'),
 };
 
 // LIST
 const LIST_METADATA_SCHEMA = 'ListManager';
 export const LIST_METADATA_TABLES = {
     SCHEMA: LIST_METADATA_SCHEMA,
-    LIST_MANAGER: SchemaQuery.create(LIST_METADATA_SCHEMA, 'ListManager'),
-    PICKLISTS: SchemaQuery.create(LIST_METADATA_SCHEMA, 'Picklists'),
+    LIST_MANAGER: new SchemaQuery(LIST_METADATA_SCHEMA, 'ListManager'),
+    PICKLISTS: new SchemaQuery(LIST_METADATA_SCHEMA, 'Picklists'),
 };
 
 const PICKLIST_SCHEMA = 'lists';

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -45,7 +45,7 @@ export class QueryLookup extends Record({
     static create(rawLookup): QueryLookup {
         return new QueryLookup(
             Object.assign({}, rawLookup, {
-                schemaQuery: SchemaQuery.create(rawLookup.schemaName, rawLookup.queryName, rawLookup.viewName),
+                schemaQuery: new SchemaQuery(rawLookup.schemaName, rawLookup.queryName, rawLookup.viewName),
             })
         );
     }

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -110,7 +110,7 @@ export class QueryInfo extends Record({
         let schemaQuery: SchemaQuery;
 
         if (rawQueryInfo.schemaName && rawQueryInfo.name) {
-            schemaQuery = SchemaQuery.create(rawQueryInfo.schemaName, rawQueryInfo.name);
+            schemaQuery = new SchemaQuery(rawQueryInfo.schemaName, rawQueryInfo.name);
         }
 
         return new QueryInfo(
@@ -130,7 +130,7 @@ export class QueryInfo extends Record({
         let schemaQuery: SchemaQuery;
 
         if (queryInfoJson.schemaName && queryInfoJson.name) {
-            schemaQuery = SchemaQuery.create(queryInfoJson.schemaName, queryInfoJson.name);
+            schemaQuery = new SchemaQuery(queryInfoJson.schemaName, queryInfoJson.name);
         }
         let columns = OrderedMap<string, QueryColumn>();
         Object.keys(queryInfoJson.columns).forEach(columnKey => {

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -299,7 +299,7 @@ describe('CustomizeGridViewModal', () => {
             views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }),
             columns,
         });
-        let model = makeTestQueryModel(SchemaQuery.create('test', QUERY_NAME), queryInfo);
+        let model = makeTestQueryModel(new SchemaQuery('test', QUERY_NAME), queryInfo);
         model = model.mutate({ title: 'Title' });
         const wrapper = mount(<CustomizeGridViewModal model={model} onCancel={jest.fn()} onUpdate={jest.fn()} />);
         expect(wrapper.find(Modal.Title).text()).toBe('Customize Title Grid');
@@ -313,7 +313,7 @@ describe('CustomizeGridViewModal', () => {
             views: fromJS({ [viewName.toLowerCase()]: view }),
             columns,
         });
-        const model = makeTestQueryModel(SchemaQuery.create('test', QUERY_NAME, viewName), queryInfo);
+        const model = makeTestQueryModel(new SchemaQuery('test', QUERY_NAME, viewName), queryInfo);
         const wrapper = mount(<CustomizeGridViewModal model={model} onCancel={jest.fn()} onUpdate={jest.fn()} />);
         expect(wrapper.find(Modal.Title).text()).toBe('Customize ' + QUERY_NAME + ' Grid - ' + viewName);
         wrapper.unmount();
@@ -328,7 +328,7 @@ describe('CustomizeGridViewModal', () => {
             views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }),
             columns,
         });
-        const model = makeTestQueryModel(SchemaQuery.create('test', QUERY_NAME), queryInfo);
+        const model = makeTestQueryModel(new SchemaQuery('test', QUERY_NAME), queryInfo);
         const wrapper = mount(<CustomizeGridViewModal model={model} onCancel={jest.fn()} onUpdate={jest.fn()} />);
         let columnChoices = wrapper.find(ColumnChoice);
         expect(columnChoices).toHaveLength(3);
@@ -389,7 +389,7 @@ describe('CustomizeGridViewModal', () => {
             views: fromJS({ [ViewInfo.DEFAULT_NAME.toLowerCase()]: view }),
             columns,
         });
-        const model = makeTestQueryModel(SchemaQuery.create('test', QUERY_NAME), queryInfo);
+        const model = makeTestQueryModel(new SchemaQuery('test', QUERY_NAME), queryInfo);
         const wrapper = mount(
             <CustomizeGridViewModal
                 model={model}

--- a/packages/components/src/public/QueryModel/GridFilterModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridFilterModal.spec.tsx
@@ -21,7 +21,7 @@ describe('GridFilterModal', () => {
         api: getTestAPIWrapper(jest.fn, {}),
         initFilters: [],
         model: makeTestQueryModel(
-            SchemaQuery.create('schema', 'query', 'view'),
+            new SchemaQuery('schema', 'query', 'view'),
             QueryInfo.create({ name: 'Query', title: 'Query Title' })
         ),
         onApply: jest.fn,

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -29,7 +29,7 @@ import { ActionValue } from './grid/actions/Action';
 // The wrapper's return type for mount<GridPanel>(<GridPanel ... />)
 type GridPanelWrapper = ReactWrapper<Readonly<GridPanel['props']>, Readonly<GridPanel['state']>, GridPanel>;
 
-const SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
+const SCHEMA_QUERY = new SchemaQuery('exp.data', 'mixtures');
 let QUERY_INFO: QueryInfo;
 let DATA: RowsResponse;
 
@@ -276,7 +276,7 @@ describe('GridPanel', () => {
         const nameFilter = Filter.create('Name', 'DMXP', Filter.Types.EQUAL);
         const expirFilter = Filter.create('expirationTime', '1', Filter.Types.EQUAL);
         const viewName = 'noMixtures';
-        const noMixturesSQ = SchemaQuery.create(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, viewName);
+        const noMixturesSQ = new SchemaQuery(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, viewName);
         const search = Filter.create('*', 'foobar', Filter.Types.Q);
 
         expectBoundState(wrapper, {}, 0, []);
@@ -517,7 +517,7 @@ describe('GridTitle', () => {
     });
 
     test('view, no title', () => {
-        const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
+        const viewSchemaQuery = new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn');
         const modelWithView = makeTestQueryModel(viewSchemaQuery, QUERY_INFO);
         const wrapper = mountWithServerContext(<GridTitle {...GRID_TITLE_PROPS} model={modelWithView} />, {
             user: TEST_USER_EDITOR,
@@ -527,7 +527,7 @@ describe('GridTitle', () => {
     });
 
     test('title and view', () => {
-        const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
+        const viewSchemaQuery = new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn');
         const modelWithView = makeTestQueryModel(viewSchemaQuery, QUERY_INFO);
         const wrapper = mountWithServerContext(<GridTitle {...GRID_TITLE_PROPS} model={modelWithView} />, {
             user: TEST_USER_EDITOR,
@@ -566,7 +566,7 @@ describe('GridTitle', () => {
     });
 
     test('updated named view, no title, customizable', () => {
-        const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
+        const viewSchemaQuery = new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn');
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'session'], true).setIn(
             ['views', 'noextracolumn', 'revertable'],
             true
@@ -581,7 +581,7 @@ describe('GridTitle', () => {
     });
 
     test('updated named view with title', () => {
-        const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
+        const viewSchemaQuery = new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn');
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'session'], true).setIn(
             ['views', 'noextracolumn', 'revertable'],
             true
@@ -596,7 +596,7 @@ describe('GridTitle', () => {
     });
 
     test('hidden view, edited', () => {
-        const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
+        const viewSchemaQuery = new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn');
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'session'], true)
             .setIn(['views', 'noextracolumn', 'revertable'], true)
             .setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
@@ -610,7 +610,7 @@ describe('GridTitle', () => {
     });
 
     test('hidden view, edited, no title', () => {
-        const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
+        const viewSchemaQuery = new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn');
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'session'], true)
             .setIn(['views', 'noextracolumn', 'revertable'], true)
             .setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
@@ -624,7 +624,7 @@ describe('GridTitle', () => {
     });
 
     test('hidden view, not edited, no title', () => {
-        const viewSchemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn');
+        const viewSchemaQuery = new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn');
         const sessionQueryInfo = QUERY_INFO.setIn(['views', 'noextracolumn', 'hidden'], true) as QueryInfo;
         const model = makeTestQueryModel(viewSchemaQuery, sessionQueryInfo);
         const wrapper = mountWithServerContext(

--- a/packages/components/src/public/QueryModel/QueryModel.spec.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.spec.ts
@@ -15,7 +15,7 @@ import { ViewInfo } from '../../internal/ViewInfo';
 import { flattenValuesFromRow, QueryConfig, QueryModel } from './QueryModel';
 import { makeTestQueryModel } from './testUtils';
 
-const SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
+const SCHEMA_QUERY = new SchemaQuery('exp.data', 'mixtures');
 let QUERY_INFO: QueryInfo;
 const ROWS = {
     '0': {
@@ -49,7 +49,7 @@ describe('QueryModel', () => {
         expect(model.viewName).toEqual(undefined);
         // Auto-generated model ids are based off of the SchemaQuery in the QueryConfig
         expect(model.id).toEqual('exp.data.mixtures');
-        const schemaQuery = SchemaQuery.create('exp.data', 'mixtures', 'someViewName');
+        const schemaQuery = new SchemaQuery('exp.data', 'mixtures', 'someViewName');
         model = new QueryModel({ schemaQuery });
         expect(model.viewName).toEqual('someViewName');
         model = new QueryModel({ id: 'custom', schemaQuery: SCHEMA_QUERY });
@@ -150,7 +150,7 @@ describe('QueryModel', () => {
 
         // Change view to noExtraColumn which should change our expected columns.
         model = model.mutate({
-            schemaQuery: SchemaQuery.create('exp.data', 'mixtures', 'noExtraColumn'),
+            schemaQuery: new SchemaQuery('exp.data', 'mixtures', 'noExtraColumn'),
         });
         expectedDisplayCols = [
             cols.get('name'),
@@ -245,7 +245,7 @@ describe('QueryModel', () => {
         const queryInfo = QueryInfo.create({
             views: fromJS({ [viewName.toLowerCase()]: view }),
         });
-        const sq = SchemaQuery.create('exp.data', 'mixtures', viewName);
+        const sq = new SchemaQuery('exp.data', 'mixtures', viewName);
 
         const model = makeTestQueryModel(sq, queryInfo).mutate({
             baseFilters: [

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -373,7 +373,7 @@ export class QueryModel {
         // Note: this default may not be appropriate outside of Biologics/SM
         if (keyValue !== undefined && schemaQuery.viewName === undefined) {
             const { schemaName, queryName } = schemaQuery;
-            this.schemaQuery = SchemaQuery.create(schemaName, queryName, ViewInfo.DETAIL_NAME);
+            this.schemaQuery = new SchemaQuery(schemaName, queryName, ViewInfo.DETAIL_NAME);
             this.bindURL = false;
         } else {
             this.schemaQuery = schemaQuery;
@@ -980,7 +980,7 @@ export class QueryModel {
         const columnFilters = Filter.getFiltersFromParameters(queryParams, prefix) || [];
         let filterArray = columnFilters.concat(searchFilters);
         let offset = offsetFromString(this.maxRows, queryParams[`${prefix}.p`]) ?? DEFAULT_OFFSET;
-        let schemaQuery = SchemaQuery.create(this.schemaName, this.queryName, viewName);
+        let schemaQuery = new SchemaQuery(this.schemaName, this.queryName, viewName);
         let selectedReportId = queryParams[`${prefix}.reportId`] ?? undefined;
         let sorts = querySortsFromString(queryParams[`${prefix}.sort`]) ?? [];
 

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.spec.tsx
@@ -41,7 +41,7 @@ describe('TabbedGridPanel', () => {
 
     beforeEach(() => {
         mixturesModel = makeTestQueryModel(
-            SchemaQuery.create('exp.data', 'mixtures'),
+            new SchemaQuery('exp.data', 'mixtures'),
             MIXTURES_QUERY_INFO,
             MIXTURES_DATA.rows,
             MIXTURES_DATA.orderedRows,
@@ -49,7 +49,7 @@ describe('TabbedGridPanel', () => {
             'mixtures'
         );
         aminoAcidsModel = makeTestQueryModel(
-            SchemaQuery.create('assay.General.Amino Acids', 'Runs'),
+            new SchemaQuery('assay.General.Amino Acids', 'Runs'),
             AMINO_ACIDS_QUERY_INFO,
             AMINO_ACIDS_DATA.rows,
             AMINO_ACIDS_DATA.orderedRows,

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -13,7 +13,7 @@ import { QueryInfo } from '../QueryInfo';
 import { ViewMenu } from './ViewMenu';
 import { makeTestQueryModel } from './testUtils';
 
-const SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
+const SCHEMA_QUERY = new SchemaQuery('exp.data', 'mixtures');
 let QUERY_INFO_NO_VIEWS: QueryInfo;
 let QUERY_INFO_PUBLIC_VIEWS: QueryInfo;
 let QUERY_INFO_PRIVATE_VIEWS: QueryInfo;
@@ -80,7 +80,7 @@ describe('ViewMenu', () => {
 
         // Same as previous, but the No Extra Column view is set to active.
         model = model.mutate({
-            schemaQuery: SchemaQuery.create(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, 'noExtraColumn'),
+            schemaQuery: new SchemaQuery(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, 'noExtraColumn'),
         });
         tree = renderer.create(<ViewMenu {...DEFAULT_PROPS} hideEmptyViewMenu={true} model={model} />);
         expect(tree.toJSON()).toMatchSnapshot();

--- a/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
@@ -30,10 +30,10 @@ import { RowsResponse } from './QueryModelLoader';
  * better idea by all means try it.
  */
 
-const MIXTURES_SCHEMA_QUERY = SchemaQuery.create('exp.data', 'mixtures');
+const MIXTURES_SCHEMA_QUERY = new SchemaQuery('exp.data', 'mixtures');
 let MIXTURES_QUERY_INFO: QueryInfo;
 let MIXTURES_DATA: RowsResponse;
-const AMINO_ACIDS_SCHEMA_QUERY = SchemaQuery.create('assay.General.Amino Acids', 'Runs');
+const AMINO_ACIDS_SCHEMA_QUERY = new SchemaQuery('assay.General.Amino Acids', 'Runs');
 let AMINO_ACIDS_QUERY_INFO: QueryInfo;
 let AMINO_ACIDS_DATA: RowsResponse;
 

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -752,7 +752,7 @@ export function withQueryModels<Props>(
 
                     if (model.viewName !== viewName) {
                         shouldLoad = true;
-                        model.schemaQuery = SchemaQuery.create(model.schemaName, model.queryName, viewName);
+                        model.schemaQuery = new SchemaQuery(model.schemaName, model.queryName, viewName);
                         // We need to reset all data for the model because changing the view will change things such as
                         // columns and rowCount. If we don't do this we'll render a grid with empty rows/columns.
                         resetRowsState(model);

--- a/packages/components/src/public/SchemaQuery.spec.ts
+++ b/packages/components/src/public/SchemaQuery.spec.ts
@@ -1,27 +1,4 @@
-import { getSchemaQuery, resolveKey, resolveKeyFromJson, resolveSchemaQuery, SchemaQuery } from './SchemaQuery';
-
-describe('resolveSchemaQuery', () => {
-    test('handle undefined schemaQuery', () => {
-        expect(resolveSchemaQuery(undefined)).toBeNull();
-    });
-
-    test('schema without encoding required', () => {
-        const schemaQuery = new SchemaQuery({
-            schemaName: 'name',
-            queryName: 'my favorite query',
-        });
-        expect(resolveSchemaQuery(schemaQuery)).toBe('name/my favorite query');
-    });
-
-    test('schema with view', () => {
-        const schemaQuery = new SchemaQuery({
-            schemaName: 'name',
-            queryName: 'my favorite query',
-            viewName: 'view2'
-        });
-        expect(resolveSchemaQuery(schemaQuery)).toBe('name/my favorite query/view2');
-    });
-});
+import { getSchemaQuery, resolveKey, resolveKeyFromJson, SchemaQuery } from './SchemaQuery';
 
 describe('getSchemaQuery', () => {
     test('no decoding required, no view', () => {

--- a/packages/components/src/public/SchemaQuery.spec.ts
+++ b/packages/components/src/public/SchemaQuery.spec.ts
@@ -2,20 +2,22 @@ import { getSchemaQuery, resolveKey, resolveKeyFromJson, SchemaQuery } from './S
 
 describe('getSchemaQuery', () => {
     test('no decoding required, no view', () => {
-        expect(getSchemaQuery('name/query')).toEqual(new SchemaQuery({
-            schemaName: 'name',
-            queryName: 'query',
-        }));
-        expect(getSchemaQuery('name/query/view')).toEqual(new SchemaQuery({
-            schemaName: 'name',
-            queryName: 'query',
-            viewName: 'view'
-        }));
+        expect(getSchemaQuery('name/query')).toEqual(
+            new SchemaQuery({
+                schemaName: 'name',
+                queryName: 'query',
+            })
+        );
+        expect(getSchemaQuery('name/query/view')).toEqual(
+            new SchemaQuery({
+                schemaName: 'name',
+                queryName: 'query',
+                viewName: 'view',
+            })
+        );
     });
 
-    test('no decoding required, with view', () => {
-
-    });
+    test('no decoding required, with view', () => {});
 
     test('decoding required', () => {
         expect(getSchemaQuery('my$Sname/just$pask')).toEqual(
@@ -34,7 +36,7 @@ describe('getSchemaQuery', () => {
             new SchemaQuery({
                 schemaName: 'one.two.three$',
                 queryName: 'q1',
-                viewName: 'view/2$'
+                viewName: 'view/2$',
             })
         );
     });
@@ -57,8 +59,12 @@ describe('resolveKeyFromJson', () => {
     test('schema name with one part', () => {
         expect(resolveKeyFromJson({ schemaName: ['partOne'], queryName: 'q/Name' })).toBe('partone/q$sname');
         expect(resolveKeyFromJson({ schemaName: ['p&rtOne'], queryName: '//$Name' })).toBe('p$dartone/$s$s$dname');
-        expect(resolveKeyFromJson({ schemaName: ['p&rtOne'], queryName: '//$Name', viewName: 'view' })).toBe('p$dartone/$s$s$dname/view');
-        expect(resolveKeyFromJson({ schemaName: ['p&rtOne'], queryName: '//$Name', viewName: 'new/view$' })).toBe('p$dartone/$s$s$dname/new$sview$d');
+        expect(resolveKeyFromJson({ schemaName: ['p&rtOne'], queryName: '//$Name', viewName: 'view' })).toBe(
+            'p$dartone/$s$s$dname/view'
+        );
+        expect(resolveKeyFromJson({ schemaName: ['p&rtOne'], queryName: '//$Name', viewName: 'new/view$' })).toBe(
+            'p$dartone/$s$s$dname/new$sview$d'
+        );
     });
 
     test('schema name with multiple parts', () => {

--- a/packages/components/src/public/SchemaQuery.spec.ts
+++ b/packages/components/src/public/SchemaQuery.spec.ts
@@ -2,42 +2,17 @@ import { getSchemaQuery, resolveKey, resolveKeyFromJson, SchemaQuery } from './S
 
 describe('getSchemaQuery', () => {
     test('no decoding required, no view', () => {
-        expect(getSchemaQuery('name/query')).toEqual(
-            new SchemaQuery({
-                schemaName: 'name',
-                queryName: 'query',
-            })
-        );
-        expect(getSchemaQuery('name/query/view')).toEqual(
-            new SchemaQuery({
-                schemaName: 'name',
-                queryName: 'query',
-                viewName: 'view',
-            })
-        );
+        expect(getSchemaQuery('name/query')).toEqual(new SchemaQuery('name', 'query'));
+        expect(getSchemaQuery('name/query/view')).toEqual(new SchemaQuery('name', 'query', 'view'));
     });
 
     test('no decoding required, with view', () => {});
 
     test('decoding required', () => {
-        expect(getSchemaQuery('my$Sname/just$pask')).toEqual(
-            new SchemaQuery({
-                schemaName: 'my/name',
-                queryName: 'just.ask',
-            })
-        );
-        expect(getSchemaQuery('one$ptwo$pthree$d/q1')).toEqual(
-            new SchemaQuery({
-                schemaName: 'one.two.three$',
-                queryName: 'q1',
-            })
-        );
+        expect(getSchemaQuery('my$Sname/just$pask')).toEqual(new SchemaQuery('my/name', 'just.ask'));
+        expect(getSchemaQuery('one$ptwo$pthree$d/q1')).toEqual(new SchemaQuery('one.two.three$', 'q1'));
         expect(getSchemaQuery('one$ptwo$pthree$d/q1/view$s2$d')).toEqual(
-            new SchemaQuery({
-                schemaName: 'one.two.three$',
-                queryName: 'q1',
-                viewName: 'view/2$',
-            })
+            new SchemaQuery('one.two.three$', 'q1', 'view/2$')
         );
     });
 });

--- a/packages/components/src/public/SchemaQuery.ts
+++ b/packages/components/src/public/SchemaQuery.ts
@@ -66,12 +66,10 @@ export class SchemaQuery {
     queryName: string;
     viewName: string;
 
-    constructor(schemaQuery: Partial<SchemaQuery>) {
-        Object.assign(this, schemaQuery);
-    }
-
-    static create(schemaName: string, queryName: string, viewName?: string): SchemaQuery {
-        return new SchemaQuery({ schemaName, queryName, viewName });
+    constructor(schemaName: string, queryName: string, viewName?: string) {
+        this.schemaName = schemaName;
+        this.queryName = queryName;
+        this.viewName = viewName;
     }
 
     isEqual(sq: SchemaQuery): boolean {
@@ -112,5 +110,5 @@ export class SchemaQuery {
 export function getSchemaQuery(encodedKey: string): SchemaQuery {
     const [encodedSchema, encodedQuery, encodedViewName] = encodedKey.split('/');
 
-    return SchemaQuery.create(decodePart(encodedSchema), decodePart(encodedQuery), decodePart(encodedViewName));
+    return new SchemaQuery(decodePart(encodedSchema), decodePart(encodedQuery), decodePart(encodedViewName));
 }

--- a/packages/components/src/public/SchemaQuery.ts
+++ b/packages/components/src/public/SchemaQuery.ts
@@ -32,9 +32,10 @@ export function encodePart(s: string): string {
 
 export function resolveKey(schema: string, query: string, viewName?: string): string {
     /*
-       It's questionable if we really need to encodePart schema here and the suspicion is that this would result in double encoding.
-       Since schema is not recognisable by api when not encoded, it would be reasonable to assume the passed in schema is already QueryKey encoded.
-       Though it won't hurt to double encode as long as resolveKey, resolveKeyFromJson and getSchemaQuery have the same assumption on the need to encode/decode
+       It's questionable if we really need to encodePart schema here and the suspicion is that this would result in
+       double encoding. Since schema is not recognisable by api when not encoded, it would be reasonable to assume the
+       passed in schema is already QueryKey encoded.  Though it won't hurt to double encode as long as resolveKey,
+       resolveKeyFromJson and getSchemaQuery have the same assumption on the need to encode/decode
     */
     const parts = [encodePart(schema), encodePart(query)];
     if (viewName) parts.push(encodePart(viewName));
@@ -75,21 +76,6 @@ export class SchemaQuery extends Record({
         return new SchemaQuery({ schemaName, queryName, viewName });
     }
 
-    // TODO: remove unnecessary function, Records are Immutable and/or this can be a getter function.
-    getSchema() {
-        return this.schemaName;
-    }
-
-    // TODO: remove unnecessary function, Records are Immutable and/or this can be a getter function.
-    getQuery() {
-        return this.queryName;
-    }
-
-    // TODO: remove unnecessary function, Records are Immutable and/or this can be a getter function.
-    getView() {
-        return this.viewName;
-    }
-
     isEqual(sq: SchemaQuery): boolean {
         if (!sq) return false;
         return this.toString().toLowerCase() === sq.toString().toLowerCase();
@@ -123,14 +109,6 @@ export class SchemaQuery extends Record({
     toString(): string {
         return [this.schemaName, this.queryName, this.viewName].join('|');
     }
-}
-
-// TODO: resolveSchemaQuery should have a better name, and it should be added as a property on the SchemaQuery record
-//  class. I'm really not sure what resolve is supposed to mean in this context, but I think we can add this as a
-//  property called "key", or something similar since it mostly seems to be used as a state key.
-/** @deprecated Use schemaQuery.getKey() instead */
-export function resolveSchemaQuery(schemaQuery: SchemaQuery): string {
-    return schemaQuery ? resolveKey(schemaQuery.getSchema(), schemaQuery.getQuery(), schemaQuery.getView()) : null;
 }
 
 export function getSchemaQuery(encodedKey: string): SchemaQuery {

--- a/packages/components/src/public/SchemaQuery.ts
+++ b/packages/components/src/public/SchemaQuery.ts
@@ -1,5 +1,3 @@
-import { Record } from 'immutable';
-
 const APP_SELECTION_PREFIX = 'appkey';
 
 // 36009: Case-insensitive variant of QueryKey.decodePart
@@ -63,14 +61,14 @@ export interface IParsedSelectionKey {
     schemaQuery: SchemaQuery;
 }
 
-export class SchemaQuery extends Record({
-    schemaName: undefined,
-    queryName: undefined,
-    viewName: undefined,
-}) {
-    declare schemaName: string;
-    declare queryName: string;
-    declare viewName: string;
+export class SchemaQuery {
+    schemaName: string;
+    queryName: string;
+    viewName: string;
+
+    constructor(schemaQuery: Partial<SchemaQuery>) {
+        Object.assign(this, schemaQuery);
+    }
 
     static create(schemaName: string, queryName: string, viewName?: string): SchemaQuery {
         return new SchemaQuery({ schemaName, queryName, viewName });

--- a/packages/components/src/test/data/constants.ts
+++ b/packages/components/src/test/data/constants.ts
@@ -428,8 +428,8 @@ export const TEST_FOLDER_CONTAINER = new Container({
 });
 
 export const TestTypeDataType: EntityDataType = {
-    typeListingSchemaQuery: SchemaQuery.create('TestListing', 'query'),
-    listingSchemaQuery: SchemaQuery.create('Test', 'query'),
+    typeListingSchemaQuery: new SchemaQuery('TestListing', 'query'),
+    listingSchemaQuery: new SchemaQuery('Test', 'query'),
     instanceSchemaName: 'TestSchema',
     operationConfirmationControllerName: 'controller',
     operationConfirmationActionName: 'test-delete-confirmation.api',


### PR DESCRIPTION
#### Rationale
SchemaQuery doesn't need to be an Immutable class, and it doesn't need the various getter methods.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1095
- https://github.com/LabKey/labkey-ui-premium/pull/35
- https://github.com/LabKey/platform/pull/4078
- https://github.com/LabKey/sampleManagement/pull/1584
- https://github.com/LabKey/inventory/pull/714
- https://github.com/LabKey/labbook/pull/410
- https://github.com/LabKey/biologics/pull/1901

#### Changes
- Make SchemaQuery a vanilla class
- Remove getQuery, getSchema, and getView methods from SchemaQuery
- Remove deprecated and unused method resolveSchemaQuery
