### PR TITLE
Fix issue 46768: App is not respecting filter on drop-down

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.295.0",
+  "version": "2.296.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.296.0
+*Released*: ?? February 2023
+- QueryLookup: convert to regular class, add filterGroups attribute, use filterGroups in getQueryFilters
+- QueryFormInputs: Add optional "operation" prop
+  - Add equivalent prop to QueryInfoForm, AssayImportPanels (and child components), BulkAddUpdateForm, LookupCell
+- DetailDisplay: use QueryColumn.getQueryFilters when rendering QuerySelect
+
 ### version 2.295.0
 *Released*: 22 February 2023
 - QueryModel switch to default to includeTotalCount false

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.296.0
-*Released*: ?? February 2023
+*Released*: 22 February 2023
 - QueryLookup: convert to regular class, add filterGroups attribute, use filterGroups in getQueryFilters
 - QueryFormInputs: Add optional "operation" prop
   - Add equivalent prop to QueryInfoForm, AssayImportPanels (and child components), BulkAddUpdateForm, LookupCell

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -35,7 +35,7 @@ import {
     resolveKey,
     SchemaQuery,
 } from './public/SchemaQuery';
-import { insertColumnFilter, QueryColumn, QueryLookup } from './public/QueryColumn';
+import { insertColumnFilter, Operation, QueryColumn, QueryLookup } from './public/QueryColumn';
 import { QuerySort } from './public/QuerySort';
 import { LastActionStatus, MessageLevel } from './internal/LastActionStatus';
 import { InferDomainResponse } from './public/InferDomainResponse';
@@ -1337,6 +1337,7 @@ export {
     QueryColumn,
     QueryInfo,
     QueryLookup,
+    Operation,
     QueryInfoStatus,
     QuerySort,
     SchemaDetails,

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -102,7 +102,6 @@ interface OwnProps {
     onCancel: () => void;
     onComplete: (response: AssayUploadResultModel, isAsync?: boolean) => void;
     onSave?: (response: AssayUploadResultModel, isAsync?: boolean) => void;
-    runDataPanelTitle?: string;
     runId?: string;
     setIsDirty?: (isDirty: boolean) => void;
     showUploadTabs?: boolean;
@@ -653,7 +652,6 @@ class AssayImportPanelsBody extends Component<Props, State> {
             maxRows,
             onSave,
             showUploadTabs,
-            runDataPanelTitle,
             fileSizeLimits,
             user,
             getIsDirty,
@@ -678,6 +676,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
         }
 
         const isReimport = this.isReimport();
+        const operation = isReimport ? 'update' : 'insert';
         const runContainerId = runPropsModel.getRowValue('Folder');
         const folderNoun = isPremiumProductEnabled() ? 'project' : 'folder';
 
@@ -705,8 +704,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
                     />
                 )}
                 <Alert bsStyle="warning">{sampleStatusWarning}</Alert>
-                <BatchPropertiesPanel model={model} onChange={this.handleBatchChange} />
-                <RunPropertiesPanel model={model} onChange={this.handleRunChange} />
+                <BatchPropertiesPanel model={model} operation={operation} onChange={this.handleBatchChange} />
+                <RunPropertiesPanel model={model} operation={operation} onChange={this.handleRunChange} />
                 <RunDataPanel
                     acceptedPreviewFileFormats={acceptedPreviewFileFormats}
                     allowBulkRemove={allowBulkRemove}
@@ -720,11 +719,11 @@ class AssayImportPanelsBody extends Component<Props, State> {
                     onFileChange={this.handleFileChange}
                     onFileRemoval={this.handleFileRemove}
                     onGridChange={this.onGridChange}
+                    operation={operation}
                     onTextChange={this.handleDataTextChange}
                     queryModel={dataModel}
                     runPropertiesRow={runProps}
                     showTabs={showUploadTabs}
-                    title={runDataPanelTitle}
                     wizardModel={model}
                     getIsDirty={getIsDirty}
                     setIsDirty={setIsDirty}

--- a/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/BatchPropertiesPanel.tsx
@@ -22,9 +22,7 @@ import { getContainerFilterForLookups } from '../../query/api';
 
 import { AssayPropertiesPanelProps } from './models';
 
-export const BatchPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
-    const { model, onChange, title = 'Batch Details' } = props;
-
+export const BatchPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, onChange, operation }) => {
     if (model.batchColumns.size === 0) {
         return null;
     }
@@ -33,15 +31,16 @@ export const BatchPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props =>
 
     return (
         <div className="panel panel-default">
-            <div className="panel-heading">{title}</div>
+            <div className="panel-heading">Batch Details</div>
 
             <div className="panel-body">
                 <Formsy className="form-horizontal" onChange={onChange} disabled={disabled}>
                     <QueryFormInputs
+                        containerFilter={getContainerFilterForLookups()}
                         fieldValues={model.batchProperties.toObject()}
+                        operation={operation}
                         queryColumns={model.batchColumns}
                         renderFileInputs
-                        containerFilter={getContainerFilterForLookups()}
                     />
                 </Formsy>
             </div>

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -15,6 +15,7 @@
  */
 import React, { PureComponent, ReactNode } from 'react';
 import { List, Map } from 'immutable';
+import { Operation } from '../../../public/QueryColumn';
 
 import { AssayUploadTabs } from '../../constants';
 import { InferDomainResponse } from '../../../public/InferDomainResponse';
@@ -58,12 +59,12 @@ interface Props {
         dataKeys?: List<any>,
         data?: Map<any, Map<string, any>>
     ) => void;
+    operation: Operation;
     onTextChange: (value: any) => any;
     queryModel: QueryModel;
     runPropertiesRow?: Record<string, any>;
     setIsDirty?: (isDirty: boolean) => void;
     showTabs?: boolean;
-    title: string;
     wizardModel: AssayWizardModel;
 }
 
@@ -85,7 +86,6 @@ export class RunDataPanel extends PureComponent<Props, State> {
         allowBulkRemove: false,
         allowBulkInsert: false,
         allowBulkUpdate: false,
-        title: 'Results',
         showTabs: true,
     };
 
@@ -214,7 +214,6 @@ export class RunDataPanel extends PureComponent<Props, State> {
             editorModel,
             maxEditableGridRowMsg,
             queryModel,
-            title,
             showTabs,
             wizardModel,
             getIsDirty,
@@ -226,7 +225,7 @@ export class RunDataPanel extends PureComponent<Props, State> {
 
         return (
             <div className="panel panel-default">
-                <div className="panel-heading">{title}</div>
+                <div className="panel-heading">Results</div>
                 <div className="panel-body">
                     {isLoading ? (
                         <LoadingSpinner />

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, memo, useMemo } from 'react';
+import React, { FC, memo } from 'react';
 import Formsy from 'formsy-react';
 import { Input, Textarea } from 'formsy-react-components';
 
@@ -29,32 +29,30 @@ import { useServerContext } from '../base/ServerContext';
 
 import { AssayPropertiesPanelProps } from './models';
 
-export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
-    const { model, onChange, title = 'Run Details' } = props;
+const NAME_LABEL = (
+    <LabelOverlay
+        description="The assay/experiment ID that uniquely identifies this assay run."
+        label="Assay ID"
+        type="Text (String)"
+    />
+);
+
+const COMMENT_LABEL = (
+    <LabelOverlay description="Contains comments about this run" label="Comments" type="Text (String)" />
+);
+
+export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, onChange, operation }) => {
     const { moduleContext } = useServerContext();
-    const nameLabel = useMemo(
-        () => (
-            <LabelOverlay
-                description="The assay/experiment ID that uniquely identifies this assay run."
-                label="Assay ID"
-                type="Text (String)"
-            />
-        ),
-        []
-    );
-    const commentLabel = useMemo(
-        () => <LabelOverlay description="Contains comments about this run" label="Comments" type="Text (String)" />,
-        []
-    );
+
     return (
         <div className="panel panel-default">
-            <div className="panel-heading">{title}</div>
+            <div className="panel-heading">Run Details</div>
             <div className="panel-body">
                 <Formsy className="form-horizontal" onChange={onChange}>
                     <Input
                         changeDebounceInterval={0}
                         id="runname"
-                        label={nameLabel}
+                        label={NAME_LABEL}
                         labelClassName="text-left"
                         name="runname"
                         type="text"
@@ -64,7 +62,7 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                         changeDebounceInterval={0}
                         cols={60}
                         id="comment"
-                        label={commentLabel}
+                        label={COMMENT_LABEL}
                         labelClassName="text-left"
                         name="comment"
                         rows={2}
@@ -73,18 +71,19 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(props => {
                     {isWorkflowEnabled(moduleContext) && (
                         <AssayTaskInput
                             assayId={model.assayDef.id}
+                            containerFilter={getContainerFilterForLookups()}
                             formsy
                             name="workflowtask"
                             value={model.workflowTask}
-                            containerFilter={getContainerFilterForLookups()}
                         />
                     )}
                     {model.runColumns.size !== 0 && (
                         <QueryFormInputs
+                            containerFilter={getContainerFilterForLookups()}
                             fieldValues={model.runProperties.toObject()}
+                            operation={operation}
                             queryColumns={model.runColumns}
                             renderFileInputs
-                            containerFilter={getContainerFilterForLookups()}
                         />
                     )}
                 </Formsy>

--- a/packages/components/src/internal/components/assay/models.ts
+++ b/packages/components/src/internal/components/assay/models.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Draft, immerable, produce } from 'immer';
+import { Operation } from '../../../public/QueryColumn';
 
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 import { LoadingState } from '../../../public/LoadingState';
@@ -21,9 +22,9 @@ import { LoadingState } from '../../../public/LoadingState';
 import { AssayWizardModel } from './AssayWizardModel';
 
 export interface AssayPropertiesPanelProps {
+    operation: Operation;
     model: AssayWizardModel;
-    onChange: Function;
-    title?: string;
+    onChange: (fieldValues: any, isChanged?: boolean) => void;
 }
 
 export class AssayUploadResultModel {

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -46,6 +46,7 @@ interface Props {
     filteredLookupKeys?: List<any>;
     filteredLookupValues?: List<string>;
     focused?: boolean;
+    forUpdate: boolean;
     getFilteredLookupKeys?: (linkedValues: any[]) => Promise<List<any>>;
     lastSelection?: boolean;
     linkedValues?: any[];
@@ -273,6 +274,7 @@ export class Cell extends React.PureComponent<Props, State> {
             colIdx,
             containerFilter,
             focused,
+            forUpdate,
             lastSelection,
             message,
             placeholder,
@@ -382,6 +384,7 @@ export class Cell extends React.PureComponent<Props, State> {
                     disabled={this.isReadOnly()}
                     filteredLookupKeys={filteredLookupKeys}
                     filteredLookupValues={filteredLookupValues}
+                    forUpdate={forUpdate}
                     modifyCell={cellActions.modifyCell}
                     rowIdx={rowIdx}
                     select={cellActions.selectCell}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Query } from '@labkey/api';
 import classNames from 'classnames';
+import { List, Map, OrderedMap, Set } from 'immutable';
 import React, { ChangeEvent, MouseEvent, PureComponent, ReactNode, SyntheticEvent } from 'react';
 import { Button, Nav, NavItem, OverlayTrigger, Popover, Tab, TabContainer } from 'react-bootstrap';
-import { List, Map, OrderedMap, Set } from 'immutable';
-import { Query } from '@labkey/api';
+import { Operation, QueryColumn } from '../../../public/QueryColumn';
+import { QueryInfo } from '../../../public/QueryInfo';
+
+import { EditableGridExportMenu, ExportOption } from '../../../public/QueryModel/ExportMenu';
+import { Key } from '../../../public/useEnterEscape';
 
 import {
     addRows,
@@ -31,10 +36,6 @@ import {
     pasteEvent,
     updateGridFromBulkForm,
 } from '../../actions';
-import { genCellKey, parseCellKey } from '../../utils';
-
-import { headerSelectionCell } from '../../renderers';
-import { QueryInfoForm, QueryInfoFormProps } from '../forms/QueryInfoForm';
 import {
     GRID_CHECKBOX_OPTIONS,
     GRID_EDIT_INDEX,
@@ -43,26 +44,25 @@ import {
     MODIFICATION_TYPES,
     SELECTION_TYPES,
 } from '../../constants';
+import { cancelEvent } from '../../events';
+
+import { headerSelectionCell } from '../../renderers';
 import { blurActiveElement, capitalizeFirstChar, caseInsensitive, not } from '../../util/utils';
-
-import { BulkAddUpdateForm } from '../forms/BulkAddUpdateForm';
-
-import { EditableGridExportMenu, ExportOption } from '../../../public/QueryModel/ExportMenu';
+import { genCellKey, parseCellKey } from '../../utils';
+import { Alert } from '../base/Alert';
+import { DeleteIcon } from '../base/DeleteIcon';
+import { Grid } from '../base/Grid';
 
 import { GridColumn } from '../base/models/GridColumn';
-import { QueryInfo } from '../../../public/QueryInfo';
-import { QueryColumn } from '../../../public/QueryColumn';
-import { DeleteIcon } from '../base/DeleteIcon';
-import { Key } from '../../../public/useEnterEscape';
-import { cancelEvent } from '../../events';
-import { Grid } from '../base/Grid';
-import { Alert } from '../base/Alert';
 
-import { CellMessage, EditorModel, EditorModelProps, ValueDescriptor } from './models';
+import { BulkAddUpdateForm } from '../forms/BulkAddUpdateForm';
+import { QueryInfoForm, QueryInfoFormProps } from '../forms/QueryInfoForm';
+import { Cell } from './Cell';
 
 import { CellActions, EDITABLE_GRID_CONTAINER_CLS } from './constants';
-import { Cell } from './Cell';
 import { AddRowsControl, AddRowsControlProps, PlacementType } from './Controls';
+
+import { CellMessage, EditorModel, EditorModelProps, ValueDescriptor } from './models';
 
 function isCellEmpty(values: List<ValueDescriptor>): boolean {
     return !values || values.isEmpty() || values.some(v => v.raw === undefined || v.raw === null || v.raw === '');
@@ -1201,7 +1201,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 maxCount={maxToAdd}
                 onHide={this.toggleBulkAdd}
                 onCancel={this.toggleBulkAdd}
-                operation={forUpdate ? 'update' : 'insert'}
+                operation={forUpdate ? Operation.update : Operation.insert}
                 onSuccess={this.toggleBulkAdd}
                 queryInfo={queryInfo.getInsertQueryInfo()}
                 header={
@@ -1326,7 +1326,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 onCancel={this.toggleBulkUpdate}
                 onFormChangeWithData={showAsTab ? this.onBulkUpdateFormDataChange : undefined}
                 onHide={this.toggleBulkUpdate}
-                operation={forUpdate ? 'update' : 'insert'}
+                operation={forUpdate ? Operation.update : Operation.insert}
                 onSubmitForEdit={this.bulkUpdate}
                 onSuccess={this.toggleBulkUpdate}
                 pluralNoun={addControlProps.nounPlural}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -109,7 +109,8 @@ function inputCellFactory(
     readonlyRows: List<any>,
     lockedRows: List<any>,
     cellActions: CellActions,
-    containerFilter: Query.ContainerFilter
+    containerFilter: Query.ContainerFilter,
+    forUpdate: boolean
 ) {
     return (value: any, row: any, c: GridColumn, rn: number, cn: number) => {
         let colOffset = 0;
@@ -147,6 +148,7 @@ function inputCellFactory(
                 locked={isLockedRow}
                 rowIdx={rn}
                 focused={editorModel ? editorModel.isFocused(colIdx, rn) : false}
+                forUpdate={forUpdate}
                 message={editorModel?.getMessage(colIdx, rn)}
                 selected={editorModel ? editorModel.isSelected(colIdx, rn) : false}
                 selection={editorModel ? editorModel.inSelection(colIdx, rn) : false}
@@ -634,6 +636,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             allowRemove,
             containerFilter,
             editorModel,
+            forUpdate,
             hideCountCol,
             queryInfo,
             rowNumColumn,
@@ -677,7 +680,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                         readonlyRows,
                         lockedRows,
                         this.cellActions,
-                        containerFilter
+                        containerFilter,
+                        forUpdate
                     ),
                     index: qCol.fieldKey,
                     raw: qCol,
@@ -1183,7 +1187,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     renderBulkAdd = (): ReactNode => {
-        const { addControlProps, allowFieldDisable, bulkAddProps, data, maxRows, queryInfo } = this.props;
+        const { addControlProps, allowFieldDisable, bulkAddProps, data, forUpdate, maxRows, queryInfo } = this.props;
         const maxToAdd =
             maxRows && maxRows - data.size < MAX_EDITABLE_GRID_ROWS ? maxRows - data.size : MAX_EDITABLE_GRID_ROWS;
         return (
@@ -1197,6 +1201,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 maxCount={maxToAdd}
                 onHide={this.toggleBulkAdd}
                 onCancel={this.toggleBulkAdd}
+                operation={forUpdate ? 'update' : 'insert'}
                 onSuccess={this.toggleBulkAdd}
                 queryInfo={queryInfo.getInsertQueryInfo()}
                 header={
@@ -1286,7 +1291,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         this.props.cancelBtnProps?.onClick?.();
     };
 
-    renderTabButtons = () => {
+    renderTabButtons = (): ReactNode => {
         const { primaryBtnProps, cancelBtnProps, tabBtnProps } = this.props;
         if (!tabBtnProps?.show) return null;
 
@@ -1307,8 +1312,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         );
     };
 
-    renderBulkUpdate = () => {
-        const { addControlProps, editorModel, bulkUpdateProps, data, dataKeys, queryInfo, showAsTab } = this.props;
+    renderBulkUpdate = (): ReactNode => {
+        const { addControlProps, bulkUpdateProps, data, dataKeys, editorModel, forUpdate, queryInfo, showAsTab } = this.props;
 
         return (
             <BulkAddUpdateForm
@@ -1321,6 +1326,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 onCancel={this.toggleBulkUpdate}
                 onFormChangeWithData={showAsTab ? this.onBulkUpdateFormDataChange : undefined}
                 onHide={this.toggleBulkUpdate}
+                operation={forUpdate ? 'update' : 'insert'}
                 onSubmitForEdit={this.bulkUpdate}
                 onSuccess={this.toggleBulkUpdate}
                 pluralNoun={addControlProps.nounPlural}
@@ -1332,7 +1338,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         );
     };
 
-    render() {
+    render(): ReactNode {
         const {
             allowAdd,
             editorModel,

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -6,7 +6,7 @@ import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
 import { getUniqueIdColumnMetadata } from '../entities/utils';
 
-import { QueryColumn } from '../../../public/QueryColumn';
+import { Operation, QueryColumn } from '../../../public/QueryColumn';
 
 import { EXPORT_TYPES } from '../../constants';
 

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { PureComponent, ReactNode } from 'react';
-import { List } from 'immutable';
-
 import { Filter, Query } from '@labkey/api';
+import { List } from 'immutable';
+import React, { PureComponent, ReactNode } from 'react';
 
-import { LOOKUP_DEFAULT_SIZE, MODIFICATION_TYPES, SELECTION_TYPES } from '../../constants';
-import { TextChoiceInput } from '../forms/input/TextChoiceInput';
-import { QueryColumn } from '../../../public/QueryColumn';
-import { QuerySelect } from '../forms/QuerySelect';
-import { SelectInputChange } from '../forms/input/SelectInput';
-import { ViewInfo } from '../../ViewInfo';
+import { Operation, QueryColumn } from '../../../public/QueryColumn';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 
+import { LOOKUP_DEFAULT_SIZE, MODIFICATION_TYPES, SELECTION_TYPES } from '../../constants';
+
 import { getContainerFilterForLookups } from '../../query/api';
+import { ViewInfo } from '../../ViewInfo';
+import { SelectInputChange } from '../forms/input/SelectInput';
+import { TextChoiceInput } from '../forms/input/TextChoiceInput';
+import { QuerySelect } from '../forms/QuerySelect';
 
 import { ValueDescriptor } from './models';
 
@@ -57,7 +57,8 @@ export class LookupCell extends PureComponent<LookupCellProps> {
     };
 
     render(): ReactNode {
-        const { col, containerFilter, disabled, filteredLookupKeys, filteredLookupValues, forUpdate, values } = this.props;
+        const { col, containerFilter, disabled, filteredLookupKeys, filteredLookupValues, forUpdate, values } =
+            this.props;
 
         const rawValues = values
             .filter(vd => vd.raw !== undefined)
@@ -93,7 +94,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
             );
         }
 
-        const operation = forUpdate ? 'update' : 'insert';
+        const operation = forUpdate ? Operation.update : Operation.insert;
         if (lookup.hasQueryFilters(operation)) {
             queryFilters = queryFilters.push(...lookup.getQueryFilters(operation));
         }
@@ -111,11 +112,9 @@ export class LookupCell extends PureComponent<LookupCellProps> {
                 preLoad
                 queryFilters={queryFilters}
                 // use detail view to assure we get values that may have been filtered out in the default view
-                schemaQuery={new SchemaQuery(
-                    lookup.schemaQuery.schemaName,
-                    lookup.schemaQuery.queryName,
-                    ViewInfo.DETAIL_NAME
-                )}
+                schemaQuery={
+                    new SchemaQuery(lookup.schemaQuery.schemaName, lookup.schemaQuery.queryName, ViewInfo.DETAIL_NAME)
+                }
                 value={isMultiple ? rawValues : rawValues[0]}
             />
         );

--- a/packages/components/src/internal/components/forms/BulkAddUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkAddUpdateForm.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useMemo } from 'react';
 import { List, Map } from 'immutable';
+import { Operation } from '../../../public/QueryColumn';
 
 import { capitalizeFirstChar, getCommonDataValues } from '../../util/utils';
 import { EditorModel } from '../editable/models';
@@ -12,6 +13,7 @@ interface BulkAddUpdateFormProps extends Omit<QueryInfoFormProps, 'fieldValues'>
     data: Map<any, Map<string, any>>;
     dataKeys: List<any>;
     editorModel: EditorModel;
+    operation: Operation;
     selectedRowIndexes: List<number>;
     warning?: string;
 }

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -1,15 +1,15 @@
-import React, { PureComponent, ReactNode } from 'react';
-import { List, Map, OrderedMap } from 'immutable';
 import { Query, Utils } from '@labkey/api';
+import { List, Map, OrderedMap } from 'immutable';
+import React, { PureComponent, ReactNode } from 'react';
+import { Operation, QueryColumn } from '../../../public/QueryColumn';
+
+import { QueryInfo } from '../../../public/QueryInfo';
+import { SchemaQuery } from '../../../public/SchemaQuery';
 
 import { getSelectedData } from '../../actions';
 import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
 
 import { capitalizeFirstChar, getCommonDataValues, getUpdatedData } from '../../util/utils';
-
-import { QueryInfo } from '../../../public/QueryInfo';
-import { SchemaQuery } from '../../../public/SchemaQuery';
-import { QueryColumn } from '../../../public/QueryColumn';
 
 import { QueryInfoForm } from './QueryInfoForm';
 
@@ -194,7 +194,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                 isLoading={isLoadingDataForSelection}
                 onCancel={onCancel}
                 onHide={onCancel}
-                operation="update"
+                operation={Operation.update}
                 onSubmitForEdit={this.onSubmitForEdit}
                 onSubmit={this.onSubmit}
                 onSuccess={onComplete}

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -194,6 +194,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                 isLoading={isLoadingDataForSelection}
                 onCancel={onCancel}
                 onHide={onCancel}
+                operation="update"
                 onSubmitForEdit={this.onSubmitForEdit}
                 onSubmit={this.onSubmit}
                 onSuccess={onComplete}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -211,7 +211,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 data={fieldValues}
                                 formsy
                                 initiallyDisabled={shouldDisableField}
-                                key={col.name}
+                                key={i}
                                 onAdditionalFormDataChange={onAdditionalFormDataChange}
                                 onSelectChange={this.onSelectChange}
                                 onToggleDisable={this.onToggleDisable}
@@ -233,7 +233,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 ? List(col.lookup.getQueryFilters(operation))
                                 : queryFilters?.[col.fieldKey];
                             return (
-                                <React.Fragment key={col.name}>
+                                <React.Fragment key={i}>
                                     {this.renderLabelField(col)}
                                     <QuerySelect
                                         addLabelAsterisk={showAsteriskSymbol}
@@ -274,7 +274,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 allowDisable={allowFieldDisable}
                                 formsy
                                 initiallyDisabled={shouldDisableField}
-                                key={col.name}
+                                key={i}
                                 onChange={this.onSelectChange}
                                 onToggleDisable={this.onToggleDisable}
                                 placeholder="Select or type to search..."
@@ -288,7 +288,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (col.inputType === 'textarea') {
                         return (
                             <TextAreaInput
-                                key={col.name}
+                                key={i}
                                 queryColumn={col}
                                 value={value}
                                 allowDisable={allowFieldDisable}
@@ -302,7 +302,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         return (
                             <FileInput
                                 formsy
-                                key={col.name}
+                                key={i}
                                 queryColumn={col}
                                 initialValue={value}
                                 name={col.fieldKey}
@@ -319,7 +319,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         case 'date':
                             return (
                                 <DatePickerInput
-                                    key={col.name}
+                                    key={i}
                                     queryColumn={col}
                                     value={value}
                                     initValueFormatted={false}
@@ -333,7 +333,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         case 'boolean':
                             return (
                                 <CheckboxInput
-                                    key={col.name}
+                                    key={i}
                                     queryColumn={col}
                                     value={value}
                                     allowDisable={allowFieldDisable}
@@ -346,7 +346,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         default:
                             return (
                                 <TextInput
-                                    key={col.name}
+                                    key={i}
                                     queryColumn={col}
                                     value={value ? String(value) : value}
                                     allowDisable={allowFieldDisable}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -18,7 +18,7 @@ import { List, Map, OrderedMap } from 'immutable';
 import { Input } from 'formsy-react-components';
 import { Filter, Query } from '@labkey/api';
 
-import { insertColumnFilter, QueryColumn } from '../../../public/QueryColumn';
+import { insertColumnFilter, Operation, QueryColumn } from '../../../public/QueryColumn';
 
 import { QueryInfo } from '../../../public/QueryInfo';
 
@@ -53,6 +53,7 @@ export interface QueryFormInputsProps {
     lookups?: Map<string, number>;
     onAdditionalFormDataChange?: (name: string, value: any) => void;
     onFieldsEnabledChange?: (numEnabled: number) => void;
+    operation?: Operation;
     onSelectChange?: SelectInputChange;
     queryColumns?: OrderedMap<string, QueryColumn>;
     queryFilters?: Record<string, List<Filter.IFilter>>;
@@ -157,6 +158,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             showLabelAsterisk,
             initiallyDisableFields,
             lookups,
+            operation,
             queryColumns,
             queryInfo,
             renderFileInputs,
@@ -209,7 +211,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 data={fieldValues}
                                 formsy
                                 initiallyDisabled={shouldDisableField}
-                                key={i}
+                                key={col.name}
                                 onAdditionalFormDataChange={onAdditionalFormDataChange}
                                 onSelectChange={this.onSelectChange}
                                 onToggleDisable={this.onToggleDisable}
@@ -227,17 +229,15 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         if (col.displayAsLookup !== false) {
                             const multiple = col.isJunctionLookup();
                             const joinValues = multiple;
-                            const id = col.fieldKey + i + (componentKey ?? '');
-                            const queryFilter = col.lookup.hasQueryFilters()
-                                ? List(col.lookup.getQueryFilters())
+                            const queryFilter = col.lookup.hasQueryFilters(operation)
+                                ? List(col.lookup.getQueryFilters(operation))
                                 : queryFilters?.[col.fieldKey];
                             return (
-                                <React.Fragment key={i}>
+                                <React.Fragment key={col.name}>
                                     {this.renderLabelField(col)}
                                     <QuerySelect
                                         addLabelAsterisk={showAsteriskSymbol}
                                         allowDisable={allowFieldDisable}
-                                        key={id}
                                         containerFilter={col.lookup.containerFilter ?? containerFilter}
                                         containerPath={col.lookup.containerPath}
                                         description={col.description}
@@ -274,7 +274,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 allowDisable={allowFieldDisable}
                                 formsy
                                 initiallyDisabled={shouldDisableField}
-                                key={i}
+                                key={col.name}
                                 onChange={this.onSelectChange}
                                 onToggleDisable={this.onToggleDisable}
                                 placeholder="Select or type to search..."
@@ -288,7 +288,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (col.inputType === 'textarea') {
                         return (
                             <TextAreaInput
-                                key={i}
+                                key={col.name}
                                 queryColumn={col}
                                 value={value}
                                 allowDisable={allowFieldDisable}
@@ -302,7 +302,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         return (
                             <FileInput
                                 formsy
-                                key={i}
+                                key={col.name}
                                 queryColumn={col}
                                 initialValue={value}
                                 name={col.fieldKey}
@@ -319,7 +319,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         case 'date':
                             return (
                                 <DatePickerInput
-                                    key={i}
+                                    key={col.name}
                                     queryColumn={col}
                                     value={value}
                                     initValueFormatted={false}
@@ -333,7 +333,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         case 'boolean':
                             return (
                                 <CheckboxInput
-                                    key={i}
+                                    key={col.name}
                                     queryColumn={col}
                                     value={value}
                                     allowDisable={allowFieldDisable}
@@ -346,7 +346,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         default:
                             return (
                                 <TextInput
-                                    key={i}
+                                    key={col.name}
                                     queryColumn={col}
                                     value={value ? String(value) : value}
                                     allowDisable={allowFieldDisable}

--- a/packages/components/src/internal/components/forms/QueryInfoForm.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.tsx
@@ -18,6 +18,7 @@ import { OrderedMap } from 'immutable';
 import { Alert, Button, Modal } from 'react-bootstrap';
 import Formsy from 'formsy-react';
 import { Utils } from '@labkey/api';
+import { Operation } from '../../../public/QueryColumn';
 
 import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
 
@@ -54,6 +55,7 @@ export interface QueryInfoFormProps extends Omit<QueryFormInputsProps, 'onFields
     // allow passing of full form data, compare with onFormChange
     onFormChangeWithData?: (formData?: any) => void;
     onHide?: () => void;
+    operation?: Operation;
     onSubmit?: (data: OrderedMap<string, any>) => Promise<any>;
     onSubmitForEdit?: (data: OrderedMap<string, any>) => Promise<any>;
     onSuccess?: (data: any, submitForEdit: boolean) => void;

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.spec.tsx
@@ -1,4 +1,3 @@
-import * as console from 'console';
 import { List, fromJS, Map } from 'immutable';
 import React from 'react';
 import Formsy from 'formsy-react';

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.spec.tsx
@@ -1,3 +1,4 @@
+import * as console from 'console';
 import { List, fromJS, Map } from 'immutable';
 import React from 'react';
 import Formsy from 'formsy-react';
@@ -213,7 +214,7 @@ describe('resolveDetailEditRenderer', () => {
     });
 
     test('isPublicLookup, displayAsLookup = true', () => {
-        const col = new QueryColumn({
+        const col = QueryColumn.create({
             ...default_props,
             lookup: { isPublic: true },
             displayAsLookup: true,

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -7,7 +7,7 @@ import { DETAIL_TABLE_CLASSES } from '../constants';
 
 import { decodePart } from '../../../../public/SchemaQuery';
 
-import { QueryColumn } from '../../../../public/QueryColumn';
+import { Operation, QueryColumn } from '../../../../public/QueryColumn';
 import { DefaultRenderer } from '../../../renderers/DefaultRenderer';
 import { LabelHelpTip } from '../../base/LabelHelpTip';
 
@@ -302,8 +302,8 @@ export function resolveDetailEditRenderer(
                 // Issue 29232: When displaying a lookup, always use the value
                 const multiple = col.isJunctionLookup();
                 const joinValues = multiple && !col.isDataInput();
-                const queryFilters = col.lookup.hasQueryFilters('update')
-                    ? List(col.lookup.getQueryFilters('update'))
+                const queryFilters = col.lookup.hasQueryFilters(Operation.update)
+                    ? List(col.lookup.getQueryFilters(Operation.update))
                     : undefined;
 
                 return (

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -302,10 +302,13 @@ export function resolveDetailEditRenderer(
                 // Issue 29232: When displaying a lookup, always use the value
                 const multiple = col.isJunctionLookup();
                 const joinValues = multiple && !col.isDataInput();
+                const queryFilters = col.lookup.hasQueryFilters('update')
+                    ? List(col.lookup.getQueryFilters('update'))
+                    : undefined;
 
                 return (
                     <QuerySelect
-                        key={col.fieldKey}
+                        autoFocus={options?.autoFocus}
                         containerFilter={col.lookup.containerFilter ?? options?.containerFilter}
                         containerPath={col.lookup.containerPath ?? options?.containerPath}
                         description={col.description}
@@ -313,14 +316,15 @@ export function resolveDetailEditRenderer(
                         formsy
                         inputClass="col-sm-12"
                         joinValues={joinValues}
+                        key={col.fieldKey}
                         label={col.caption}
                         maxRows={10}
                         multiple={multiple}
                         name={col.name}
-                        autoFocus={options?.autoFocus}
                         onBlur={options?.onBlur}
                         onQSChange={options?.onSelectChange}
                         placeholder={options?.placeholder ?? 'Select or type to search...'}
+                        queryFilters={queryFilters}
                         required={col.required}
                         schemaQuery={col.lookup.schemaQuery}
                         showLabel={showLabel}

--- a/packages/components/src/public/QueryColumn.spec.ts
+++ b/packages/components/src/public/QueryColumn.spec.ts
@@ -6,7 +6,7 @@ import { insertColumnFilter, QueryColumn, QueryLookup } from './QueryColumn';
 
 describe('QueryLookup', () => {
     test('Not samples lookup', () => {
-        const lookup = QueryLookup.create({
+        const lookup = new QueryLookup({
             schemaName: 'test',
             queryName: 'lookup',
         });
@@ -15,7 +15,7 @@ describe('QueryLookup', () => {
     });
 
     test('Samples lookup', () => {
-        const lookup = QueryLookup.create({
+        const lookup = new QueryLookup({
             schemaName: 'exp',
             queryName: 'materials',
         });

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -15,7 +15,10 @@ import { SAMPLES_WITH_TYPES_FILTER } from '../internal/components/samples/consta
 
 import { SchemaQuery } from './SchemaQuery';
 
-export type Operation = 'insert' | 'update';
+export enum Operation {
+    insert = 'insert',
+    update = 'update',
+}
 
 interface FilterGroupFilter {
     column: string;
@@ -58,7 +61,7 @@ export class QueryLookup {
     }
 
     getFilterGroup(operation: Operation): FilterGroup {
-        return this.filterGroups?.find((filterGroup: FilterGroup) => filterGroup.operation === operation);
+        return this.filterGroups?.find(filterGroup => filterGroup.operation === operation);
     }
 
     getQueryFilters(operation?: Operation): Filter.IFilter[] {

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -1,6 +1,6 @@
 // Consider having this implement Query.QueryColumn from @labkey/api
 // commented out attributes are not used in app
-import { Record } from 'immutable';
+import { Record as ImmutableRecord } from 'immutable';
 import { Filter, Query } from '@labkey/api';
 
 import {
@@ -15,22 +15,24 @@ import { SAMPLES_WITH_TYPES_FILTER } from '../internal/components/samples/consta
 
 import { SchemaQuery } from './SchemaQuery';
 
-export class QueryLookup extends Record({
-    containerFilter: undefined,
-    containerPath: undefined,
-    displayColumn: undefined,
-    isPublic: false,
-    keyColumn: undefined,
-    junctionLookup: undefined,
-    multiValued: undefined,
-    queryName: undefined,
-    schemaName: undefined,
-    schemaQuery: undefined,
-    table: undefined,
-}) {
+export type Operation = 'insert' | 'update';
+
+interface FilterGroupFilter {
+    column: string;
+    operator: string;
+    value: string;
+}
+
+interface FilterGroup {
+    filters: FilterGroupFilter[];
+    operation: Operation;
+}
+
+export class QueryLookup {
     declare containerFilter: Query.ContainerFilter;
     declare containerPath: string;
     declare displayColumn: string;
+    declare filterGroups: FilterGroup[];
     declare isPublic: boolean;
     declare junctionLookup: string; // name of the column on the junction table that is also a lookup
     declare keyColumn: string;
@@ -42,29 +44,46 @@ export class QueryLookup extends Record({
     declare schemaQuery: SchemaQuery;
     // declare table: string; -- NOT ALLOWING -- USE queryName
 
-    static create(rawLookup): QueryLookup {
-        return new QueryLookup(
-            Object.assign({}, rawLookup, {
-                schemaQuery: new SchemaQuery(rawLookup.schemaName, rawLookup.queryName, rawLookup.viewName),
-            })
+    constructor(rawLookup: Record<string, any>) {
+        Object.assign(this, rawLookup, {
+            schemaQuery: new SchemaQuery(rawLookup.schemaName, rawLookup.queryName, rawLookup.viewName),
+        });
+    }
+
+    hasQueryFilters(operation?: Operation): boolean {
+        return (
+            isAllSamplesSchema(this.schemaQuery) ||
+            (operation !== undefined && this.getFilterGroup(operation) !== undefined)
         );
     }
 
-    hasQueryFilters(): boolean {
-        return isAllSamplesSchema(this.schemaQuery);
+    getFilterGroup(operation: Operation): FilterGroup {
+        return this.filterGroups?.find((filterGroup: FilterGroup) => filterGroup.operation === operation);
     }
 
-    getQueryFilters(): Filter.IFilter[] {
+    getQueryFilters(operation?: Operation): Filter.IFilter[] {
         // Issue 46037: Some plate-based assays (e.g., NAB) create samples with a bogus 'Material' sample type, which should get excluded here
         if (isAllSamplesSchema(this.schemaQuery)) {
             return [SAMPLES_WITH_TYPES_FILTER];
-        } else {
-            return undefined;
         }
+
+        const filterGroup = this.getFilterGroup(operation);
+
+        if (filterGroup) {
+            return filterGroup.filters.map(filterGroupFilter =>
+                Filter.create(
+                    filterGroupFilter.column,
+                    filterGroupFilter.value,
+                    Filter.Types[filterGroupFilter.operator.toUpperCase()]
+                )
+            );
+        }
+
+        return undefined;
     }
 }
 
-export class QueryColumn extends Record({
+export class QueryColumn extends ImmutableRecord({
     align: undefined,
     // autoIncrement: undefined,
     // calculated: undefined,
@@ -223,7 +242,7 @@ export class QueryColumn extends Record({
         if (rawColumn && rawColumn.lookup !== undefined) {
             return new QueryColumn(
                 Object.assign({}, rawColumn, {
-                    lookup: QueryLookup.create(rawColumn.lookup),
+                    lookup: new QueryLookup(rawColumn.lookup),
                 })
             );
         }
@@ -404,9 +423,9 @@ export class QueryColumn extends Record({
                 // OR if it is of type : (boolean, int, date, text), multiline excluded
                 if (this.lookup || this.dimension) return true;
                 else if (
-                    this.jsonType == 'boolean' ||
-                    this.jsonType == 'int' ||
-                    (this.jsonType == 'string' && this.inputType != 'textarea')
+                    this.jsonType === 'boolean' ||
+                    this.jsonType === 'int' ||
+                    (this.jsonType === 'string' && this.inputType !== 'textarea')
                 )
                     return true;
         }


### PR DESCRIPTION
#### Rationale
QuerySelect was not using the FilterGroups attribute returned by the server to filter drop downs. This PR wires up an "operation" property to the necessary components, and uses that to add the appropriate query filters if they exist on the column.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1115
- https://github.com/LabKey/biologics/pull/1945
- https://github.com/LabKey/labbook/pull/426
- https://github.com/LabKey/inventory/pull/744
- https://github.com/LabKey/sampleManagement/pull/1618

#### Changes
- QueryLookup: convert to regular class, add filterGroups attribute, use filterGroups in getQueryFilters
- QueryFormInputs: Add optional "operation" prop
  - Add equivalent prop to QueryInfoForm, AssayImportPanels (and child components), BulkAddUpdateForm, LookupCell
- DetailDisplay: use QueryColumn.getQueryFilters when rendering QuerySelect
