### PR TITLE
Issue 47084: App Sample type grids issue the query for the grid twice

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.304.0-fb-misc234Cory.0",
+  "version": "2.304.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.304.0",
+  "version": "2.304.0-fb-misc234Cory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD March 2023
+* Issue 47084: App Sample type grids issue the query for the grid twice
+
 ### version 2.304.0
 *Released*: 1 March 2023
 * Refactor all reducers declared by this package to no longer utilize `handleActions`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD March 2023
+### version 2.304.1
+*Released*: 3 March 2023
 * Issue 47084: App Sample type grids issue the query for the grid twice
 
 ### version 2.304.0

--- a/packages/components/src/entities/SampleListingPage.spec.tsx
+++ b/packages/components/src/entities/SampleListingPage.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { MenuItem } from 'react-bootstrap';
 import { ReactWrapper } from 'enzyme';
 import { PermissionTypes } from '@labkey/api';
-import { List } from 'immutable';
 
 import { makeTestActions, makeTestQueryModel } from '../public/QueryModel/testUtils';
 import { QueryInfo } from '../public/QueryInfo';
@@ -38,6 +37,8 @@ import { PrintLabelsModal } from '../internal/components/labels/PrintLabelsModal
 import { ColorIcon } from '../internal/components/base/ColorIcon';
 
 import { SampleTypeAppContext } from '../internal/AppContext';
+
+import { getQueryTestAPIWrapper } from '../internal/query/APIWrapper';
 
 import { SampleTypeBasePage } from './SampleTypeBasePage';
 import {
@@ -93,47 +94,34 @@ describe('hasPermissions', () => {
         expect(hasPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert, PermissionTypes.Update])).toBeTruthy();
         expect(hasPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert, PermissionTypes.Update], false)).toBeTruthy();
         expect(
-            hasPermissions(
-                TEST_USER_EDITOR,
-                [PermissionTypes.Insert, PermissionTypes.Update],
-                false,
-                [PermissionTypes.Insert]
-            )
+            hasPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert, PermissionTypes.Update], false, [
+                PermissionTypes.Insert,
+            ])
         ).toBeTruthy();
     });
 
     test('shared container', () => {
         expect(
-            hasPermissions(
-                TEST_USER_AUTHOR,
-                [PermissionTypes.Insert, PermissionTypes.Update],
-                true,
-                [PermissionTypes.Insert]
-            )
+            hasPermissions(TEST_USER_AUTHOR, [PermissionTypes.Insert, PermissionTypes.Update], true, [
+                PermissionTypes.Insert,
+            ])
         ).toBeFalsy();
         expect(
-            hasPermissions(
-                TEST_USER_AUTHOR,
-                [PermissionTypes.Insert, PermissionTypes.Update],
-                true,
-                [PermissionTypes.Insert, PermissionTypes.Update]
-            )
+            hasPermissions(TEST_USER_AUTHOR, [PermissionTypes.Insert, PermissionTypes.Update], true, [
+                PermissionTypes.Insert,
+                PermissionTypes.Update,
+            ])
         ).toBeTruthy();
         expect(
-            hasPermissions(
-                TEST_USER_EDITOR,
-                [PermissionTypes.Insert, PermissionTypes.Update],
-                true,
-                [PermissionTypes.Insert]
-            )
+            hasPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert, PermissionTypes.Update], true, [
+                PermissionTypes.Insert,
+            ])
         ).toBeFalsy();
         expect(
-            hasPermissions(
-                TEST_USER_EDITOR,
-                [PermissionTypes.Insert, PermissionTypes.Update],
-                true,
-                [PermissionTypes.Insert, PermissionTypes.Update]
-            )
+            hasPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert, PermissionTypes.Update], true, [
+                PermissionTypes.Insert,
+                PermissionTypes.Update,
+            ])
         ).toBeTruthy();
         expect(hasPermissions(TEST_USER_EDITOR, [PermissionTypes.Insert, PermissionTypes.Update], true)).toBeFalsy();
     });
@@ -216,7 +204,15 @@ describe('SampleListingPageBody', () => {
                 {...getDefaultProps()}
                 queryModels={{ 'samples-listing': queryModel, 'samples-details': QUERY_MODEL }}
             />,
-            { api: API_APP_CONTEXT, sampleType: SAMPLE_TYPE_APP_CONTEXT },
+            {
+                api: {
+                    ...API_APP_CONTEXT,
+                    query: getQueryTestAPIWrapper(jest.fn, {
+                        getQueryDetails: () => Promise.resolve(new QueryInfo({ title: 'Test title' })),
+                    }),
+                },
+                sampleType: SAMPLE_TYPE_APP_CONTEXT,
+            },
             DEFAULT_CONTEXT
         );
         await waitForLifecycle(wrapper, 100);


### PR DESCRIPTION
#### Rationale
Issue [47084](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47084): App Sample type grids issue the query for the grid twice

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1131
- https://github.com/LabKey/labkey-ui-premium/pull/59
- https://github.com/LabKey/sampleManagement/pull/1649
- https://github.com/LabKey/biologics/pull/1979
- https://github.com/LabKey/inventory/pull/759 

#### Changes
- SampleListingPage.tsx update to not require QueryModel to load so that the component can get the queryInfo (load it separately)
