### PR TITLE
Fix EntityInsertPanel UI issues

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.1",
+  "version": "2.293.2-fb-fixEntityInsertUI.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.2-fb-fixEntityInsertUI.1",
+  "version": "2.293.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.293.2
+*Released*: 15 February 2023
+* Fix EntityInsertPanel UI issues
+    * fix alignment of parent type inputs on sample creation grid
+    * fix extra caret on entity insert panel when alias cells are present
+
 ### version 2.293.1
 *Released*: 15 February 2023
 * Merge release23.2-SNAPSHOT to develop:

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -303,7 +303,7 @@ export class Cell extends React.PureComponent<Props, State> {
                     'cell-warning': message !== undefined,
                     'cell-read-only': this.isReadOnly(),
                     'cell-locked': this.isLocked(),
-                    'cell-menu': showLookup,
+                    'cell-menu': showLookup || col.inputRenderer,
                     'cell-placeholder': valueDisplay.length === 0 && placeholder !== undefined,
                 }),
                 onDoubleClick: this.handleDblClick,

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -668,8 +668,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                     <LabelHelpTip title="Import Options" placement="top">
                         {this.renderUpdateTooltipText()}
                         <p>
-                            For more information on import options for {nounPlural}, see the {this.props.importHelpLinkNode}{' '}
-                            documentation page.
+                            For more information on import options for {nounPlural}, see the{' '}
+                            {this.props.importHelpLinkNode} documentation page.
                         </p>
                     </LabelHelpTip>
                 </div>

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -658,19 +658,21 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         const mergeMsg = `Allow new ${nounPlural}`;
 
         return (
-            <div className="pull-right">
-                <input type="checkbox" checked={isMerge} onChange={this.toggleInsertOptionChange} />
-                <span className="entity-mergeoption-checkbox" onClick={this.toggleInsertOptionChange}>
-                    {mergeMsg}
-                </span>
-                &nbsp;
-                <LabelHelpTip title="Import Options" placement="top">
-                    {this.renderUpdateTooltipText()}
-                    <p>
-                        For more information on import options for {nounPlural}, see the {this.props.importHelpLinkNode}{' '}
-                        documentation page.
-                    </p>
-                </LabelHelpTip>
+            <div className="col-sm-3">
+                <div className="pull-right">
+                    <input type="checkbox" checked={isMerge} onChange={this.toggleInsertOptionChange} />
+                    <span className="entity-mergeoption-checkbox" onClick={this.toggleInsertOptionChange}>
+                        {mergeMsg}
+                    </span>
+                    &nbsp;
+                    <LabelHelpTip title="Import Options" placement="top">
+                        {this.renderUpdateTooltipText()}
+                        <p>
+                            For more information on import options for {nounPlural}, see the {this.props.importHelpLinkNode}{' '}
+                            documentation page.
+                        </p>
+                    </LabelHelpTip>
+                </div>
             </div>
         );
     };
@@ -706,8 +708,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             <>
                 {insertModel.isInit && (
                     <div className="row">
-                        <div className="col-sm-9">{this.renderTargetEntitySelect()}</div>
-                        <div className="col-sm-3">{this.renderMergeOption(isGrid)}</div>
+                        <div className={isGrid ? 'col-sm-12' : 'col-sm-9'}>{this.renderTargetEntitySelect()}</div>
+                        {this.renderMergeOption(isGrid)}
                     </div>
                 )}
                 {insertModel.isError && (


### PR DESCRIPTION
#### Rationale
2 issues are noted on entity insert panel:
- parent type inputs on sample creation grid are not aligned
- there is an extra caret on the upper right side of the panel when an alias input cell is added

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1110
- https://github.com/LabKey/sampleManagement/pull/1610
- https://github.com/LabKey/biologics/pull/1937

#### Changes
- fix alignment of parent type inputs on sample creation grid
- fix extra caret on entity insert panel when alias cells are present