### PR TITLE
Issue 47202: Options to reduce payload of getContainers.api response

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
+    "@labkey/api": "1.18.8",
     "bootstrap": "~3.4.1",
     "classnames": "~2.3.2",
     "enzyme": "~3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.18.7",
+    "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
     "bootstrap": "~3.4.1",
     "classnames": "~2.3.2",
     "enzyme": "~3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.302.0-fb-47202-getContainersAPIOptions.0",
+  "version": "2.302.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.302.0",
+  "version": "2.302.0-fb-47202-getContainersAPIOptions.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,6 +3,11 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.302.0
 *Released*: 28 February 2023
+- Issue 47202: Options to reduce payload of getContainers.api response
+  - Field editor only needs the base set of container info for lookups so use new props to reduce response object size (includeWorkbookChildren and includeStandardProperties)
+
+### version 2.302.0
+*Released*: 28 February 2023
 - SampleStatusTag to query for status type if not provided
 - getSampleStatuses() boolean property for whether API should include inUse information or not
 - Issue 47411: Include viewName in selectDistinct query for FilterFacetedSelector

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.302.0
-*Released*: 28 February 2023
+### version 2.302.1
+*Released*: 02 March 2023
 - Issue 47202: Options to reduce payload of getContainers.api response
   - Field editor only needs the base set of container info for lookups so use new props to reduce response object size (includeWorkbookChildren and includeStandardProperties)
 

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -112,6 +112,8 @@ export function fetchContainers(): Promise<List<Container>> {
                     containerPath: '/',
                     includeSubfolders: true,
                     includeEffectivePermissions: false,
+                    includeWorkbookChildren: false,
+                    includeStandardProperties: false,
                     success,
                 });
             })

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1506,10 +1506,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.18.7":
-  version "1.18.7"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7.tgz#6de906de8a49fa5baf978ddd18a5d1da74b10611"
-  integrity sha512-MNSiG2xz5RzDKtucXBo5QMsToa8wxVWZc08Leh4mK+e9AhP/Tq7CKOs/+1wZS/mAetbWwB3fBnrMRkeo9relXg==
+"@labkey/api@1.18.7-fb-47202-getContainersAPIOptions.0":
+  version "1.18.7-fb-47202-getContainersAPIOptions.0"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7-fb-47202-getContainersAPIOptions.0.tgz#b34bcc60508c4f9b134b3c6444712e6014326d8f"
+  integrity sha512-CFRi+gnkAzt7J6vWaRtWzPP5sWAKYZubZsqTTj9Mdp9j1+l/VFUO2d9ypAvirWCiFXYzjZUCH1PrvLP7Nsowww==
 
 "@labkey/build@6.9.0":
   version "6.9.0"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1506,10 +1506,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.18.7-fb-47202-getContainersAPIOptions.0":
-  version "1.18.7-fb-47202-getContainersAPIOptions.0"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7-fb-47202-getContainersAPIOptions.0.tgz#b34bcc60508c4f9b134b3c6444712e6014326d8f"
-  integrity sha512-CFRi+gnkAzt7J6vWaRtWzPP5sWAKYZubZsqTTj9Mdp9j1+l/VFUO2d9ypAvirWCiFXYzjZUCH1PrvLP7Nsowww==
+"@labkey/api@1.18.8":
+  version "1.18.8"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz#e7d94c3a1056e8841380f9e7ddbd39568739752c"
+  integrity sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA==
 
 "@labkey/build@6.9.0":
   version "6.9.0"


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47202

The field editor only needs the base set of container info for lookups so use new props to reduce response object size (includeWorkbookChildren and includeStandardProperties).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4159

#### Changes
- update @labkey/api package version
- set includeWorkbookChildren and includeStandardProperties false in getContainers() call from field editor
