### PR TITLE
Sample aliquots panel should not show "Assay Data with Aliquots" when isAssayEnabled false

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.312.0",
+  "version": "2.312.0-fb-sampleAliquotStarterFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.314.0",
+  "version": "2.314.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD March 2023
+### version 2.314.1
+*Released*: 24 March 2023
 * Sample aliquots panel should not show "Assay Data with Aliquots" when isAssayEnabled false
 
 ### version 2.314.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD March 2023
+* Sample aliquots panel should not show "Assay Data with Aliquots" when isAssayEnabled false
+
 ### version 2.312.0
 *Released*: 21 March 2023
 * Sample assay grid and aliquot summary to only query for data from assays that have data for that sample/aliquot ID set

--- a/packages/components/src/entities/SampleAliquotAssaysCount.tsx
+++ b/packages/components/src/entities/SampleAliquotAssaysCount.tsx
@@ -44,17 +44,22 @@ interface Props {
 const SampleAliquotAssaysCountImpl: FC<Props & InjectedAssayModel> = props => {
     const { assayModel, sampleId, sampleSchemaQuery, aliquotIds, api } = props;
     const [distinctAssays, setDistinctAssays] = useState<string[]>();
+    const [loadingDistinctAssays, setLoadingDistinctAssays] = useState<boolean>(true);
     const loadingDefinitions = isLoading(assayModel.definitionsLoadingState);
 
     useEffect(() => {
         (async () => {
-            const distinctAssays_ = await api.samples.getDistinctAssaysPerSample(aliquotIds);
-            setDistinctAssays(distinctAssays_);
+            try {
+                const distinctAssays_ = await api.samples.getDistinctAssaysPerSample(aliquotIds);
+                setDistinctAssays(distinctAssays_);
+            } finally {
+                setLoadingDistinctAssays(false);
+            }
         })();
     }, [aliquotIds, api.samples]);
 
     const queryConfigs = useMemo(() => {
-        if (loadingDefinitions || !distinctAssays) {
+        if (loadingDefinitions || loadingDistinctAssays) {
             return;
         }
 
@@ -73,9 +78,17 @@ const SampleAliquotAssaysCountImpl: FC<Props & InjectedAssayModel> = props => {
             configs[modelId] = config;
             return configs;
         }, {});
-    }, [loadingDefinitions, aliquotIds, assayModel, sampleId, sampleSchemaQuery, distinctAssays]);
+    }, [
+        loadingDefinitions,
+        loadingDistinctAssays,
+        assayModel,
+        aliquotIds,
+        sampleId,
+        sampleSchemaQuery,
+        distinctAssays,
+    ]);
 
-    if (loadingDefinitions || !queryConfigs) {
+    if (loadingDefinitions || loadingDistinctAssays) {
         return <LoadingSpinner msg="" />;
     }
 

--- a/packages/components/src/entities/SampleAliquotsSummary.spec.tsx
+++ b/packages/components/src/entities/SampleAliquotsSummary.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { ReactWrapper } from 'enzyme';
 
 import { makeTestQueryModel } from '../public/QueryModel/testUtils';
 import { SchemaQuery } from '../public/SchemaQuery';
@@ -8,7 +8,11 @@ import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 
 import { QueryModel } from '../public/QueryModel/QueryModel';
 
+import { mountWithServerContext } from '../internal/testHelpers';
+import { TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT, TEST_LKSM_STARTER_MODULE_CONTEXT } from '../internal/productFixtures';
+
 import { SampleAliquotsSummaryWithModels, SampleAliquotsSummaryWithModelsProps } from './SampleAliquotsSummary';
+import { SampleAliquotAssaysCount } from './SampleAliquotAssaysCount';
 
 const noAliquotVolume = {
     AliquotVolume: {
@@ -52,7 +56,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     }
 
     function validateStats(
-        wrapper: ShallowWrapper,
+        wrapper: ReactWrapper,
         loading = false,
         empty?: boolean,
         totalAliquots?: number,
@@ -67,7 +71,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
         if (empty) return;
 
         const stats = wrapper.find('.aliquot-stats-value');
-        expect(stats).toHaveLength(5);
+        expect(stats).toHaveLength(4);
         expect(stats.at(0).text()).toBe(totalAliquots + '');
         expect(stats.at(1).text()).toBe(availableCount + '/' + totalAliquots);
         expect(stats.at(2).text()).toBe(totalVolume);
@@ -75,14 +79,17 @@ describe('SampleAliquotsSummaryWithModels', () => {
     }
 
     test('no aliquots present', () => {
-        const wrapper = shallow(<SampleAliquotsSummaryWithModels {...defaultProps()} sampleRow={noAliquotVolume} />);
+        const wrapper = mountWithServerContext(
+            <SampleAliquotsSummaryWithModels {...defaultProps()} sampleRow={noAliquotVolume} />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
+        );
 
         validateStats(wrapper, false, true);
         wrapper.unmount();
     });
 
     test('has single aliquot, not in storage, not added to job', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={zeroAliquotVolume}
@@ -93,7 +100,8 @@ describe('SampleAliquotsSummaryWithModels', () => {
                         Units: { value: null },
                     },
                 })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 1, 0, '0', 0);
@@ -101,7 +109,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     });
 
     test('has single aliquot, in storage, no volume, added to job', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={zeroAliquotVolume}
@@ -113,7 +121,8 @@ describe('SampleAliquotsSummaryWithModels', () => {
                     },
                 })}
                 jobsModel={getQueryModelFromRows({ 1: { RowId: { value: 1 } } })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 1, 1, '0', 1);
@@ -121,7 +130,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     });
 
     test('has single aliquot, in storage, without amount, but with unit', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={{
@@ -140,7 +149,8 @@ describe('SampleAliquotsSummaryWithModels', () => {
                     },
                 })}
                 jobsModel={getQueryModelFromRows({ 1: { RowId: { value: 1 } } })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 1, 1, '0 g', 1);
@@ -148,7 +158,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     });
 
     test('has single aliquot, in storage, with amount, but without unit', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={{
@@ -167,7 +177,8 @@ describe('SampleAliquotsSummaryWithModels', () => {
                     },
                 })}
                 jobsModel={getQueryModelFromRows({ 1: { RowId: { value: 1 } } })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 1, 1, '100.1', 1);
@@ -175,7 +186,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     });
 
     test('has multiple aliquots, some storage, without unit, some has jobs', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={{
@@ -211,7 +222,8 @@ describe('SampleAliquotsSummaryWithModels', () => {
                         RowId: { value: 3 },
                     },
                 })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 3, 2, '150.6', 2);
@@ -219,7 +231,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     });
 
     test('has multiple aliquots, some storage, with same unit', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={{
@@ -247,7 +259,8 @@ describe('SampleAliquotsSummaryWithModels', () => {
                         Units: { value: 'mL' },
                     },
                 })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 3, 2, '150.6 mL', 0);
@@ -255,7 +268,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     });
 
     test('has multiple aliquots, some storage, with different unit', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={{
@@ -283,7 +296,8 @@ describe('SampleAliquotsSummaryWithModels', () => {
                         Units: { value: 'L' },
                     },
                 })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 3, 2, '50,600.1 mL', 0);
@@ -291,7 +305,7 @@ describe('SampleAliquotsSummaryWithModels', () => {
     });
 
     test('has multiple aliquots, all in storage, but some are checked out', () => {
-        const wrapper = shallow(
+        const wrapper = mountWithServerContext(
             <SampleAliquotsSummaryWithModels
                 {...defaultProps()}
                 sampleRow={{
@@ -327,10 +341,43 @@ describe('SampleAliquotsSummaryWithModels', () => {
                         RowId: { value: 3 },
                     },
                 })}
-            />
+            />,
+            { moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT }
         );
 
         validateStats(wrapper, false, false, 3, 2, '1,100.1 mL', 2);
+        wrapper.unmount();
+    });
+
+    test('LKSM professional should show assay count', () => {
+        const wrapper = mountWithServerContext(
+            <SampleAliquotsSummaryWithModels
+                {...defaultProps()}
+                sampleRow={zeroAliquotVolume}
+                aliquotsModel={getQueryModelFromRows({
+                    1: {
+                        StorageStatus: { value: 'Not in storage' },
+                        StoredAmount: { value: null },
+                        Units: { value: null },
+                    },
+                })}
+            />,
+            { moduleContext: TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT }
+        );
+
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
+        expect(wrapper.find('.sample-aliquots-stats-empty')).toHaveLength(0);
+        expect(wrapper.find('.sample-aliquots-stats-table')).toHaveLength(1);
+        expect(wrapper.find(SampleAliquotAssaysCount)).toHaveLength(1);
+
+        const tableRows = wrapper.find('.sample-aliquots-stats-table tr');
+        expect(tableRows).toHaveLength(5);
+        expect(tableRows.at(4).text()).toBe('Assay Data with Aliquots ');
+
+        expect(wrapper.find('.aliquot-stats-value a').last().prop('href')).toBe(
+            '#/samples/dirt/86873/Assays?sampleAliquotType=aliquots'
+        );
+
         wrapper.unmount();
     });
 });

--- a/packages/components/src/entities/SampleAliquotsSummary.tsx
+++ b/packages/components/src/entities/SampleAliquotsSummary.tsx
@@ -17,6 +17,9 @@ import { ALIQUOT_FILTER_MODE } from '../internal/components/samples/constants';
 import { SampleAliquotsStats } from '../internal/components/samples/models';
 import { getSampleAliquotsQueryConfig, getSampleAliquotsStats } from '../internal/components/samples/actions';
 
+import { isAssayEnabled } from '../internal/app/utils';
+import { useServerContext } from '../internal/components/base/ServerContext';
+
 import { SampleAliquotAssaysCount } from './SampleAliquotAssaysCount';
 
 interface OwnProps {
@@ -35,8 +38,9 @@ export interface SampleAliquotsSummaryWithModelsProps extends OwnProps {
 // exported for jest testing
 export const SampleAliquotsSummaryWithModels: FC<SampleAliquotsSummaryWithModelsProps> = memo(props => {
     const { aliquotsModel, jobsModel, sampleSchemaQuery, sampleSet, sampleId, sampleRow } = props;
-    let stats: SampleAliquotsStats;
+    const { moduleContext } = useServerContext();
 
+    let stats: SampleAliquotsStats;
     if (aliquotsModel.rowCount > 0) {
         stats = getSampleAliquotsStats(aliquotsModel.rows);
         if (jobsModel) {
@@ -89,18 +93,20 @@ export const SampleAliquotsSummaryWithModels: FC<SampleAliquotsSummaryWithModels
                                 <a href={jobUrl}>{stats.jobsCount}</a>
                             </td>
                         </tr>
-                        <tr>
-                            <td>Assay Data with Aliquots</td>
-                            <td className="aliquot-stats-value">
-                                <a href={assayDataUrl}>
-                                    <SampleAliquotAssaysCount
-                                        aliquotIds={stats.aliquotIds}
-                                        sampleSchemaQuery={sampleSchemaQuery}
-                                        sampleId={sampleId}
-                                    />
-                                </a>
-                            </td>
-                        </tr>
+                        {isAssayEnabled(moduleContext) && (
+                            <tr>
+                                <td>Assay Data with Aliquots</td>
+                                <td className="aliquot-stats-value">
+                                    <a href={assayDataUrl}>
+                                        <SampleAliquotAssaysCount
+                                            aliquotIds={stats.aliquotIds}
+                                            sampleSchemaQuery={sampleSchemaQuery}
+                                            sampleId={sampleId}
+                                        />
+                                    </a>
+                                </td>
+                            </tr>
+                        )}
                     </tbody>
                 </table>
             )}


### PR DESCRIPTION
#### Rationale
Recent changes to the sample assay QueryModel loading exposed an issue where the sample Aliquots panel was showing the "Assay Data with Aliquots" stat for SM Starter where isAssayEnabled is false. This PR adds that isAssayEnabled check to that panel and also adds a try/catch for the related component.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1146
- https://github.com/LabKey/biologics/pull/2020
- https://github.com/LabKey/sampleManagement/pull/1699
- https://github.com/LabKey/inventory/pull/784

#### Changes
- add check for isAssayEnabled for "Assay Data with Aliquots" stat
- add try/finally for SampleAliquotAssaysCount data loading
