### PR TITLE
Issue47306: Permissions page error

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.298.0",
+  "version": "2.298.0-fb-issue47306.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 47306: Resolve Permissions page error by skipping no-resolvable users.
+
 ### version 2.298.0
 *Released*: 25 February 2023
 - Support Enable/Disable “System Default Fields”

--- a/packages/components/src/internal/components/administration/GroupAssignments.tsx
+++ b/packages/components/src/internal/components/administration/GroupAssignments.tsx
@@ -146,6 +146,10 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
             .sort((id1, id2) => naturalSort(groupMembership[id1].groupName, groupMembership[id2].groupName));
     }, [groupMembership]);
 
+    // Folder and Project Admins may receive inaccurate group membership counts due to lack of permissions for viewing
+    // data for users outside their Project. In this case, we opt to not display counts.
+    const userIsAppAdmin = user.isAppAdmin();
+
     return (
         <Row>
             <Col xs={12} md={showDetailsPanel ? 8 : 12}>
@@ -202,6 +206,7 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
                             members={groupMembership[selectedPrincipal?.userId]?.members}
                             isSiteGroup={groupMembership[selectedPrincipal?.userId]?.type === MemberType.siteGroup}
                             getAuditLogData={getAuditLogData}
+                            displayCounts={userIsAppAdmin}
                         />
                     ) : (
                         <UserDetailsPanel

--- a/packages/components/src/internal/components/administration/actions.spec.ts
+++ b/packages/components/src/internal/components/administration/actions.spec.ts
@@ -110,6 +110,13 @@ describe('Administration actions', () => {
                 UserId: 1066,
                 GroupId: 1064,
             },
+            {
+                'UserId/Email': null,
+                'UserId/DisplayName': null,
+                'GroupId/Name': 'group1',
+                UserId: 1000,
+                GroupId: 1064,
+            },
         ];
 
         const expected = {

--- a/packages/components/src/internal/components/permissions/GroupDetailsPanel.spec.tsx
+++ b/packages/components/src/internal/components/permissions/GroupDetailsPanel.spec.tsx
@@ -112,4 +112,35 @@ describe('<GroupDetailsPanel/>', () => {
 
         component.unmount();
     });
+
+    test("as site group, don't display counts", () => {
+        const component = mountWithServerContext(
+            <GroupDetailsPanel
+                principal={GROUP}
+                policy={POLICY}
+                rolesByUniqueName={ROLES_BY_NAME}
+                members={[
+                    { id: 1, name: 'user1', type: MemberType.user },
+                    { id: 3, name: 'group1', type: MemberType.group },
+                ]}
+                isSiteGroup={true}
+                getAuditLogData={jest.fn()}
+                displayCounts={false}
+            />,
+            { user: TEST_USER_APP_ADMIN }
+        );
+
+        expect(component.find('.panel-heading').text()).toBe(GROUP.name);
+
+        expect(component.find(UserProperties)).toHaveLength(2);
+        expect(component.find(UserProperties).at(0).text()).toBe('Created');
+        expect(component.find(UserProperties).at(1).text()).toBe('Site Grouptrue');
+
+        expect(component.find('.principal-detail-li')).toHaveLength(3);
+        expect(component.find('.principal-detail-li').at(0).text()).toBe('Editor');
+        expect(component.find('.principal-detail-li').at(1).text()).toBe('user1');
+        expect(component.find('.principal-detail-li').at(2).text()).toBe('group1');
+
+        component.unmount();
+    });
 });

--- a/packages/components/src/internal/components/permissions/GroupDetailsPanel.tsx
+++ b/packages/components/src/internal/components/permissions/GroupDetailsPanel.tsx
@@ -19,6 +19,7 @@ import { Principal, SecurityPolicy, SecurityRole } from './models';
 import { MembersList } from './MembersList';
 
 interface Props {
+    displayCounts?: boolean;
     getAuditLogData: (columns: string, filterCol: string, filterVal: string | number) => Promise<string>;
     isSiteGroup: boolean;
     members?: Member[];
@@ -29,7 +30,14 @@ interface Props {
 }
 
 export const GroupDetailsPanel: FC<Props> = memo(props => {
-    const { getAuditLogData, principal, members, isSiteGroup, showPermissionListLinks = true } = props;
+    const {
+        getAuditLogData,
+        principal,
+        members,
+        isSiteGroup,
+        displayCounts = true,
+        showPermissionListLinks = true,
+    } = props;
     const [created, setCreated] = useState<string>('');
     const { user } = useServerContext();
 
@@ -60,10 +68,14 @@ export const GroupDetailsPanel: FC<Props> = memo(props => {
             <Panel.Body>
                 {principal ? (
                     <>
-                        <UserProperties prop={usersCount.toString()} title="User Count" />
-                        <UserProperties prop={groupsCount} title="Group Count" />
+                        {displayCounts && (
+                            <>
+                                <UserProperties prop={usersCount.toString()} title="User Count" />
+                                <UserProperties prop={groupsCount} title="Group Count" />
+                                <hr className="principal-hr" />
+                            </>
+                        )}
 
-                        <hr className="principal-hr" />
                         <UserProperties prop={created} title="Created" />
                         {isSiteGroup && <UserProperties prop="true" title="Site Group" />}
 


### PR DESCRIPTION
#### Rationale
When a member is not resolvable (for various reasons), the permissions and groups pages in the apps would display an unhelpful error. This resolves that issue by properly discarding unresolvable members.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1127
- https://github.com/LabKey/biologics/pull/1970
- https://github.com/LabKey/sampleManagement/pull/1644

#### Changes
- Update tests
- Do not display counts if they may be incorrect (user must be app admin, not just project or folder admin)
- Update getGroupMembership algorithm
