### PR TITLE
Add LK version to app admin settings page header

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.292.1-fb-appLKVersion.1",
+  "version": "2.293.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.292.1",
+  "version": "2.292.1-fb-appLKVersion.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.292.1-fb-appLKVersion.0",
+  "version": "2.292.1-fb-appLKVersion.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD February 2023
+- Add LK version to app admin settings page header
+
 ### version 2.292.1
 *Released*: 13 February 2023
 - Issue 47190: Don't warn about required fields added to default grid from lookups

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD February 2023
+### version 2.293.0
+*Released*: 15 February 2023
 - Add LK version to app admin settings page header
 
 ### version 2.292.1

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useCallback } from 'react';
+import { getServerContext } from '@labkey/api';
 
 import { InjectedRouteLeaveProps, withRouteLeave } from '../../util/RouteLeave';
 import { useServerContext } from '../base/ServerContext';
@@ -42,6 +43,10 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
         createNotification('Successfully updated BarTender configuration.');
     }, [createNotification, dismissNotifications, setIsDirty]);
 
+    const lkVersion = useCallback(() => {
+        return <div className="gray-text">Version: {getServerContext().versionString}</div>;
+    }, []);
+
     if (!user.isAdmin) {
         return <InsufficientPermissionsPage title={TITLE} />;
     }
@@ -71,7 +76,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
     }
 
     return (
-        <BasePermissionsCheckPage user={user} title={TITLE} hasPermission={user.isAdmin}>
+        <BasePermissionsCheckPage user={user} title={TITLE} hasPermission={user.isAdmin} renderButtons={lkVersion}>
             <ActiveUserLimit />
             {isProductProjectsEnabled(moduleContext) && (
                 <ProjectSettings onChange={onSettingsChange} onSuccess={onSettingsSuccess} />

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -44,7 +44,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
     }, [createNotification, dismissNotifications, setIsDirty]);
 
     const lkVersion = useCallback(() => {
-        return <div className="gray-text">Version: {getServerContext().versionString}</div>;
+        return <div className="gray-text admin-settings-version">Version: {getServerContext().versionString}</div>;
     }, []);
 
     if (!user.isAdmin) {

--- a/packages/components/src/internal/components/base/CreatedModified.tsx
+++ b/packages/components/src/internal/components/base/CreatedModified.tsx
@@ -141,7 +141,10 @@ export class CreatedModified extends Component<CreatedModifiedProps, State> {
             const displayTxt = serverDate ? moment(timestamp).from(serverDate) : moment(timestamp).fromNow();
 
             return (
-                <span title={this.formatTitle(config)} className={classNames('createdmodified', className)}>
+                <span
+                    title={this.formatTitle(config)}
+                    className={classNames('createdmodified', 'gray-text', className)}
+                >
                     {config.useCreated ? 'Created' : 'Modified'} {displayTxt}
                 </span>
             );

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -182,14 +182,6 @@
 
 // CreatedModified component
 
-.createdmodified {
-  color: grey;
-
-  &:hover {
-    cursor: pointer;
-  }
-}
-
 .cbmb-inline {
   display: inline-block;
   margin-right: 10px;


### PR DESCRIPTION
#### Rationale
We want to make it easy for customers to see what version of LabKey they have running without having to leave the app. This PR adds the LABKEY.versionString display on the app admin settings page.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1107
- https://github.com/LabKey/inventory/pull/735
- https://github.com/LabKey/biologics/pull/1928
- https://github.com/LabKey/sampleManagement/pull/1604

#### Changes
- display LABKEY.versionString on app admin settings page
- cleanup unnecessary text color css for createdmodified
