### PR TITLE
Inherit sample statuses from higher in the hierarchy

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.314.2-sampleStatusInheritance.4",
+  "version": "2.315.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.313.0",
+  "version": "2.313.1-sampleStatusInheritance.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.314.2-sampleStatusInheritance.3",
+  "version": "2.314.2-sampleStatusInheritance.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.314.1-sampleStatusInheritance.1",
+  "version": "2.314.1-sampleStatusInheritance.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.315.0
+*Released*: 27 March 2023
 * Update sample statuses to inherit from the parent and no longer support creation in subfolders
 * Update `ManageSampleStatusesPanel`
   * Display statuses from higher up the hierarchy as locked statuses

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Update sample statuses to inherit from the parent and no longer support creation in subfolders
+* Update `ManageSampleStatusesPanel`
+  * Display statuses from higher up the hierarchy as locked statuses
+  * Don't allow adding new statuses when in sub-folders
 
 ### version 2.314.1
 *Released*: 24 March 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Update sample statuses to inherit from the parent and no longer support creation in subfolders
+
 ### version 2.313.0
 *Released*: 23 March 2023
 * Issue 47503: Sample Manager: Sample Finder not working for sample type with double quotes in name

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -18,6 +18,7 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../../APIWrapper'
 import { LOOKUP_DEFAULT_SIZE } from '../../../constants';
 
 import { InputRendererProps } from './types';
+import { getContainerFilterForLookups } from '../../../query/api';
 
 interface SampleStatusInputProps extends Omit<QuerySelectOwnProps, 'schemaQuery' | 'valueColumn'> {
     api?: ComponentsAPIWrapper;
@@ -112,7 +113,7 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
         <>
             {renderLabelField?.(col)}
             <QuerySelect
-                containerFilter={col.lookup.containerFilter}
+                containerFilter={getContainerFilterForLookups()}
                 containerPath={col.lookup.containerPath}
                 description={col.description}
                 displayColumn={col.lookup.displayColumn}

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, ReactNode, useCallback, useEffect, useState, useMemo } from 'react';
+import React, { FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
     DISCARD_CONSUMED_CHECKBOX_FIELD,
@@ -18,7 +18,7 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../../APIWrapper'
 import { LOOKUP_DEFAULT_SIZE } from '../../../constants';
 
 import { InputRendererProps } from './types';
-import { getContainerFilterForLookups } from '../../../query/api';
+import { getSampleStatusContainerFilter } from '../../samples/utils';
 
 interface SampleStatusInputProps extends Omit<QuerySelectOwnProps, 'schemaQuery' | 'valueColumn'> {
     api?: ComponentsAPIWrapper;
@@ -113,7 +113,7 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
         <>
             {renderLabelField?.(col)}
             <QuerySelect
-                containerFilter={getContainerFilterForLookups()}
+                containerFilter={getSampleStatusContainerFilter()}
                 containerPath={col.lookup.containerPath}
                 description={col.description}
                 displayColumn={col.lookup.displayColumn}

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -282,7 +282,6 @@ interface SampleStatusesListProps {
 // exported for jest testing
 export const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
     const { states, onSelect, selected } = props;
-    const { project } = useServerContext();
 
     return (
         <div className="list-group">
@@ -322,6 +321,8 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
     const addNew = useMemo(() => selected === NEW_STATUS_INDEX, [selected]);
+    const { container } = useServerContext();
+    const showAdd = container.isProject || !isProductProjectsEnabled();
 
     const querySampleStatuses = useCallback(
         (newStatusLabel?: string) => {
@@ -376,7 +377,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                     <div className="row choices-container">
                         <div className="col-lg-4 col-md-6 choices-container-left-panel">
                             <SampleStatusesList states={states} selected={selected} onSelect={onSetSelected} />
-                            <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />
+                            {showAdd && <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />}
                         </div>
                         <div className="col-lg-8 col-md-6">
                             <SampleStatusDetail

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -27,14 +27,13 @@ import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 import { SampleState } from './models';
 import { useServerContext } from '../base/ServerContext';
 import { isProductProjectsEnabled } from '../../app/utils';
+import { getSampleStatusLockedMessage } from './utils';
 
 const TITLE = 'Manage Sample Statuses';
 const STATE_TYPE_SQ = new SchemaQuery('exp', 'SampleStateType');
 const DEFAULT_TYPE_OPTIONS = [{ value: 'Available' }, { value: 'Consumed' }, { value: 'Locked' }];
 const NEW_STATUS_INDEX = -1;
 const SAMPLE_STATUS_LOCKED_TITLE = 'Sample Status Locked';
-const SAMPLE_STATUS_NOT_LOCAL_LOCKED_TIP = 'This sample status can be changed only in the home project ';
-const SAMPLE_STATUS_LOCKED_TIP = 'This sample status cannot change status type or be deleted because it is in use.';
 
 interface SampleStatusDetailProps {
     addNew: boolean;
@@ -43,13 +42,6 @@ interface SampleStatusDetailProps {
     state: SampleState;
 }
 
-const getDisabledMsg = (state: SampleState, saving: boolean, projectName: string) => {
-    if (state?.inUse || saving)
-        return SAMPLE_STATUS_LOCKED_TIP;
-    if (!state?.isLocal)
-        return SAMPLE_STATUS_NOT_LOCAL_LOCKED_TIP + "(" + projectName + "). ";
-    return undefined;
-};
 
 // exported for jest testing
 export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
@@ -176,7 +168,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
     }, [updatedState, onActionComplete]);
 
     const disabledMsg = useMemo( () => {
-        return getDisabledMsg(updatedState, saving, project.name);
+        return getSampleStatusLockedMessage(updatedState, saving, project.name);
     }, [updatedState, saving, project.name]);
 
     return (
@@ -306,7 +298,7 @@ export const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
                         (state.inUse || !state.isLocal) && (
                             <LockIcon
                                 iconCls="pull-right choices-list__locked"
-                                body={getDisabledMsg(state, false, project.name)}
+                                body={getSampleStatusLockedMessage(state, false, project.name)}
                                 id="sample-state-lock-icon"
                                 title={SAMPLE_STATUS_LOCKED_TITLE}
                             />

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -168,7 +168,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
     }, [updatedState, onActionComplete]);
 
     const disabledMsg = useMemo( () => {
-        return getSampleStatusLockedMessage(updatedState, saving, project.name);
+        return getSampleStatusLockedMessage(updatedState, saving);
     }, [updatedState, saving, project.name]);
 
     return (
@@ -298,7 +298,7 @@ export const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
                         (state.inUse || !state.isLocal) && (
                             <LockIcon
                                 iconCls="pull-right choices-list__locked"
-                                body={getSampleStatusLockedMessage(state, false, project.name)}
+                                body={getSampleStatusLockedMessage(state, false)}
                                 id="sample-state-lock-icon"
                                 title={SAMPLE_STATUS_LOCKED_TITLE}
                             />
@@ -322,8 +322,6 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
     const addNew = useMemo(() => selected === NEW_STATUS_INDEX, [selected]);
-    const { container } = useServerContext();
-    const showAdd = container.isProject || !isProductProjectsEnabled();
 
     const querySampleStatuses = useCallback(
         (newStatusLabel?: string) => {
@@ -378,7 +376,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                     <div className="row choices-container">
                         <div className="col-lg-4 col-md-6 choices-container-left-panel">
                             <SampleStatusesList states={states} selected={selected} onSelect={onSetSelected} />
-                            {showAdd && <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />}
+                            <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />
                         </div>
                         <div className="col-lg-8 col-md-6">
                             <SampleStatusDetail

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -169,7 +169,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
 
     const disabledMsg = useMemo( () => {
         return getSampleStatusLockedMessage(updatedState, saving);
-    }, [updatedState, saving, project.name]);
+    }, [updatedState, saving]);
 
     return (
         <>

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -25,12 +25,15 @@ import { DisableableButton } from '../buttons/DisableableButton';
 import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 
 import { SampleState } from './models';
+import { useServerContext } from '../base/ServerContext';
+import { isProductProjectsEnabled } from '../../app/utils';
 
 const TITLE = 'Manage Sample Statuses';
 const STATE_TYPE_SQ = new SchemaQuery('exp', 'SampleStateType');
 const DEFAULT_TYPE_OPTIONS = [{ value: 'Available' }, { value: 'Consumed' }, { value: 'Locked' }];
 const NEW_STATUS_INDEX = -1;
 const SAMPLE_STATUS_LOCKED_TITLE = 'Sample Status Locked';
+const SAMPLE_STATUS_NOT_LOCAL_LOCKED_TIP = 'This sample status can be changed only in the home project ';
 const SAMPLE_STATUS_LOCKED_TIP = 'This sample status cannot change status type or be deleted because it is in use.';
 
 interface SampleStatusDetailProps {
@@ -39,6 +42,14 @@ interface SampleStatusDetailProps {
     onChange: () => void;
     state: SampleState;
 }
+
+const getDisabledMsg = (state: SampleState, saving: boolean, projectName: string) => {
+    if (state?.inUse || saving)
+        return SAMPLE_STATUS_LOCKED_TIP;
+    if (!state?.isLocal)
+        return SAMPLE_STATUS_NOT_LOCAL_LOCKED_TIP + "(" + projectName + "). ";
+    return undefined;
+};
 
 // exported for jest testing
 export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
@@ -49,6 +60,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
     const [saving, setSaving] = useState<boolean>();
     const [error, setError] = useState<string>();
     const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>();
+    const { project } = useServerContext();
 
     useEffect(() => {
         selectRowsDeprecated({
@@ -78,7 +90,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
 
     useEffect(() => {
         if (addNew) {
-            setUpdatedState(new SampleState({ stateType: typeOptions?.[0]?.value }));
+            setUpdatedState(new SampleState({ stateType: typeOptions?.[0]?.value, isLocal: true }));
         } else {
             setUpdatedState(state);
         }
@@ -163,6 +175,10 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
         }
     }, [updatedState, onActionComplete]);
 
+    const disabledMsg = useMemo( () => {
+        return getDisabledMsg(updatedState, saving, project.name);
+    }, [updatedState, saving, project.name]);
+
     return (
         <>
             {/* using null for state value to indicate that we don't want to show the empty message*/}
@@ -181,7 +197,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 className="form-control"
                                 name="label"
                                 onChange={onFormChange}
-                                disabled={saving}
+                                disabled={saving || !updatedState.isLocal}
                                 placeholder="Enter status label"
                                 type="text"
                                 value={updatedState.label ?? ''}
@@ -197,7 +213,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 className="form-control"
                                 name="description"
                                 onChange={onFormChange}
-                                disabled={saving}
+                                disabled={saving || !updatedState.isLocal}
                                 value={updatedState.description ?? ''}
                             />
                         </div>
@@ -213,17 +229,17 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 labelKey="value"
                                 clearable={false}
                                 onChange={onSelectChange}
-                                disabled={updatedState.inUse || saving}
+                                disabled={updatedState.inUse || !updatedState.isLocal || saving}
                                 options={typeOptions}
                                 value={updatedState.stateType}
                             />
                         </div>
                     </FormGroup>
                     <div>
-                        {!addNew && (
+                        {!addNew && updatedState.isLocal && (
                             <DisableableButton
                                 bsStyle="default"
-                                disabledMsg={updatedState.inUse || saving ? SAMPLE_STATUS_LOCKED_TIP : undefined}
+                                disabledMsg={disabledMsg}
                                 onClick={onToggleDeleteConfirm}
                                 title={SAMPLE_STATUS_LOCKED_TITLE}
                             >
@@ -236,9 +252,11 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 Cancel
                             </Button>
                         )}
-                        <Button bsStyle="success" className="pull-right" disabled={!dirty || saving} onClick={onSave}>
-                            {saving ? 'Saving...' : 'Save'}
-                        </Button>
+                        {updatedState.isLocal && (
+                            <Button bsStyle="success" className="pull-right" disabled={!dirty || saving} onClick={onSave}>
+                                {saving ? 'Saving...' : 'Save'}
+                            </Button>
+                        )}
                     </div>
                 </form>
             )}
@@ -272,6 +290,7 @@ interface SampleStatusesListProps {
 // exported for jest testing
 export const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
     const { states, onSelect, selected } = props;
+    const { project } = useServerContext();
 
     return (
         <div className="list-group">
@@ -284,10 +303,10 @@ export const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
                     label={state.label}
                     onSelect={onSelect}
                     componentRight={
-                        state.inUse && (
+                        (state.inUse || !state.isLocal) && (
                             <LockIcon
                                 iconCls="pull-right choices-list__locked"
-                                body={SAMPLE_STATUS_LOCKED_TIP}
+                                body={getDisabledMsg(state, false, project.name)}
                                 id="sample-state-lock-icon"
                                 title={SAMPLE_STATUS_LOCKED_TITLE}
                             />
@@ -311,6 +330,8 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
     const addNew = useMemo(() => selected === NEW_STATUS_INDEX, [selected]);
+    const { container } = useServerContext();
+    const showAdd = container.isProject || !isProductProjectsEnabled();
 
     const querySampleStatuses = useCallback(
         (newStatusLabel?: string) => {
@@ -365,7 +386,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                     <div className="row choices-container">
                         <div className="col-lg-4 col-md-6 choices-container-left-panel">
                             <SampleStatusesList states={states} selected={selected} onSelect={onSetSelected} />
-                            <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />
+                            {showAdd && <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />}
                         </div>
                         <div className="col-lg-8 col-md-6">
                             <SampleStatusDetail

--- a/packages/components/src/internal/components/samples/SampleStatusLegend.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusLegend.tsx
@@ -1,5 +1,4 @@
 import React, { FC, memo } from 'react';
-import { Query } from '@labkey/api';
 
 import { QuerySort } from '../../../public/QuerySort';
 import { isLoading } from '../../../public/LoadingState';
@@ -11,8 +10,7 @@ import { SCHEMAS } from '../../schemas';
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 
 import { SampleStatusTag } from './SampleStatusTag';
-import { getSampleStatus } from './utils';
-import { getContainerFilterForLookups } from '../../query/api';
+import { getSampleStatus, getSampleStatusContainerFilter } from './utils';
 
 export const SAMPLE_STATUS_LEGEND = 'SampleStatusLegend';
 
@@ -66,7 +64,7 @@ export const SampleStatusLegend: FC<OwnProps> = () => {
         model: {
             id: 'sample-statuses-model',
             schemaQuery: SCHEMAS.EXP_TABLES.SAMPLE_STATUS,
-            containerFilter: getContainerFilterForLookups(),
+            containerFilter: getSampleStatusContainerFilter(),
             maxRows: -1,
             sorts: [new QuerySort({ fieldKey: 'StatusType' }), new QuerySort({ fieldKey: 'Label' })],
         },

--- a/packages/components/src/internal/components/samples/SampleStatusLegend.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusLegend.tsx
@@ -64,7 +64,7 @@ export const SampleStatusLegend: FC<OwnProps> = () => {
         model: {
             id: 'sample-statuses-model',
             schemaQuery: SCHEMAS.EXP_TABLES.SAMPLE_STATUS,
-            containerFilter: getSampleStatusContainerFilter(),
+            containerFilter: getSampleStatusContainerFilter(true),
             maxRows: -1,
             sorts: [new QuerySort({ fieldKey: 'StatusType' }), new QuerySort({ fieldKey: 'Label' })],
         },

--- a/packages/components/src/internal/components/samples/SampleStatusLegend.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusLegend.tsx
@@ -12,6 +12,7 @@ import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel
 
 import { SampleStatusTag } from './SampleStatusTag';
 import { getSampleStatus } from './utils';
+import { getContainerFilterForLookups } from '../../query/api';
 
 export const SAMPLE_STATUS_LEGEND = 'SampleStatusLegend';
 
@@ -65,7 +66,7 @@ export const SampleStatusLegend: FC<OwnProps> = () => {
         model: {
             id: 'sample-statuses-model',
             schemaQuery: SCHEMAS.EXP_TABLES.SAMPLE_STATUS,
-            containerFilter: Query.ContainerFilter.current, // only get statuses for the current container
+            containerFilter: getContainerFilterForLookups(),
             maxRows: -1,
             sorts: [new QuerySort({ fieldKey: 'StatusType' }), new QuerySort({ fieldKey: 'Label' })],
         },

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -180,6 +180,7 @@ export class SampleState {
     readonly publicData: boolean;
     readonly inUse: boolean;
     readonly isLocal: boolean;
+    readonly containerPath: string;
 
     constructor(values?: Partial<SampleState>) {
         Object.assign(this, values);

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -179,6 +179,7 @@ export class SampleState {
     readonly stateType: string;
     readonly publicData: boolean;
     readonly inUse: boolean;
+    readonly isLocal: boolean;
 
     constructor(values?: Partial<SampleState>) {
         Object.assign(this, values);

--- a/packages/components/src/internal/components/samples/utils.spec.tsx
+++ b/packages/components/src/internal/components/samples/utils.spec.tsx
@@ -408,7 +408,7 @@ describe('getConvertedSampleStorageUpdateData1', () => {
     });
 });
 
-describe("getSampleStatusLockedMsg", () => {
+describe("getSampleStatusLockedMessage", () => {
     test("no state", () => {
         expect(getSampleStatusLockedMessage(undefined, false)).toBeUndefined();
     });

--- a/packages/components/src/internal/components/samples/utils.spec.tsx
+++ b/packages/components/src/internal/components/samples/utils.spec.tsx
@@ -466,7 +466,7 @@ describe("getSampleStatusLockedMsg", () => {
            inUse: false,
            containerPath: "/Test Project",
            isLocal: false
-       }), false)).toBe("This sample status can be changed only in the home project (Test Project).");
+       }), false)).toBe("This sample status can be changed only in the Test Project project.");
 
    });
 
@@ -478,7 +478,7 @@ describe("getSampleStatusLockedMsg", () => {
            inUse: true,
            containerPath: "/Test Project",
            isLocal: false
-       }), false)).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the home project (Test Project).");
+       }), false)).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the Test Project project.");
    });
 
     test("in use, saving, and not local", () => {
@@ -489,6 +489,6 @@ describe("getSampleStatusLockedMsg", () => {
             inUse: true,
             containerPath: "/Test Project",
             isLocal: false
-        }), true)).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the home project (Test Project).");
+        }), true)).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the Test Project project.");
     });
 });

--- a/packages/components/src/internal/components/samples/utils.spec.tsx
+++ b/packages/components/src/internal/components/samples/utils.spec.tsx
@@ -410,86 +410,85 @@ describe('getConvertedSampleStorageUpdateData1', () => {
 
 describe("getSampleStatusLockedMsg", () => {
     test("no state", () => {
-        expect(getSampleStatusLockedMessage(
-           undefined, false, "Test Project")).toBeUndefined();
+        expect(getSampleStatusLockedMessage(undefined, false)).toBeUndefined();
     });
 
    test("not locked", () => {
-       expect(getSampleStatusLockedMessage(
-           new SampleState({
-               rowId: 1,
-               label: 'Available',
-               stateType: SampleStateType.Available,
-               inUse: false,
-               isLocal: true
-           }), false, "Test Project")).toBeUndefined();
+       expect(getSampleStatusLockedMessage(new SampleState({
+           rowId: 1,
+           label: 'Available',
+           stateType: SampleStateType.Available,
+           inUse: false,
+           containerPath: "/Test Project",
+           isLocal: true
+       }), false)).toBeUndefined();
    });
 
    test("saving but not in use", () => {
-       expect(getSampleStatusLockedMessage(
-           new SampleState({
-               rowId: 1,
-               label: 'Available',
-               stateType: SampleStateType.Available,
-               inUse: false,
-               isLocal: true
-           }), true, "Test Project")).toBe("This sample status cannot change status type or be deleted because it is in use.");
+       expect(getSampleStatusLockedMessage(new SampleState({
+           rowId: 1,
+           label: 'Available',
+           stateType: SampleStateType.Available,
+           inUse: false,
+           containerPath: "/Test Project",
+           isLocal: true
+       }), true)).toBe("This sample status cannot change status type or be deleted because it is in use.");
    });
 
    test("in use", () => {
-       expect(getSampleStatusLockedMessage(
-           new SampleState({
-               rowId: 1,
-               label: 'Available',
-               stateType: SampleStateType.Available,
-               inUse: true,
-               isLocal: true
-           }), false, "Test Project")).toBe("This sample status cannot change status type or be deleted because it is in use.");
+       expect(getSampleStatusLockedMessage(new SampleState({
+           rowId: 1,
+           label: 'Available',
+           stateType: SampleStateType.Available,
+           inUse: true,
+           containerPath: "/Test Project",
+           isLocal: true
+       }), false)).toBe("This sample status cannot change status type or be deleted because it is in use.");
 
    });
 
     test("in use and saving", () => {
-        expect(getSampleStatusLockedMessage(
-            new SampleState({
-                rowId: 1,
-                label: 'Available',
-                stateType: SampleStateType.Available,
-                inUse: true,
-                isLocal: true
-            }), true, "Test Project")).toBe("This sample status cannot change status type or be deleted because it is in use.");
+        expect(getSampleStatusLockedMessage(new SampleState({
+            rowId: 1,
+            label: 'Available',
+            stateType: SampleStateType.Available,
+            inUse: true,
+            containerPath: "/Test Project",
+            isLocal: true
+        }), true)).toBe("This sample status cannot change status type or be deleted because it is in use.");
     });
 
    test("not in use, not local", () => {
-       expect(getSampleStatusLockedMessage(
-           new SampleState({
-               rowId: 1,
-               label: 'Available',
-               stateType: SampleStateType.Available,
-               inUse: false,
-               isLocal: false
-           }), false, "Test Project")).toBe("This sample status can be changed only in the home project (Test Project).");
+       expect(getSampleStatusLockedMessage(new SampleState({
+           rowId: 1,
+           label: 'Available',
+           stateType: SampleStateType.Available,
+           inUse: false,
+           containerPath: "/Test Project",
+           isLocal: false
+       }), false)).toBe("This sample status can be changed only in the home project (Test Project).");
 
    });
 
    test("in use and not local", () => {
-       expect(getSampleStatusLockedMessage(
-           new SampleState({
-               rowId: 1,
-               label: 'Available',
-               stateType: SampleStateType.Available,
-               inUse: true,
-               isLocal: false
-           }), false, "Test Project")).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the home project (Test Project).");
+       expect(getSampleStatusLockedMessage(new SampleState({
+           rowId: 1,
+           label: 'Available',
+           stateType: SampleStateType.Available,
+           inUse: true,
+           containerPath: "/Test Project",
+           isLocal: false
+       }), false)).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the home project (Test Project).");
    });
 
     test("in use, saving, and not local", () => {
-        expect(getSampleStatusLockedMessage(
-            new SampleState({
-                rowId: 1,
-                label: 'Available',
-                stateType: SampleStateType.Available,
-                inUse: true,
-                isLocal: false
-            }), true, "Test Project")).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the home project (Test Project).");
+        expect(getSampleStatusLockedMessage(new SampleState({
+            rowId: 1,
+            label: 'Available',
+            stateType: SampleStateType.Available,
+            inUse: true,
+            containerPath: "/Test Project",
+            isLocal: false
+        }), true)).toBe("This sample status cannot change status type or be deleted because it is in use and can be changed only in the home project (Test Project).");
     });
 });

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -20,7 +20,7 @@ import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
 import { SystemField } from '../domainproperties/models';
 
-import { SampleStatus } from './models';
+import { SampleState, SampleStatus } from './models';
 
 import {
     operationRestrictionMessage,
@@ -296,4 +296,15 @@ export function getStorageItemUpdateData(
         errors: errors.length > 0 ? errors : undefined,
     };
 }
+
+export const getSampleStatusLockedMessage = (state: SampleState, saving: boolean, projectName: string) => {
+    let msgs = [];
+    if (state?.inUse || saving)
+        msgs.push('cannot change status type or be deleted because it is in use');
+    if (state && !state.isLocal)
+        msgs.push('can be changed only in the home project (' + projectName + ')');
+    if (msgs.length > 0)
+        return 'This sample status ' + msgs.join(' and ') + '.'
+    return undefined;
+};
 

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -4,7 +4,12 @@ import { Filter, Query } from '@labkey/api';
 
 import { User } from '../base/models/User';
 
-import { isFreezerManagementEnabled, isSampleStatusEnabled } from '../../app/utils';
+import {
+    isFreezerManagementEnabled,
+    isProductProjectsEnabled,
+    isProjectContainer,
+    isSampleStatusEnabled
+} from '../../app/utils';
 
 import { OperationConfirmationData } from '../entities/models';
 
@@ -308,6 +313,18 @@ export function getSampleStatusLockedMessage(state: SampleState, saving: boolean
     return undefined;
 }
 
-export function getSampleStatusContainerFilter() : Query.ContainerFilter {
-    return Query.containerFilter.currentPlusProjectAndShared;
+export function getSampleStatusContainerFilter(forLegend?: boolean, containerPath?: string, moduleContext?: ModuleContext) : Query.ContainerFilter {
+    // Check to see if product projects support is enabled.
+    if (!isProductProjectsEnabled(moduleContext)) {
+        return undefined;
+    }
+
+    // The legend should show statuses for all the samples that can be seen in the project.
+    if (forLegend && isProjectContainer(containerPath)) {
+        return Query.ContainerFilter.currentAndSubfoldersPlusShared;
+    }
+
+    // When requesting data from a sub-folder context the ContainerFilter filters
+    // "up" the folder hierarchy for data.
+    return Query.ContainerFilter.currentPlusProjectAndShared;
 }

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Filter } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { User } from '../base/models/User';
 
@@ -297,14 +297,17 @@ export function getStorageItemUpdateData(
     };
 }
 
-export const getSampleStatusLockedMessage = (state: SampleState, saving: boolean, projectName: string) => {
+export function getSampleStatusLockedMessage(state: SampleState, saving: boolean) : string {
     let msgs = [];
     if (state?.inUse || saving)
         msgs.push('cannot change status type or be deleted because it is in use');
     if (state && !state.isLocal)
-        msgs.push('can be changed only in the home project (' + projectName + ')');
+        msgs.push('can be changed only in the ' + state.containerPath.substring(1) + ' project');
     if (msgs.length > 0)
         return 'This sample status ' + msgs.join(' and ') + '.'
     return undefined;
-};
+}
 
+export function getSampleStatusContainerFilter() : Query.ContainerFilter {
+    return Query.containerFilter.currentPlusProjectAndShared;
+}


### PR DESCRIPTION
#### Rationale
Previously, we had been creating sample statuses for each folder that was created and limiting the user to choosing only statuses from the current folder, resulting in an overabundance of the default statuses and no way to unify the statuses for shared sample type.  With this PR, we make the adjustment to show the statuses from the current, project and shared containers and allow them to be used when creating and updating samples.

#### Related Pull Requests

- https://github.com/LabKey/platform/pull/4224
- https://github.com/LabKey/biologics/pull/2023
- https://github.com/LabKey/sampleManagement/pull/1702
- https://github.com/LabKey/inventory/pull/787

#### Changes
- Update sample statuses to inherit from the parent and no longer support creation in subfolders
- Update `ManageSampleStatusesPanel`
  - Display statuses from higher up the hierarchy as locked statuses
  - Don't allow adding new statuses when in sub-folders