### PR TITLE
Issue 47123: Focus graph on lineage seed in "large" graphs

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.18.5-fb-lineage-46469.1",
+    "@labkey/api": "1.18.6",
     "bootstrap": "~3.4.1",
     "classnames": "~2.3.2",
     "enzyme": "~3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.18.5",
+    "@labkey/api": "1.18.5-fb-lineage-46469.0",
     "bootstrap": "~3.4.1",
     "classnames": "~2.3.2",
     "enzyme": "~3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.18.5-fb-lineage-46469.0",
+    "@labkey/api": "1.18.5-fb-lineage-46469.1",
     "bootstrap": "~3.4.1",
     "classnames": "~2.3.2",
     "enzyme": "~3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.300.0",
+  "version": "2.300.0-fb-lineage-zoom.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.300.0-fb-lineage-zoom.0",
+  "version": "2.300.0-fb-lineage-zoom.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.300.0-fb-lineage-zoom.1",
+  "version": "2.300.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.300.1
+*Released*: 28 February 2023
+- Add a `focusSeed` method to the `VisGraph` component which fits the graph to the seed node and then zooms in to an appropriate level.
+- Revise `fitGraph` to take determine whether or not the graph should be focused on the seed.
+
 ### version 2.300.0
 *Released*: 28 February 2023
 - FilterFacetedSelector fix to better handle selection filters when we don't have all distinct values (i.e. > 250 facet filter values)

--- a/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
+++ b/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
@@ -2,44 +2,49 @@ import React, { PureComponent, ReactNode } from 'react';
 import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import { Network } from 'vis-network';
 
+const PAN_INCREMENT = 20;
+const ZOOM_INCREMENT = 0.05;
+
 interface GraphControlsProps {
     getNetwork: () => Network;
-    onReset: (selectSeed) => any;
+    onReset: (selectSeed: boolean) => void;
 }
 
 export class VisGraphControls extends PureComponent<GraphControlsProps> {
-    graphReset = (selectSeed: boolean): void => {
-        if (this.props.onReset) {
-            this.props.onReset(selectSeed);
-        }
-    };
-
     panDown = (): void => {
-        this.props.getNetwork().moveTo({ offset: { x: 0, y: -20 } });
+        this.props.getNetwork().moveTo({ offset: { x: 0, y: -PAN_INCREMENT } });
     };
 
     panUp = (): void => {
-        this.props.getNetwork().moveTo({ offset: { x: 0, y: 20 } });
+        this.props.getNetwork().moveTo({ offset: { x: 0, y: PAN_INCREMENT } });
     };
 
     panLeft = (): void => {
-        this.props.getNetwork().moveTo({ offset: { x: 20, y: 0 } });
+        this.props.getNetwork().moveTo({ offset: { x: PAN_INCREMENT, y: 0 } });
     };
 
     panRight = (): void => {
-        this.props.getNetwork().moveTo({ offset: { x: -20, y: 0 } });
+        this.props.getNetwork().moveTo({ offset: { x: -PAN_INCREMENT, y: 0 } });
+    };
+
+    reset = (): void => {
+        this.props.onReset?.(false);
+    };
+
+    resetSelect = (): void => {
+        this.props.onReset?.(true);
     };
 
     zoomIn = (): void => {
         const network = this.props.getNetwork();
         network.moveTo({
-            scale: network.getScale() + 0.05,
+            scale: network.getScale() + ZOOM_INCREMENT,
         });
     };
 
     zoomOut = (): void => {
         const network = this.props.getNetwork();
-        const scale = network.getScale() - 0.05;
+        const scale = network.getScale() - ZOOM_INCREMENT;
         if (scale > 0) {
             network.moveTo({ scale });
         }
@@ -51,8 +56,8 @@ export class VisGraphControls extends PureComponent<GraphControlsProps> {
                 <div className="lineage-visgraph-control-settings">
                     <div className="btn-group">
                         <DropdownButton id="graph-control-dd" title={<i className="fa fa-undo" />} pullRight>
-                            <MenuItem onClick={() => this.graphReset(true)}>Reset view and select seed</MenuItem>
-                            <MenuItem onClick={() => this.graphReset(false)}>Reset view</MenuItem>
+                            <MenuItem onClick={this.resetSelect}>Reset view and select seed</MenuItem>
+                            <MenuItem onClick={this.reset}>Reset view</MenuItem>
                         </DropdownButton>
                     </div>
                 </div>

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -174,11 +174,9 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                     <div className="name-id-setting__setting-section">
                         <div className="list__bold-text margin-bottom margin-top">ID/Name Prefix</div>
                         <div>
-                            Enter a prefix to be applied to all Sample Types and{' '}
-                            {sampleManagerIsPrimaryApp(moduleContext)
-                                ? 'Source Types'
-                                : 'Data Classes (e.g., CellLine, Construct)'}
-                            . Prefixes generally are 2-3 characters long but will not be limited.
+                            Enter a prefix to the Naming Pattern for all new Samples and{' '}
+                            {sampleManagerIsPrimaryApp(moduleContext) ? 'Sources' : 'Data Classes'}. No existing
+                            IDs/Names will be changed.
                         </div>
 
                         {loading && <LoadingSpinner />}

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1506,10 +1506,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.18.5":
-  version "1.18.5"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.5.tgz#35fb69bedc74d3f06f84f23a9e7af35e514b3ad9"
-  integrity sha512-vgjLTTE34wd1xUI1wsy5661SykxJ6KRdr25zNYb9EaFHhTBcrAQlIVucyqv3ZxRP0EuUQvM3+8/N3a3tOLXNsQ==
+"@labkey/api@1.18.5-fb-lineage-46469.0":
+  version "1.18.5-fb-lineage-46469.0"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.5-fb-lineage-46469.0.tgz#c90164f26254b8d0066103750f26bb7ad48819c4"
+  integrity sha512-p0BGZGA6BaXfcj09o4fO7x5XckIL27EpoS2NaQUDfyXkQGkrGA4JGV2Kk7t0DxaQJk3MKuqcUtm4ncfI2RCVXQ==
 
 "@labkey/build@6.9.0":
   version "6.9.0"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1506,10 +1506,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.18.5-fb-lineage-46469.1":
-  version "1.18.5-fb-lineage-46469.1"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.5-fb-lineage-46469.1.tgz#e3a333630d5c25710c9c01c699a1690fc5e7663a"
-  integrity sha512-GGsCKpTUO252H3IszAyKMhaeyTkPRqRocDLY2/PvQ9uPP6fMQLyX3tmYnYbc+KLbSBQ+TR9qZgmUPnzhtCOH2A==
+"@labkey/api@1.18.6":
+  version "1.18.6"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.6.tgz#af9f6e5f46021f405363616a34098e8060a3067b"
+  integrity sha512-DkAbYotXJ2v4sgY22CFMbaOUeLS/SHOXyZgeObPsSi20KDXtGwGwLHxrO13u4qB8ayegsxsIUgm9l5VlSwxjUg==
 
 "@labkey/build@6.9.0":
   version "6.9.0"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1506,10 +1506,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.18.5-fb-lineage-46469.0":
-  version "1.18.5-fb-lineage-46469.0"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.5-fb-lineage-46469.0.tgz#c90164f26254b8d0066103750f26bb7ad48819c4"
-  integrity sha512-p0BGZGA6BaXfcj09o4fO7x5XckIL27EpoS2NaQUDfyXkQGkrGA4JGV2Kk7t0DxaQJk3MKuqcUtm4ncfI2RCVXQ==
+"@labkey/api@1.18.5-fb-lineage-46469.1":
+  version "1.18.5-fb-lineage-46469.1"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.5-fb-lineage-46469.1.tgz#e3a333630d5c25710c9c01c699a1690fc5e7663a"
+  integrity sha512-GGsCKpTUO252H3IszAyKMhaeyTkPRqRocDLY2/PvQ9uPP6fMQLyX3tmYnYbc+KLbSBQ+TR9qZgmUPnzhtCOH2A==
 
 "@labkey/build@6.9.0":
   version "6.9.0"


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47123](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47123) by attempting to focus the graph on the seed node when a large number of nodes are in the graph.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/148
- https://github.com/LabKey/labkey-ui-components/pull/1124
- https://github.com/LabKey/labkey-ui-premium/pull/55
- https://github.com/LabKey/biologics/pull/1962
- https://github.com/LabKey/sampleManagement/pull/1636
- https://github.com/LabKey/inventory/pull/751
- https://github.com/LabKey/platform/pull/4157

#### Changes
- Add a `focusSeed` method to the `VisGraph` component which fits the graph to the seed node and then zooms in to an appropriate level.
- Revise `fitGraph` to take determine whether or not the graph should be focused on the seed.
- Update `@labkey/api` to pull in updates for [Issue 46469](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46469).
