### PR TITLE
Issue 46618: respect sort keys in QuerySelect

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.288.0",
+  "version": "2.288.0-fb-fix-46618.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.288.0-fb-fix-46618.0",
+  "version": "2.288.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.288.1
+*Released*: 6 February 2023
+- Issue 46618: Retain result row ordering in `formatSavedResults` and `formatResults` when processing results of `QuerySelect` queries.
+- Add the `hasSortKey` property to the `QueryColumn` model. Now supported by `query-getQueryDetails.api`.
+
 ### version 2.288.0
 *Released*: 1 February 2023
 - Create components for `SamplesCreatedSuccessMessage` and `SamplesImportSuccessMessage`. Utilize `withRouter`.

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { FC, PureComponent, ReactNode } from 'react';
-import { fromJS, List, Map } from 'immutable';
+import { List, Map } from 'immutable';
 import { Filter, Query, Utils } from '@labkey/api';
 
 import { SchemaQuery } from '../../../public/SchemaQuery';
@@ -230,12 +230,10 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
                     if (request !== this.lastRequest) return;
                     delete this.lastRequest;
 
-                    const models = fromJS(data.models[data.key]);
-
-                    resolve(model.formatSavedResults(models, input));
+                    resolve(model.formatSavedResults(data, input));
 
                     this.setState(() => ({
-                        model: model.saveSearchResults(models),
+                        model: model.saveSearchResults(data),
                     }));
                 } catch (error) {
                     const errorMsg = resolveErrorMessage(error) ?? 'Failed to retrieve search results.';

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -87,6 +87,7 @@ export class QueryColumn extends Record({
     filterable: true,
     format: undefined,
     // friendlyType: undefined,
+    hasSortKey: false,
     hidden: undefined,
     inputType: undefined,
     // isAutoIncrement: undefined, // DUPLICATE
@@ -163,6 +164,7 @@ export class QueryColumn extends Record({
     declare filterable: boolean;
     declare format: string;
     // declare friendlyType: string;
+    declare hasSortKey: boolean;
     declare hidden: boolean;
     declare inputType: string;
     // declare isAutoIncrement: boolean; // DUPLICATE


### PR DESCRIPTION
#### Rationale
This addresses [Issue 46618](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46618) where QuerySelect-based dropdowns in our applications were not respecting the `<sortColumn>` property that is definable on XML query metadata for a column. With these changes if a column has a sort key specified, as determined by the server, then the QuerySelect will skip doing a client-side sort of the results.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1098
- https://github.com/LabKey/labkey-ui-premium/pull/37
- https://github.com/LabKey/platform/pull/4095
- https://github.com/LabKey/biologics/pull/1910
- https://github.com/LabKey/inventory/pull/718
- https://github.com/LabKey/sampleManagement/pull/1591

#### Changes
- Add the `hasSortKey` property to the `QueryColumn` model. Now supported by `query-getQueryDetails.api`.
- Retain result row ordering in `formatSavedResults` and `formatResults` when processing results of `QuerySelect` queries.
