### PR TITLE
Remove redux-actions dependency

### DIFF
--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -131,7 +131,6 @@ module.exports = {
         'react-test-renderer',
         'react-treebeard',
         'redux',
-        'redux-actions',
         'remirror',
         '@remirror',
         '@remirror/core',

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.303.0-fb-redux-actions.0",
+  "version": "2.304.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.303.0",
+  "version": "2.303.0-fb-redux-actions.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,6 @@
     "react-router": "~3.2.6",
     "react-select": "~5.7.0",
     "react-treebeard": "~3.2.4",
-    "redux-actions": "~2.3.2",
     "vis-network": "~6.5.2"
   },
   "devDependencies": {

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.304.0
+*Released*: 1 March 2023
+* Refactor all reducers declared by this package to no longer utilize `handleActions`.
+* Remove `redux-actions` as a dependency.
+
 ### version 2.303.0
 *Released*: 1 March 2023
 * Migrate inventory.item.volume to exp.materials.storedAmount and inventory.item.volumeUnits to exp.materials.Units

--- a/packages/components/src/internal/app/reducers.ts
+++ b/packages/components/src/internal/app/reducers.ts
@@ -3,7 +3,6 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { Map } from 'immutable';
-import { handleActions } from 'redux-actions';
 import { User } from '../components/base/models/User';
 
 import { ProductMenuModel } from '../components/navigation/model';
@@ -32,105 +31,81 @@ import {
 
 export type AppReducerState = AppModel;
 
-export const AppReducers = handleActions<AppReducerState, any>(
-    {
-        [SET_RELOAD_REQUIRED]: (state: AppReducerState) => state.set('reloadRequired', true),
-
-        [UPDATE_USER]: (state: AppReducerState, action: any) => {
+export function AppReducers(state = new AppModel(), action): AppReducerState {
+    switch (action.type) {
+        case SET_RELOAD_REQUIRED:
+            return state.set('reloadRequired', true) as AppModel;
+        case UPDATE_USER:
+            return state.merge({ user: new User({ ...state.user, ...action.userProps }) }) as AppModel;
+        case UPDATE_USER_DISPLAY_NAME:
+            return state.merge({ user: new User({ ...state.user, displayName: action.displayName }) }) as AppModel;
+        case SECURITY_LOGOUT:
             return state.merge({
-                user: new User({ ...state.user, ...action.userProps }),
-            });
-        },
-
-        [UPDATE_USER_DISPLAY_NAME]: (state: AppReducerState, action: any) => {
-            return state.merge({
-                user: new User({ ...state.user, displayName: action.displayName }),
-            });
-        },
-
-        [SECURITY_LOGOUT]: (state: AppReducerState) => {
-            return state.merge({
-                reloadRequired: true,
                 logoutReason: LogoutReason.SERVER_LOGOUT,
-            });
-        },
-
-        [SECURITY_SESSION_TIMEOUT]: (state: AppReducerState) => {
-            return state.merge({
                 reloadRequired: true,
+            }) as AppModel;
+        case SECURITY_SESSION_TIMEOUT:
+            return state.merge({
                 logoutReason: LogoutReason.SESSION_EXPIRED,
-            });
-        },
-
-        [SECURITY_SERVER_UNAVAILABLE]: (state: AppReducerState) => {
-            return state.merge({
                 reloadRequired: true,
+            }) as AppModel;
+        case SECURITY_SERVER_UNAVAILABLE:
+            return state.merge({
                 logoutReason: LogoutReason.SERVER_UNAVAILABLE,
-            });
-        },
-    },
-    new AppModel()
-);
+                reloadRequired: true,
+            }) as AppModel;
+        default:
+            return state;
+    }
+}
 
 export type RoutingTableState = Map<string, string | boolean>;
 
-export const RoutingTableReducers = handleActions<RoutingTableState, any>(
-    {
-        [ADD_TABLE_ROUTE]: (state: any, action: any) => {
-            const { fromRoute, toRoute } = action;
-
-            return state.set(fromRoute, toRoute) as RoutingTableState;
-        },
-    },
-    Map<string, string | boolean>()
-);
+export function RoutingTableReducers(state = Map<string, string | boolean>(), action): RoutingTableState {
+    switch (action.type) {
+        case ADD_TABLE_ROUTE:
+            return state.set(action.fromRoute, action.toRoute) as RoutingTableState;
+        default:
+            return state;
+    }
+}
 
 export type ProductMenuState = ProductMenuModel;
 
-export const ProductMenuReducers = handleActions<ProductMenuState, any>(
-    {
-        [MENU_INVALIDATE]: () => new ProductMenuModel(),
-
-        [MENU_RELOAD]: (state: ProductMenuState) => state.setNeedsReload(),
-
-        [MENU_LOADING_START]: (state: ProductMenuState, action: any) => {
-            const { currentProductId,  productIds } = action;
-
+export function ProductMenuReducers(state = new ProductMenuModel(), action): ProductMenuState {
+    switch (action.type) {
+        case MENU_INVALIDATE:
+            return new ProductMenuModel();
+        case MENU_RELOAD:
+            return state.setNeedsReload();
+        case MENU_LOADING_START:
             return state.merge({
-                currentProductId,
-                productIds,
+                currentProductId: action.currentProductId,
                 isLoading: true,
-            });
-        },
-
-        [MENU_LOADING_ERROR]: (state: ProductMenuState, action: any) => {
+                productIds: action.productIds,
+            }) as ProductMenuModel;
+        case MENU_LOADING_ERROR:
             return state.setError(action.message);
-        },
-
-        [MENU_LOADING_END]: (state: ProductMenuState, action: any) => {
+        case MENU_LOADING_END:
             return state.setLoadedSections(action.sections);
-        },
-    },
-    new ProductMenuModel()
-);
+        default:
+            return state;
+    }
+}
 
 export type ServerNotificationState = ServerNotificationModel;
 
-export const ServerNotificationReducers = handleActions<ServerNotificationState, any>(
-    {
-        [SERVER_NOTIFICATIONS_INVALIDATE]: () => new ServerNotificationModel(),
-
-        [SERVER_NOTIFICATIONS_LOADING_START]: (state: ServerNotificationState) => {
+export function ServerNotificationReducers(state = new ServerNotificationModel(), action): ServerNotificationState {
+    switch (action.type) {
+        case SERVER_NOTIFICATIONS_INVALIDATE:
+            return new ServerNotificationModel();
+        case SERVER_NOTIFICATIONS_LOADING_START:
             return state.setLoadingStart();
-        },
-
-        [SERVER_NOTIFICATIONS_LOADING_END]: (state: ServerNotificationState, action: any) => {
+        case SERVER_NOTIFICATIONS_LOADING_END:
             return state.setLoadingComplete(action.serverActivity);
-        },
-
-        [SERVER_NOTIFICATIONS_LOADING_ERROR]: (state: ServerNotificationState, action: any) => {
+        case SERVER_NOTIFICATIONS_LOADING_ERROR:
             return state.setError(action.message);
-        },
-    },
-    new ServerNotificationModel()
-);
+        default:
+            return state;
+    }
+}

--- a/packages/components/src/internal/app/reducers.ts
+++ b/packages/components/src/internal/app/reducers.ts
@@ -3,6 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { Map } from 'immutable';
+
 import { User } from '../components/base/models/User';
 
 import { ProductMenuModel } from '../components/navigation/model';

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -5608,7 +5608,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.15, lodash-es@^4.17.4:
+lodash-es@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -5643,7 +5643,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.0.1, lodash@^4.13.1, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
+lodash@^4.0.1, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6775,21 +6775,6 @@ rechoir@^0.8.0:
   integrity sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==
   dependencies:
     resolve "^1.20.0"
-
-reduce-reducers@^0.1.0:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.5.tgz#ff77ca8068ff41007319b8b4b91533c7e0e54576"
-  integrity sha512-uoVmQnZQ+BtKKDKpBdbBri5SLNyIK9ULZGOA504++VbHcwouWE+fJDIo8AuESPF9/EYSkI0v05LDEQK6stCbTA==
-
-redux-actions@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/redux-actions/-/redux-actions-2.3.2.tgz#b93cf1585c7d8d1b15800d093427c9d75c53222f"
-  integrity sha512-PPclrJFIbDzD48oNj46biisg34NTtb1VxP9MTTAxsgIFuV4mEe5UXLRNBwyqrlXrMQHUbmpnjJupxocS4mxpvA==
-  dependencies:
-    invariant "^2.2.1"
-    lodash "^4.13.1"
-    lodash-es "^4.17.4"
-    reduce-reducers "^0.1.0"
 
 redux@^4.0.0, redux@^4.0.4:
   version "4.2.0"


### PR DESCRIPTION
#### Rationale
This removes our dependency on `redux-actions` by refactoring away our usages of `handleActions`. While arguably useful when using redux it is unnecessary for us to continue to need these helpers as we continue to migrate away from redux.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1128
- https://github.com/LabKey/labkey-ui-premium/pull/56
- https://github.com/LabKey/biologics/pull/1971
- https://github.com/LabKey/sampleManagement/pull/1645
- https://github.com/LabKey/inventory/pull/755

#### Changes
- Refactor all reducers declared by this package to no longer utilize `handleActions`. 
- Remove `redux-actions` as a dependency.
- Update `@labkey/build` to no longer specify `redux-actions` as an external package we utilize. Note, I'm not rev'ing @labkey/build with this set of PRs and will defer this change coming through to the next published version.
