### PR TITLE
Issue 47303: Fix bad URL in route change after clicking link in success message

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.288.1",
+  "version": "2.288.2-badAddToStorageUrl.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.288.2-badAddToStorageUrl.0",
+  "version": "2.288.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.288.2
+*Released*: TBD
+- Issue 47303: fix bad URL redirection from SamplesCreatedSuccessMessage
+
 ### version 2.288.1
 *Released*: 6 February 2023
 - Issue 46618: Retain result row ordering in `formatSavedResults` and `formatResults` when processing results of `QuerySelect` queries.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.288.2
-*Released*: TBD
+*Released*: 14 February 2023
 - Issue 47303: fix bad URL redirection from SamplesCreatedSuccessMessage
 
 ### version 2.288.1

--- a/packages/components/src/entities/SamplesCreatedSuccessMessage.tsx
+++ b/packages/components/src/entities/SamplesCreatedSuccessMessage.tsx
@@ -75,7 +75,7 @@ const SamplesCreatedSuccessMessageImpl: FC<SamplesCreatedSuccessMessageProps & W
                 sampleListingGridId,
                 actions
             );
-            router.push(url.toHref());
+            router.push(url.toString());
         } catch (e) {
             setError(resolveErrorMessage(e));
         }


### PR DESCRIPTION
#### Rationale
In the related PR, there was an update to how the routing happens in the `SamplesCreatedSuccessMessage` that inadvertently added an extra `#` in the URL causing it to not have the desired effect of opening the add to storage modal.

#### Related Pull Requests
- #1094 
- https://github.com/LabKey/sampleManagement/pull/1601
- https://github.com/LabKey/biologics/pull/1923
- https://github.com/LabKey/inventory/pull/731


#### Changes
- Use `toString` instead of `toHref` since we're in the app already.
