### PR TITLE
Issue 47569: Remove setting for inheriting permissions for the Site Roles and Assignments

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.302.3-noSiteRoleInheritance.1",
+  "version": "2.302.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.302.2",
+  "version": "2.302.3-noSiteRoleInheritance.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.302.3-noSiteRoleInheritance.0",
+  "version": "2.302.3-noSiteRoleInheritance.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 47569: Remove setting for inheriting permissions for the Site Roles and Assignments
+
 ### version 2.302.2
 *Released*: 03 March 2023
 - Issue 47306: Resolve Permissions page error by skipping no-resolvable users.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.302.3
+*Released*: 27 March 2023
 - Issue 47569: Remove setting for inheriting permissions for the Site Roles and Assignments
 
 ### version 2.302.2
@@ -28,7 +28,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.300.1
 *Released*: 28 February 2023
 - Add a `focusSeed` method to the `VisGraph` component which fits the graph to the seed node and then zooms in to an appropriate level.
-- Revise `fitGraph` to take determine whether or not the graph should be focused on the seed.
+- Revise `fitGraph` to take determine whether the graph should be focused on the seed.
 
 ### version 2.300.0
 *Released*: 28 February 2023

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.spec.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.spec.tsx
@@ -179,7 +179,24 @@ describe('PermissionAssignments', () => {
         wrapper.unmount();
     });
 
-    test('respects rolesToShow', async () => {
+    test('cannot inherit', () => {
+        const defaultProps = getDefaultProps();
+
+        // permission assignments for the root project from a subfolder
+        const wrapper = mountWithAppServerContext(
+            <PermissionAssignments {...defaultProps} containerId={TEST_PROJECT.rootId} />,
+            getDefaultAppContext(),
+            getDefaultServerContext({ container: TEST_FOLDER_CONTAINER })
+        );
+
+        // Does not display inherit checkbox
+        expect(wrapper.find('.permissions-assignment-inherit').exists()).toEqual(false);
+        expect(wrapper.find(PermissionsRole).length).toEqual(defaultProps.policy.relevantRoles.size);
+
+        wrapper.unmount();
+    });
+
+    test('respects rolesToShow', () => {
         const defaultProps = getDefaultProps();
         const rolesToShow = List<string>([SECURITY_ROLE_EDITOR, SECURITY_ROLE_READER]);
 

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -72,10 +72,10 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
     const [groupMembership, setGroupMembership] = useState<GroupMembership>();
     const [error, setError] = useState<string>();
     const [submitting, setSubmitting] = useState<boolean>(false);
-    const canInherit = getServerContext().project.rootId !== containerId;
 
     const { api } = useAppContext<AppContext>();
     const { container, project, user } = useServerContext();
+    const canInherit = project.rootId !== containerId;
 
     const selectedPrincipal = principalsById?.get(selectedUserId);
     const initExpandedRole = getLocation().query?.get('expand')

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -5,7 +5,7 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Button, Checkbox, Col, Row } from 'react-bootstrap';
 import { List } from 'immutable';
-import { Security } from '@labkey/api';
+import { getServerContext, Security } from '@labkey/api';
 
 import { UserDetailsPanel } from '../user/UserDetailsPanel';
 
@@ -72,6 +72,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
     const [groupMembership, setGroupMembership] = useState<GroupMembership>();
     const [error, setError] = useState<string>();
     const [submitting, setSubmitting] = useState<boolean>(false);
+    const canInherit = getServerContext().project.rootId !== containerId;
 
     const { api } = useAppContext<AppContext>();
     const { container, project, user } = useServerContext();
@@ -245,7 +246,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                             </Alert>
                         )}
 
-                        {isSubfolder && (
+                        {isSubfolder && canInherit && (
                             <div>
                                 <form>
                                     <Checkbox


### PR DESCRIPTION
#### Rationale
We should not allow inheriting permissions for site roles in subfolders since those roles are defined in the root container that doesn't have any useful application permissions. 

#### Related Pull Requests

- https://github.com/LabKey/biologics/pull/2025
- https://github.com/LabKey/sampleManagement/pull/1703
- https://github.com/LabKey/inventory/pull/789

#### Changes
- Remove ability to inherit permissions from the root container.
