### PR TITLE
Add “ExpirationDate” field to exp.material

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.5",
+  "version": "2.293.6-fb-materialExpDate.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.6-fb-materialExpDate.2",
+  "version": "2.293.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.6-fb-materialExpDate.1",
+  "version": "2.293.6-fb-materialExpDate.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X February 2023
+- Add “ExpirationDate” field to exp.material
+    - Add Expiration Date to the set of aliquot fields
+
 ### version 2.293.5
 *Released*: 17 February 2023
 - Issue 46465: Grid actions that use a selectionKey doesn't get expected selections when filters applied to grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.X
-*Released*: X February 2023
+### version 2.293.6
+*Released*: 20 February 2023
 - Add “ExpirationDate” field to exp.material
     - Add Expiration Date to the set of aliquot fields
 

--- a/packages/components/src/entities/SampleAliquotDetailHeader.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotDetailHeader.spec.tsx
@@ -53,7 +53,7 @@ describe('<SampleAliquotDetailHeader/>', () => {
         const component = shallow(
             <SampleAliquotDetailHeader row={dataRow} aliquotHeaderDisplayColumns={aliquotCols} />
         );
-        expect(component.find(DefaultRenderer)).toHaveLength(4);
+        expect(component.find(DefaultRenderer)).toHaveLength(5);
         expect(component.find(UserDetailsRenderer)).toHaveLength(1);
         expect(component.find(SampleStatusTag)).toHaveLength(0);
     });
@@ -64,7 +64,7 @@ describe('<SampleAliquotDetailHeader/>', () => {
         const component = shallow(
             <SampleAliquotDetailHeader row={dataRow} aliquotHeaderDisplayColumns={aliquotCols} />
         );
-        expect(component.find(DefaultRenderer)).toHaveLength(4);
+        expect(component.find(DefaultRenderer)).toHaveLength(5);
         expect(component.find(UserDetailsRenderer)).toHaveLength(1);
         expect(component.find(SampleStatusTag)).toHaveLength(1);
     });

--- a/packages/components/src/entities/SampleAliquotDetailHeader.tsx
+++ b/packages/components/src/entities/SampleAliquotDetailHeader.tsx
@@ -37,7 +37,7 @@ export class SampleAliquotDetailHeader extends PureComponent<SampleAliquotDetail
 
         const description = newRow.get('description');
         const created = newRow.get('created');
-        const expDate = newRow.get('materialExpDate');
+        const expDate = newRow.get('materialexpdate');
         const status = newRow.get(SAMPLE_STATE_COLUMN_NAME.toLowerCase());
         const createdBy = newRow.get('createdby');
         const parent = newRow.get('aliquotedfromlsid/name');

--- a/packages/components/src/entities/SampleAliquotDetailHeader.tsx
+++ b/packages/components/src/entities/SampleAliquotDetailHeader.tsx
@@ -37,6 +37,7 @@ export class SampleAliquotDetailHeader extends PureComponent<SampleAliquotDetail
 
         const description = newRow.get('description');
         const created = newRow.get('created');
+        const expDate = newRow.get('materialExpDate');
         const status = newRow.get(SAMPLE_STATE_COLUMN_NAME.toLowerCase());
         const createdBy = newRow.get('createdby');
         const parent = newRow.get('aliquotedfromlsid/name');
@@ -48,6 +49,7 @@ export class SampleAliquotDetailHeader extends PureComponent<SampleAliquotDetail
                         {this.renderDetailRow(QueryColumn.ALIQUOTED_FROM_CAPTION, parent, 'aliquotedfrom')}
                         {this.renderDetailRow('Aliquoted By', createdBy, 'aliquotedby', true)}
                         {this.renderDetailRow('Aliquot Date', created, 'aliquoteddate')}
+                        {this.renderDetailRow('Aliquot Expiration Date', expDate, 'aliquotedexpdate')}
                         {this.renderDetailRow('Aliquot Description', description, 'aliquoteddescription')}
                         {isSampleStatusEnabled() && status !== undefined && (
                             <tr key="aliquotedstatus">

--- a/packages/components/src/entities/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/entities/SamplesBulkUpdateForm.tsx
@@ -115,12 +115,14 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
         // if the selection includes any aliquots, only show pk, aliquot specific and description/samplestate columns
         if (aliquots?.length > 0) {
             originalQueryInfo.columns.forEach((column, key) => {
-                const isAliquotField = sampleTypeDomainFields.aliquotFields.indexOf(column.fieldKey.toLowerCase()) > -1;
+                const colLc = column.fieldKey.toLowerCase();
+                const isAliquotField = sampleTypeDomainFields.aliquotFields.indexOf(colLc) > -1;
                 const isIndependentField =
-                    sampleTypeDomainFields.independentFields.indexOf(column.fieldKey.toLowerCase()) > -1;
+                    sampleTypeDomainFields.independentFields.indexOf(colLc) > -1;
                 if (
-                    column.fieldKey.toLowerCase() === 'description' ||
-                    column.fieldKey.toLowerCase() === 'samplestate' ||
+                    colLc === 'description' ||
+                    colLc === 'samplestate' ||
+                    colLc === 'materialexpdate' ||
                     isAliquotField ||
                     isIndependentField
                 )

--- a/packages/components/src/entities/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/entities/SamplesBulkUpdateForm.tsx
@@ -117,8 +117,7 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
             originalQueryInfo.columns.forEach((column, key) => {
                 const colLc = column.fieldKey.toLowerCase();
                 const isAliquotField = sampleTypeDomainFields.aliquotFields.indexOf(colLc) > -1;
-                const isIndependentField =
-                    sampleTypeDomainFields.independentFields.indexOf(colLc) > -1;
+                const isIndependentField = sampleTypeDomainFields.independentFields.indexOf(colLc) > -1;
                 if (
                     colLc === 'description' ||
                     colLc === 'samplestate' ||

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -1314,8 +1314,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         const uniqueIdFields = [];
         const unknownFields = [];
         const { domainDesign } = domainDetails;
-        let allowedFields = [],
-            lcDisallowedUdateFields = [];
+        let allowedFields = [];
         if (domainDetails.options.has('importAliases')) {
             allowedFields = Object.keys(domainDetails.options.get('importAliases')).map(key => key.toLowerCase());
         }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -568,7 +568,7 @@ export interface GroupedSampleDisplayColumns {
 }
 
 function isAliquotEditableField(colName: string): boolean {
-    return colName === 'name' || colName === 'description' || (isSampleStatusEnabled() && colName === 'samplestate');
+    return colName === 'name' || colName === 'description' || colName === 'materialexpdate' || (isSampleStatusEnabled() && colName === 'samplestate');
 }
 
 export function getGroupedSampleDisplayColumns(

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -568,7 +568,12 @@ export interface GroupedSampleDisplayColumns {
 }
 
 function isAliquotEditableField(colName: string): boolean {
-    return colName === 'name' || colName === 'description' || colName === 'materialexpdate' || (isSampleStatusEnabled() && colName === 'samplestate');
+    return (
+        colName === 'name' ||
+        colName === 'description' ||
+        colName === 'materialexpdate' ||
+        (isSampleStatusEnabled() && colName === 'samplestate')
+    );
 }
 
 export function getGroupedSampleDisplayColumns(

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -51,6 +51,11 @@ export function isDateTimeCol(col: QueryColumn): boolean {
         if (rangeURI?.indexOf('datetime') > -1) {
             return true;
         }
+
+        // material.materialexpdate is a non domain property datetime field that doesn't have rangeURI, but should be treated as datetime
+        if (!rangeURI && col?.jsonType === 'date' && col?.name.toLowerCase() === 'materialexpdate') {
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
#### Rationale
Add Expiration Date to the set of fields that's separately editable for parents and aliquots

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1113
* https://github.com/LabKey/platform/pull/4121
* https://github.com/LabKey/sampleManagement/pull/1607
* https://github.com/LabKey/biologics/pull/1932
* https://github.com/LabKey/inventory/pull/737
* https://github.com/LabKey/testAutomation/pull/1384

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
