### PR TITLE
Refactor immutable classes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.298.0",
+  "version": "2.299.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -8,6 +8,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Container: convert to plain class
 - User: convert to plain class
 - QuerySort: convert to plain class
+- WebDavFile: convert to plain class
 
 ### version 2.298.0
 *Released*: 25 February 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.299.0
+*Released*: 27 February 2023
+- QueryColumn: convert to plain class
+- AppURL: convert to plain class
+- Container: convert to plain class
+- User: convert to plain class
+- QuerySort: convert to plain class
+
 ### version 2.298.0
 *Released*: 25 February 2023
 - Support Enable/Disable “System Default Fields”

--- a/packages/components/src/entities/SampleListingPage.spec.tsx
+++ b/packages/components/src/entities/SampleListingPage.spec.tsx
@@ -97,7 +97,7 @@ describe('hasPermissions', () => {
                 TEST_USER_EDITOR,
                 [PermissionTypes.Insert, PermissionTypes.Update],
                 false,
-                List.of(PermissionTypes.Insert)
+                [PermissionTypes.Insert]
             )
         ).toBeTruthy();
     });
@@ -108,7 +108,7 @@ describe('hasPermissions', () => {
                 TEST_USER_AUTHOR,
                 [PermissionTypes.Insert, PermissionTypes.Update],
                 true,
-                List.of(PermissionTypes.Insert)
+                [PermissionTypes.Insert]
             )
         ).toBeFalsy();
         expect(
@@ -116,7 +116,7 @@ describe('hasPermissions', () => {
                 TEST_USER_AUTHOR,
                 [PermissionTypes.Insert, PermissionTypes.Update],
                 true,
-                List.of(PermissionTypes.Insert, PermissionTypes.Update)
+                [PermissionTypes.Insert, PermissionTypes.Update]
             )
         ).toBeTruthy();
         expect(
@@ -124,7 +124,7 @@ describe('hasPermissions', () => {
                 TEST_USER_EDITOR,
                 [PermissionTypes.Insert, PermissionTypes.Update],
                 true,
-                List.of(PermissionTypes.Insert)
+                [PermissionTypes.Insert]
             )
         ).toBeFalsy();
         expect(
@@ -132,7 +132,7 @@ describe('hasPermissions', () => {
                 TEST_USER_EDITOR,
                 [PermissionTypes.Insert, PermissionTypes.Update],
                 true,
-                List.of(PermissionTypes.Insert, PermissionTypes.Update)
+                [PermissionTypes.Insert, PermissionTypes.Update]
             )
         ).toBeTruthy();
         expect(hasPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert, PermissionTypes.Update], true)).toBeFalsy();

--- a/packages/components/src/entities/SampleListingPage.tsx
+++ b/packages/components/src/entities/SampleListingPage.tsx
@@ -64,9 +64,9 @@ export const hasPermissions = (
     user: User,
     perms: string[],
     isSharedContainer?: boolean,
-    sharedContainerPermissions?: List<string>
+    sharedContainerPermissions?: string[]
 ): boolean => {
-    const allPerms = isSharedContainer ? sharedContainerPermissions : user.get('permissionsList');
+    const allPerms = isSharedContainer ? sharedContainerPermissions : user.permissionsList;
 
     if (!allPerms) return false;
 
@@ -140,7 +140,7 @@ export const SampleListingPageBody: FC<SampleListingPageBodyProps> = props => {
     const [showPrintDialog, setShowPrintDialog] = useState(false);
     const [showAddToStorage, setShowAddToStorage] = useState(false);
     const [showConfirmDeleteSampleType, setShowConfirmDeleteSampleType] = useState(false);
-    const [sharedContainerPermissions, setSharedContainerPermissions] = useState<List<string>>();
+    const [sharedContainerPermissions, setSharedContainerPermissions] = useState<string[]>();
     const containerFilter = useMemo(() => getContainerFilterForLookups(), []);
 
     const detailsModel = queryModels[DETAIL_GRID_ID];
@@ -150,7 +150,7 @@ export const SampleListingPageBody: FC<SampleListingPageBodyProps> = props => {
     useEffect(() => {
         getUserSharedContainerPermissions()
             .then(permissions => {
-                setSharedContainerPermissions(fromJS(permissions));
+                setSharedContainerPermissions(permissions);
             })
             .catch(reason => {
                 console.error(reason);

--- a/packages/components/src/entities/SamplesBulkUpdateForm.spec.tsx
+++ b/packages/components/src/entities/SamplesBulkUpdateForm.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 
 import { fromJS } from 'immutable';
 
@@ -103,19 +103,30 @@ describe('SamplesBulkUpdateForm', () => {
         user: TEST_USER_EDITOR,
         createNotification: jest.fn(),
         dismissNotifications: jest.fn(),
+        viewName: undefined,
     };
 
     test('all selected are samples', () => {
         const wrapper = mount(<SamplesBulkUpdateFormBase {...DEFAULT_PROPS} />);
         const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
         expect(queryInfo.columns.size).toBe(4);
-        expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
-        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
-        expect(queryInfo.columns.get('meta')).toBe(COLUMN_META);
-        expect(queryInfo.columns.get('independent')).toBe(COLUMN_INDEPENDENT);
+        expect(queryInfo.columns.get('description')).toStrictEqual(COLUMN_DESCRIPTION);
+        expect(queryInfo.columns.get('samplestate')).toStrictEqual(COLUMN_STATUS);
+        expect(queryInfo.columns.get('meta')).toStrictEqual(COLUMN_META);
+        expect(queryInfo.columns.get('independent')).toStrictEqual(COLUMN_INDEPENDENT);
         expect(queryInfo.columns.get('aliquotspecific')).toBeUndefined();
         wrapper.unmount();
     });
+
+    function validateWithAliquots(wrapper: ReactWrapper) {
+        const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
+        expect(queryInfo.columns.size).toBe(4);
+        expect(queryInfo.columns.get('description')).toStrictEqual(COLUMN_DESCRIPTION);
+        expect(queryInfo.columns.get('samplestate')).toStrictEqual(COLUMN_STATUS);
+        expect(queryInfo.columns.get('meta')).toBeUndefined();
+        expect(queryInfo.columns.get('aliquotspecific')).toStrictEqual(COLUMN_ALIQUOT);
+        expect(queryInfo.columns.get('independent')).toStrictEqual(COLUMN_INDEPENDENT);
+    }
 
     test('all selected are aliquots', () => {
         const props = {
@@ -123,14 +134,7 @@ describe('SamplesBulkUpdateForm', () => {
             aliquots: [1, 2, 3],
         };
         const wrapper = mount(<SamplesBulkUpdateFormBase {...props} />);
-        const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(4);
-        expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
-        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
-        expect(queryInfo.columns.get('meta')).toBeUndefined();
-        expect(queryInfo.columns.get('aliquotspecific')).toBe(COLUMN_ALIQUOT);
-        expect(queryInfo.columns.get('independent')).toBe(COLUMN_INDEPENDENT);
-
+        validateWithAliquots(wrapper);
         wrapper.unmount();
     });
 
@@ -140,14 +144,7 @@ describe('SamplesBulkUpdateForm', () => {
             aliquots: [1],
         };
         const wrapper = mount(<SamplesBulkUpdateFormBase {...props} />);
-        const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(4);
-        expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
-        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
-        expect(queryInfo.columns.get('meta')).toBeUndefined();
-        expect(queryInfo.columns.get('aliquotspecific')).toBe(COLUMN_ALIQUOT);
-        expect(queryInfo.columns.get('independent')).toBe(COLUMN_INDEPENDENT);
-
+        validateWithAliquots(wrapper);
         wrapper.unmount();
     });
 
@@ -157,14 +154,7 @@ describe('SamplesBulkUpdateForm', () => {
             aliquots: [1, 2],
         };
         const wrapper = mount(<SamplesBulkUpdateFormBase {...props} />);
-        const queryInfo = wrapper.find(BulkUpdateForm).prop('queryInfo');
-        expect(queryInfo.columns.size).toBe(4);
-        expect(queryInfo.columns.get('description')).toBe(COLUMN_DESCRIPTION);
-        expect(queryInfo.columns.get('samplestate')).toBe(COLUMN_STATUS);
-        expect(queryInfo.columns.get('meta')).toBeUndefined();
-        expect(queryInfo.columns.get('aliquotspecific')).toBe(COLUMN_ALIQUOT);
-        expect(queryInfo.columns.get('independent')).toBe(COLUMN_INDEPENDENT);
-
+        validateWithAliquots(wrapper);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/entities/SamplesEditableGrid.tsx
+++ b/packages/components/src/entities/SamplesEditableGrid.tsx
@@ -493,10 +493,10 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
                     queryInfoCols = queryInfoCols.set(key, column);
                     updateColumns = updateColumns.push(column);
                 } else if (STORAGE_UPDATE_FIELDS.indexOf(column.fieldKey) > -1) {
-                    const updatedCol = column.merge({
+                    const updatedCol = column.mutate({
                         shownInUpdateView: true,
                         userEditable: true,
-                    }) as QueryColumn;
+                    });
                     queryInfoCols = queryInfoCols.set(key, updatedCol);
                     updateColumns = updateColumns.push(updatedCol);
                 }

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -79,7 +79,7 @@ export class AssayDefinitionModel extends Record({
 
             if (rawModel.domains) {
                 const rawDomains = Object.keys(rawModel.domains).reduce((result, k) => {
-                    result[k] = List<QueryColumn>(rawModel.domains[k].map(rawColumn => QueryColumn.create(rawColumn)));
+                    result[k] = List<QueryColumn>(rawModel.domains[k].map(rawColumn => new QueryColumn(rawColumn)));
                     return result;
                 }, {});
                 domains = Map<string, List<QueryColumn>>(rawDomains);

--- a/packages/components/src/internal/app/models.ts
+++ b/packages/components/src/internal/app/models.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { List, Record } from 'immutable';
+import { Record } from 'immutable';
 import { ActionURL, getServerContext } from '@labkey/api';
 
 import { ComponentType } from 'react';
@@ -12,7 +12,7 @@ import { User } from '../components/base/models/User';
 
 const user = new User({
     ...getServerContext().user,
-    permissionsList: List(getServerContext().container?.effectivePermissions ?? []),
+    permissionsList: getServerContext().container?.effectivePermissions ?? [],
 });
 
 export enum LogoutReason {

--- a/packages/components/src/internal/app/reducers.ts
+++ b/packages/components/src/internal/app/reducers.ts
@@ -4,6 +4,7 @@
  */
 import { Map } from 'immutable';
 import { handleActions } from 'redux-actions';
+import { User } from '../components/base/models/User';
 
 import { ProductMenuModel } from '../components/navigation/model';
 
@@ -37,13 +38,13 @@ export const AppReducers = handleActions<AppReducerState, any>(
 
         [UPDATE_USER]: (state: AppReducerState, action: any) => {
             return state.merge({
-                user: state.user.merge(action.userProps),
+                user: new User({ ...state.user, ...action.userProps }),
             });
         },
 
         [UPDATE_USER_DISPLAY_NAME]: (state: AppReducerState, action: any) => {
             return state.merge({
-                user: state.user.set('displayName', action.displayName),
+                user: new User({ ...state.user, displayName: action.displayName }),
             });
         },
 

--- a/packages/components/src/internal/components/EditInlineField.spec.tsx
+++ b/packages/components/src/internal/components/EditInlineField.spec.tsx
@@ -157,7 +157,7 @@ describe('EditInlineField', () => {
                 {...DEFAULT_PROPS}
                 type="date"
                 value="2022-08-11"
-                column={QueryColumn.create({ format: 'MM/dd/YYYY HH:mm:ss' })}
+                column={new QueryColumn({ format: 'MM/dd/YYYY HH:mm:ss' })}
             />,
             SERVER_CONTEXT
         );
@@ -175,7 +175,7 @@ describe('EditInlineField', () => {
         const wrapper = mountWithServerContext(
             <EditInlineField
                 {...DEFAULT_PROPS}
-                column={QueryColumn.create({
+                column={new QueryColumn({
                     fieldKey: 'test',
                     readOnly: false,
                     userEditable: true,
@@ -199,7 +199,7 @@ describe('EditInlineField', () => {
         const wrapper = mountWithServerContext(
             <EditInlineField
                 {...DEFAULT_PROPS}
-                column={QueryColumn.create({
+                column={new QueryColumn({
                     fieldKey: 'test',
                     caption: 'Test',
                     readOnly: false,

--- a/packages/components/src/internal/components/base/Permissions.spec.tsx
+++ b/packages/components/src/internal/components/base/Permissions.spec.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import { PermissionTypes } from '@labkey/api';
 
-import {
-    TEST_USER_APP_ADMIN,
-    TEST_USER_ASSAY_DESIGNER,
-    TEST_USER_EDITOR, TEST_USER_FOLDER_ADMIN,
-    TEST_USER_READER,
-} from '../../userFixtures';
+import { TEST_USER_APP_ADMIN, TEST_USER_ASSAY_DESIGNER, TEST_USER_EDITOR, TEST_USER_READER } from '../../userFixtures';
 import { mountWithServerContext } from '../../testHelpers';
+
 import { User } from './models/User';
 
 import { RequiresPermission } from './Permissions';

--- a/packages/components/src/internal/components/base/Permissions.spec.tsx
+++ b/packages/components/src/internal/components/base/Permissions.spec.tsx
@@ -4,10 +4,11 @@ import { PermissionTypes } from '@labkey/api';
 import {
     TEST_USER_APP_ADMIN,
     TEST_USER_ASSAY_DESIGNER,
-    TEST_USER_EDITOR,
+    TEST_USER_EDITOR, TEST_USER_FOLDER_ADMIN,
     TEST_USER_READER,
 } from '../../userFixtures';
 import { mountWithServerContext } from '../../testHelpers';
+import { User } from './models/User';
 
 import { RequiresPermission } from './Permissions';
 
@@ -89,7 +90,7 @@ describe('<RequiresPermission/>', () => {
     });
     test('respects checkIsAdmin', () => {
         // Arrange
-        const ADMIN_READER = TEST_USER_READER.set('isAdmin', true);
+        const ADMIN_READER = new User({ ...TEST_USER_READER, isAdmin: true });
 
         // Act
         // "checkIsAdmin" defaults to true

--- a/packages/components/src/internal/components/base/models/Container.ts
+++ b/packages/components/src/internal/components/base/models/Container.ts
@@ -1,4 +1,3 @@
-import { Record } from 'immutable';
 import { Container as IContainer } from '@labkey/api';
 
 export interface ContainerDateFormats {
@@ -34,7 +33,7 @@ const defaultContainer: IContainer = {
 /**
  * Model for org.labkey.api.data.Container as returned by Container.toJSON()
  */
-export class Container extends Record(defaultContainer) implements IContainer {
+export class Container implements IContainer {
     declare activeModules: string[];
     declare effectivePermissions: string[];
     declare folderType: string;
@@ -52,6 +51,10 @@ export class Container extends Record(defaultContainer) implements IContainer {
     declare startUrl: string;
     declare title: string;
     declare type: string;
+
+    constructor(props) {
+        Object.assign(this, defaultContainer, props);
+    }
 
     /**
      * Verify if the given moduleName parameter is in the array of active modules for this container object.

--- a/packages/components/src/internal/components/base/models/User.ts
+++ b/packages/components/src/internal/components/base/models/User.ts
@@ -1,8 +1,7 @@
-import { List, Record } from 'immutable';
 import { ActionURL, PermissionTypes, UserWithPermissions } from '@labkey/api';
 
 interface IUserProps extends UserWithPermissions {
-    permissionsList: List<string>;
+    permissionsList: string[];
 }
 
 const defaultUser: IUserProps = {
@@ -29,13 +28,13 @@ const defaultUser: IUserProps = {
     isTrusted: false,
 
     maxAllowedPhi: undefined,
-    permissionsList: List(),
+    permissionsList: [],
 };
 
 /**
  * Model for org.labkey.api.security.User as returned by User.getUserProps()
  */
-export class User extends Record(defaultUser) implements IUserProps {
+export class User implements IUserProps {
     declare id: number;
 
     declare canDelete: boolean;
@@ -59,7 +58,11 @@ export class User extends Record(defaultUser) implements IUserProps {
     declare isTrusted: boolean;
 
     declare maxAllowedPhi: string;
-    declare permissionsList: List<string>;
+    declare permissionsList: string[];
+
+    constructor(props) {
+        Object.assign(this, defaultUser, props);
+    }
 
     static getDefaultUser(): User {
         return new User(defaultUser);
@@ -124,7 +127,7 @@ export function hasPermissions(
     if (checkIsAdmin && user.isAdmin) {
         return perms?.length > 0;
     } else if (perms) {
-        const allPerms = user.get('permissionsList');
+        const allPerms = user.permissionsList;
 
         if (permissionCheck === 'any') {
             return perms.some(p => allPerms.indexOf(p) > -1);

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { List } from 'immutable';
 import { PermissionTypes } from '@labkey/api';
 
 import { isLoading, LoadingState } from '../../../public/LoadingState';
@@ -13,23 +12,22 @@ import { resolveErrorMessage } from '../../util/messaging';
  * Applies the permissions on the container to the user. Only permission related User fields are mutated.
  */
 function applyPermissions(container: Container, user: User): User {
-    return user.withMutations(u => {
-        // Must set "isAdmin" and "permissionsList" prior to configuring
-        // permission bits (e.g. "canDelete", "canUpdate", etc).
-        const contextUser = u.merge({
-            isAdmin: container.effectivePermissions.indexOf(PermissionTypes.Admin) > -1,
-            permissionsList: List(container.effectivePermissions),
-        }) as User;
-
-        // Update permission bits that are explicitly defined on the user.
-        return contextUser.merge({
-            canDelete: contextUser.hasDeletePermission(),
-            canDeleteOwn: contextUser.hasDeletePermission(),
-            canInsert: contextUser.hasInsertPermission(),
-            canUpdate: contextUser.hasUpdatePermission(),
-            canUpdateOwn: contextUser.hasUpdatePermission(),
-        });
+    // Must set "isAdmin" and "permissionsList" prior to configuring
+    // permission bits (e.g. "canDelete", "canUpdate", etc).
+    const contextUser = new User({
+        ...user,
+        isAdmin: container.effectivePermissions.indexOf(PermissionTypes.Admin) > -1,
+        permissionsList: container.effectivePermissions,
     }) as User;
+
+    return new User({
+        ...contextUser,
+        canDelete: contextUser.hasDeletePermission(),
+        canDeleteOwn: contextUser.hasDeletePermission(),
+        canInsert: contextUser.hasInsertPermission(),
+        canUpdate: contextUser.hasUpdatePermission(),
+        canUpdateOwn: contextUser.hasUpdatePermission(),
+    });
 }
 
 export interface ContainerUser {

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
@@ -211,7 +211,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                 <FolderSelectImpl
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -250,7 +250,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                     componentClass="select"
                     context={
                       {
-                        "activeContainer": Immutable.Record {
+                        "activeContainer": Container {
                           "activeModules": [],
                           "effectivePermissions": [],
                           "folderType": "",
@@ -288,7 +288,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                       className="form-control"
                       context={
                         {
-                          "activeContainer": Immutable.Record {
+                          "activeContainer": Container {
                             "activeModules": [],
                             "effectivePermissions": [],
                             "folderType": "",
@@ -360,7 +360,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                   containerPath="/StudyVerifyProject/My Study"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -454,7 +454,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                   containerPath="/StudyVerifyProject/My Study"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -814,7 +814,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                 <FolderSelectImpl
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -853,7 +853,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                     componentClass="select"
                     context={
                       {
-                        "activeContainer": Immutable.Record {
+                        "activeContainer": Container {
                           "activeModules": [],
                           "effectivePermissions": [],
                           "folderType": "",
@@ -891,7 +891,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                       className="form-control"
                       context={
                         {
-                          "activeContainer": Immutable.Record {
+                          "activeContainer": Container {
                             "activeModules": [],
                             "effectivePermissions": [],
                             "folderType": "",
@@ -975,7 +975,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                   containerPath="/StudyVerifyProject"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -1095,7 +1095,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                   containerPath="/StudyVerifyProject"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -1496,7 +1496,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                 <FolderSelectImpl
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -1535,7 +1535,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                     componentClass="select"
                     context={
                       {
-                        "activeContainer": Immutable.Record {
+                        "activeContainer": Container {
                           "activeModules": [],
                           "effectivePermissions": [],
                           "folderType": "",
@@ -1573,7 +1573,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                       className="form-control"
                       context={
                         {
-                          "activeContainer": Immutable.Record {
+                          "activeContainer": Container {
                             "activeModules": [],
                             "effectivePermissions": [],
                             "folderType": "",
@@ -1657,7 +1657,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                   containerPath="/StudyVerifyProject"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -1777,7 +1777,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                   containerPath="/StudyVerifyProject"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -2178,7 +2178,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                 <FolderSelectImpl
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -2217,7 +2217,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                     componentClass="select"
                     context={
                       {
-                        "activeContainer": Immutable.Record {
+                        "activeContainer": Container {
                           "activeModules": [],
                           "effectivePermissions": [],
                           "folderType": "",
@@ -2255,7 +2255,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                       className="form-control"
                       context={
                         {
-                          "activeContainer": Immutable.Record {
+                          "activeContainer": Container {
                             "activeModules": [],
                             "effectivePermissions": [],
                             "folderType": "",
@@ -2339,7 +2339,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                   containerPath="/StudyVerifyProject/My Study"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",
@@ -2456,7 +2456,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                   containerPath="/StudyVerifyProject/My Study"
                   context={
                     {
-                      "activeContainer": Immutable.Record {
+                      "activeContainer": Container {
                         "activeModules": [],
                         "effectivePermissions": [],
                         "folderType": "",

--- a/packages/components/src/internal/components/domainproperties/actions.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.spec.ts
@@ -234,9 +234,9 @@ describe('domain properties actions', () => {
         expect(initDomain.fields.get(1).rangeURI).toBe(INTEGER_TYPE.rangeURI);
 
         const newFields = [
-            QueryColumn.create({ name: 'text', rangeURI: TEXT_TYPE.rangeURI }),
-            QueryColumn.create({ name: 'dbl', rangeURI: DOUBLE_TYPE.rangeURI }),
-            QueryColumn.create({ name: 'dt', rangeURI: DATETIME_TYPE.rangeURI }),
+            new QueryColumn({ name: 'text', rangeURI: TEXT_TYPE.rangeURI }),
+            new QueryColumn({ name: 'dbl', rangeURI: DOUBLE_TYPE.rangeURI }),
+            new QueryColumn({ name: 'dt', rangeURI: DATETIME_TYPE.rangeURI }),
         ];
 
         const updatedDomain = setDomainFields(initDomain, List<QueryColumn>(newFields));

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListDesignerPanels.spec.tsx.snap
@@ -26454,7 +26454,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             <FolderSelectImpl
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -26493,7 +26493,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                                 componentClass="select"
                                                                                                 context={
                                                                                                   {
-                                                                                                    "activeContainer": Immutable.Record {
+                                                                                                    "activeContainer": Container {
                                                                                                       "activeModules": [],
                                                                                                       "effectivePermissions": [],
                                                                                                       "folderType": "",
@@ -26531,7 +26531,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                                   className="form-control"
                                                                                                   context={
                                                                                                     {
-                                                                                                      "activeContainer": Immutable.Record {
+                                                                                                      "activeContainer": Container {
                                                                                                         "activeModules": [],
                                                                                                         "effectivePermissions": [],
                                                                                                         "folderType": "",
@@ -26603,7 +26603,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                               containerPath="ea23d322-acd6-1037-8e6d-25f311da6f8b"
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -26697,7 +26697,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                               containerPath="ea23d322-acd6-1037-8e6d-25f311da6f8b"
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -28762,7 +28762,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             <FolderSelectImpl
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -28801,7 +28801,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                                 componentClass="select"
                                                                                                 context={
                                                                                                   {
-                                                                                                    "activeContainer": Immutable.Record {
+                                                                                                    "activeContainer": Container {
                                                                                                       "activeModules": [],
                                                                                                       "effectivePermissions": [],
                                                                                                       "folderType": "",
@@ -28839,7 +28839,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                                   className="form-control"
                                                                                                   context={
                                                                                                     {
-                                                                                                      "activeContainer": Immutable.Record {
+                                                                                                      "activeContainer": Container {
                                                                                                         "activeModules": [],
                                                                                                         "effectivePermissions": [],
                                                                                                         "folderType": "",
@@ -28911,7 +28911,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                               containerPath="ea23d322-acd6-1037-8e6d-25f311da6f8b"
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -29005,7 +29005,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                               containerPath="ea23d322-acd6-1037-8e6d-25f311da6f8b"
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -34770,7 +34770,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                             <FolderSelectImpl
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -34809,7 +34809,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                                 componentClass="select"
                                                                                                 context={
                                                                                                   {
-                                                                                                    "activeContainer": Immutable.Record {
+                                                                                                    "activeContainer": Container {
                                                                                                       "activeModules": [],
                                                                                                       "effectivePermissions": [],
                                                                                                       "folderType": "",
@@ -34847,7 +34847,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                                   className="form-control"
                                                                                                   context={
                                                                                                     {
-                                                                                                      "activeContainer": Immutable.Record {
+                                                                                                      "activeContainer": Container {
                                                                                                         "activeModules": [],
                                                                                                         "effectivePermissions": [],
                                                                                                         "folderType": "",
@@ -34919,7 +34919,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                               containerPath="ea23d322-acd6-1037-8e6d-25f311da6f8b"
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",
@@ -35013,7 +35013,7 @@ exports[`ListDesignerPanel existing list 1`] = `
                                                                                               containerPath="ea23d322-acd6-1037-8e6d-25f311da6f8b"
                                                                                               context={
                                                                                                 {
-                                                                                                  "activeContainer": Immutable.Record {
+                                                                                                  "activeContainer": Container {
                                                                                                     "activeModules": [],
                                                                                                     "effectivePermissions": [],
                                                                                                     "folderType": "",

--- a/packages/components/src/internal/components/editable/Cell.spec.tsx
+++ b/packages/components/src/internal/components/editable/Cell.spec.tsx
@@ -46,7 +46,7 @@ beforeAll(() => {
     };
 });
 
-const queryColumn = QueryColumn.create({ lookup: undefined, name: 'myColumn' });
+const queryColumn = new QueryColumn({ lookup: undefined, name: 'myColumn' });
 
 describe('Cell', () => {
     test('default props', () => {
@@ -101,7 +101,7 @@ describe('Cell', () => {
     });
 
     test('column is readOnly', () => {
-        const roColumn = QueryColumn.create({ readOnly: true, name: 'roColumn' });
+        const roColumn = new QueryColumn({ readOnly: true, name: 'roColumn' });
         const cell = mount(<Cell cellActions={actions} col={roColumn} colIdx={4} readOnly={false} rowIdx={3} />);
         expect(cell.find('div')).toHaveLength(1);
         expect(cell.find('input')).toHaveLength(0);
@@ -128,7 +128,7 @@ describe('Cell', () => {
     });
 
     test('col is lookup, not public', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', lookup: { isPublic: false } });
+        const lookupCol = new QueryColumn({ name: 'test', lookup: { isPublic: false } });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} />);
         expect(cell.find('div')).toHaveLength(1);
         expect(cell.find('.cell-menu')).toHaveLength(0);
@@ -147,31 +147,31 @@ describe('Cell', () => {
     };
 
     test('col is lookup, public', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', lookup: { isPublic: true } });
+        const lookupCol = new QueryColumn({ name: 'test', lookup: { isPublic: true } });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} />);
         expectLookup(cell);
     });
 
     test('col is lookup, public and focused', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', lookup: { isPublic: true } });
+        const lookupCol = new QueryColumn({ name: 'test', lookup: { isPublic: true } });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} focused selected />);
         expectLookup(cell, true);
     });
 
     test('col has validValues', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', validValues: ['a', 'b'] });
+        const lookupCol = new QueryColumn({ name: 'test', validValues: ['a', 'b'] });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} />);
         expectLookup(cell);
     });
 
     test('col is a lookup, but readonly', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', validValues: ['a', 'b'] });
+        const lookupCol = new QueryColumn({ name: 'test', validValues: ['a', 'b'] });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} readOnly />);
         expectLookup(cell, false, true);
     });
 
     test('col has validValues and focused', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', validValues: ['a', 'b'] });
+        const lookupCol = new QueryColumn({ name: 'test', validValues: ['a', 'b'] });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} focused selected />);
         expect(cell.find('div')).toHaveLength(9);
         expect(cell.find('.cell-menu')).toHaveLength(0);
@@ -183,7 +183,7 @@ describe('Cell', () => {
     });
 
     test('cell lastSelection', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', validValues: ['a', 'b'] });
+        const lookupCol = new QueryColumn({ name: 'test', validValues: ['a', 'b'] });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} lastSelection />);
         expect(cell.find('div')).toHaveLength(2);
         expect(cell.find('.cell-menu')).toHaveLength(1);
@@ -206,7 +206,7 @@ describe('Cell', () => {
     };
 
     test('col is date', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', jsonType: 'date' });
+        const lookupCol = new QueryColumn({ name: 'test', jsonType: 'date' });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} />);
         expectDate(cell);
         cell.unmount();
@@ -219,14 +219,14 @@ describe('Cell', () => {
                 raw: '2022-08-05 00:00:00.000',
             },
         ]);
-        const lookupCol = QueryColumn.create({ name: 'test', jsonType: 'date' });
+        const lookupCol = new QueryColumn({ name: 'test', jsonType: 'date' });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} values={values} />);
         expectDate(cell, false, '2022-08-05 00:00');
         cell.unmount();
     });
 
     test('col is date, focused', () => {
-        const lookupCol = QueryColumn.create({ name: 'test', jsonType: 'date', caption: 'Test' });
+        const lookupCol = new QueryColumn({ name: 'test', jsonType: 'date', caption: 'Test' });
         const cell = mount(<Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} focused selected />);
         expectDate(cell, true);
         cell.unmount();
@@ -239,7 +239,7 @@ describe('Cell', () => {
                 raw: '2022-08-05 00:00:00.000',
             },
         ]);
-        const lookupCol = QueryColumn.create({ name: 'test', jsonType: 'date', caption: 'Test' });
+        const lookupCol = new QueryColumn({ name: 'test', jsonType: 'date', caption: 'Test' });
         const cell = mount(
             <Cell cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} values={values} focused selected />
         );

--- a/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.spec.ts
+++ b/packages/components/src/internal/components/editable/LineageEditableGridLoaderFromSelection.spec.ts
@@ -34,7 +34,7 @@ describe('getLineageEditorUpdateColumns', () => {
         expect(cols.queryInfoColumns.get('name')).toBeDefined();
         expect(cols.queryInfoColumns.get('other')).toBeUndefined();
         expect(cols.columns.size).toBe(1);
-        expect(cols.columns.get(0).get('fieldKey')).toBe('name');
+        expect(cols.columns.get(0).fieldKey).toBe('name');
     });
 
     test('with parent types', () => {
@@ -70,9 +70,9 @@ describe('getLineageEditorUpdateColumns', () => {
         expect(cols.queryInfoColumns.get('materialinputs/test1')).toBeDefined();
         expect(cols.queryInfoColumns.get('datainputs/test2')).toBeDefined();
         expect(cols.columns.size).toBe(3);
-        expect(cols.columns.get(0).get('fieldKey')).toBe('name');
-        expect(cols.columns.get(1).get('fieldKey')).toBe('DataInputs/Test2');
-        expect(cols.columns.get(2).get('fieldKey')).toBe('MaterialInputs/Test1');
+        expect(cols.columns.get(0).fieldKey).toBe('name');
+        expect(cols.columns.get(1).fieldKey).toBe('DataInputs/Test2');
+        expect(cols.columns.get(2).fieldKey).toBe('MaterialInputs/Test1');
     });
 
     // Regression coverage to ensure the "name" column is included in the lineage

--- a/packages/components/src/internal/components/editable/LookupCell.spec.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.spec.tsx
@@ -13,7 +13,7 @@ import { Query } from '@labkey/api';
 
 describe('LookupCell', () => {
     const DEFAULT_PROPS = {
-        col: QueryColumn.create({
+        col: new QueryColumn({
             lookup: {
                 schemaName: 'schema',
                 queryName: 'query',
@@ -47,7 +47,7 @@ describe('LookupCell', () => {
         const wrapper = mount(
             <LookupCell
                 {...DEFAULT_PROPS}
-                col={QueryColumn.create({
+                col={new QueryColumn({
                     lookup: {
                         schemaName: 'exp',
                         queryName: 'materials',
@@ -75,7 +75,7 @@ describe('LookupCell', () => {
         const wrapper = mount(
             <LookupCell
                 {...DEFAULT_PROPS}
-                col={QueryColumn.create({
+                col={new QueryColumn({
                     lookup: { schemaName: 'schema', queryName: 'query', multiValued: 'junction' },
                 })}
             />
@@ -114,7 +114,7 @@ describe('LookupCell', () => {
     test('QuerySelect lookup with container filter', () => {
         const wrapper = mount(<LookupCell
             {...DEFAULT_PROPS}
-            col={ QueryColumn.create({
+            col={ new QueryColumn({
                 lookup: {
                     schemaName: 'schema',
                     queryName: 'query',
@@ -148,7 +148,7 @@ describe('LookupCell', () => {
         const wrapper = mount(
             <LookupCell
                 {...DEFAULT_PROPS}
-                col={QueryColumn.create({
+                col={new QueryColumn({
                     validValues: ['a', 'b'],
                 })}
             />

--- a/packages/components/src/internal/components/editable/models.spec.ts
+++ b/packages/components/src/internal/components/editable/models.spec.ts
@@ -937,17 +937,17 @@ describe('getPkData', () => {
         appEditableTable: true,
         pkCols: List(['RowId']),
         columns: fromJS({
-            rowid: QueryColumn.create({
+            rowid: new QueryColumn({
                 caption: 'Row Id',
                 fieldKey: 'RowId',
                 inputType: 'number',
             }),
-            lsid: QueryColumn.create({
+            lsid: new QueryColumn({
                 caption: 'LSID',
                 fieldKey: 'lsid',
                 inputType: 'text',
             }),
-            description: QueryColumn.create({
+            description: new QueryColumn({
                 caption: 'Description',
                 fieldKey: 'Description',
                 inputType: 'textarea',

--- a/packages/components/src/internal/components/editable/models.spec.ts
+++ b/packages/components/src/internal/components/editable/models.spec.ts
@@ -24,10 +24,7 @@ import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 
 import { CellMessage, EditorModel, getPkData, ValueDescriptor } from './models';
 
-const schemaQ = new SchemaQuery({
-    schemaName: 'samples',
-    queryName: 'Sample Set 2',
-});
+const schemaQ = new SchemaQuery('samples', 'Sample Set 2');
 
 const COLUMN_CAN_INSERT_AND_UPDATE = new QueryColumn({
     fieldKey: 'both',
@@ -666,24 +663,24 @@ describe('EditorModel', () => {
             const editorModel = new EditorModel({});
             const columns = editorModel.getColumns(QUERY_INFO);
             expect(columns.size).toBe(2);
-            expect(columns.get(0)).toBe(COLUMN_CAN_INSERT_AND_UPDATE);
-            expect(columns.get(1)).toBe(COLUMN_CAN_INSERT);
+            expect(columns.get(0)).toStrictEqual(COLUMN_CAN_INSERT_AND_UPDATE);
+            expect(columns.get(1)).toStrictEqual(COLUMN_CAN_INSERT);
         });
 
         test('getColumns forUpdate', () => {
             const editorModel = new EditorModel({});
             const columns = editorModel.getColumns(QUERY_INFO, true);
             expect(columns.size).toBe(2);
-            expect(columns.get(0)).toBe(COLUMN_CAN_INSERT_AND_UPDATE);
-            expect(columns.get(1)).toBe(COLUMN_CAN_UPDATE);
+            expect(columns.get(0)).toStrictEqual(COLUMN_CAN_INSERT_AND_UPDATE);
+            expect(columns.get(1)).toStrictEqual(COLUMN_CAN_UPDATE);
         });
 
         test('getColumns readOnlyColumns', () => {
             const editorModel = new EditorModel({});
             const columns = editorModel.getColumns(QUERY_INFO, true, List(['neither']));
             expect(columns.size).toBe(3);
-            expect(columns.get(0)).toBe(COLUMN_CAN_INSERT_AND_UPDATE);
-            expect(columns.get(1)).toBe(COLUMN_CAN_UPDATE);
+            expect(columns.get(0)).toStrictEqual(COLUMN_CAN_INSERT_AND_UPDATE);
+            expect(columns.get(1)).toStrictEqual(COLUMN_CAN_UPDATE);
             expect(columns.get(2).fieldKey).toBe(COLUMN_CANNOT_INSERT_AND_UPDATE.fieldKey);
             expect(columns.get(2).readOnly).toBe(true);
         });
@@ -957,7 +954,7 @@ describe('getPkData', () => {
     const queryInfo = new QueryInfo(config);
     const queryInfoWithAltKey = new QueryInfo({
         ...config,
-        altUpdateKeys: new Set<strin>(['lsid']),
+        altUpdateKeys: Set<string>(['lsid']),
     });
 
     test('as value', () => {

--- a/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
@@ -89,7 +89,7 @@ describe('getFieldKeysOfRequiredCols', () => {
         expect(
             getFieldKeysOfRequiredCols(
                 List.of(
-                    QueryColumn.create({
+                    new QueryColumn({
                         fieldKey: 'col1',
                         fieldKeyArray: ['col1'],
                         readOnly: false,
@@ -104,7 +104,7 @@ describe('getFieldKeysOfRequiredCols', () => {
         expect(
             getFieldKeysOfRequiredCols(
                 List.of(
-                    QueryColumn.create({
+                    new QueryColumn({
                         fieldKey: 'col1',
                         fieldKeyArray: ['col1'],
                         readOnly: false,
@@ -121,7 +121,7 @@ describe('getFieldKeysOfRequiredCols', () => {
         expect(
             getFieldKeysOfRequiredCols(
                 List.of(
-                    QueryColumn.create({
+                    new QueryColumn({
                         fieldKey: 'col1',
                         fieldKeyArray: ['col1'],
                         readOnly: false,
@@ -138,7 +138,7 @@ describe('getFieldKeysOfRequiredCols', () => {
         expect(
             getFieldKeysOfRequiredCols(
                 List.of(
-                    QueryColumn.create({
+                    new QueryColumn({
                         fieldKey: 'col1',
                         fieldKeyArray: ['col1'],
                         readOnly: false,
@@ -155,7 +155,7 @@ describe('getFieldKeysOfRequiredCols', () => {
         expect(
             getFieldKeysOfRequiredCols(
                 List.of(
-                    QueryColumn.create({
+                    new QueryColumn({
                         fieldKey: 'col1',
                         fieldKeyArray: ['col1'],
                         readOnly: false,
@@ -172,7 +172,7 @@ describe('getFieldKeysOfRequiredCols', () => {
         expect(
             getFieldKeysOfRequiredCols(
                 List.of(
-                    QueryColumn.create({
+                    new QueryColumn({
                         fieldKey: 'lookup/col1',
                         fieldKeyArray: ['lookup', 'col1'],
                         readOnly: false,

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.spec.tsx
@@ -38,13 +38,13 @@ describe('EntityInsertPanel.getWarningFieldList', () => {
 
 describe('EntityInsertPanel.getInferredFieldWarnings', () => {
     const lookup = { containerPath: '/Look', keyColumn: 'Name', displayColumn: 'Name', query: 'LookHere' };
-    const knownColumn = QueryColumn.create({
+    const knownColumn = new QueryColumn({
         name: 'known',
     });
-    const alsoKnownColumn = QueryColumn.create({
+    const alsoKnownColumn = new QueryColumn({
         name: 'alsoKnown',
     });
-    const aliasedColumn = QueryColumn.create({
+    const aliasedColumn = new QueryColumn({
         name: 'aliased',
     });
 
@@ -75,8 +75,8 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'aliasName' }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'aliasName' }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),
@@ -92,7 +92,7 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
     test('none unknown, one unique', () => {
         const columns = baseColumns.set(
             'barcode1',
-            QueryColumn.create({
+            new QueryColumn({
                 name: 'barcode1',
                 caption: 'Barcode 1',
                 conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
@@ -105,8 +105,8 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'barcode1' }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'barcode1' }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),
@@ -124,12 +124,12 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
     test('none unknown, multiple unique', () => {
         const columns = baseColumns.merge(
             OrderedMap<string, QueryColumn>({
-                barcode1: QueryColumn.create({
+                barcode1: new QueryColumn({
                     name: 'barcode1',
                     caption: 'Barcode 1',
                     conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
                 }),
-                otherCode: QueryColumn.create({
+                otherCode: new QueryColumn({
                     name: 'otherCode',
                     caption: 'Other Code',
                     conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
@@ -143,9 +143,9 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'barcode1' }),
-                            QueryColumn.create({ name: 'Other Code' }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'barcode1' }),
+                            new QueryColumn({ name: 'Other Code' }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),
@@ -167,8 +167,8 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'Nonesuch' }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'Nonesuch' }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),
@@ -184,12 +184,12 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
     test('multiple unknown, multiple unique', () => {
         const columns = baseColumns.merge(
             OrderedMap<string, QueryColumn>({
-                bcode: QueryColumn.create({
+                bcode: new QueryColumn({
                     name: 'bcode',
                     caption: 'Barcode',
                     conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
                 }),
-                otherCode: QueryColumn.create({
+                otherCode: new QueryColumn({
                     name: 'otherCode',
                     caption: 'Other Code',
                     conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
@@ -203,13 +203,13 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'Nonesuch' }),
-                            QueryColumn.create({ name: 'Nonesuch' }),
-                            QueryColumn.create({ name: 'Not Again' }),
-                            QueryColumn.create({ name: 'bcode' }),
-                            QueryColumn.create({ name: 'OtherCode' }),
-                            QueryColumn.create({ name: 'OtherCode' }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'Nonesuch' }),
+                            new QueryColumn({ name: 'Nonesuch' }),
+                            new QueryColumn({ name: 'Not Again' }),
+                            new QueryColumn({ name: 'bcode' }),
+                            new QueryColumn({ name: 'OtherCode' }),
+                            new QueryColumn({ name: 'OtherCode' }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),
@@ -232,12 +232,12 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'parentA' }),
-                            QueryColumn.create({ name: 'parentB' }),
-                            QueryColumn.create({ name: 'parentc' }),
-                            QueryColumn.create({ name: 'materialInputs/X', lookup }),
-                            QueryColumn.create({ name: 'dataInputs/Y', lookup }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'parentA' }),
+                            new QueryColumn({ name: 'parentB' }),
+                            new QueryColumn({ name: 'parentc' }),
+                            new QueryColumn({ name: 'materialInputs/X', lookup }),
+                            new QueryColumn({ name: 'dataInputs/Y', lookup }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),
@@ -257,10 +257,10 @@ describe('EntityInsertPanel.getInferredFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'alsoAllowed' }),
-                            QueryColumn.create({ name: 'materialInputs/X', lookup }),
-                            QueryColumn.create({ name: 'dataInputs/Y', lookup }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'alsoAllowed' }),
+                            new QueryColumn({ name: 'materialInputs/X', lookup }),
+                            new QueryColumn({ name: 'dataInputs/Y', lookup }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),
@@ -285,10 +285,10 @@ describe('EntityInsertPanel.getNoUpdateFieldWarnings', () => {
                     new InferDomainResponse({
                         data: List<any>(),
                         fields: List<QueryColumn>([
-                            QueryColumn.create({ name: 'known' }),
-                            QueryColumn.create({ name: 'alsoAllowed' }),
-                            QueryColumn.create({ name: 'materialInputs/X', lookup }),
-                            QueryColumn.create({ name: 'dataInputs/Y', lookup }),
+                            new QueryColumn({ name: 'known' }),
+                            new QueryColumn({ name: 'alsoAllowed' }),
+                            new QueryColumn({ name: 'materialInputs/X', lookup }),
+                            new QueryColumn({ name: 'dataInputs/Y', lookup }),
                         ]),
                         reservedFields: List<QueryColumn>(),
                     }),

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -464,10 +464,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             if (this.isAliquotField(column)) {
                 let col = column;
                 // Aliquot name can be auto generated, regardless of sample name expression config
-                if (column.fieldKey.toLowerCase() === 'name')
-                    col = col.merge({
-                        required: false,
-                    }) as QueryColumn;
+                if (column.fieldKey.toLowerCase() === 'name') col = col.mutate({ required: false });
                 columns = columns.set(key, col);
             }
         });

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -22,7 +22,7 @@ import { decodePart, encodePart, SchemaQuery } from '../../../public/SchemaQuery
 import { IEntityDetails } from '../domainproperties/entities/models';
 import { SelectInputOption } from '../forms/input/SelectInput';
 import { capitalizeFirstChar, caseInsensitive, generateId } from '../../util/utils';
-import { QueryColumn } from '../../../public/QueryColumn';
+import { QueryColumn, QueryLookup } from '../../../public/QueryColumn';
 import { SCHEMAS } from '../../schemas';
 import { SampleCreationType } from '../samples/models';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
@@ -136,14 +136,14 @@ export class EntityParentType extends Record({
             displayColumn = 'scientificName';
         }
 
-        return QueryColumn.create({
+        return new QueryColumn({
             caption: this.isAliquotParent ? QueryColumn.ALIQUOTED_FROM_CAPTION : formattedQueryName + captionSuffix,
             description: this.isAliquotParent
                 ? 'The parent sample of the aliquot'
                 : 'Contains optional parent entity for this ' + formattedQueryName,
             fieldKeyArray: [parentColName],
             fieldKey: parentColName,
-            lookup: {
+            lookup: new QueryLookup({
                 displayColumn,
                 isPublic: true,
                 keyColumn: 'RowId',
@@ -151,8 +151,7 @@ export class EntityParentType extends Record({
                 queryName: this.query,
                 schemaName: this.schema,
                 viewName: ViewInfo.DETAIL_NAME, // use the details view to assure we see values even if default view is filtered
-                table: this.isAliquotParent ? QueryColumn.MATERIAL_INPUTS : parentInputType,
-            },
+            }),
             name: parentColName,
             required: this.isAliquotParent,
             shownInInsertView: true,

--- a/packages/components/src/internal/components/files/actions.ts
+++ b/packages/components/src/internal/components/files/actions.ts
@@ -28,7 +28,7 @@ export function convertRowDataIntoPreviewData(
     const integerFieldInds = [];
     if (fields && fields.size > 0) {
         fields.forEach((field, ind) => {
-            const rangeURI = field.get('rangeURI');
+            const rangeURI = field.rangeURI;
             if (
                 rangeURI &&
                 (rangeURI.toLowerCase() === 'xsd:int' ||

--- a/packages/components/src/internal/components/forms/FieldLabel.spec.tsx
+++ b/packages/components/src/internal/components/forms/FieldLabel.spec.tsx
@@ -12,7 +12,7 @@ import { FieldLabel } from './FieldLabel';
 import { LabelOverlay } from './LabelOverlay';
 import { ToggleWithInputField } from './input/ToggleWithInputField';
 
-const queryColumn = QueryColumn.create({
+const queryColumn = new QueryColumn({
     name: 'testColumn',
     caption: 'test Column',
 });

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -186,7 +186,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     }
                     let showAsteriskSymbol = false;
                     if (!checkRequiredFields && col.required) {
-                        col = col.set('required', false) as QueryColumn;
+                        col = col.mutate({ required: false });
                         showAsteriskSymbol = showLabelAsterisk;
                     }
 

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.spec.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.spec.tsx
@@ -213,7 +213,7 @@ describe('resolveDetailEditRenderer', () => {
     });
 
     test('isPublicLookup, displayAsLookup = true', () => {
-        const col = QueryColumn.create({
+        const col = new QueryColumn({
             ...default_props,
             lookup: { isPublic: true },
             displayAsLookup: true,

--- a/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
@@ -9,7 +9,7 @@ import { SelectInput } from './SelectInput';
 
 describe('AliasInput', () => {
     const fieldKey = 'Alias';
-    const aliasColumn = QueryColumn.create({
+    const aliasColumn = new QueryColumn({
         caption: fieldKey,
         fieldKey,
         required: false,

--- a/packages/components/src/internal/components/forms/input/AppendUnitsInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/AppendUnitsInput.spec.tsx
@@ -8,7 +8,7 @@ import { QueryColumn } from '../../../../public/QueryColumn';
 import { AppendUnitsInput } from './AppendUnitsInput';
 
 describe('AppendUnitsInput', () => {
-    const column = QueryColumn.create({
+    const column = new QueryColumn({
         caption: 'Molecular Weight',
         fieldKey: 'appendUnitsColumn',
         name: 'appendUnitsColumn',

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.spec.tsx
@@ -19,7 +19,7 @@ beforeAll(() => {
 
 describe('DatePickerInput', () => {
     const DEFAULT_PROPS = {
-        queryColumn: QueryColumn.create({ fieldKey: 'col', caption: 'Test Column', required: true }),
+        queryColumn: new QueryColumn({ fieldKey: 'col', caption: 'Test Column', required: true }),
     };
 
     function validate(wrapper: ReactWrapper, hasFieldLabel = true): void {

--- a/packages/components/src/internal/components/forms/input/InputRenderFactory.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/InputRenderFactory.spec.tsx
@@ -14,26 +14,26 @@ describe('resolveInputRenderer', () => {
     });
 
     test('appendunitsinput', () => {
-        const appendUnitsCol = column.set('inputRenderer', 'appendunitsinput') as QueryColumn;
-        const AppendUnitsInputComponent = resolveInputRenderer(appendUnitsCol);
+        column.inputRenderer = 'appendunitsinput';
+        const AppendUnitsInputComponent = resolveInputRenderer(column);
         expect(AppendUnitsInputComponent).toEqual(AppendUnitsInput);
     });
 
     test('experimentalias', () => {
-        const appendUnitsCol = column.set('inputRenderer', 'experimentalias') as QueryColumn;
-        const AppendUnitsInputComponent = resolveInputRenderer(appendUnitsCol);
+        column.inputRenderer = 'experimentalias';
+        const AppendUnitsInputComponent = resolveInputRenderer(column);
         expect(AppendUnitsInputComponent).toEqual(AliasInput);
     });
 
     test('samplestatusinput', () => {
-        const appendUnitsCol = column.set('inputRenderer', 'samplestatusinput') as QueryColumn;
-        const AppendUnitsInputComponent = resolveInputRenderer(appendUnitsCol);
+        column.inputRenderer = 'samplestatusinput';
+        const AppendUnitsInputComponent = resolveInputRenderer(column);
         expect(AppendUnitsInputComponent).toEqual(SampleStatusInputRenderer);
     });
 
     test('workflowtask', () => {
-        const appendUnitsCol = column.set('inputRenderer', 'workflowtask') as QueryColumn;
-        const AppendUnitsInputComponent = resolveInputRenderer(appendUnitsCol);
+        column.inputRenderer = 'workflowtask';
+        const AppendUnitsInputComponent = resolveInputRenderer(column);
         expect(AppendUnitsInputComponent).toEqual(AssayTaskInputRenderer);
     });
 });

--- a/packages/components/src/internal/components/forms/input/InputRenderFactory.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/InputRenderFactory.spec.tsx
@@ -9,7 +9,7 @@ import { AppendUnitsInput } from './AppendUnitsInput';
 import { resolveInputRenderer } from './InputRenderFactory';
 
 describe('resolveInputRenderer', () => {
-    const column = QueryColumn.create({
+    const column = new QueryColumn({
         name: 'resolveInputRendererTestColumn',
     });
 

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
@@ -386,10 +386,9 @@ exports[`ProductMenuSection render section with custom headerURL and headerText 
       "emptyText": undefined,
       "emptyAppURL": undefined,
       "emptyURLText": "Get started...",
-      "headerURLPart": Immutable.Record {
+      "headerURLPart": AppURL {
         "_baseUrl": "/sample/new",
-        "_filters": undefined,
-        "_params": Immutable.Map {
+        "_params": {
           "sort": "date",
         },
       },

--- a/packages/components/src/internal/components/permissions/BasePermissionsCheckPage.tsx
+++ b/packages/components/src/internal/components/permissions/BasePermissionsCheckPage.tsx
@@ -30,7 +30,7 @@ export const BasePermissionsCheckPage: FC<Props> = memo(props => {
     }
 
     let body;
-    if (!user.permissionsList || user.permissionsList.size === 0) {
+    if (!user.permissionsList) {
         body = <LoadingSpinner />;
     }
 

--- a/packages/components/src/internal/components/permissions/BasePermissionsCheckPage.tsx
+++ b/packages/components/src/internal/components/permissions/BasePermissionsCheckPage.tsx
@@ -30,7 +30,7 @@ export const BasePermissionsCheckPage: FC<Props> = memo(props => {
     }
 
     let body;
-    if (!user.permissionsList) {
+    if (!user.permissionsList || user.permissionsList.length === 0) {
         body = <LoadingSpinner />;
     }
 

--- a/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
@@ -9,31 +9,31 @@ import { SelectInput } from '../forms/input/SelectInput';
 
 import { FilterExpressionView } from './FilterExpressionView';
 
-const stringField = QueryColumn.create({
+const stringField = new QueryColumn({
     name: 'StringField',
     caption: 'StringField',
     rangeURI: TEXT_TYPE.rangeURI,
     jsonType: 'string',
 });
-const doubleField = QueryColumn.create({
+const doubleField = new QueryColumn({
     name: 'DoubleField',
     caption: 'DoubleField',
     rangeURI: DOUBLE_TYPE.rangeURI,
     jsonType: 'float',
 });
-const intField = QueryColumn.create({
+const intField = new QueryColumn({
     name: 'IntField',
     caption: 'IntField',
     rangeURI: INTEGER_TYPE.rangeURI,
     jsonType: 'int',
 });
-const booleanField = QueryColumn.create({
+const booleanField = new QueryColumn({
     name: 'BooleanField',
     caption: 'BooleanField',
     rangeURI: BOOLEAN_TYPE.rangeURI,
     jsonType: 'boolean',
 });
-const dateField = QueryColumn.create({
+const dateField = new QueryColumn({
     name: 'DateField',
     caption: 'DateField',
     rangeURI: DATE_TYPE.rangeURI,

--- a/packages/components/src/internal/components/search/QueryFilterPanel.spec.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.spec.tsx
@@ -47,8 +47,9 @@ describe('QueryFilterPanel', () => {
         wrapper.unmount();
     });
 
-    test('skipDefaultViewCheck', () => {
+    test('skipDefaultViewCheck', async () => {
         const wrapper = mount(<QueryFilterPanel {...DEFAULT_PROPS} skipDefaultViewCheck />);
+        await waitForLifecycle(wrapper);
         validate(wrapper, 28);
         wrapper.unmount();
     });
@@ -99,7 +100,7 @@ describe('QueryFilterPanel', () => {
         const props = {...DEFAULT_PROPS};
         let queryInfo = props.queryInfo;
         let col: QueryColumn = queryInfo.getDisplayColumns().find(field => field.jsonType === 'string');
-        col = col.set('filterable', false) as QueryColumn;
+        col = col.mutate({ filterable: false });
         queryInfo = queryInfo.setIn(['columns', col.fieldKey.toLowerCase()], col) as QueryInfo;
         props.queryInfo = queryInfo;
         const wrapper = mount(

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -137,16 +137,15 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
         if (!queryInfo) return;
 
         const fields = skipDefaultViewCheck ? queryInfo.getAllColumns(viewName) : queryInfo.getDisplayColumns(viewName);
-        setQueryFields(
-            fromJS(
-                fields.filter(
-                    field => field.filterable && (
-                        !validFilterField ||
-                        validFilterField(field, queryInfo, entityDataType?.exprColumnsWithSubSelect)
-                    )
+        const qF = fromJS(
+            fields.filter(
+                field => field.filterable && (
+                    !validFilterField ||
+                    validFilterField(field, queryInfo, entityDataType?.exprColumnsWithSubSelect)
                 )
             )
         );
+        setQueryFields(qF);
         if (fieldKey) {
             const field = fields.find(f => f.getDisplayFieldKey() === fieldKey);
             setActiveField(field);

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -118,15 +118,15 @@ describe('getFinderViewColumnsConfig', () => {
         appEditableTable: true,
         pkCols: List(['RowId']),
         columns: fromJS({
-            rowid: QueryColumn.create({ caption: 'Row Id', fieldKey: 'RowId', inputType: 'number' }),
-            description: QueryColumn.create({
+            rowid: new QueryColumn({ caption: 'Row Id', fieldKey: 'RowId', inputType: 'number' }),
+            description: new QueryColumn({
                 caption: 'Description',
                 fieldKey: 'Description',
                 inputType: 'textarea',
             }),
-            samplestate: QueryColumn.create({ caption: 'SampleState', fieldKey: 'SampleState', inputType: 'text' }),
-            name: QueryColumn.create({ caption: 'Name', fieldKey: 'Name', inputType: 'text' }),
-            extrafield: QueryColumn.create({ caption: 'Extra', fieldKey: 'ExtraField', inputType: 'text' }),
+            samplestate: new QueryColumn({ caption: 'SampleState', fieldKey: 'SampleState', inputType: 'text' }),
+            name: new QueryColumn({ caption: 'Name', fieldKey: 'Name', inputType: 'text' }),
+            extrafield: new QueryColumn({ caption: 'Extra', fieldKey: 'ExtraField', inputType: 'text' }),
         }),
         views: Map({
             '~~default~~': {
@@ -197,15 +197,15 @@ describe('getFinderViewColumnsConfig', () => {
             appEditableTable: true,
             pkCols: List(['RowId']),
             columns: fromJS({
-                rowid: QueryColumn.create({ caption: 'Row Id', fieldKey: 'RowId', inputType: 'number' }),
-                description: QueryColumn.create({
+                rowid: new QueryColumn({ caption: 'Row Id', fieldKey: 'RowId', inputType: 'number' }),
+                description: new QueryColumn({
                     caption: 'Description',
                     fieldKey: 'Description',
                     inputType: 'textarea',
                 }),
-                samplestate: QueryColumn.create({ caption: 'SampleState', fieldKey: 'SampleState', inputType: 'text' }),
-                name: QueryColumn.create({ caption: 'Name', fieldKey: 'Name', inputType: 'text' }),
-                extrafield: QueryColumn.create({ caption: 'Extra', fieldKey: 'ExtraField', inputType: 'text' }),
+                samplestate: new QueryColumn({ caption: 'SampleState', fieldKey: 'SampleState', inputType: 'text' }),
+                name: new QueryColumn({ caption: 'Name', fieldKey: 'Name', inputType: 'text' }),
+                extrafield: new QueryColumn({ caption: 'Extra', fieldKey: 'ExtraField', inputType: 'text' }),
             }),
             views: Map({
                 '~~default~~': {
@@ -873,7 +873,7 @@ describe('getFieldFiltersValidationResult', () => {
 
 describe('getUpdateFilterExpressionFilter', () => {
     const fieldKey = 'StringField';
-    const stringField = QueryColumn.create({
+    const stringField = new QueryColumn({
         name: fieldKey,
         rangeURI: TEXT_TYPE.rangeURI,
         jsonType: 'string',
@@ -1481,7 +1481,7 @@ describe('getSampleFinderColumnNames', () => {
 
 describe('isValidFilterField', () => {
     test('lookup field', () => {
-        const field = QueryColumn.create({ name: 'test', lookup: { isPublic: true } });
+        const field = new QueryColumn({ name: 'test', lookup: { isPublic: true } });
         const queryInfo = QueryInfo.create({
             schemaName: 'test',
             name: 'query',
@@ -1497,7 +1497,7 @@ describe('isValidFilterField', () => {
     });
 
     test('mult-value lookup field', () => {
-        const field = QueryColumn.create({ name: 'test', lookup: { isPublic: true }, multiValue: true });
+        const field = new QueryColumn({ name: 'test', lookup: { isPublic: true }, multiValue: true });
         const queryInfo = QueryInfo.create({
             schemaName: 'test',
             name: 'query',
@@ -1513,7 +1513,7 @@ describe('isValidFilterField', () => {
     });
 
     test('mult-value lookup field and not supportGroupConcatSubSelect', () => {
-        const field = QueryColumn.create({ name: 'test', lookup: { isPublic: true }, multiValue: true });
+        const field = new QueryColumn({ name: 'test', lookup: { isPublic: true }, multiValue: true });
         const queryInfo = QueryInfo.create({
             schemaName: 'test',
             name: 'query',
@@ -1529,7 +1529,7 @@ describe('isValidFilterField', () => {
     });
 
     test('Units field', () => {
-        const field = QueryColumn.create({ name: 'Units', fieldKey: 'Units' });
+        const field = new QueryColumn({ name: 'Units', fieldKey: 'Units' });
         const queryInfo = QueryInfo.create({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             name: 'test',
@@ -1545,7 +1545,7 @@ describe('isValidFilterField', () => {
     });
 
     test('group concat field not supported', () => {
-        const field = QueryColumn.create({ name: 'StorageStatus', fieldKey: 'StorageStatus' });
+        const field = new QueryColumn({ name: 'StorageStatus', fieldKey: 'StorageStatus' });
         const queryInfo = QueryInfo.create({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             name: 'test',
@@ -1561,7 +1561,7 @@ describe('isValidFilterField', () => {
     });
 
     test('group concat field not supported, regular field', () => {
-        const field = QueryColumn.create({ name: 'RowId', fieldKey: 'RowId' });
+        const field = new QueryColumn({ name: 'RowId', fieldKey: 'RowId' });
         const queryInfo = QueryInfo.create({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             name: 'test',
@@ -1577,7 +1577,7 @@ describe('isValidFilterField', () => {
     });
 
     test('group concat field not supported, no group concat fields', () => {
-        const field = QueryColumn.create({ name: 'RowId', fieldKey: 'RowId' });
+        const field = new QueryColumn({ name: 'RowId', fieldKey: 'RowId' });
         const queryInfo = QueryInfo.create({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             name: 'test',
@@ -1589,7 +1589,7 @@ describe('isValidFilterField', () => {
     });
 
     test('group concat field is supported', () => {
-        const field = QueryColumn.create({ name: 'StorageStatus', fieldKey: 'StorageStatus' });
+        const field = new QueryColumn({ name: 'StorageStatus', fieldKey: 'StorageStatus' });
         const queryInfo = QueryInfo.create({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             name: 'test',
@@ -1605,7 +1605,7 @@ describe('isValidFilterField', () => {
     });
 
     test('regular field', () => {
-        const field = QueryColumn.create({ name: 'Regular', fieldKey: 'Regular' });
+        const field = new QueryColumn({ name: 'Regular', fieldKey: 'Regular' });
         const queryInfo = QueryInfo.create({
             schemaName: SCHEMAS.SAMPLE_SETS.SCHEMA,
             name: 'test',
@@ -1633,7 +1633,7 @@ describe('getUpdatedDataTypeFilters', () => {
         const updatedFilters = getUpdatedDataTypeFilters(
             DATA_TYPE_FILTERS,
             PARENT_WITH_FILTERS,
-            QueryColumn.create({
+            new QueryColumn({
                 caption: floatBetweenFilter.fieldCaption,
                 fieldKey: floatBetweenFilter.fieldKey,
             }),
@@ -1646,7 +1646,7 @@ describe('getUpdatedDataTypeFilters', () => {
         const updatedFilters = getUpdatedDataTypeFilters(
             DATA_TYPE_FILTERS,
             PARENT_WITH_FILTERS,
-            QueryColumn.create({
+            new QueryColumn({
                 name: stringEqualFilter.fieldKey,
                 caption: stringEqualFilter.fieldCaption,
                 fieldKey: stringEqualFilter.fieldKey,
@@ -1663,7 +1663,7 @@ describe('getUpdatedDataTypeFilters', () => {
         const updatedFilters = getUpdatedDataTypeFilters(
             DATA_TYPE_FILTERS,
             PARENT_WITH_FILTERS,
-            QueryColumn.create({
+            new QueryColumn({
                 name: stringEqualFilter.fieldKey,
                 caption: stringEqualFilter.fieldCaption,
                 fieldKey: stringEqualFilter.fieldKey,
@@ -1680,7 +1680,7 @@ describe('getUpdatedDataTypeFilters', () => {
         const updatedFilters = getUpdatedDataTypeFilters(
             DATA_TYPE_FILTERS,
             PARENT_WITH_FILTERS,
-            QueryColumn.create({
+            new QueryColumn({
                 name: stringEqualFilter.fieldKey,
                 caption: stringEqualFilter.fieldCaption,
                 fieldKey: stringEqualFilter.fieldKey,
@@ -1697,7 +1697,7 @@ describe('getUpdatedDataTypeFilters', () => {
         const updatedFilters = getUpdatedDataTypeFilters(
             DATA_TYPE_FILTERS,
             PARENT_WITH_FILTERS,
-            QueryColumn.create({
+            new QueryColumn({
                 name: stringEqualFilter.fieldKey,
                 caption: stringEqualFilter.fieldCaption,
                 fieldKey: stringEqualFilter.fieldKey,
@@ -1714,7 +1714,7 @@ describe('getUpdatedDataTypeFilters', () => {
         const updatedFilters = getUpdatedDataTypeFilters(
             DATA_TYPE_FILTERS,
             PARENT_WITHOUT_FILTERS,
-            QueryColumn.create({
+            new QueryColumn({
                 name: stringEqualFilter.fieldKey,
                 caption: stringEqualFilter.fieldCaption,
                 fieldKey: stringEqualFilter.fieldKey,
@@ -1914,7 +1914,7 @@ describe('getFilterSelections', () => {
 });
 
 describe('getUpdatedFilters', () => {
-    const field = QueryColumn.create({
+    const field = new QueryColumn({
         name: stringEqualFilter.fieldKey,
         caption: stringEqualFilter.fieldCaption,
         fieldKey: stringEqualFilter.fieldKey,

--- a/packages/components/src/internal/components/settings/ProjectSettings.tsx
+++ b/packages/components/src/internal/components/settings/ProjectSettings.tsx
@@ -55,10 +55,11 @@ export const ProjectSettings: FC<ProjectSettingsProps> = memo(({ onChange, onSuc
             // context update of the container's name and title.
             if (project?.id === container.id) {
                 dispatch({
-                    container: container.merge({
+                    container: new Container({
+                        ...container,
                         name: project.name,
                         title: project.title,
-                    }) as Container,
+                    }),
                 });
             }
         },

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { PureComponent } from 'react';
+import React, { PureComponent, ReactNode } from 'react';
 import { List, OrderedMap } from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 import { ActionURL, PermissionTypes } from '@labkey/api';
@@ -99,11 +99,11 @@ export class UserProfile extends PureComponent<Props, State> {
 
     columnFilter = (col: QueryColumn): boolean => {
         // make sure all columns are set as shownInInsertView and those that are marked as editable are not also readOnly
-        const _col = col.merge({ shownInInsertView: true, readOnly: !col.get('userEditable') }) as QueryColumn;
+        const _col = col.mutate({ shownInInsertView: true, readOnly: !col.userEditable });
         return insertColumnFilter(_col) && !FIELDS_TO_EXCLUDE.contains(_col.fieldKey.toLowerCase());
     };
 
-    footer() {
+    footer(): ReactNode {
         const { user } = this.props;
         const { groups } = this.state;
 

--- a/packages/components/src/internal/components/user/__snapshots__/UserDetailsPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/user/__snapshots__/UserDetailsPanel.spec.tsx.snap
@@ -61,8 +61,8 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
     />
     <EffectiveRolesList
       currentUser={
-        Immutable.Record {
-          "id": 1005,
+        User {
+          "avatar": "/labkey/_images/defaultavatar.png",
           "canDelete": true,
           "canDeleteOwn": true,
           "canInsert": true,
@@ -70,8 +70,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
           "canUpdateOwn": true,
           "displayName": "AppAdminDisplayName",
           "email": "guest",
-          "phone": null,
-          "avatar": "/labkey/_images/defaultavatar.png",
+          "id": 1005,
           "isAdmin": true,
           "isAnalyst": false,
           "isDeveloper": false,
@@ -81,7 +80,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
           "isSystemAdmin": false,
           "isTrusted": false,
           "maxAllowedPhi": undefined,
-          "permissionsList": Immutable.List [
+          "permissionsList": [
             "org.labkey.api.security.permissions.DeletePermission",
             "org.labkey.api.security.permissions.ReadPermission",
             "org.labkey.api.security.permissions.DesignDataClassPermission",
@@ -104,6 +103,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
             "org.labkey.api.security.permissions.SeeGroupDetailsPermission",
             "org.labkey.api.security.permissions.SeeUserDetailsPermission",
           ],
+          "phone": null,
         }
       }
       policy={
@@ -1009,8 +1009,8 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
     />
     <Memo()
       currentUser={
-        Immutable.Record {
-          "id": 1005,
+        User {
+          "avatar": "/labkey/_images/defaultavatar.png",
           "canDelete": true,
           "canDeleteOwn": true,
           "canInsert": true,
@@ -1018,8 +1018,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
           "canUpdateOwn": true,
           "displayName": "AppAdminDisplayName",
           "email": "guest",
-          "phone": null,
-          "avatar": "/labkey/_images/defaultavatar.png",
+          "id": 1005,
           "isAdmin": true,
           "isAnalyst": false,
           "isDeveloper": false,
@@ -1029,7 +1028,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
           "isSystemAdmin": false,
           "isTrusted": false,
           "maxAllowedPhi": undefined,
-          "permissionsList": Immutable.List [
+          "permissionsList": [
             "org.labkey.api.security.permissions.DeletePermission",
             "org.labkey.api.security.permissions.ReadPermission",
             "org.labkey.api.security.permissions.DesignDataClassPermission",
@@ -1052,6 +1051,7 @@ exports[`<UserDetailsPanel/> with principal and buttons 1`] = `
             "org.labkey.api.security.permissions.SeeGroupDetailsPermission",
             "org.labkey.api.security.permissions.SeeUserDetailsPermission",
           ],
+          "phone": null,
         }
       }
       showLinks={true}
@@ -1135,8 +1135,8 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
     />
     <EffectiveRolesList
       currentUser={
-        Immutable.Record {
-          "id": 1005,
+        User {
+          "avatar": "/labkey/_images/defaultavatar.png",
           "canDelete": true,
           "canDeleteOwn": true,
           "canInsert": true,
@@ -1144,8 +1144,7 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
           "canUpdateOwn": true,
           "displayName": "AppAdminDisplayName",
           "email": "guest",
-          "phone": null,
-          "avatar": "/labkey/_images/defaultavatar.png",
+          "id": 1005,
           "isAdmin": true,
           "isAnalyst": false,
           "isDeveloper": false,
@@ -1155,7 +1154,7 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
           "isSystemAdmin": false,
           "isTrusted": false,
           "maxAllowedPhi": undefined,
-          "permissionsList": Immutable.List [
+          "permissionsList": [
             "org.labkey.api.security.permissions.DeletePermission",
             "org.labkey.api.security.permissions.ReadPermission",
             "org.labkey.api.security.permissions.DesignDataClassPermission",
@@ -1178,6 +1177,7 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
             "org.labkey.api.security.permissions.SeeGroupDetailsPermission",
             "org.labkey.api.security.permissions.SeeUserDetailsPermission",
           ],
+          "phone": null,
         }
       }
       policy={
@@ -2083,8 +2083,8 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
     />
     <Memo()
       currentUser={
-        Immutable.Record {
-          "id": 1005,
+        User {
+          "avatar": "/labkey/_images/defaultavatar.png",
           "canDelete": true,
           "canDeleteOwn": true,
           "canInsert": true,
@@ -2092,8 +2092,7 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
           "canUpdateOwn": true,
           "displayName": "AppAdminDisplayName",
           "email": "guest",
-          "phone": null,
-          "avatar": "/labkey/_images/defaultavatar.png",
+          "id": 1005,
           "isAdmin": true,
           "isAnalyst": false,
           "isDeveloper": false,
@@ -2103,7 +2102,7 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
           "isSystemAdmin": false,
           "isTrusted": false,
           "maxAllowedPhi": undefined,
-          "permissionsList": Immutable.List [
+          "permissionsList": [
             "org.labkey.api.security.permissions.DeletePermission",
             "org.labkey.api.security.permissions.ReadPermission",
             "org.labkey.api.security.permissions.DesignDataClassPermission",
@@ -2126,6 +2125,7 @@ exports[`<UserDetailsPanel/> with principal and buttons not allowDelete or allow
             "org.labkey.api.security.permissions.SeeGroupDetailsPermission",
             "org.labkey.api.security.permissions.SeeUserDetailsPermission",
           ],
+          "phone": null,
         }
       }
       showLinks={true}
@@ -2210,8 +2210,8 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
     />
     <EffectiveRolesList
       currentUser={
-        Immutable.Record {
-          "id": 1005,
+        User {
+          "avatar": "/labkey/_images/defaultavatar.png",
           "canDelete": true,
           "canDeleteOwn": true,
           "canInsert": true,
@@ -2219,8 +2219,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
           "canUpdateOwn": true,
           "displayName": "AppAdminDisplayName",
           "email": "guest",
-          "phone": null,
-          "avatar": "/labkey/_images/defaultavatar.png",
+          "id": 1005,
           "isAdmin": true,
           "isAnalyst": false,
           "isDeveloper": false,
@@ -2230,7 +2229,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
           "isSystemAdmin": false,
           "isTrusted": false,
           "maxAllowedPhi": undefined,
-          "permissionsList": Immutable.List [
+          "permissionsList": [
             "org.labkey.api.security.permissions.DeletePermission",
             "org.labkey.api.security.permissions.ReadPermission",
             "org.labkey.api.security.permissions.DesignDataClassPermission",
@@ -2253,6 +2252,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
             "org.labkey.api.security.permissions.SeeGroupDetailsPermission",
             "org.labkey.api.security.permissions.SeeUserDetailsPermission",
           ],
+          "phone": null,
         }
       }
       policy={
@@ -3158,8 +3158,8 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
     />
     <Memo()
       currentUser={
-        Immutable.Record {
-          "id": 1005,
+        User {
+          "avatar": "/labkey/_images/defaultavatar.png",
           "canDelete": true,
           "canDeleteOwn": true,
           "canInsert": true,
@@ -3167,8 +3167,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
           "canUpdateOwn": true,
           "displayName": "AppAdminDisplayName",
           "email": "guest",
-          "phone": null,
-          "avatar": "/labkey/_images/defaultavatar.png",
+          "id": 1005,
           "isAdmin": true,
           "isAnalyst": false,
           "isDeveloper": false,
@@ -3178,7 +3177,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
           "isSystemAdmin": false,
           "isTrusted": false,
           "maxAllowedPhi": undefined,
-          "permissionsList": Immutable.List [
+          "permissionsList": [
             "org.labkey.api.security.permissions.DeletePermission",
             "org.labkey.api.security.permissions.ReadPermission",
             "org.labkey.api.security.permissions.DesignDataClassPermission",
@@ -3201,6 +3200,7 @@ exports[`<UserDetailsPanel/> with principal no buttons because of self 1`] = `
             "org.labkey.api.security.permissions.SeeGroupDetailsPermission",
             "org.labkey.api.security.permissions.SeeUserDetailsPermission",
           ],
+          "phone": null,
         }
       }
       groups={4973}

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -268,7 +268,7 @@ function applyColumnMetadata(schemaQuery: SchemaQuery, rawColumn: any): QueryCol
         }
     }
 
-    return QueryColumn.create(Object.assign({}, rawColumn, columnMetadata));
+    return new QueryColumn(Object.assign({}, rawColumn, columnMetadata));
 }
 
 // As of r57235 some column info's are only found on the views "fields" property that were previously

--- a/packages/components/src/internal/renderers.spec.tsx
+++ b/packages/components/src/internal/renderers.spec.tsx
@@ -25,34 +25,34 @@ describe('isFilterColumnNameMatch', () => {
     const filter = Filter.create('Column', 'Value');
 
     test('by column name', () => {
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ name: '' }))).toBeFalsy();
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ name: 'column' }))).toBeFalsy();
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ name: ' Column ' }))).toBeFalsy();
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ name: 'Column' }))).toBeTruthy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ name: '' }))).toBeFalsy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ name: 'column' }))).toBeFalsy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ name: ' Column ' }))).toBeFalsy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ name: 'Column' }))).toBeTruthy();
     });
 
     test('by fieldKey', () => {
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ fieldKey: '' }))).toBeFalsy();
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ fieldKey: 'column' }))).toBeFalsy();
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ fieldKey: ' Column ' }))).toBeFalsy();
-        expect(isFilterColumnNameMatch(filter, QueryColumn.create({ fieldKey: 'Column' }))).toBeTruthy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ fieldKey: '' }))).toBeFalsy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ fieldKey: 'column' }))).toBeFalsy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ fieldKey: ' Column ' }))).toBeFalsy();
+        expect(isFilterColumnNameMatch(filter, new QueryColumn({ fieldKey: 'Column' }))).toBeTruthy();
     });
 
     test('lookup fieldKey', () => {
         const lkFilter = Filter.create('Column/Lookup', 'Value');
         expect(
-            isFilterColumnNameMatch(lkFilter, QueryColumn.create({ fieldKey: 'Column', lookup: { displayColumn: '' } }))
+            isFilterColumnNameMatch(lkFilter, new QueryColumn({ fieldKey: 'Column', lookup: { displayColumn: '' } }))
         ).toBeFalsy();
         expect(
             isFilterColumnNameMatch(
                 lkFilter,
-                QueryColumn.create({ fieldKey: 'Column', lookup: { displayColumn: 'lookup' } })
+                new QueryColumn({ fieldKey: 'Column', lookup: { displayColumn: 'lookup' } })
             )
         ).toBeFalsy();
         expect(
             isFilterColumnNameMatch(
                 lkFilter,
-                QueryColumn.create({ fieldKey: 'Column', lookup: { displayColumn: 'Lookup' } })
+                new QueryColumn({ fieldKey: 'Column', lookup: { displayColumn: 'Lookup' } })
             )
         ).toBeTruthy();
     });
@@ -64,7 +64,7 @@ describe('HeaderCellDropdown', () => {
         column: new GridColumn({
             index: 'column',
             title: 'Column',
-            raw: QueryColumn.create({ fieldKey: 'column', sortable: true, filterable: true }),
+            raw: new QueryColumn({ fieldKey: 'column', sortable: true, filterable: true }),
         }),
         model: makeTestQueryModel(new SchemaQuery('schema', 'query')),
         handleSort: jest.fn,
@@ -119,7 +119,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: false }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: false, filterable: false }),
                     })
                 }
             />
@@ -136,7 +136,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: false }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: false, filterable: false }),
                     })
                 }
                 handleAddColumn={jest.fn}
@@ -155,7 +155,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: false }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: false, filterable: false }),
                     })
                 }
                 handleAddColumn={jest.fn}
@@ -177,7 +177,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: false }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: false, filterable: false }),
                     })
                 }
                 handleAddColumn={jest.fn}
@@ -199,7 +199,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: true, filterable: false }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: true, filterable: false }),
                     })
                 }
             />
@@ -216,7 +216,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: true, filterable: false }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: true, filterable: false }),
                     })
                 }
                 handleHideColumn={jest.fn}
@@ -234,7 +234,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: true }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: false, filterable: true }),
                     })
                 }
             />
@@ -251,7 +251,7 @@ describe('HeaderCellDropdown', () => {
                     new GridColumn({
                         index: 'column',
                         title: 'Column',
-                        raw: QueryColumn.create({ fieldKey: 'column', sortable: false, filterable: true }),
+                        raw: new QueryColumn({ fieldKey: 'column', sortable: false, filterable: true }),
                     })
                 }
                 handleHideColumn={jest.fn}
@@ -417,7 +417,7 @@ describe('HeaderCellDropdown', () => {
 
 describe('EditableColumnTitle', () => {
     test('Not editing, with caption', () => {
-        const column = QueryColumn.create({
+        const column = new QueryColumn({
             caption: 'Test Column',
             name: 'Testing',
         });
@@ -430,7 +430,7 @@ describe('EditableColumnTitle', () => {
     test('Not editing, no caption', () => {
         const wrapper = mount(
             <EditableColumnTitle
-                column={QueryColumn.create({ name: 'TestName' })}
+                column={new QueryColumn({ name: 'TestName' })}
                 onChange={jest.fn()}
                 onCancel={jest.fn()}
             />
@@ -443,7 +443,7 @@ describe('EditableColumnTitle', () => {
     test('Not editing with nbsp', () => {
         const wrapper = mount(
             <EditableColumnTitle
-                column={QueryColumn.create({ name: 'TestName', caption: '&nbsp;' })}
+                column={new QueryColumn({ name: 'TestName', caption: '&nbsp;' })}
                 onChange={jest.fn()}
                 onCancel={jest.fn()}
             />
@@ -456,7 +456,7 @@ describe('EditableColumnTitle', () => {
     test('Editing with nbsp', () => {
         const wrapper = mount(
             <EditableColumnTitle
-                column={QueryColumn.create({ name: 'TestName', caption: '&nbsp;' })}
+                column={new QueryColumn({ name: 'TestName', caption: '&nbsp;' })}
                 onChange={jest.fn()}
                 onCancel={jest.fn()}
                 editing
@@ -468,7 +468,7 @@ describe('EditableColumnTitle', () => {
     });
 
     test('Editing', async () => {
-        const column = QueryColumn.create({
+        const column = new QueryColumn({
             caption: 'Test Column',
             name: 'Testing',
         });

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -376,7 +376,7 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
     const onColumnTitleUpdate = useCallback(
         (newTitle: string) => {
             setEditingTitle(false);
-            onColumnTitleChange(queryColumn.set('caption', newTitle) as QueryColumn);
+            onColumnTitleChange(queryColumn.mutate({ caption: newTitle }));
             onColumnTitleEdit?.(queryColumn);
         },
         [onColumnTitleChange, queryColumn, onColumnTitleEdit]

--- a/packages/components/src/internal/renderers.tsx
+++ b/packages/components/src/internal/renderers.tsx
@@ -400,8 +400,8 @@ export const HeaderCellDropdown: FC<HeaderCellDropdownProps> = memo(props => {
     if (viewColFilters?.length) colFilters = colFilters.concat(viewColFilters);
     // first check the model users (user-defined) and then fall back to the view sorts
     const colQuerySortDir =
-        model?.sorts?.find(sort => sort.get('fieldKey') === queryColumn.resolveFieldKey())?.get('dir') ??
-        view?.sorts?.find(sort => sort.get('fieldKey') === queryColumn.resolveFieldKey())?.get('dir');
+        model?.sorts?.find(sort => sort.fieldKey === queryColumn.resolveFieldKey())?.dir ??
+        view?.sorts?.find(sort => sort.fieldKey === queryColumn.resolveFieldKey())?.dir;
     const isSortAsc = queryColumn.sorts === '+' || colQuerySortDir === '+' || colQuerySortDir === '';
     const isSortDesc = queryColumn.sorts === '-' || colQuerySortDir === '-';
 

--- a/packages/components/src/internal/url/AppURL.spec.ts
+++ b/packages/components/src/internal/url/AppURL.spec.ts
@@ -89,12 +89,6 @@ describe('AppURL', () => {
         expected = '/labkey/controller/action.view?returnUrl=somewhere';
         expect(buildURL('controller', 'action', {}, { returnUrl: 'somewhere' })).toBe(expected);
     });
-
-    test('equivalency', () => {
-        expect(AppURL.create('x', 'y', 'z')).toEqual(AppURL.create('x', 'y', 'z'));
-        expect(AppURL.create('x').addParam('f', 5)).toEqual(AppURL.create('x').addParam('f', 5));
-        expect(AppURL.create('x').addParam('f', 10)).not.toEqual(AppURL.create('x').addParam('f', 50));
-    });
 });
 
 describe('createProductUrlFromParts', () => {

--- a/packages/components/src/internal/url/AppURL.spec.ts
+++ b/packages/components/src/internal/url/AppURL.spec.ts
@@ -89,6 +89,12 @@ describe('AppURL', () => {
         expected = '/labkey/controller/action.view?returnUrl=somewhere';
         expect(buildURL('controller', 'action', {}, { returnUrl: 'somewhere' })).toBe(expected);
     });
+
+    test('equivalency', () => {
+        expect(AppURL.create('x', 'y', 'z')).toEqual(AppURL.create('x', 'y', 'z'));
+        expect(AppURL.create('x').addParam('f', 5)).toEqual(AppURL.create('x').addParam('f', 5));
+        expect(AppURL.create('x').addParam('f', 10)).not.toEqual(AppURL.create('x').addParam('f', 50));
+    });
 });
 
 describe('createProductUrlFromParts', () => {

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -134,7 +134,11 @@ export class AppURL {
         let baseUrl = '';
         for (let i = 0; i < parts.length; i++) {
             if (parts[i] === undefined || parts[i] === null || parts[i] === '') {
-                throw 'AppURL: Unable to create URL with empty parts. Parts are [' + parts.join(', ') + '].';
+                throw (
+                    'AppURL: Unable to create URL with empty parts. Parts are [' +
+                    parts.map(p => p + '').join(', ') +
+                    '].'
+                );
             }
 
             const stringPart = parts[i].toString();
@@ -156,6 +160,7 @@ export class AppURL {
 
     addFilters(...filters: Filter.IFilter[]): AppURL {
         return new AppURL({
+            ...this,
             _filters: this._filters ? this._filters.concat(filters) : filters,
         });
     }
@@ -173,6 +178,7 @@ export class AppURL {
                 encodedParams[encodeURIComponent(key)] = encodeURIComponent(params[key]);
             });
             return new AppURL({
+                ...this,
                 _params: this._params ? { ...this._params, ...encodedParams } : encodedParams,
             });
         }

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List, Map, Record } from 'immutable';
 import { ActionURL, Filter } from '@labkey/api';
 
 export function createProductUrlFromParts(
@@ -120,29 +119,22 @@ export function buildURL(controller: string, action: string, params?: any, optio
     return ActionURL.buildURL(controller, action, options?.container, parameters);
 }
 
-export class AppURL extends Record({
-    _baseUrl: undefined,
-    _filters: undefined,
-    _params: undefined,
-}) {
+type URLParam = boolean | number | string;
+
+export class AppURL {
     declare _baseUrl: string;
-    declare _filters: List<Filter.IFilter>;
-    declare _params: Map<string, any>;
+    declare _filters: Filter.IFilter[];
+    declare _params: Record<string, string>;
+
+    constructor(partial: Partial<AppURL>) {
+        Object.assign(this, partial);
+    }
 
     static create(...parts): AppURL {
         let baseUrl = '';
         for (let i = 0; i < parts.length; i++) {
             if (parts[i] === undefined || parts[i] === null || parts[i] === '') {
-                let sep = '';
-                throw (
-                    'AppURL: Unable to create URL with empty parts. Parts are [' +
-                    parts.reduce((str, part) => {
-                        str += sep + part;
-                        sep = ', ';
-                        return str;
-                    }, '') +
-                    '].'
-                );
+                throw 'AppURL: Unable to create URL with empty parts. Parts are [' + parts.join(', ') + '].';
             }
 
             const stringPart = parts[i].toString();
@@ -163,28 +155,26 @@ export class AppURL extends Record({
     }
 
     addFilters(...filters: Filter.IFilter[]): AppURL {
-        return this.merge({
-            _filters: this._filters ? this._filters.concat(filters) : List(filters),
-        }) as AppURL;
+        return new AppURL({
+            _filters: this._filters ? this._filters.concat(filters) : filters,
+        });
     }
 
-    addParam(key: string, value: any): AppURL {
+    addParam(key: string, value: URLParam): AppURL {
         return this.addParams({
             [key]: value,
         });
     }
 
-    addParams(params: any): AppURL {
+    addParams(params: Record<string, URLParam>): AppURL {
         if (params) {
-            let mapParams = Map<string, any>();
-            mapParams = mapParams.merge(params);
-            let encodedParams = Map<string, any>();
-            mapParams.forEach((value, key) => {
-                encodedParams = encodedParams.set(encodeURIComponent(key), encodeURIComponent(value));
+            const encodedParams: Record<string, string> = {};
+            Object.keys(params).forEach(key => {
+                encodedParams[encodeURIComponent(key)] = encodeURIComponent(params[key]);
             });
-            return this.merge({
-                _params: this._params ? this._params.merge(encodedParams) : encodedParams,
-            }) as AppURL;
+            return new AppURL({
+                _params: this._params ? { ...this._params, ...encodedParams } : encodedParams,
+            });
         }
 
         return this;
@@ -194,14 +184,8 @@ export class AppURL extends Record({
         return '#' + this.toString(urlPrefix);
     }
 
-    toQuery(urlPrefix?: string): { [key: string]: any } {
-        const query = {};
-
-        if (this._params) {
-            this._params.forEach((value: any, key: string) => {
-                query[key] = value;
-            });
-        }
+    toQuery(urlPrefix?: string): Record<string, string> {
+        const query = { ...this._params };
 
         if (this._filters) {
             this._filters.forEach(f => {
@@ -217,8 +201,8 @@ export class AppURL extends Record({
         const parts = [];
 
         if (this._params) {
-            this._params.forEach((value: any, key: string) => {
-                parts.push(key + '=' + value);
+            Object.keys(this._params).forEach(key => {
+                parts.push(key + '=' + this._params[key]);
             });
         }
 

--- a/packages/components/src/internal/userFixtures.ts
+++ b/packages/components/src/internal/userFixtures.ts
@@ -17,7 +17,7 @@ export const TEST_USER_GUEST = new User({
     isSignedIn: false,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([PermissionTypes.Read]),
+    permissionsList: [PermissionTypes.Read],
 });
 
 export const TEST_USER_READER = new User({
@@ -36,13 +36,13 @@ export const TEST_USER_READER = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Read,
         PermissionTypes.ReadDataClass,
         PermissionTypes.ReadAssay,
         PermissionTypes.ReadMedia,
         PermissionTypes.ReadNotebooks,
-    ]),
+    ],
 });
 
 export const TEST_USER_AUTHOR = new User({
@@ -61,7 +61,7 @@ export const TEST_USER_AUTHOR = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([PermissionTypes.Read, PermissionTypes.Insert]),
+    permissionsList: [PermissionTypes.Read, PermissionTypes.Insert],
 });
 
 export const TEST_USER_EDITOR = new User({
@@ -80,7 +80,7 @@ export const TEST_USER_EDITOR = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Delete,
         PermissionTypes.Read,
         PermissionTypes.Insert,
@@ -92,7 +92,7 @@ export const TEST_USER_EDITOR = new User({
         PermissionTypes.ReadDataClass,
         PermissionTypes.ReadAssay,
         PermissionTypes.ReadMedia,
-    ]),
+    ],
 });
 
 export const TEST_USER_EDITOR_WITHOUT_DELETE = new User({
@@ -111,7 +111,7 @@ export const TEST_USER_EDITOR_WITHOUT_DELETE = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Read,
         PermissionTypes.Insert,
         PermissionTypes.Update,
@@ -121,7 +121,7 @@ export const TEST_USER_EDITOR_WITHOUT_DELETE = new User({
         PermissionTypes.ReadDataClass,
         PermissionTypes.ReadAssay,
         PermissionTypes.ReadMedia,
-    ]),
+    ],
 });
 
 export const TEST_USER_ASSAY_DESIGNER = new User({
@@ -140,7 +140,7 @@ export const TEST_USER_ASSAY_DESIGNER = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([PermissionTypes.Read, PermissionTypes.DesignAssay]),
+    permissionsList: [PermissionTypes.Read, PermissionTypes.DesignAssay],
 });
 
 export const TEST_USER_FOLDER_ADMIN = new User({
@@ -159,7 +159,7 @@ export const TEST_USER_FOLDER_ADMIN = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: true,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Delete,
         PermissionTypes.Read,
         PermissionTypes.DesignDataClass,
@@ -178,7 +178,7 @@ export const TEST_USER_FOLDER_ADMIN = new User({
         PermissionTypes.ReadMedia,
         PermissionTypes.CanSeeGroupDetails,
         PermissionTypes.CanSeeUserDetails,
-    ]),
+    ],
 });
 
 export const TEST_USER_PROJECT_ADMIN = new User({
@@ -197,7 +197,7 @@ export const TEST_USER_PROJECT_ADMIN = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: true,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Delete,
         PermissionTypes.Read,
         PermissionTypes.DesignDataClass,
@@ -217,7 +217,7 @@ export const TEST_USER_PROJECT_ADMIN = new User({
         PermissionTypes.ReadMedia,
         PermissionTypes.CanSeeGroupDetails,
         PermissionTypes.CanSeeUserDetails,
-    ]),
+    ],
 });
 
 export const TEST_USER_APP_ADMIN = new User({
@@ -236,7 +236,7 @@ export const TEST_USER_APP_ADMIN = new User({
     isSignedIn: true,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Delete,
         PermissionTypes.Read,
         PermissionTypes.DesignDataClass,
@@ -258,7 +258,7 @@ export const TEST_USER_APP_ADMIN = new User({
         PermissionTypes.ReadMedia,
         PermissionTypes.CanSeeGroupDetails,
         PermissionTypes.CanSeeUserDetails,
-    ]),
+    ],
 });
 
 export const TEST_USER_STORAGE_DESIGNER = new User({
@@ -275,7 +275,7 @@ export const TEST_USER_STORAGE_DESIGNER = new User({
     isSignedIn: false,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([PermissionTypes.Read, PermissionTypes.DesignStorage]),
+    permissionsList: [PermissionTypes.Read, PermissionTypes.DesignStorage],
 });
 
 export const TEST_USER_STORAGE_EDITOR = new User({
@@ -292,12 +292,12 @@ export const TEST_USER_STORAGE_EDITOR = new User({
     isSignedIn: false,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Read,
         PermissionTypes.EditStorageData,
         PermissionTypes.ManageSampleWorkflows,
         PermissionTypes.ManagePicklists,
-    ]),
+    ],
 });
 
 export const TEST_USER_WORKFLOW_EDITOR = new User({
@@ -336,5 +336,5 @@ export const TEST_USER_QC_ANALYST = new User({
     isSignedIn: false,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([PermissionTypes.QCAnalyst]),
+    permissionsList: [PermissionTypes.QCAnalyst],
 });

--- a/packages/components/src/internal/userFixtures.ts
+++ b/packages/components/src/internal/userFixtures.ts
@@ -1,4 +1,3 @@
-import { List } from 'immutable';
 import { PermissionTypes } from '@labkey/api';
 
 import { User } from './components/base/models/User';

--- a/packages/components/src/internal/userFixtures.ts
+++ b/packages/components/src/internal/userFixtures.ts
@@ -313,12 +313,12 @@ export const TEST_USER_WORKFLOW_EDITOR = new User({
     isSignedIn: false,
     isSystemAdmin: false,
     isTrusted: false,
-    permissionsList: List<string>([
+    permissionsList: [
         PermissionTypes.Read,
         PermissionTypes.ManageSampleWorkflows,
         PermissionTypes.SampleWorkflowDelete,
         PermissionTypes.ManagePicklists,
-    ]),
+    ],
 });
 
 export const TEST_USER_QC_ANALYST = new User({

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -101,19 +101,19 @@ describe('Date Utilities', () => {
 
     describe('getColDateFormat', () => {
         test('datePlaceholder', () => {
-            const col = QueryColumn.create({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
+            const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
             expect(getColDateFormat(col)).toBe('yyyy-MM-dd HH:mm');
             expect(getColDateFormat(col, null, true)).toBe('yyyy-MM-dd');
         });
 
         test('datePlaceholder without col.rangeURI', () => {
-            const col = QueryColumn.create({ shortCaption: 'DateCol', rangeURI: undefined });
+            const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: undefined });
             expect(getColDateFormat(col)).toBe('yyyy-MM-dd HH:mm');
             expect(getColDateFormat(col, null, true)).toBe('yyyy-MM-dd');
         });
 
         test('queryColumn.format', () => {
-            const col = QueryColumn.create({
+            const col = new QueryColumn({
                 shortCaption: 'DateCol',
                 rangeURI: DATETIME_TYPE.rangeURI,
                 format: 'dd/MM/yyyy HH:mm',
@@ -123,7 +123,7 @@ describe('Date Utilities', () => {
         });
 
         test('provided dateFormat', () => {
-            const col = QueryColumn.create({
+            const col = new QueryColumn({
                 shortCaption: 'DateCol',
                 rangeURI: DATETIME_TYPE.rangeURI,
                 format: 'dd/MM/yyyy HH:mm',
@@ -134,13 +134,13 @@ describe('Date Utilities', () => {
         });
 
         test('moment.js replacement', () => {
-            const col = QueryColumn.create({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
+            const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
             expect(getColDateFormat(col, 'YYYY-MM-DD')).toBe('yyyy-MM-dd');
             expect(getColDateFormat(col, 'YY-MM-dd')).toBe('yy-MM-dd');
         });
 
         test('shortcut formats', () => {
-            const col = QueryColumn.create({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
+            const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
             expect(getColDateFormat(col, 'Date')).toBe('yyyy-MM-dd');
             expect(getColDateFormat(col, 'DateTime')).toBe('yyyy-MM-dd HH:mm');
             expect(getColDateFormat(col, 'DateTime', true)).toBe('yyyy-MM-dd HH:mm');
@@ -150,7 +150,7 @@ describe('Date Utilities', () => {
 
     describe('getColFormattedDateFilterValue', () => {
         test('formatDateTime with QueryColumn format', () => {
-            const col = QueryColumn.create({
+            const col = new QueryColumn({
                 shortCaption: 'DateCol',
                 rangeURI: DATETIME_TYPE.rangeURI,
                 format: 'dd/MM/yyyy HH:mm',
@@ -159,12 +159,12 @@ describe('Date Utilities', () => {
         });
 
         test('formatDateTime without QueryColumn format', () => {
-            const col = QueryColumn.create({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
+            const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
             expect(getColFormattedDateFilterValue(col, '2022-04-19 01:02')).toBe('2022-04-19');
         });
 
         test('formatDate with QueryColumn format', () => {
-            const col = QueryColumn.create({
+            const col = new QueryColumn({
                 shortCaption: 'DateCol',
                 rangeURI: DATE_TYPE.rangeURI,
                 format: 'dd/MM/yyyy',
@@ -173,17 +173,17 @@ describe('Date Utilities', () => {
         });
 
         test('formatDate without QueryColumn format', () => {
-            const col = QueryColumn.create({ shortCaption: 'DateCol', rangeURI: DATE_TYPE.rangeURI });
+            const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATE_TYPE.rangeURI });
             expect(getColFormattedDateFilterValue(col, '2022-04-19 01:02')).toBe('2022-04-19');
         });
 
         test('formatDate without QueryColumn format, without timestamp', () => {
-            const col = QueryColumn.create({ shortCaption: 'DateCol', rangeURI: DATE_TYPE.rangeURI });
+            const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATE_TYPE.rangeURI });
             expect(getColFormattedDateFilterValue(col, '2022-04-19')).toBe('2022-04-19');
         });
 
         test('formatDate with QueryColumn format, without timestamp', () => {
-            const col = QueryColumn.create({
+            const col = new QueryColumn({
                 shortCaption: 'DateCol',
                 rangeURI: DATE_TYPE.rangeURI,
                 format: 'dd/MM/yyyy',

--- a/packages/components/src/public/InferDomainResponse.ts
+++ b/packages/components/src/public/InferDomainResponse.ts
@@ -22,11 +22,11 @@ export class InferDomainResponse extends Record({
             }
 
             if (rawModel.fields) {
-                fields = List(rawModel.fields.map(QueryColumn.create));
+                fields = List(rawModel.fields.map(field => new QueryColumn(field)));
             }
 
             if (rawModel.reservedFields) {
-                reservedFields = List(rawModel.reservedFields.map(QueryColumn.create));
+                reservedFields = List(rawModel.reservedFields.map(field => new QueryColumn(field)));
             }
         }
 

--- a/packages/components/src/public/QueryColumn.spec.ts
+++ b/packages/components/src/public/QueryColumn.spec.ts
@@ -26,7 +26,7 @@ describe('QueryLookup', () => {
 
 describe('QueryColumn', () => {
     // prepare stuff we need
-    const validColumn = QueryColumn.create({
+    const validColumn = new QueryColumn({
         align: 'left',
         caption: 'Special Column',
         conceptURI: null,
@@ -59,7 +59,7 @@ describe('QueryColumn', () => {
         removeFromViews: false,
     });
 
-    const bogusColumn = QueryColumn.create({
+    const bogusColumn = new QueryColumn({
         align: 'left',
         caption: 'Special Column',
         conceptURI: null,
@@ -92,7 +92,7 @@ describe('QueryColumn', () => {
         removeFromViews: false,
     });
 
-    const materialSamplesColumn = QueryColumn.create({
+    const materialSamplesColumn = new QueryColumn({
         align: 'left',
         caption: 'Special Column',
         conceptURI: null,
@@ -125,7 +125,7 @@ describe('QueryColumn', () => {
         removeFromViews: false,
     });
 
-    const materialSamplesWithAllCapsColumn = QueryColumn.create({
+    const materialSamplesWithAllCapsColumn = new QueryColumn({
         align: 'left',
         caption: 'Special Column',
         conceptURI: null,
@@ -161,14 +161,14 @@ describe('QueryColumn', () => {
     test('index', () => {
         const singlePartFieldKey = new FieldKey(null, 'This<Arro|?#$!Thing');
 
-        const singlePartFieldKeyColumn = QueryColumn.create({
+        const singlePartFieldKeyColumn = new QueryColumn({
             fieldKey: singlePartFieldKey.toString(),
             fieldKeyArray: singlePartFieldKey.getParts(),
         });
 
         expect(singlePartFieldKeyColumn.index).toEqual(singlePartFieldKey.name);
 
-        const lookupFieldKeyColumn = QueryColumn.create({
+        const lookupFieldKeyColumn = new QueryColumn({
             fieldKey: singlePartFieldKey.toString(),
             fieldKeyArray: singlePartFieldKey.getParts(),
             fieldKeyPath: 'parent/' + singlePartFieldKey.toString(),
@@ -179,7 +179,7 @@ describe('QueryColumn', () => {
         const parentFieldKey = new FieldKey(null, 'runApplicationOutput');
         const multiPartFieldKey = new FieldKey(parentFieldKey, 'urn:recipe.labkey.org/#RecipeAmount');
 
-        const multiPartFieldKeyColumn = QueryColumn.create({
+        const multiPartFieldKeyColumn = new QueryColumn({
             fieldKey: multiPartFieldKey.toString(),
             fieldKeyArray: multiPartFieldKey.getParts(),
         });
@@ -193,12 +193,12 @@ describe('QueryColumn', () => {
         expect(materialSamplesColumn.isSampleLookup()).toBe(true);
         expect(materialSamplesWithAllCapsColumn.isSampleLookup()).toBe(true);
 
-        const samplesDataTypeColumnNonLookup = QueryColumn.create({
+        const samplesDataTypeColumnNonLookup = new QueryColumn({
             conceptURI: 'http://www.labkey.org/exp/xml#sample',
         });
         expect(samplesDataTypeColumnNonLookup.isSampleLookup()).toBe(false);
 
-        const samplesDataTypeColumnLookup = QueryColumn.create({
+        const samplesDataTypeColumnLookup = new QueryColumn({
             conceptURI: 'http://www.labkey.org/exp/xml#sample',
             lookup: {
                 displayColumn: 'Name',

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -87,6 +87,16 @@ export class QueryLookup {
     }
 }
 
+const defaultQueryColumn = {
+    conceptURI: null,
+    defaultValue: null,
+    filterable: true,
+    hasSortKey: false,
+    multiValue: false,
+    sortable: true,
+    removeFromViews: false,
+};
+
 export class QueryColumn {
     declare align: string;
     // declare autoIncrement: boolean;
@@ -166,7 +176,7 @@ export class QueryColumn {
     declare conceptSubtree: string;
 
     constructor(rawColumn: Partial<QueryColumn>) {
-        Object.assign(this, rawColumn);
+        Object.assign(this, defaultQueryColumn, rawColumn);
 
         if (rawColumn && rawColumn.lookup !== undefined) {
             Object.assign(this, { lookup: new QueryLookup(rawColumn.lookup) });

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -46,6 +46,7 @@ export class QueryLookup {
     declare schemaName: string;
     declare schemaQuery: SchemaQuery;
     // declare table: string; -- NOT ALLOWING -- USE queryName
+    declare viewName: string;
 
     constructor(rawLookup: Record<string, any>) {
         Object.assign(this, rawLookup, {
@@ -86,84 +87,7 @@ export class QueryLookup {
     }
 }
 
-export class QueryColumn extends ImmutableRecord({
-    align: undefined,
-    // autoIncrement: undefined,
-    // calculated: undefined,
-    caption: undefined,
-    conceptURI: null,
-    // defaultScale: undefined,
-    defaultValue: null,
-    description: undefined,
-    dimension: undefined,
-    displayAsLookup: undefined,
-    displayField: undefined,
-    displayFieldSqlType: undefined,
-    displayFieldJsonType: undefined,
-    // excludeFromShifting: undefined,
-    // ext: undefined,
-    facetingBehaviorType: undefined,
-    fieldKey: undefined,
-    fieldKeyArray: undefined,
-    fieldKeyPath: undefined,
-    filterable: true,
-    format: undefined,
-    // friendlyType: undefined,
-    hasSortKey: false,
-    hidden: undefined,
-    inputType: undefined,
-    // isAutoIncrement: undefined, // DUPLICATE
-    // isHidden: undefined, // DUPLICATE
-    isKeyField: undefined,
-    // isMvEnabled: undefined,
-    // isNullable: undefined,
-    // isReadOnly: undefined,
-    // isSelectable: undefined, // DUPLICATE
-    // isUserEditable: undefined, // DUPLICATE
-    // isVersionField: undefined,
-    jsonType: undefined,
-    // keyField: undefined,
-    lookup: undefined,
-    measure: undefined,
-    multiValue: false,
-    // mvEnabled: undefined,
-    name: undefined,
-    nameExpression: undefined,
-    // nullable: undefined,
-    phiProtected: undefined,
-    protected: undefined,
-    rangeURI: undefined,
-    readOnly: undefined,
-    // recommendedVariable: undefined,
-    required: undefined,
-    selectable: undefined,
-    shortCaption: undefined,
-    addToSystemView: undefined,
-    removeFromViewCustomization: undefined,
-    shownInDetailsView: undefined,
-    shownInInsertView: undefined,
-    shownInLookupView: undefined,
-    shownInUpdateView: undefined,
-    sortable: true,
-    // sqlType: undefined,
-    type: undefined,
-    userEditable: undefined,
-    validValues: undefined,
-    // versionField: undefined,
-
-    cell: undefined,
-    columnRenderer: undefined,
-    detailRenderer: undefined,
-    helpTipRenderer: undefined,
-    inputRenderer: undefined,
-    removeFromViews: false,
-    sorts: undefined,
-    units: undefined,
-    derivationDataScope: undefined,
-
-    sourceOntology: undefined,
-    conceptSubtree: undefined,
-}) {
+export class QueryColumn {
     declare align: string;
     // declare autoIncrement: boolean;
     // declare calculated: boolean;
@@ -241,16 +165,12 @@ export class QueryColumn extends ImmutableRecord({
     declare sourceOntology: string;
     declare conceptSubtree: string;
 
-    static create(rawColumn): QueryColumn {
-        if (rawColumn && rawColumn.lookup !== undefined) {
-            return new QueryColumn(
-                Object.assign({}, rawColumn, {
-                    lookup: new QueryLookup(rawColumn.lookup),
-                })
-            );
-        }
+    constructor(rawColumn: Partial<QueryColumn>) {
+        Object.assign(this, rawColumn);
 
-        return new QueryColumn(rawColumn);
+        if (rawColumn && rawColumn.lookup !== undefined) {
+            Object.assign(this, { lookup: new QueryLookup(rawColumn.lookup) });
+        }
     }
 
     static DATA_INPUTS = 'DataInputs';
@@ -446,6 +366,10 @@ export class QueryColumn extends ImmutableRecord({
 
     get customViewTitle(): string {
         return this.caption === this.name ? '' : this.caption;
+    }
+
+    mutate(partial: Partial<QueryColumn>): QueryColumn {
+        return new QueryColumn(Object.assign({}, this, partial));
     }
 }
 

--- a/packages/components/src/public/QueryInfo.spec.ts
+++ b/packages/components/src/public/QueryInfo.spec.ts
@@ -51,8 +51,8 @@ describe('QueryInfo', () => {
 
     const queryInfo = QueryInfo.fromJSON(sampleSetQueryInfo);
     let newColumns = OrderedMap<string, QueryColumn>();
-    newColumns = newColumns.set(FIRST_COL_KEY, QueryColumn.create(sampleSet3QueryColumn));
-    newColumns = newColumns.set(SECOND_COL_KEY, QueryColumn.create(nameExpSetQueryColumn));
+    newColumns = newColumns.set(FIRST_COL_KEY, new QueryColumn(sampleSet3QueryColumn));
+    newColumns = newColumns.set(SECOND_COL_KEY, new QueryColumn(nameExpSetQueryColumn));
 
     describe('insertColumns', () => {
         test('negative columnIndex', () => {

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -137,7 +137,7 @@ export class QueryInfo extends Record({
         let columns = OrderedMap<string, QueryColumn>();
         Object.keys(queryInfoJson.columns).forEach(columnKey => {
             const rawColumn = queryInfoJson.columns[columnKey];
-            columns = columns.set(rawColumn.fieldKey.toLowerCase(), QueryColumn.create(rawColumn));
+            columns = columns.set(rawColumn.fieldKey.toLowerCase(), new QueryColumn(rawColumn));
         });
 
         const disabledSystemFields = new Set<string>();
@@ -219,10 +219,10 @@ export class QueryInfo extends Record({
 
                 if (c !== undefined) {
                     if (col.title !== undefined) {
-                        c = c.merge({
+                        c = c.mutate({
                             caption: col.title,
                             shortCaption: col.title,
-                        }) as QueryColumn;
+                        });
                     }
 
                     return list.push(c);
@@ -313,7 +313,7 @@ export class QueryInfo extends Record({
             })
             .map(column => {
                 if (lowerReadOnlyColumnsList && lowerReadOnlyColumnsList.indexOf(column.fieldKey.toLowerCase()) > -1) {
-                    return column.set('readOnly', true) as QueryColumn;
+                    return column.mutate({ readOnly: true });
                 } else {
                     return column;
                 }

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -25,7 +25,7 @@ import {
     includedColumnsForCustomizationFilter,
 } from './CustomizeGridViewModal';
 
-const QUERY_COL = QueryColumn.create({
+const QUERY_COL = new QueryColumn({
     name: 'test/Column',
     fieldKey: 'test$SColumn',
     fieldKeyArray: ['test/Column'],
@@ -34,7 +34,7 @@ const QUERY_COL = QueryColumn.create({
     selectable: true,
 });
 
-const QUERY_COL_LOOKUP = QueryColumn.create({
+const QUERY_COL_LOOKUP = new QueryColumn({
     name: 'test/Column',
     fieldKey: 'test$SColumn',
     fieldKeyArray: ['test/Column'],
@@ -159,7 +159,7 @@ describe('ColumnInView', () => {
     });
 
     test('addToDisplayView can be removed', () => {
-        const column = QueryColumn.create({
+        const column = new QueryColumn({
             name: 'testColumn',
             fieldKey: 'testColumn',
             fieldKeyArray: ['testColumn'],
@@ -187,7 +187,7 @@ describe('ColumnInView', () => {
     });
 
     test('drag disabled', () => {
-        const column = QueryColumn.create({
+        const column = new QueryColumn({
             name: 'testColumn',
             fieldKey: 'testColumn',
             fieldKeyArray: ['testColumn'],
@@ -215,7 +215,7 @@ describe('ColumnInView', () => {
     });
 
     test('Editing', () => {
-        const column = QueryColumn.create({
+        const column = new QueryColumn({
             name: 'testColumn',
             fieldKey: 'testColumn',
             fieldKeyArray: ['testColumn'],
@@ -535,7 +535,7 @@ describe('ColumnChoiceGroup', () => {
     });
 
     test('lookup column with children, child hidden', () => {
-        const colHidden = QueryColumn.create({ ...QUERY_COL.toJS(), hidden: true });
+        const colHidden = new QueryColumn({ ...QUERY_COL.toJS(), hidden: true });
         const queryInfo = QueryInfo.create({ columns: fromJS({ [colHidden.fieldKey]: colHidden }) });
         const wrapper = mount(
             <ColumnChoiceGroup
@@ -550,7 +550,7 @@ describe('ColumnChoiceGroup', () => {
     });
 
     test('lookup column with children, child hidden with showAllColumns', () => {
-        const colHidden = QueryColumn.create({ ...QUERY_COL.toJS(), hidden: true });
+        const colHidden = new QueryColumn({ ...QUERY_COL.toJS(), hidden: true });
         const queryInfo = QueryInfo.create({ columns: fromJS({ [colHidden.fieldKey]: colHidden }) });
         const wrapper = mount(
             <ColumnChoiceGroup
@@ -568,7 +568,7 @@ describe('ColumnChoiceGroup', () => {
     });
 
     test('lookup column with children, child removeFromViews', () => {
-        const colHidden = QueryColumn.create({ ...QUERY_COL.toJS(), removeFromViews: true });
+        const colHidden = new QueryColumn({ ...QUERY_COL.toJS(), removeFromViews: true });
         const queryInfo = QueryInfo.create({ columns: fromJS({ [colHidden.fieldKey]: colHidden }) });
         const wrapper = mount(
             <ColumnChoiceGroup
@@ -585,29 +585,29 @@ describe('ColumnChoiceGroup', () => {
 
 describe('includedColumnsForCustomizationFilter', () => {
     test('hidden', () => {
-        let col = QueryColumn.create({ name: 'testColumn', hidden: false });
+        let col = new QueryColumn({ name: 'testColumn', hidden: false });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy;
         expect(includedColumnsForCustomizationFilter(col, true)).toBeTruthy;
 
-        col = QueryColumn.create({ name: 'testColumn', hidden: true });
+        col = new QueryColumn({ name: 'testColumn', hidden: true });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeFalsy();
         expect(includedColumnsForCustomizationFilter(col, true)).toBeTruthy;
     });
 
     test('removeFromViews', () => {
-        let col = QueryColumn.create({ name: 'testColumn', removeFromViews: false });
+        let col = new QueryColumn({ name: 'testColumn', removeFromViews: false });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
 
-        col = QueryColumn.create({ name: 'testColumn', removeFromViews: true });
+        col = new QueryColumn({ name: 'testColumn', removeFromViews: true });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeFalsy();
     });
 
     test('removeFromViewCustomization', () => {
-        let col = QueryColumn.create({ name: 'testColumn', removeFromViewCustomization: false });
+        let col = new QueryColumn({ name: 'testColumn', removeFromViewCustomization: false });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
         expect(includedColumnsForCustomizationFilter(col, true)).toBeTruthy();
 
-        col = QueryColumn.create({ name: 'testColumn', removeFromViewCustomization: true });
+        col = new QueryColumn({ name: 'testColumn', removeFromViewCustomization: true });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeFalsy();
         expect(includedColumnsForCustomizationFilter(col, true)).toBeFalsy();
 

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -11,7 +11,7 @@ import { Draggable } from 'react-beautiful-dnd';
 import { SchemaQuery } from '../SchemaQuery';
 import { QueryInfo } from '../QueryInfo';
 import { ViewInfo } from '../../internal/ViewInfo';
-import { QueryColumn } from '../QueryColumn';
+import { QueryColumn, QueryLookup } from '../QueryColumn';
 import { wrapDraggable } from '../../internal/testHelpers';
 
 import { makeTestQueryModel } from './testUtils';
@@ -41,9 +41,7 @@ const QUERY_COL_LOOKUP = new QueryColumn({
     fieldKeyPath: 'parent1/parent2/test$SColumn',
     caption: 'Test Column',
     selectable: true,
-    lookup: {
-        /* this would define the schema/query */
-    },
+    lookup: new QueryLookup({}),
 });
 
 describe('ColumnChoice', () => {
@@ -165,7 +163,6 @@ describe('ColumnInView', () => {
             fieldKeyArray: ['testColumn'],
             fieldKeyPath: 'testColumn',
             caption: 'Test Column',
-            addToDisplayView: true,
         });
 
         const wrapper = mount(
@@ -193,7 +190,6 @@ describe('ColumnInView', () => {
             fieldKeyArray: ['testColumn'],
             fieldKeyPath: 'testColumn',
             caption: 'Test Column',
-            addToDisplayView: true,
         });
 
         const wrapper = mount(
@@ -221,7 +217,6 @@ describe('ColumnInView', () => {
             fieldKeyArray: ['testColumn'],
             fieldKeyPath: 'testColumn',
             caption: 'Test Column',
-            addToDisplayView: true,
         });
 
         const wrapper = mount(
@@ -535,7 +530,7 @@ describe('ColumnChoiceGroup', () => {
     });
 
     test('lookup column with children, child hidden', () => {
-        const colHidden = new QueryColumn({ ...QUERY_COL.toJS(), hidden: true });
+        const colHidden = new QueryColumn({ ...QUERY_COL, hidden: true });
         const queryInfo = QueryInfo.create({ columns: fromJS({ [colHidden.fieldKey]: colHidden }) });
         const wrapper = mount(
             <ColumnChoiceGroup
@@ -550,7 +545,7 @@ describe('ColumnChoiceGroup', () => {
     });
 
     test('lookup column with children, child hidden with showAllColumns', () => {
-        const colHidden = new QueryColumn({ ...QUERY_COL.toJS(), hidden: true });
+        const colHidden = new QueryColumn({ ...QUERY_COL, hidden: true });
         const queryInfo = QueryInfo.create({ columns: fromJS({ [colHidden.fieldKey]: colHidden }) });
         const wrapper = mount(
             <ColumnChoiceGroup
@@ -568,7 +563,7 @@ describe('ColumnChoiceGroup', () => {
     });
 
     test('lookup column with children, child removeFromViews', () => {
-        const colHidden = new QueryColumn({ ...QUERY_COL.toJS(), removeFromViews: true });
+        const colHidden = new QueryColumn({ ...QUERY_COL, removeFromViews: true });
         const queryInfo = QueryInfo.create({ columns: fromJS({ [colHidden.fieldKey]: colHidden }) });
         const wrapper = mount(
             <ColumnChoiceGroup

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -351,8 +351,8 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
     }, []);
 
     const updateColumnTitle = useCallback(
-        (updatedColumn: QueryColumn, title: string) => {
-            const relabeledColumn = updatedColumn.set('caption', title);
+        (updatedColumn: QueryColumn, caption: string) => {
+            const relabeledColumn = updatedColumn.mutate({ caption });
             const index = columnsInView.findIndex(column => column.index === updatedColumn.index);
             setColumnsInView([...columnsInView.slice(0, index), relabeledColumn, ...columnsInView.slice(index + 1)]);
             setIsDirty(true);

--- a/packages/components/src/public/QueryModel/GridFilterModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridFilterModal.spec.tsx
@@ -61,7 +61,7 @@ describe('GridFilterModal', () => {
 
         // add a filter
         wrapper.find(QueryFilterPanel).prop('onFilterUpdate')(
-            QueryColumn.create({ fieldKey: 'a' }),
+            new QueryColumn({ fieldKey: 'a' }),
             [Filter.create('a', '1')],
             0
         );
@@ -69,7 +69,7 @@ describe('GridFilterModal', () => {
         expect(wrapper.find('.btn-success').prop('disabled')).toBe(false);
 
         // remove the filter for the same field
-        wrapper.find(QueryFilterPanel).prop('onFilterUpdate')(QueryColumn.create({ fieldKey: 'a' }), undefined, 0);
+        wrapper.find(QueryFilterPanel).prop('onFilterUpdate')(new QueryColumn({ fieldKey: 'a' }), undefined, 0);
         await waitForLifecycle(wrapper);
         expect(wrapper.find('.btn-success').prop('disabled')).toBe(true);
         wrapper.unmount();

--- a/packages/components/src/public/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/public/QueryModel/QueryModelLoader.ts
@@ -34,8 +34,10 @@ export function bindColumnRenderers(columns: OrderedMap<string, QueryColumn>): O
             }
 
             // TODO: Just generate one function per type
-            return queryCol.set('cell', (data, row, col, rowIndex, columnIndex) => {
-                return React.createElement(node, { data, row, col: queryCol, rowIndex, columnIndex });
+            return queryCol.mutate({
+                cell: (data, row, col, rowIndex, columnIndex) => {
+                    return React.createElement(node, { data, row, col: queryCol, rowIndex, columnIndex });
+                },
             });
         }) as OrderedMap<string, QueryColumn>;
     }

--- a/packages/components/src/public/QueryModel/grid/actions/Filter.spec.tsx
+++ b/packages/components/src/public/QueryModel/grid/actions/Filter.spec.tsx
@@ -59,7 +59,7 @@ describe('FilterAction::actionValueFromFilter', () => {
     });
 
     test('with label from QueryColumn', () => {
-        const col = QueryColumn.create({ shortCaption: 'otherLabel' });
+        const col = new QueryColumn({ shortCaption: 'otherLabel' });
         const filter = Filter.create('U mgS$L', 'x', Filter.Types.EQUAL);
         const value: ActionValue = action.actionValueFromFilter(filter, col);
         expect(value.displayValue).toBe('otherLabel = x');
@@ -67,21 +67,21 @@ describe('FilterAction::actionValueFromFilter', () => {
     });
 
     test('date formatting, date and time', () => {
-        const col = QueryColumn.create({ shortCaption: 'DateCol', jsonType: 'date', format: 'dd/MM/yyyy HH:mm' });
+        const col = new QueryColumn({ shortCaption: 'DateCol', jsonType: 'date', format: 'dd/MM/yyyy HH:mm' });
         const filter = Filter.create('DateCol', '2022-04-19 01:02', Filter.Types.EQUAL);
         const value: ActionValue = action.actionValueFromFilter(filter, col);
         expect(value.displayValue).toBe('DateCol = 19/04/2022 01:02');
     });
 
     test('date formatting, date only', () => {
-        const col = QueryColumn.create({ shortCaption: 'DateCol', jsonType: 'date', format: 'dd/MM/yyyy' });
+        const col = new QueryColumn({ shortCaption: 'DateCol', jsonType: 'date', format: 'dd/MM/yyyy' });
         const filter = Filter.create('DateCol', '2022-04-19 01:02', Filter.Types.EQUAL);
         const value: ActionValue = action.actionValueFromFilter(filter, col);
         expect(value.displayValue).toBe('DateCol = 19/04/2022');
     });
 
     test('date formatting, time only', () => {
-        const col = QueryColumn.create({ shortCaption: 'DateCol', jsonType: 'date', format: 'HH:mm:ss' });
+        const col = new QueryColumn({ shortCaption: 'DateCol', jsonType: 'date', format: 'HH:mm:ss' });
         const filter = Filter.create('DateCol', '2022-04-19 01:02', Filter.Types.EQUAL);
         const value: ActionValue = action.actionValueFromFilter(filter, col);
         expect(value.displayValue).toBe('DateCol = 01:02:00');

--- a/packages/components/src/public/QueryModel/grid/actions/Filter.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Filter.ts
@@ -100,9 +100,7 @@ export function resolveFilterType(token: string, column: QueryColumn): Filter.IF
             const suffix = getURLSuffix(types[i]);
             if (symbolTypes.has(suffix)) {
                 if (match) {
-                    console.warn(
-                        `Column of type \"${column.get('jsonType')}\" has multiple filters for symbol \"${token}\".`
-                    );
+                    console.warn(`Column of type "${column.jsonType}" has multiple filters for symbol "${token}".`);
                     match = false;
                     value = undefined;
                     break; // stop the loop, ambiguous

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -77,10 +77,7 @@ export function runDetailsColumnsForQueryModel(model: QueryModel, reRunSupport: 
     if (replacedByIndex > -1) {
         if (includeRerunColumns) {
             // Direct manipulation by index is ok here because displayColumns returns a new array every time.
-            columns[replacedByIndex] = columns[replacedByIndex].set(
-                'detailRenderer',
-                'assayrunreference'
-            ) as QueryColumn;
+            columns[replacedByIndex] = columns[replacedByIndex].mutate({ detailRenderer: 'assayrunreference' });
         } else {
             columns = columns.filter((col, index): boolean => replacedByIndex !== index);
         }
@@ -90,7 +87,7 @@ export function runDetailsColumnsForQueryModel(model: QueryModel, reRunSupport: 
         const replaces = model.getColumn('ReplacesRun');
 
         if (replaces) {
-            const column = replaces.set('detailRenderer', 'assayrunreference') as QueryColumn;
+            const column = replaces.mutate({ detailRenderer: 'assayrunreference' });
 
             if (replacedByIndex > -1) {
                 columns = [...columns.slice(0, replacedByIndex + 1), column, ...columns.slice(replacedByIndex)];

--- a/packages/components/src/public/QuerySort.ts
+++ b/packages/components/src/public/QuerySort.ts
@@ -1,13 +1,12 @@
-import { Record } from 'immutable';
-
-export class QuerySort extends Record({
-    dir: '',
-    fieldKey: undefined,
-}) {
+export class QuerySort {
     declare dir: string;
     declare fieldKey: string;
 
-    toRequestString() {
+    constructor(props: Partial<QuerySort>) {
+        Object.assign(this, { dir: '' }, props);
+    }
+
+    toRequestString(): string {
         const { dir, fieldKey } = this;
         return dir === '-' ? '-' + fieldKey : fieldKey;
     }


### PR DESCRIPTION
#### Rationale
This PR converts a number of our classes that extend Immtuable's Record class to be plain classes

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/52
- https://github.com/LabKey/biologics/pull/1957
- https://github.com/LabKey/sampleManagement/pull/1634
- https://github.com/LabKey/inventory/pull/749
- https://github.com/LabKey/labbook/pull/430

#### Changes
- QueryColumn: convert to plain class
- AppURL: convert to plain class
- Container: convert to plain class
- User: convert to plain class
- QuerySort: convert to plain class
- WebDavFile: convert to plain class
