### PR TITLE
Add LK version to app admin settings page header - fix for non-premium app case

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.6",
+  "version": "2.293.6-fb-lkVersionNonPremium.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.293.6-fb-lkVersionNonPremium.0",
+  "version": "2.294.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD February 2023
+- Add LK version to app admin settings page header - fix for non-premium app case
+
 ### version 2.293.6
 *Released*: 20 February 2023
 - Add “ExpirationDate” field to exp.material

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD February 2023
+### version 2.294.0
+*Released*: 21 February 2023
 - Add LK version to app admin settings page header - fix for non-premium app case
 
 ### version 2.293.6

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -1,6 +1,8 @@
 import React, { FC, useCallback } from 'react';
 import { getServerContext } from '@labkey/api';
 
+import classNames from 'classnames';
+
 import { InjectedRouteLeaveProps, withRouteLeave } from '../../util/RouteLeave';
 import { useServerContext } from '../base/ServerContext';
 import { useNotificationsContext } from '../notifications/NotificationsContext';
@@ -19,7 +21,6 @@ import { SITE_SECURITY_ROLES } from './constants';
 import { BasePermissions } from './BasePermissions';
 import { showPremiumFeatures } from './utils';
 import { useAdminAppContext } from './useAdminAppContext';
-import classNames from "classnames";
 
 const TITLE = 'Settings';
 

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -19,6 +19,7 @@ import { SITE_SECURITY_ROLES } from './constants';
 import { BasePermissions } from './BasePermissions';
 import { showPremiumFeatures } from './utils';
 import { useAdminAppContext } from './useAdminAppContext';
+import classNames from "classnames";
 
 const TITLE = 'Settings';
 
@@ -44,8 +45,16 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
     }, [createNotification, dismissNotifications, setIsDirty]);
 
     const lkVersion = useCallback(() => {
-        return <div className="gray-text admin-settings-version">Version: {getServerContext().versionString}</div>;
-    }, []);
+        return (
+            <span
+                className={classNames('gray-text', 'admin-settings-version', {
+                    'margin-right': !showPremiumFeatures(moduleContext),
+                })}
+            >
+                Version: {getServerContext().versionString}
+            </span>
+        );
+    }, [moduleContext]);
 
     if (!user.isAdmin) {
         return <InsufficientPermissionsPage title={TITLE} />;
@@ -61,6 +70,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
                 rolesMap={SITE_SECURITY_ROLES}
                 showDetailsPanel={false}
                 disableRemoveSelf
+                lkVersion={lkVersion}
             >
                 <ActiveUserLimit />
                 <BarTenderSettingsForm

--- a/packages/components/src/internal/components/administration/BasePermissions.tsx
+++ b/packages/components/src/internal/components/administration/BasePermissions.tsx
@@ -37,6 +37,7 @@ interface OwnProps {
     description?: ReactNode;
     disableRemoveSelf: boolean;
     hasPermission: boolean;
+    lkVersion?: () => ReactNode;
     pageTitle: string;
     panelTitle: string;
     rolesMap: Map<string, string>;
@@ -61,6 +62,7 @@ export const BasePermissionsImpl: FC<BasePermissionsImplProps> = memo(props => {
         roles,
         rolesMap,
         setIsDirty,
+        lkVersion,
     } = props;
     const [error, setError] = useState<string>();
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
@@ -114,7 +116,8 @@ export const BasePermissionsImpl: FC<BasePermissionsImplProps> = memo(props => {
 
         return (
             <>
-                <CreatedModified row={row} />
+                {lkVersion?.()}
+                {!lkVersion && <CreatedModified row={row} />}
                 <ManageDropdownButton collapsed id="admin-page-manage" pullRight>
                     <MenuItem
                         href={AppURL.create(AUDIT_KEY)


### PR DESCRIPTION
#### Rationale
SMPermissionsTest.testLKVersionDisplay failed when the premium module is not present because we show a slightly different set of panels on the Admin > Settings page. This PR fixes that so that we make sure to show the LK version in both cases.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1107
- https://github.com/LabKey/labkey-ui-components/pull/1117
- https://github.com/LabKey/sampleManagement/pull/1624
- https://github.com/LabKey/biologics/pull/1950
- https://github.com/LabKey/inventory/pull/746

#### Changes
- Add LK version to app admin settings page header in non-premium case
