### PR TITLE
Issue 46767: Set DatePicker disabled when showing an invalid date value

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.3",
+  "version": "2.293.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.0",
+  "version": "2.293.0-fb-datepickerInvalid46767.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD February 2023
+- Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))
+  - set the DatePicker as disabled in an invalid date is used, still allows it to be removed
+
 ### version 2.293.0
 *Released*: 15 February 2023
 - Add LK version to app admin settings page header

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD February 2023
+### version 2.293.4
+*Released*: 16 February 2023
 - Issue 46767: DatePicker valid dates start at year 1000 (i.e. new Date('1000-01-01'))
   - set the DatePicker as disabled in an invalid date is used, still allows it to be removed
 

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -51,8 +51,8 @@ export interface DatePickerInputProps extends DisableableInputProps, WithFormsyP
 }
 
 interface DatePickerInputState extends DisableableInputState {
-    selectedDate: any;
     invalid: boolean;
+    selectedDate: any;
 }
 
 // export for jest testing


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46767

The first version of the fix for issue 46767 prevented the JS error when trying to use the DatePicker with an invalid date (i.e. a date prior to year 1000, which was entered from a typo). However, it would null out the date in the details panel edit mode, which would clear the value on save without the user seeing it. This PR, disabled the DatePicker in the details panel edit mode when an invalid date is already saved for a field. It can still be cleared and then updated.

<img width="1308" alt="Screen Shot 2023-02-15 at 10 13 10 AM" src="https://user-images.githubusercontent.com/6411206/219095366-c35b050a-d973-4cc4-b751-f5e2e3d54c72.png">


#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1108
- https://github.com/LabKey/sampleManagement/pull/1605
- https://github.com/LabKey/biologics/pull/1930
- https://github.com/LabKey/inventory/pull/736

#### Changes
- set the DatePicker as disabled in an invalid date is used, still allows it to be removed
