### PR TITLE
SampleStatusTag display issue when status type not provided

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.300.0-fb-workflowTemplateFix.0",
+  "version": "2.300.0-fb-workflowTemplateFix.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.300.0",
+  "version": "2.300.0-fb-workflowTemplateFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.301.0",
+  "version": "2.302.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.300.1",
+  "version": "2.300.1-fb-workflowTemplateFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 - SampleStatusTag to query for status type if not provided
 - getSampleStatuses() boolean property for whether API should include inUse information or not
+- Issue 47411: Include viewName in selectDistinct query for FilterFacetedSelector
 
 ### version 2.300.1
 *Released*: 28 February 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - SampleStatusTag to query for status type if not provided
+- getSampleStatuses() boolean property for whether API should include inUse information or not
 
 ### version 2.300.0
 *Released*: 28 February 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.302.0
+*Released*: 28 February 2023
 - SampleStatusTag to query for status type if not provided
 - getSampleStatuses() boolean property for whether API should include inUse information or not
 - Issue 47411: Include viewName in selectDistinct query for FilterFacetedSelector

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- SampleStatusTag to query for status type if not provided
+
 ### version 2.300.0
 *Released*: 28 February 2023
 - FilterFacetedSelector fix to better handle selection filters when we don't have all distinct values (i.e. > 250 facet filter values)
@@ -10,7 +14,6 @@ Components, models, actions, and utility functions for LabKey applications and p
   - Issue 47266: For a grid the filter dialog does not enable the 'Apply' button if I type in a value unless I uncheck the [All] option first
   - Issue 47247: LKSM: Filtering values >250 doesn't save selection
 - Issue 46870: Don't allow selection/inclusion of multi-valued lookup fields from Ancestors
-
 
 ### version 2.299.0
 *Released*: 27 February 2023

--- a/packages/components/src/entities/SamplesEditableGrid.tsx
+++ b/packages/components/src/entities/SamplesEditableGrid.tsx
@@ -460,9 +460,10 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
             originalParents,
             includedTabs,
             parentTypeOptions,
+            consumedStatusIds,
         } = this.state;
 
-        if (determineLineage && this.hasParentDataTypes() && !originalParents) {
+        if ((determineLineage && this.hasParentDataTypes() && !originalParents) || !consumedStatusIds) {
             return <LoadingSpinner />;
         }
 

--- a/packages/components/src/entities/SingleParentEntityPanel.tsx
+++ b/packages/components/src/entities/SingleParentEntityPanel.tsx
@@ -14,7 +14,11 @@ import { capitalizeFirstChar, caseInsensitive, quoteValueWithDelimiters } from '
 import { QueryModel } from '../public/QueryModel/QueryModel';
 import { Alert } from '../internal/components/base/Alert';
 import { SchemaQuery } from '../public/SchemaQuery';
-import { SampleOperation } from '../internal/components/samples/constants';
+import {
+    SAMPLE_STATE_COLUMN_NAME,
+    SAMPLE_STATE_TYPE_COLUMN_NAME,
+    SampleOperation,
+} from '../internal/components/samples/constants';
 import { SelectInput } from '../internal/components/forms/input/SelectInput';
 import { RemoveEntityButton } from '../internal/components/buttons/RemoveEntityButton';
 import { QuerySelect } from '../internal/components/forms/QuerySelect';
@@ -271,7 +275,7 @@ export const SingleParentEntityPanel: FC<Props> = memo(props => {
                 containerPath,
                 schemaQuery: new SchemaQuery(chosenType.schema, chosenType.query, ViewInfo.DETAIL_NAME),
                 omittedColumns: ['Run'],
-                requiredColumns: ['Name'],
+                requiredColumns: ['Name', SAMPLE_STATE_COLUMN_NAME, SAMPLE_STATE_TYPE_COLUMN_NAME],
             },
         };
     }, [chosenType, containerPath, parentTypeOptions, parentLSIDs]);

--- a/packages/components/src/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
+++ b/packages/components/src/entities/__snapshots__/SingleParentEntityPanel.spec.tsx.snap
@@ -5883,6 +5883,8 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
           ],
           "requiredColumns": [
             "Name",
+            "SampleState",
+            "SampleState/StatusType",
           ],
           "schemaQuery": SchemaQuery {
             "queryName": "Second Source",
@@ -6041,6 +6043,8 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
             ],
             "requiredColumns": [
               "Name",
+              "SampleState",
+              "SampleState/StatusType",
             ],
             "schemaQuery": SchemaQuery {
               "queryName": "Second Source",
@@ -6231,6 +6235,8 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
               "queryParameters": undefined,
               "requiredColumns": [
                 "Name",
+                "SampleState",
+                "SampleState/StatusType",
               ],
               "rowCount": undefined,
               "rows": undefined,
@@ -6367,6 +6373,8 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                 "queryParameters": undefined,
                 "requiredColumns": [
                   "Name",
+                  "SampleState",
+                  "SampleState/StatusType",
                 ],
                 "rowCount": undefined,
                 "rows": undefined,
@@ -6484,6 +6492,8 @@ exports[`<SingleParentEntityPanel> with data not editing 1`] = `
                     "queryParameters": undefined,
                     "requiredColumns": [
                       "Name",
+                      "SampleState",
+                      "SampleState/StatusType",
                     ],
                     "rowCount": undefined,
                     "rows": undefined,

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -52,7 +52,7 @@ export interface SamplesAPIWrapper {
         useSnapshotSelection?: boolean,
        ) => Promise<OperationConfirmationData>;
 
-    getSampleStatuses: () => Promise<SampleState[]>;
+    getSampleStatuses: (includeInUse?: boolean) => Promise<SampleState[]>;
 
     getSampleStorageId: (sampleRowId: number) => Promise<number>;
 

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -49,8 +49,8 @@ export interface SamplesAPIWrapper {
         operation: SampleOperation,
         rowIds: number[] | string[],
         selectionKey?: string,
-        useSnapshotSelection?: boolean,
-       ) => Promise<OperationConfirmationData>;
+        useSnapshotSelection?: boolean
+    ) => Promise<OperationConfirmationData>;
 
     getSampleStatuses: (includeInUse?: boolean) => Promise<SampleState[]>;
 

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -317,7 +317,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
             setError(undefined);
 
             api.samples
-                .getSampleStatuses()
+                .getSampleStatuses(true)
                 .then(statuses => {
                     setStates(statuses);
                     if (newStatusLabel) setSelected(statuses.findIndex(state => state.label === newStatusLabel));

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -866,10 +866,10 @@ export async function createSessionAssayRunSummaryQuery(sampleIds: number[]): Pr
     });
 }
 
-export function getSampleStatuses(): Promise<SampleState[]> {
+export function getSampleStatuses(includeInUse = false): Promise<SampleState[]> {
     return new Promise((resolve, reject) => {
         return Ajax.request({
-            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getSampleStatuses.api'),
+            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getSampleStatuses.api', { includeInUse }),
             method: 'GET',
             success: Utils.getCallbackWrapper(response => {
                 resolve(response.statuses?.map(state => new SampleState(state)) ?? []);

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -307,6 +307,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                                     column: activeFieldKey,
                                                     schemaName: queryInfo.schemaName,
                                                     queryName,
+                                                    viewName,
                                                     filterArray: fieldDistinctValueFilters,
                                                 }}
                                                 fieldFilters={currentFieldFilters?.map(filter => filter.filter)}


### PR DESCRIPTION
#### Rationale
In most places in the app where the Sample status tag is shown, the status type is also included in the QueryModel data. However, a few places in the app were not included this type. I've added the status type to the parent entity grid QueryConfig, but this also adds a backup (for places like the lineage details panel) so that the component will query for that status type if not provided.

<img width="875" alt="Screen Shot 2023-02-22 at 4 29 55 PM" src="https://user-images.githubusercontent.com/6411206/221939466-f3464adc-6968-4bd3-b636-2d42394fdc5b.png">


#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1126
- https://github.com/LabKey/labkey-ui-premium/pull/54
- https://github.com/LabKey/sampleManagement/pull/1642
- https://github.com/LabKey/biologics/pull/1968
- https://github.com/LabKey/inventory/pull/754

#### Changes
- SampleStatusTag to query for status type if not provided
- getSampleStatuses() boolean property for whether API should include inUse information or not
