### PR TITLE
Issue 47229: Support all characters within aliases

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.313.0",
+  "version": "2.313.0-fb-alias-47229.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.313.0-fb-alias-47229.0",
+  "version": "2.313.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.313.1
+*Released*: 23 March 2023
+* Issue 47229: Support all characters within aliases
+
 ### version 2.313.0
 *Released*: 23 March 2023
 * Issue 47503: Sample Manager: Sample Finder not working for sample type with double quotes in name

--- a/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
@@ -39,4 +39,18 @@ describe('AliasInput', () => {
         expect(resolveFormValue([])).toEqual([]);
         expect(resolveFormValue([{ value: 'x', label: 'y' }])).toEqual(['y']);
     });
+
+    test('isValidNewOption', () => {
+        const wrapper = shallow(<AliasSelectInput col={aliasColumn} />);
+        const isValidNewOption = wrapper.find(SelectInput).prop('isValidNewOption');
+
+        expect(isValidNewOption(undefined)).toBe(false);
+        expect(isValidNewOption('')).toBe(false);
+        expect(isValidNewOption(' ')).toBe(false);
+        expect(isValidNewOption('a')).toBe(true);
+        expect(isValidNewOption('a ')).toBe(true);
+        expect(isValidNewOption('a b')).toBe(true);
+        expect(isValidNewOption('a,b')).toBe(true);
+        expect(isValidNewOption(' a, b')).toBe(true);
+    });
 });

--- a/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.spec.tsx
@@ -39,18 +39,4 @@ describe('AliasInput', () => {
         expect(resolveFormValue([])).toEqual([]);
         expect(resolveFormValue([{ value: 'x', label: 'y' }])).toEqual(['y']);
     });
-
-    test('isValidNewOption', () => {
-        const wrapper = shallow(<AliasSelectInput col={aliasColumn} />);
-        const isValidNewOption = wrapper.find(SelectInput).prop('isValidNewOption');
-
-        expect(isValidNewOption(undefined)).toBe(false);
-        expect(isValidNewOption('')).toBe(false);
-        expect(isValidNewOption(' ')).toBe(false);
-        expect(isValidNewOption('a')).toBe(true);
-        expect(isValidNewOption('a ')).toBe(true);
-        expect(isValidNewOption('a b')).toBe(true);
-        expect(isValidNewOption('a,b')).toBe(false);
-        expect(isValidNewOption(' a, b')).toBe(false);
-    });
 });

--- a/packages/components/src/internal/components/forms/input/AliasInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useMemo, useState } from 'react';
+import React, { FC, memo, useCallback, useMemo } from 'react';
 import { Map } from 'immutable';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
@@ -15,26 +15,7 @@ interface Props extends Omit<SelectInputProps, 'loadOptions' | 'options' | 'reso
 
 export const AliasSelectInput: FC<Props> = memo(props => {
     const { col, data, ...selectProps } = props;
-    const [containsCommas, setContainsComma] = useState<boolean>();
     const generatedId = useMemo(() => generateId(), []);
-
-    // Issue 45729: Inform user that commas are not supported for values in the alias field.
-    const isValidNewOption = useCallback((inputValue: string) => {
-        const isEmpty = inputValue?.trim().length === 0;
-        const _containsComma = inputValue?.indexOf(',') > -1;
-        setContainsComma(_containsComma);
-
-        // Empty string is considered invalid. This matches default react-select behavior.
-        return !!inputValue && !isEmpty && !_containsComma;
-    }, []);
-
-    // Here we utilize the noResultsText to display a validation message.
-    const noResultsText = useMemo(() => {
-        if (containsCommas) {
-            return <span className="has-error">Aliases cannot include the "," character</span>;
-        }
-        return 'Enter alias name(s)';
-    }, [containsCommas]);
 
     // AliasInput supplies its own formValue resolution
     // - The value is mapped from the "label"
@@ -57,10 +38,8 @@ export const AliasSelectInput: FC<Props> = memo(props => {
         <SelectInput
             description={col.description}
             id={generatedId}
-            isValidNewOption={isValidNewOption}
             label={col.caption}
             name={col.fieldKey}
-            noResultsText={noResultsText}
             required={col.required}
             {...selectProps}
             resolveFormValue={resolveFormValue}
@@ -80,7 +59,7 @@ AliasSelectInput.defaultProps = {
     showLabel: true,
 };
 
-AliasSelectInput.displayName = 'AliasInput';
+AliasSelectInput.displayName = 'AliasSelectInput';
 
 export const AliasInput: FC<InputRendererProps> = memo(props => {
     const {
@@ -107,3 +86,5 @@ export const AliasInput: FC<InputRendererProps> = memo(props => {
         />
     );
 });
+
+AliasInput.displayName = 'AliasInput';

--- a/packages/components/src/internal/components/forms/input/AliasInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.tsx
@@ -17,6 +17,12 @@ export const AliasSelectInput: FC<Props> = memo(props => {
     const { col, data, ...selectProps } = props;
     const generatedId = useMemo(() => generateId(), []);
 
+    const isValidNewOption = useCallback((inputValue: string) => {
+        const isEmpty = inputValue?.trim().length === 0;
+        // Empty string is considered invalid. This matches default react-select behavior.
+        return !!inputValue && !isEmpty;
+    }, []);
+
     // AliasInput supplies its own formValue resolution
     // - The value is mapped from the "label"
     // - When empty the server expects an empty Array and not undefined/null
@@ -38,8 +44,10 @@ export const AliasSelectInput: FC<Props> = memo(props => {
         <SelectInput
             description={col.description}
             id={generatedId}
+            isValidNewOption={isValidNewOption}
             label={col.caption}
             name={col.fieldKey}
+            noResultsText="Enter alias name(s)"
             required={col.required}
             {...selectProps}
             resolveFormValue={resolveFormValue}


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47229](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47229) by removing the client-side messaging around the comma character not being supported by the Alias field (see [Issue 45729](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45729)). They are now supported with the associated changes on the servers-side.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4217
* https://github.com/LabKey/labkey-ui-components/pull/1145
* https://github.com/LabKey/biologics/pull/2017
* https://github.com/LabKey/sampleManagement/pull/1697
* https://github.com/LabKey/inventory/pull/782

#### Changes
- Remove check for the `,` character in Alias field values.
- Results in a simplified `noResultsText` prop.
