### PR TITLE
Issue 46465: Grid actions that use a selectionKey doesn't get expected selections when filters applied to grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.3",
+  "version": "2.293.0-fb-picklistSelection46465.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.4",
+  "version": "2.293.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD February 2023
+- Issue 46465: Grid actions that use a selectionKey doesn't get expected selections when filters applied to grid
+  - make sure setSnapshotSelections() is called before selectionKey based call to getSampleOperationConfirmationData()
+
 ### version 2.293.3
 *Released*: 15 February 2023
 * Issue 47322: Ensure node requests are grouped by schema/query

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD February 2023
+### version 2.293.5
+*Released*: 17 February 2023
 - Issue 46465: Grid actions that use a selectionKey doesn't get expected selections when filters applied to grid
   - make sure setSnapshotSelections() is called before selectionKey based call to getSampleOperationConfirmationData()
 

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -508,19 +508,17 @@ export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo(props => {
             if (useSnapshotSelection) {
                 if (!queryModel?.isLoadingSelections) {
                     try {
-                        await setSnapshotSelections(queryModel.selectionKey, [...queryModel.selections]);
-                    }
-                    catch (reason) {
+                        await setSnapshotSelections(queryModel.selectionKey, [...selections]);
+                    } catch (reason) {
                         console.error("There was a problem loading the filtered selection data. Your actions will not obey these filters.", reason);
                     }
                     setSelectionsLoading(LoadingState.LOADED);
                 }
-            }
-            else {
+            } else {
                 setSelectionsLoading(LoadingState.LOADED);
             }
         })();
-    }, [queryModel?.selectionKey, queryModel?.selections, queryModel?.isLoadingSelections, useSnapshotSelection]);
+    }, [queryModel?.selectionKey, selections, queryModel?.isLoadingSelections, useSnapshotSelection]);
 
     useEffect(() => {
         setIdsLoading(LoadingState.LOADING);
@@ -542,8 +540,7 @@ export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo(props => {
                             [...selections],
                             sampleFieldKey
                         );
-                    }
-                    catch (e) {
+                    } catch (e) {
                         setError(resolveErrorMessage(e) ?? 'Failed to retrieve picklist selection.');
                     }
                 }
@@ -555,20 +552,28 @@ export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo(props => {
                         // If sample IDs are explicitly provided, then do not pass
                         // the selectionKey to ensure the ids are processed.
                         ids_ ? undefined : selectionKey,
-                        ids_ ? false : queryModel.filterArray.length > 0
+                        ids_ ? false : useSnapshotSelection
                     );
                     setIds(ids_);
                     setStatusData(data);
                     setValidCount(data.allowed.length);
-                }
-                catch (e) {
+                } catch (e) {
                     setError(resolveErrorMessage(e) ?? 'Failed to retrieve sample operations.');
                 }
 
                 setIdsLoading(LoadingState.LOADED);
             })();
         }
-    }, [api.samples, selectionsLoading, sampleFieldKey, sampleIds, schemaQuery, selectionKey, selections]);
+    }, [
+        api.samples,
+        selectionsLoading,
+        sampleFieldKey,
+        sampleIds,
+        schemaQuery,
+        selectionKey,
+        selections,
+        useSnapshotSelection,
+    ]);
 
     return (
         <ChoosePicklistModalDisplay

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -22,9 +22,10 @@ import { useAppContext } from '../../AppContext';
 
 import { useNotificationsContext } from '../notifications/NotificationsContext';
 
+import { setSnapshotSelections } from '../../actions';
+
 import { Picklist } from './models';
 import { addSamplesToPicklist, getPicklistsForInsert, getPicklistUrl, SampleTypeCount } from './actions';
-import { setSnapshotSelections } from '../../actions';
 
 interface PicklistListProps {
     activeItem: Picklist;
@@ -262,7 +263,13 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
             let numAdded = 0;
 
             try {
-                const response = await addSamplesToPicklist(activeItem.name, statusData, false, selectionKey, sampleIds);
+                const response = await addSamplesToPicklist(
+                    activeItem.name,
+                    statusData,
+                    false,
+                    selectionKey,
+                    sampleIds
+                );
                 api.query.incrementClientSideMetricCount(metricFeatureArea, 'addSamplesToPicklist');
                 numAdded = response.rows.length;
                 setSubmitting(false);
@@ -347,18 +354,13 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
                     </div>
 
                     <div className="pull-right">
-                        <button
-                            type="button"
-                            className="btn btn-success"
-                            disabled
-                        >
+                        <button type="button" className="btn btn-success" disabled>
                             Add to Picklist
                         </button>
                     </div>
                 </>
             );
-        }
-        else if (statusData?.anyAllowed) {
+        } else if (statusData?.anyAllowed) {
             title = 'Choose a Picklist';
             body = (
                 <>
@@ -499,8 +501,7 @@ export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo(props => {
                 try {
                     const picklists = await getPicklistsForInsert();
                     setItems(picklists);
-                }
-                catch (e) {
+                } catch (e) {
                     setError(resolveErrorMessage(e) ?? 'Failed to retrieve picklists.');
                 }
                 setItemsLoading(LoadingState.LOADED);
@@ -510,7 +511,10 @@ export const ChoosePicklistModal: FC<ChoosePicklistModalProps> = memo(props => {
                     try {
                         await setSnapshotSelections(queryModel.selectionKey, [...selections]);
                     } catch (reason) {
-                        console.error("There was a problem loading the filtered selection data. Your actions will not obey these filters.", reason);
+                        console.error(
+                            'There was a problem loading the filtered selection data. Your actions will not obey these filters.',
+                            reason
+                        );
                     }
                     setSelectionsLoading(LoadingState.LOADED);
                 }

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -26,7 +26,6 @@ import { setSnapshotSelections } from '../../actions';
 // Is selectedQuantity needed if we always have either the sampleIds or the queryModel?
 export interface PicklistEditModalProps {
     selectionKey?: string; // pass in either selectionKey and selectedQuantity or sampleIds.
-    useSnapshotSelection?: boolean;
     selectedQuantity?: number;
     sampleIds?: string[];
     picklist?: Picklist;
@@ -70,7 +69,7 @@ export const PicklistEditModal: FC<PicklistEditModalProps> = memo(props => {
         })();
     }, [api, sampleFieldKey, queryModel]);
 
-    return <PicklistEditModalDisplay {...props} selectionKey={selKey} sampleIds={ids} useSnapshotSelection={queryModel?.filterArray.length > 0} />;
+    return <PicklistEditModalDisplay {...props} selectionKey={selKey} sampleIds={ids} />;
 });
 
 const PicklistEditModalDisplay: FC<PicklistEditModalProps> = memo(props => {
@@ -86,8 +85,9 @@ const PicklistEditModalDisplay: FC<PicklistEditModalProps> = memo(props => {
         currentProductId,
         picklistProductId,
         metricFeatureArea,
-        useSnapshotSelection,
+        queryModel,
     } = props;
+    const useSnapshotSelection = queryModel?.filterArray.length > 0;
     const { createNotification } = useNotificationsContext();
     const [name, setName] = useState<string>(picklist?.name ?? '');
     const onNameChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => setName(evt.target.value), []);
@@ -110,6 +110,7 @@ const PicklistEditModalDisplay: FC<PicklistEditModalProps> = memo(props => {
 
     useEffect(() => {
         (async () => {
+            if (useSnapshotSelection) await setSnapshotSelections(selectionKey, [...queryModel.selections]);
             api.samples
                 .getSampleOperationConfirmationData(SampleOperation.AddToPicklist, sampleIds, selectionKey, useSnapshotSelection)
                 .then(data => {

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -8,7 +8,6 @@ import { WizardNavButtons } from '../buttons/WizardNavButtons';
 import { Alert } from '../base/Alert';
 import { resolveErrorMessage } from '../../util/messaging';
 
-import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
 import { SampleOperation } from '../samples/constants';
 import { OperationConfirmationData } from '../entities/models';
 import { getOperationNotPermittedMessage } from '../samples/utils';
@@ -18,9 +17,11 @@ import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
 import { useNotificationsContext } from '../notifications/NotificationsContext';
 
+import { setSnapshotSelections } from '../../actions';
+
 import { Picklist } from './models';
 import { createPicklist, getPicklistUrl, updatePicklist } from './actions';
-import { setSnapshotSelections } from '../../actions';
+import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
 
 // TODO reconcile these properties. Do we need both selectionKey and queryModel.
 // Is selectedQuantity needed if we always have either the sampleIds or the queryModel?
@@ -112,7 +113,12 @@ const PicklistEditModalDisplay: FC<PicklistEditModalProps> = memo(props => {
         (async () => {
             if (useSnapshotSelection) await setSnapshotSelections(selectionKey, [...queryModel.selections]);
             api.samples
-                .getSampleOperationConfirmationData(SampleOperation.AddToPicklist, sampleIds, selectionKey, useSnapshotSelection)
+                .getSampleOperationConfirmationData(
+                    SampleOperation.AddToPicklist,
+                    sampleIds,
+                    selectionKey,
+                    useSnapshotSelection
+                )
                 .then(data => {
                     setStatusData(data);
                     setValidCount(data.allowed.length);
@@ -175,7 +181,15 @@ const PicklistEditModalDisplay: FC<PicklistEditModalProps> = memo(props => {
                     })
                 );
             } else {
-                updatedList = await createPicklist(trimmedName, description, shared, statusData, selectionKey, useSnapshotSelection, sampleIds);
+                updatedList = await createPicklist(
+                    trimmedName,
+                    description,
+                    shared,
+                    statusData,
+                    selectionKey,
+                    useSnapshotSelection,
+                    sampleIds
+                );
                 api.query.incrementClientSideMetricCount(metricFeatureArea, 'createPicklist');
             }
             reset();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46465
When you are on a sample type grid in the app and you make a selection after adding filters to the grid, the create picklist and add picklist menu options aren't pulling through the correct selections via the selectionKey. This PR fixes that issue (which was fixed for other grid menu actions for issue [47257](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47257))

#### Related Pull Requests
- Issue 47257 fix: https://github.com/LabKey/labkey-ui-components/pull/1104
- https://github.com/LabKey/labkey-ui-components/pull/1112
- https://github.com/LabKey/sampleManagement/pull/1612
- https://github.com/LabKey/biologics/pull/1940
- https://github.com/LabKey/inventory/pull/741

#### Changes
- make sure setSnapshotSelections() is called before selectionKey based call to getSampleOperationConfirmationData()
