### PR TITLE
Issues 47127, 47333, 73479: Miscellaneous fixes for 23.4

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.305.1-miscFixes234-susan.2",
+  "version": "2.305.1-miscFixes234-susan.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.304.3-miscFixes234-susan.0",
+  "version": "2.304.3-miscFixes234-susan.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.305.1-miscFixes234-susan.3",
+  "version": "2.306.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.304.2",
+  "version": "2.304.3-miscFixes234-susan.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version  2.306.0
+*Released*: 7 March 2023
 * Issue 47127: Update wording for delete reply menu item and use title casing
 * Issue 47333: When editing items individually is not possible, remove that tab
 * Remove extraneous columns from inventory columns

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### verstion 2.304.2
+### version TBD
+*Released*: TBD
+* Issue 47127: Update wording for delete reply menu item and use title casing
+* Issue 47333: When editing items individually is not possible, remove that tab
+* Remove extraneous columns from inventory columns
+* add `smaller-font` utility class
+
+### version 2.304.2
 *Released*: 3 March 2023
 * Issue 47224: Refactor `SamplesDeriveButton` to reduce redundant calls and not make unnecessary, expensive calls
 

--- a/packages/components/src/internal/announcements/ThreadBlock.tsx
+++ b/packages/components/src/internal/announcements/ThreadBlock.tsx
@@ -45,16 +45,43 @@ const DeleteThreadModal: FC<DeleteThreadModalProps> = ({ cancel, onDelete }) => 
     </Modal>
 );
 
+const DeleteReplyModal: FC<DeleteThreadModalProps> = ({ cancel, onDelete }) => (
+    <Modal show onHide={cancel} className="delete-thread-modal">
+        <Modal.Header>
+            <Modal.Title>Delete This Reply?</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+            Are you sure you want to delete this reply?
+        </Modal.Body>
+
+        <Modal.Footer>
+            <div className="pull-left">
+                <button className="btn btn-default" onClick={cancel}>
+                    Cancel
+                </button>
+            </div>
+
+            <div className="pull-right">
+                <button className="btn btn-danger delete-thread-modal__confirm" onClick={onDelete}>
+                    Yes, Delete Reply
+                </button>
+            </div>
+        </Modal.Footer>
+    </Modal>
+);
+
 interface ThreadBlockHeaderProps {
     author: User;
     created: number | string;
     modified: number | string;
+    isThread?: boolean;
     onDelete?: () => void;
     onEdit?: () => void;
 }
 
 const ThreadBlockHeader: FC<ThreadBlockHeaderProps> = props => {
-    const { created, modified, onDelete, onEdit, author } = props;
+    const { created, modified, onDelete, onEdit, author, isThread } = props;
     const [showDeleteModal, setShowDeleteModal] = useState(false);
 
     const formattedCreate = useMemo(() => moment(created).fromNow(), [created]);
@@ -88,19 +115,20 @@ const ThreadBlockHeader: FC<ThreadBlockHeaderProps> = props => {
                         <Dropdown.Menu className="pull-right">
                             {onEdit !== undefined && (
                                 <MenuItem className="thread-block-header__menu-edit" onClick={onEdit}>
-                                    Edit comment
+                                    Edit Comment
                                 </MenuItem>
                             )}
                             {onDelete !== undefined && (
                                 <MenuItem className="thread-block-header__menu-delete" onClick={onShowDelete}>
-                                    Delete thread
+                                    Delete {isThread ? 'Thread' : 'Reply'}
                                 </MenuItem>
                             )}
                         </Dropdown.Menu>
                     </Dropdown>
                 )}
             </div>
-            {showDeleteModal && <DeleteThreadModal cancel={onCancelDelete} onDelete={onDelete} />}
+            {showDeleteModal && isThread && <DeleteThreadModal cancel={onCancelDelete} onDelete={onDelete} />}
+            {showDeleteModal && !isThread && <DeleteReplyModal cancel={onCancelDelete} onDelete={onDelete} />}
         </div>
     );
 };
@@ -198,6 +226,7 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
                             onDelete={allowDelete ? onDeleteThread : undefined}
                             onEdit={allowUpdate ? onEdit : undefined}
                             author={thread.author}
+                            isThread={!thread.parent}
                         />
                         {error !== undefined && <Alert>{error}</Alert>}
                         <div className="thread-block-body__content" dangerouslySetInnerHTML={threadBody} />

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1383,8 +1383,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
         if (showAsTab) {
             const bulkDisabled = selected.size === 0;
-            // const gridDisabled = editorModel.rowCount > maxRows;
-            const gridDisabled = true;
+            const showGrid = editorModel.rowCount > maxRows;
 
             return (
                 <>
@@ -1398,7 +1397,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                                         Edit in Bulk
                                     </NavItem>
                                 )}
-                                {!gridDisabled && (
+                                {!showGrid && (
                                     <NavItem eventKey={EditableGridTabs.Grid}>
                                         Edit Individually
                                     </NavItem>

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1383,7 +1383,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
         if (showAsTab) {
             const bulkDisabled = selected.size === 0;
-            const gridDisabled = editorModel.rowCount > maxRows;
+            // const gridDisabled = editorModel.rowCount > maxRows;
+            const gridDisabled = true;
 
             return (
                 <>
@@ -1397,9 +1398,11 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                                         Edit in Bulk
                                     </NavItem>
                                 )}
-                                <NavItem disabled={gridDisabled} eventKey={EditableGridTabs.Grid}>
-                                    Edit Individually
-                                </NavItem>
+                                {!gridDisabled && (
+                                    <NavItem eventKey={EditableGridTabs.Grid}>
+                                        Edit Individually
+                                    </NavItem>
+                                )}
                             </Nav>
                             <Alert>{error}</Alert>
                             <Tab.Content className="top-spacing">

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1383,7 +1383,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
         if (showAsTab) {
             const bulkDisabled = selected.size === 0;
-            const showGrid = editorModel.rowCount > maxRows;
+            const showGrid = editorModel.rowCount <= maxRows;
 
             return (
                 <>
@@ -1397,7 +1397,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                                         Edit in Bulk
                                     </NavItem>
                                 )}
-                                {!showGrid && (
+                                {showGrid && (
                                     <NavItem eventKey={EditableGridTabs.Grid}>
                                         Edit Individually
                                     </NavItem>

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -88,8 +88,6 @@ export const INVENTORY = {
         'StorageLocation',
         'StorageRow',
         'StorageCol',
-        'StoredAmount',
-        'Units',
         'FreezeThawCount',
         'EnteredStorage',
         'CheckedOut',

--- a/packages/components/src/theme/section.scss
+++ b/packages/components/src/theme/section.scss
@@ -96,3 +96,7 @@
 .pointer {
     cursor: pointer;
 }
+
+.smaller-font {
+    font-size: 85%;
+}


### PR DESCRIPTION
#### Rationale
[Issue 47127](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47127): LKSM: "Delete thread" button on replies is misleading
[Issue 47333](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47333): When adding > 1000 samples to storage across multiple containers, the "Edit Individually" tab should be removed or have hover text
[Issue 43479](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43479):  Storage Unit / Overview tab does not show Storage Unit type

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/60
- https://github.com/LabKey/biologics/pull/1987
- https://github.com/LabKey/labbook/pull/436
- https://github.com/LabKey/sampleManagement/pull/1661
- https://github.com/LabKey/inventory/pull/767

#### Changes
* Issue 47127: Update wording for delete reply menu item and use title casing
* Issue 47333: When editing items individually is not possible, remove that tab
* Remove extraneous columns from inventory columns
* add `smaller-font` utility class
