### PR TITLE
Issue 47224: Refactor `SamplesDeriveButton` to reduce redundant calls and not make unnecessary, expensive calls

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.304.2-deriveSamplesMenu.0",
+  "version": "2.304.2-deriveSamplesMenu.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.304.2-deriveSamplesMenu.1",
+  "version": "2.304.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.304.0",
+  "version": "2.304.1-deriveSamplesMenu.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### verstion TBD
+*Released*: TBD
+* Issue 47224: Refactor `SamplesDeriveButton` to reduce redundant calls and not make unnecessary, expensive calls
+
 ### version 2.304.0
 *Released*: 1 March 2023
 * Refactor all reducers declared by this package to no longer utilize `handleActions`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### verstion TBD
-*Released*: TBD
+### verstion 2.304.2
+*Released*: 3 March 2023
 * Issue 47224: Refactor `SamplesDeriveButton` to reduce redundant calls and not make unnecessary, expensive calls
 
 ### version 2.304.1

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -88,6 +88,8 @@ export const INVENTORY = {
         'StorageLocation',
         'StorageRow',
         'StorageCol',
+        'StoredAmount',
+        'Units',
         'FreezeThawCount',
         'EnteredStorage',
         'CheckedOut',


### PR DESCRIPTION
#### Rationale
The `SamplesDeriveButton` uses three instances of `CreateSamplesSubMenu`. Within each of these instances, we had been making the same call to get the selected data, and doing that even in the case when we wouldn't allow further action because there were too many items selected. This PR pulls the collection of that data into the `SamplesDeriveButton`, where it can be queried for only once, and prevents making the query if there are too many items selected.

There may still be other optimizations needed for cases where we need the selected data outside of the CreateSamplesSubMenu, but this is at least a small improvement.

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/1651
- https://github.com/LabKey/biologics/pull/1980
- https://github.com/LabKey/inventory/pull/760

#### Changes
- Move call to `getSelectedData` from `CreaseSamplesSubMenuBase` into `SamplesDeriveButton`.
