### PR TITLE
Issue 47257: Cannot delete samples from a grid that has a filter applied

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.288.2-fb-selectionWithFilter.1",
+  "version": "2.288.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.288.2-fb-selectionWithFilter.0",
+  "version": "2.288.2-fb-selectionWithFilter.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.288.2",
+  "version": "2.288.2-fb-selectionWithFilter.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.288.TBD
+*Released*: TBD February 2023
+- Issue 47257: ...
+  - make sure setSnapshotSelections() is called before selectionKey based call to getCrossFolderSelectionResult()
+
 ### version 2.288.2
 *Released*: 14 February 2023
 - Issue 47303: fix bad URL redirection from SamplesCreatedSuccessMessage

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.288.TBD
 *Released*: TBD February 2023
-- Issue 47257: ...
+- Issue 47257: Cannot delete samples from a grid that has a filter applied
   - make sure setSnapshotSelections() is called before selectionKey based call to getCrossFolderSelectionResult()
 
 ### version 2.288.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.288.TBD
-*Released*: TBD February 2023
+### version 2.288.3
+*Released*: 14 February 2023
 - Issue 47257: Cannot delete samples from a grid that has a filter applied
   - make sure setSnapshotSelections() is called before selectionKey based call to getCrossFolderSelectionResult()
 

--- a/packages/components/src/entities/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/entities/AssayImportSubMenuItem.tsx
@@ -16,6 +16,8 @@ import { MenuOption, SubMenu } from '../internal/components/menus/SubMenu';
 import { isProjectContainer } from '../internal/app/utils';
 import { EntityCrossProjectSelectionConfirmModal } from '../internal/components/entities/EntityCrossProjectSelectionConfirmModal';
 
+import { setSnapshotSelections } from '../internal/actions';
+
 import { getImportItemsForAssayDefinitions } from './utils';
 
 interface Props extends SubMenuItemProps {
@@ -54,7 +56,15 @@ export const AssayImportSubMenuItemImpl: FC<Props & InjectedAssayModel> = props 
             // check cross folder selection
             if (queryModel?.hasSelections) {
                 setCrossFolderSelectionResult(undefined);
-                const result = await getCrossFolderSelectionResult(queryModel.id, 'sample', queryModel.filterArray.length > 0, undefined, picklistName);
+                const useSnapshotSelection = queryModel.filterArray.length > 0;
+                if (useSnapshotSelection) await setSnapshotSelections(queryModel.id, [...queryModel.selections]);
+                const result = await getCrossFolderSelectionResult(
+                    queryModel.id,
+                    'sample',
+                    useSnapshotSelection,
+                    undefined,
+                    picklistName
+                );
 
                 if (result.crossFolderSelectionCount > 0) {
                     setCrossFolderSelectionResult({
@@ -127,7 +137,7 @@ export const AssayImportSubMenuItemImpl: FC<Props & InjectedAssayModel> = props 
         return null;
     }
 
-    const badSelection = overlayMessage.length > 0
+    const badSelection = overlayMessage.length > 0;
     const menuProps = Object.assign({}, props, {
         disabled: badSelection,
         options: items,

--- a/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
+++ b/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
@@ -183,8 +183,9 @@ const CreateSamplesSubMenuBaseImpl: FC<CreateSamplesSubMenuBaseProps & WithRoute
                 !skipCrossFolderCheck &&
                 !allowCrossFolderDerive
             ) {
-                const dataType = parentQueryModel.schemaName === SCHEMAS.DATA_CLASSES.SCHEMA ? 'data' : 'sample';
                 setCrossFolderSelectionResult(undefined);
+                const dataType = parentQueryModel.schemaName === SCHEMAS.DATA_CLASSES.SCHEMA ? 'data' : 'sample';
+                if (useSnapshotSelection) await setSnapshotSelections(selectionKey, [...parentQueryModel.selections]);
                 const result = await getCrossFolderSelectionResult(parentQueryModel.id, dataType, useSnapshotSelection);
 
                 if (result.crossFolderSelectionCount > 0) {
@@ -216,6 +217,7 @@ const CreateSamplesSubMenuBaseImpl: FC<CreateSamplesSubMenuBaseProps & WithRoute
             allowCrossFolderDerive,
             onSampleCreationMenuSelect,
             useSnapshotSelection,
+            selectionKey,
             selectedType,
         ]
     );

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -50,11 +50,9 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
     let rowIds;
     let numSelected = 0;
     let selectionKey: string;
-    let useSnapshotSelection = false;
 
     if (useSelected) {
         selectionKey = queryModel.selectionKey;
-        useSnapshotSelection = queryModel.filterArray.length > 0;
     } else if (queryModel.hasData) {
         rowIds = [Object.keys(queryModel.rows)[0]];
         numSelected = 1;
@@ -116,7 +114,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
             {!showProgress && (
                 <EntityDeleteConfirmModal
                     selectionKey={selectionKey}
-                    useSnapshotSelection={useSnapshotSelection}
+                    model={queryModel}
                     rowIds={rowIds}
                     onConfirm={onConfirm}
                     onCancel={onCancel}

--- a/packages/components/src/entities/SampleCreationTypeModal.tsx
+++ b/packages/components/src/entities/SampleCreationTypeModal.tsx
@@ -82,6 +82,7 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
             }
         } else {
             try {
+                // no need to setSnapshotSelections for this selectionKey case since if the model had filters it would use the selectionData case above
                 const confirmationData = await api.samples.getSampleOperationConfirmationData(SampleOperation.EditLineage, undefined, selectionKey);
                 if (this._mounted) {
                     this.setState({

--- a/packages/components/src/entities/SampleCreationTypeModal.tsx
+++ b/packages/components/src/entities/SampleCreationTypeModal.tsx
@@ -10,11 +10,13 @@ import { MAX_EDITABLE_GRID_ROWS } from '../internal/constants';
 
 import { Alert } from '../internal/components/base/Alert';
 
-import { SampleCreationTypeOption } from './SampleCreationTypeOption';
 import { SampleCreationType, SampleCreationTypeModel } from '../internal/components/samples/models';
 import { getOperationNotPermittedMessage } from '../internal/components/samples/utils';
-import { filterSampleRowsForOperation } from './utils';
+
 import { SampleOperation } from '../internal/components/samples/constants';
+
+import { filterSampleRowsForOperation } from './utils';
+import { SampleCreationTypeOption } from './SampleCreationTypeOption';
 
 interface Props {
     api?: ComponentsAPIWrapper;
@@ -83,7 +85,11 @@ export class SampleCreationTypeModal extends React.PureComponent<Props, State> {
         } else {
             try {
                 // no need to setSnapshotSelections for this selectionKey case since if the model had filters it would use the selectionData case above
-                const confirmationData = await api.samples.getSampleOperationConfirmationData(SampleOperation.EditLineage, undefined, selectionKey);
+                const confirmationData = await api.samples.getSampleOperationConfirmationData(
+                    SampleOperation.EditLineage,
+                    undefined,
+                    selectionKey
+                );
                 if (this._mounted) {
                     this.setState({
                         statusData: confirmationData,

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -27,10 +27,11 @@ import { getSampleTypeRowId } from '../internal/components/samples/actions';
 import { SampleGridButtonProps } from '../internal/components/samples/models';
 import { NEW_SAMPLES_HREF, SAMPLES_KEY } from '../internal/app/constants';
 
+import { setSnapshotSelections } from '../internal/actions';
+
 import { shouldIncludeMenuItem } from './utils';
 import { SampleDeleteMenuItem } from './SampleDeleteMenuItem';
 import { EntityLineageEditMenuItem } from './EntityLineageEditMenuItem';
-import { setSnapshotSelections } from '../internal/actions';
 
 interface OwnProps {
     combineParentTypes?: boolean;

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -75,7 +75,7 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
                 }
             }
         },
-        [model]
+        [model.filterArray.length, model?.hasSelections, model.id, model.selections]
     );
 
     const onToggleEditWithGridUpdate = useCallback(() => {

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -30,6 +30,7 @@ import { NEW_SAMPLES_HREF, SAMPLES_KEY } from '../internal/app/constants';
 import { shouldIncludeMenuItem } from './utils';
 import { SampleDeleteMenuItem } from './SampleDeleteMenuItem';
 import { EntityLineageEditMenuItem } from './EntityLineageEditMenuItem';
+import { setSnapshotSelections } from '../internal/actions';
 
 interface OwnProps {
     combineParentTypes?: boolean;
@@ -61,7 +62,9 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
         async (onClick: () => void, errorMsg?: string): Promise<void> => {
             if (model?.hasSelections) {
                 setCrossFolderSelectionResult(undefined);
-                const result = await getCrossFolderSelectionResult(model.id, 'sample', model.filterArray.length > 0);
+                const useSnapshotSelection = model.filterArray.length > 0;
+                if (useSnapshotSelection) await setSnapshotSelections(model.id, [...model.selections]);
+                const result = await getCrossFolderSelectionResult(model.id, 'sample', useSnapshotSelection);
                 if (result.crossFolderSelectionCount > 0) {
                     setCrossFolderSelectionResult({
                         ...result,
@@ -72,7 +75,7 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
                 }
             }
         },
-        [model?.hasSelections, model.id]
+        [model]
     );
 
     const onToggleEditWithGridUpdate = useCallback(() => {

--- a/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityDeleteConfirmModal.tsx
@@ -21,6 +21,10 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { Alert } from '../base/Alert';
 
+import { QueryModel } from '../../../public/QueryModel/QueryModel';
+
+import { setSnapshotSelections } from '../../actions';
+
 import { EntityDeleteConfirmHandler, EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
 import { getDeleteConfirmationData } from './actions';
 import { EntityDataType, OperationConfirmationData } from './models';
@@ -28,11 +32,11 @@ import { EntityDataType, OperationConfirmationData } from './models';
 interface Props {
     entityDataType: EntityDataType;
     getDeletionDescription?: (numToDelete: number) => React.ReactNode;
+    model?: QueryModel;
     onCancel: () => void;
     onConfirm: EntityDeleteConfirmHandler;
     rowIds?: string[];
     selectionKey?: string;
-    useSnapshotSelection?: boolean;
     verb?: string;
 }
 
@@ -73,9 +77,11 @@ export class EntityDeleteConfirmModal extends PureComponent<Props, State> {
     }
 
     init = async (): Promise<void> => {
-        const { entityDataType, rowIds, selectionKey, useSnapshotSelection } = this.props;
+        const { entityDataType, rowIds, selectionKey, model } = this.props;
 
         try {
+            const useSnapshotSelection = model?.filterArray.length > 0;
+            if (useSnapshotSelection) await setSnapshotSelections(selectionKey, [...model.selections]);
             const confirmationData = await getDeleteConfirmationData(
                 entityDataType,
                 rowIds,


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47257

There are two API actions that we do in our apps that make use of the snapshotSelections: getCrossFolderSelectionResult() and get[Entity]OperationConfirmationData(). In the case where these APIs are called using a selectionKey to get the selected row's primary keys, it is important that the call to setSnapshotSelections() has been made if there were also grid/model filters applied by the user. This PR adds those calls to setSnapshotSelections() to the various usages.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1104
- https://github.com/LabKey/labkey-ui-premium/pull/44
- https://github.com/LabKey/sampleManagement/pull/1602
- https://github.com/LabKey/biologics/pull/1926
- https://github.com/LabKey/inventory/pull/733

#### Changes
- make sure setSnapshotSelections() is called before selectionKey based call to getCrossFolderSelectionResult()
