### PR TITLE
Issue 47322: Ensure node requests are grouped by schema/query

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.2",
+  "version": "2.293.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.293.3
+*Released*: 15 February 2023
+* Issue 47322: Ensure node requests are grouped by schema/query
+
 ### version 2.293.2
 *Released*: 15 February 2023
 * Fix EntityInsertPanel UI issues

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -100,15 +100,15 @@ function fetchNodeMetadata(lineage: LineageResult): Array<Promise<ISelectRowsRes
     // keys cannot be filtered upon and thus are also not supported.
     return lineage.nodes
         .filter(n => n.schemaName !== undefined && n.queryName !== undefined && n.pkFilters.length === 1)
-        .groupBy(n => new SchemaQuery(n.schemaName, n.queryName))
-        .map((nodes, schemaQuery) => {
+        .groupBy(n => [n.schemaName, n.queryName].join('|||').toLowerCase())
+        .map(nodes => {
             const node = nodes.first();
             const { fieldKey } = node.pkFilters[0];
 
             return selectRowsDeprecated({
                 containerPath: node.container,
-                schemaName: schemaQuery.schemaName,
-                queryName: schemaQuery.queryName,
+                schemaName: node.schemaName,
+                queryName: node.queryName,
                 viewName: ViewInfo.DETAIL_NAME, // use Detail view to assure we get all data, even when default view is filtered
                 // TODO: Is there a better way to determine set of columns? Can we follow convention for detail views?
                 // See LineageNodeMetadata (and it's usages) for why this is currently necessary


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47332](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47322) by reintroducing the grouping of lineage node requests by schema/query.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1111
- https://github.com/LabKey/labkey-ui-premium/pull/46
- https://github.com/LabKey/biologics/pull/1939
- https://github.com/LabKey/sampleManagement/pull/1611
- https://github.com/LabKey/inventory/pull/740

#### Changes
- Concatenate string of schema/query and load schema/query from first node.
