### PR TITLE
Lineage: Combine nodes at each generation, introduce graph options panel

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.318.1",
+  "version": "2.319.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,16 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.319.0
+*Released*: 30 March 2023
+- Graph Options
+    - Add `LineageSettings` component that allows for manipulation of settings for the graph.
+    - Expose graph options "gear" icon via `LineageGraph` component.
+- Combine Nodes
+    - Create a `LineageNode` instance that replaces all combined nodes in processing.
+    - Factor out `applyCombineSize` method to encapsulate `combineSize` logic.
+    - Factor our `processCombinedNode` method to encapsulate construction of edges from a combined node.
+
 ### version 2.318.1
 *Released*: 30 March 2023
 * Issue 47575: Populating editable grid from bulk update doesn't account for aliquot- or sample-only fields

--- a/packages/components/src/internal/components/lineage/LineageGraph.tsx
+++ b/packages/components/src/internal/components/lineage/LineageGraph.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, memo, PureComponent } from 'react';
+import React, { FC, memo, PureComponent, useEffect, useState } from 'react';
 import { Experiment } from '@labkey/api';
 
 import { Alert } from '../base/Alert';
@@ -16,6 +16,7 @@ import { isBasicNode, VisGraphOptions, VisGraphNode, VisGraphNodeType } from './
 import { VisGraph } from './vis/VisGraph';
 import { LineageNodeDetailFactory } from './node/LineageNodeDetailFactory';
 import { DEFAULT_LINEAGE_DISTANCE } from './constants';
+import { LineageSettings } from './LineageSettings';
 
 interface LineageGraphOwnProps {
     members?: LINEAGE_DIRECTIONS;
@@ -23,6 +24,8 @@ interface LineageGraphOwnProps {
 }
 
 interface LineageGraphDisplayOwnProps {
+    options?: LineageOptions;
+    setOptions: (options: LineageOptions) => void;
     visGraphOptions: VisGraphOptions;
 }
 
@@ -30,6 +33,7 @@ interface State {
     hoverNode: string;
     nodeInteractions: WithNodeInteraction;
     selectedNodes: VisGraphNodeType[];
+    showSettings: boolean;
 }
 
 type Props = InjectedLineage & LineageGraphDisplayOwnProps & WithLineageOptions & LineageGraphOwnProps & LineageOptions;
@@ -47,6 +51,7 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
                 onNodeMouseOut: this.onSummaryNodeMouseOut,
                 onNodeClick: this.onSummaryNodeClick,
             },
+            showSettings: false,
         };
     }
 
@@ -79,13 +84,19 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
     };
 
     onVisGraphNodeDoubleClick = (visNode: VisGraphNode): void => {
-        if (this.props.navigate) {
-            this.props.navigate(visNode);
-        }
+        this.props.navigate?.(visNode);
     };
 
     onNodeSelectionChange = (selectedNodes: VisGraphNodeType[]): void => {
         this.setState({ selectedNodes });
+    };
+
+    onOptionsChange = (options: LineageOptions): void => {
+        this.props.setOptions?.(options);
+    };
+
+    onToggleSettings = (): void => {
+        this.setState(state => ({ showSettings: !state.showSettings }));
     };
 
     updateHover = (node: VisGraphNodeType): void => {
@@ -99,8 +110,8 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
     };
 
     render() {
-        const { lineage, lsid, visGraphOptions } = this.props;
-        const { hoverNode, selectedNodes } = this.state;
+        const { lineage, lsid, options, visGraphOptions } = this.props;
+        const { hoverNode, selectedNodes, showSettings } = this.state;
 
         if (lineage?.error) {
             return <Alert>{lineage.error}</Alert>;
@@ -118,6 +129,7 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
                                 onNodeDeselect={this.onNodeSelectionChange}
                                 onNodeHover={this.updateHover}
                                 onNodeBlur={this.clearHover}
+                                onToggleSettings={this.onToggleSettings}
                                 options={visGraphOptions}
                                 seed={lsid}
                             />
@@ -126,12 +138,21 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
                         )}
                     </div>
                     <div className="col-md-4 lineage-node-detail-container">
-                        <LineageNodeDetailFactory
-                            highlightNode={hoverNode}
-                            lineage={lineage}
-                            lineageOptions={this.props}
-                            selectedNodes={selectedNodes}
-                        />
+                        {!showSettings && (
+                            <LineageNodeDetailFactory
+                                highlightNode={hoverNode}
+                                lineage={lineage}
+                                lineageOptions={this.props}
+                                selectedNodes={selectedNodes}
+                            />
+                        )}
+                        {showSettings && (
+                            <LineageSettings
+                                {...this.props}
+                                options={options}
+                                onSettingsChange={this.onOptionsChange}
+                            />
+                        )}
                     </div>
                 </div>
             </NodeInteractionProvider>
@@ -140,6 +161,8 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
 }
 
 export const LineageGraph = withLineage<LineageGraphOwnProps>((props: Props) => {
+    const [options, setOptions] = useState<LineageOptions>();
+
     // Optimization: This FunctionComponent allows for "generateGraph" to only be called
     // when the lineage is updated. If it is called in the render loop of <LineageGraphDisplay/>
     // it is run each time a user interacts with the graph (e.g. hovers a node, clicks a node, etc).
@@ -147,7 +170,14 @@ export const LineageGraph = withLineage<LineageGraphOwnProps>((props: Props) => 
         return <Alert>{props.lineage.error}</Alert>;
     }
 
-    return <LineageGraphDisplay {...props} visGraphOptions={props.lineage?.generateGraph(props)} />;
+    return (
+        <LineageGraphDisplay
+            {...props}
+            options={options}
+            setOptions={setOptions}
+            visGraphOptions={props.lineage?.generateGraph({ ...props, ...options })}
+        />
+    );
 });
 
 interface LineageDepthLimitProps {

--- a/packages/components/src/internal/components/lineage/LineageGraph.tsx
+++ b/packages/components/src/internal/components/lineage/LineageGraph.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) 2016-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, memo, PureComponent, useEffect, useState } from 'react';
-import { Experiment } from '@labkey/api';
+import React, { FC, memo, PureComponent, useState } from 'react';
+import { ActionURL, Experiment } from '@labkey/api';
 
 import { Alert } from '../base/Alert';
 
@@ -53,6 +53,10 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
             },
             showSettings: false,
         };
+    }
+
+    get allowSettings(): boolean {
+        return !!ActionURL.getParameter('lineageSettings');
     }
 
     clearHover = (): void => {
@@ -129,7 +133,7 @@ class LineageGraphDisplay extends PureComponent<Props, Partial<State>> {
                                 onNodeDeselect={this.onNodeSelectionChange}
                                 onNodeHover={this.updateHover}
                                 onNodeBlur={this.clearHover}
-                                onToggleSettings={this.onToggleSettings}
+                                onToggleSettings={this.allowSettings ? this.onToggleSettings : undefined}
                                 options={visGraphOptions}
                                 seed={lsid}
                             />

--- a/packages/components/src/internal/components/lineage/LineageSettings.spec.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.spec.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { waitForLifecycle } from '../../testHelpers';
+
+import { LineageFilter } from './types';
+import { LineageSettings } from './LineageSettings';
+
+describe('LineageSettings', () => {
+    test('onFilterChange', async () => {
+        const filter = new LineageFilter('type', ['Awesome']);
+        const filter2 = new LineageFilter('lsid', ['lsid:value:1']);
+        const onSettingsChange = jest.fn();
+        const wrapper = mount(<LineageSettings filters={[filter, filter2]} onSettingsChange={onSettingsChange} />);
+
+        const input = wrapper.find('input[type="checkbox"][name="type"]');
+        expect(input.exists()).toBe(true);
+        input.simulate('change', { target: { checked: true, name: filter.field } });
+        input.simulate('change', { target: { checked: false, name: filter.field } });
+        input.simulate('change', { target: { checked: false, name: filter2.field } });
+        await waitForLifecycle(wrapper, 500);
+
+        expect(onSettingsChange).toHaveBeenCalledTimes(1);
+        expect(onSettingsChange).toHaveBeenCalledWith({ filters: [], originalFilters: [filter, filter2] });
+
+        input.simulate('change', { target: { checked: true, name: filter.field } });
+        await waitForLifecycle(wrapper, 500);
+
+        expect(onSettingsChange).toHaveBeenCalledTimes(2);
+        expect(onSettingsChange).toHaveBeenCalledWith({ filters: [filter], originalFilters: [filter, filter2] });
+
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -109,11 +109,11 @@ export const LineageSettings: FC<Props> = memo(props => {
                     value={options.grouping?.generations ?? DEFAULT_GROUPING_OPTIONS.generations}
                 />
 
-                <PanelFieldLabel>Child Depth (0-5)</PanelFieldLabel>
+                <PanelFieldLabel>Child Depth (0-10)</PanelFieldLabel>
                 <input
                     defaultValue={options.grouping?.childDepth ?? DEFAULT_GROUPING_OPTIONS.childDepth}
                     className="form-control"
-                    max={5}
+                    max={10}
                     min={0}
                     name="childDepth"
                     onChange={onGroupingChange}
@@ -121,11 +121,11 @@ export const LineageSettings: FC<Props> = memo(props => {
                     type="number"
                 />
 
-                <PanelFieldLabel>Parent Depth (0-5)</PanelFieldLabel>
+                <PanelFieldLabel>Parent Depth (0-10)</PanelFieldLabel>
                 <input
                     defaultValue={options.grouping?.parentDepth ?? DEFAULT_GROUPING_OPTIONS.childDepth}
                     className="form-control"
-                    max={5}
+                    max={10}
                     min={0}
                     name="parentDepth"
                     onChange={onGroupingChange}
@@ -133,12 +133,23 @@ export const LineageSettings: FC<Props> = memo(props => {
                     type="number"
                 />
 
-                <PanelFieldLabel>Combine Edges Threshold</PanelFieldLabel>
+                <PanelFieldLabel>Combine Depth Threshold (2+)</PanelFieldLabel>
                 <input
                     defaultValue={options.grouping?.combineSize ?? DEFAULT_GROUPING_OPTIONS.combineSize}
                     className="form-control"
-                    min={0}
+                    min={2}
                     name="combineSize"
+                    onChange={onGroupingChange}
+                    style={{ marginBottom: '16px', maxWidth: '100px' }}
+                    type="number"
+                />
+
+                <PanelFieldLabel>Combine Type Threshold (2+)</PanelFieldLabel>
+                <input
+                    defaultValue={options.grouping?.combineTypeSize ?? DEFAULT_GROUPING_OPTIONS.combineTypeSize}
+                    className="form-control"
+                    min={2}
+                    name="combineTypeSize"
                     onChange={onGroupingChange}
                     style={{ marginBottom: '16px', maxWidth: '100px' }}
                     type="number"
@@ -148,16 +159,14 @@ export const LineageSettings: FC<Props> = memo(props => {
             <div className="job-overview__section">
                 <div className="job-overview__section-header">Filters</div>
 
-                {options.originalFilters?.map(filter => {
-                    return (
-                        <div key={filter.field}>
-                            <input defaultChecked onChange={onFilterChange} name={filter.field} type="checkbox" />
-                            <span style={{ marginLeft: '5px' }}>
-                                {filter.field} = {filter.value.join(' OR ')}
-                            </span>
-                        </div>
-                    );
-                })}
+                {options.originalFilters?.map(filter => (
+                    <div key={filter.field}>
+                        <input defaultChecked onChange={onFilterChange} name={filter.field} type="checkbox" />
+                        <span style={{ marginLeft: '5px' }}>
+                            {filter.field} = {filter.value.join(' OR ')}
+                        </span>
+                    </div>
+                ))}
             </div>
         </div>
     );

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -104,7 +104,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                             </li>
                             <li>
                                 <b>Multi</b> - Include all nodes from the seed until a depth is found that contains
-                                multiple nodes..
+                                multiple nodes.
                             </li>
                             <li>
                                 <b>Nearest</b> - Include only the immediately connected nodes from the seed.
@@ -176,6 +176,9 @@ export const LineageSettings: FC<Props> = memo(props => {
                         <div className="lineage-settings__tip-body">
                             If the number of nodes in a generation is greater than or equal to this threshold, then all
                             the nodes in this generation will be combined into a single node.
+                            <div>
+                                <b>Note:</b> Aliquots are combined separately and may appear as a single combined node
+                            </div>
                         </div>
                     </LabelHelpTip>
                 </label>

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -202,26 +202,6 @@ export const LineageSettings: FC<Props> = memo(props => {
                     style={{ marginBottom: '16px', maxWidth: '100px' }}
                     type="number"
                 />
-
-                {/*<PanelFieldLabel>*/}
-                {/*    Combine Type Threshold*/}
-                {/*    <LabelHelpTip placement="bottom" title="Combine Type Threshold">*/}
-                {/*        <div style={{ maxWidth: '350px' }}>*/}
-                {/*            If the number of nodes of a common type in a generation is greater than or equal to this*/}
-                {/*            threshold, then all the nodes of a common type in a generation will be combined into a*/}
-                {/*            single node.*/}
-                {/*        </div>*/}
-                {/*    </LabelHelpTip>*/}
-                {/*</PanelFieldLabel>*/}
-                {/*<input*/}
-                {/*    defaultValue={options.grouping?.combineTypeSize ?? DEFAULT_GROUPING_OPTIONS.combineTypeSize}*/}
-                {/*    className="form-control"*/}
-                {/*    min={2}*/}
-                {/*    name="combineTypeSize"*/}
-                {/*    onChange={onGroupingChange}*/}
-                {/*    style={{ marginBottom: '16px', maxWidth: '100px' }}*/}
-                {/*    type="number"*/}
-                {/*/>*/}
             </div>
 
             <div className="job-overview__section">

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -19,8 +19,10 @@ interface Props extends LineageOptions {
 export const LineageSettings: FC<Props> = memo(props => {
     const { onSettingsChange } = props;
     const [options, setOptions] = useState<LineageSettingsOptions>(() => {
-        if (props.options) return props.options;
-        return { filters: props.filters, grouping: props.grouping, originalFilters: props.filters };
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
+        const { onSettingsChange, options, ...optionProps } = props;
+        if (options) return options;
+        return { ...optionProps, originalFilters: optionProps.filters ? [...optionProps.filters] : [] };
     });
     const generations = useMemo<SelectInputOption[]>(() => {
         const generations_ = [];
@@ -42,6 +44,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                 changeRef.current = undefined;
             }
 
+            // Debounce here for user input to skip possibly costly graph renders
             changeRef.current = setTimeout(() => {
                 onSettingsChange(options_);
             }, 500);
@@ -57,9 +60,11 @@ export const LineageSettings: FC<Props> = memo(props => {
                 let { filters } = options_;
 
                 if (checked) {
-                    const filter = originalFilters.find(f => f.field === name);
-                    if (filter) {
-                        filters.push(filter);
+                    if (!filters.find(f => f.field === name)) {
+                        const filter = originalFilters.find(f => f.field === name);
+                        if (filter) {
+                            filters.push(filter);
+                        }
                     }
                 } else {
                     filters = filters.filter(f => f.field !== name);
@@ -201,7 +206,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                     </LabelHelpTip>
                 </div>
 
-                {options.originalFilters?.map(filter => (
+                {options.originalFilters.map(filter => (
                     <div key={filter.field}>
                         <input defaultChecked onChange={onFilterChange} name={filter.field} type="checkbox" />
                         <span className="lineage-settings__filter-label">

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -131,8 +131,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                             The number of descendant generations to render from the seed node. Only applies when
                             Generations is set to "Specific".
                             <div>
-                                <b>Note:</b> A maximum of {DEFAULT_GROUPING_OPTIONS.childDepth * 2} generations are
-                                requested from the server.
+                                <b>Note:</b> This does not affect the number of generations requested from the server.
                             </div>
                         </div>
                     </LabelHelpTip>
@@ -154,8 +153,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                             The number of ancestor generations to render from the seed node. Only applies when
                             Generations is set to "Specific".
                             <div>
-                                <b>Note:</b> A maximum of {DEFAULT_GROUPING_OPTIONS.childDepth * 2} generations are
-                                requested from the server.
+                                <b>Note:</b> This does not affect the number of generations requested from the server.
                             </div>
                         </div>
                     </LabelHelpTip>

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -1,0 +1,166 @@
+import React, { ChangeEvent, FC, memo, useCallback, useEffect, useState } from 'react';
+
+import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
+
+import { LabelHelpTip } from '../base/LabelHelpTip';
+
+import { LINEAGE_GROUPING_GENERATIONS, LineageOptions } from './types';
+import { DEFAULT_GROUPING_OPTIONS } from './constants';
+
+const generations: SelectInputOption[] = [
+    { label: 'All', value: LINEAGE_GROUPING_GENERATIONS.All },
+    { label: 'Multi', value: LINEAGE_GROUPING_GENERATIONS.Multi },
+    { label: 'Nearest', value: LINEAGE_GROUPING_GENERATIONS.Nearest },
+    { label: 'Specific', value: LINEAGE_GROUPING_GENERATIONS.Specific },
+];
+
+interface PanelFieldLabelProps {
+    className?: string;
+}
+
+export const PanelFieldLabel: FC<PanelFieldLabelProps> = memo(({ children, className }) => (
+    <div className="panel-field-label">
+        <label className={className}>{children}</label>
+    </div>
+));
+
+interface Props extends LineageOptions {
+    onSettingsChange: (options: LineageOptions) => void;
+    options?: LineageOptions;
+}
+
+export const LineageSettings: FC<Props> = memo(props => {
+    const { onSettingsChange } = props;
+    const [options, setOptions] = useState<LineageOptions>(() => {
+        if (props.options) return props.options;
+        return { filters: props.filters, grouping: props.grouping, originalFilters: props.filters };
+    });
+
+    useEffect(() => {
+        onSettingsChange(options);
+    }, [onSettingsChange, options]);
+
+    const onFilterChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
+        const { checked, name } = evt.target;
+        setOptions(options_ => {
+            const { originalFilters } = options_;
+            let { filters } = options_;
+
+            if (checked) {
+                const filter = originalFilters.find(f => f.field === name);
+                if (filter) {
+                    filters.push(filter);
+                }
+            } else {
+                filters = filters.filter(f => f.field !== name);
+            }
+
+            return { ...options_, filters };
+        });
+    }, []);
+
+    const onGenerationChange = useCallback((name, value) => {
+        setOptions(options_ => ({ ...options_, grouping: { ...options_.grouping, generations: value } }));
+    }, []);
+
+    const onGroupingChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = evt.target;
+        setOptions(options_ => ({
+            ...options_,
+            grouping: { ...options_.grouping, [name]: value },
+        }));
+    }, []);
+
+    return (
+        <div>
+            <div style={{ fontSize: 18, fontWeight: 500, marginBottom: '15px' }}>Graph Options</div>
+            <div className="job-overview__section">
+                <div className="job-overview__section-header">Grouping</div>
+
+                <PanelFieldLabel>
+                    Generations
+                    <LabelHelpTip placement="bottom" title="Generations">
+                        <ul style={{ listStyle: 'none', marginLeft: 0, paddingLeft: 0 }}>
+                            <li>
+                                <span style={{ fontWeight: 'bold' }}>All</span> - Include all nodes from the seed
+                                available in the lineage response.
+                            </li>
+                            <li>
+                                <span style={{ fontWeight: 'bold' }}>Multi</span> - Include all nodes from the seed
+                                until a depth is found that contains multiple nodes..
+                            </li>
+                            <li>
+                                <span style={{ fontWeight: 'bold' }}>Nearest</span> - Include only the immediately
+                                connected nodes from the seed.
+                            </li>
+                            <li>
+                                <span style={{ fontWeight: 'bold' }}>Specific</span> - Include all nodes from the seed
+                                up to the "parentDepth" or "childDepth" specified.
+                            </li>
+                        </ul>
+                    </LabelHelpTip>
+                </PanelFieldLabel>
+                <SelectInput
+                    clearable={false}
+                    name="generations"
+                    onChange={onGenerationChange}
+                    options={generations}
+                    customStyles={{ marginBottom: '16px' }}
+                    value={options.grouping?.generations ?? DEFAULT_GROUPING_OPTIONS.generations}
+                />
+
+                <PanelFieldLabel>Child Depth (0-5)</PanelFieldLabel>
+                <input
+                    defaultValue={options.grouping?.childDepth ?? DEFAULT_GROUPING_OPTIONS.childDepth}
+                    className="form-control"
+                    max={5}
+                    min={0}
+                    name="childDepth"
+                    onChange={onGroupingChange}
+                    style={{ marginBottom: '16px', maxWidth: '100px' }}
+                    type="number"
+                />
+
+                <PanelFieldLabel>Parent Depth (0-5)</PanelFieldLabel>
+                <input
+                    defaultValue={options.grouping?.parentDepth ?? DEFAULT_GROUPING_OPTIONS.childDepth}
+                    className="form-control"
+                    max={5}
+                    min={0}
+                    name="parentDepth"
+                    onChange={onGroupingChange}
+                    style={{ marginBottom: '16px', maxWidth: '100px' }}
+                    type="number"
+                />
+
+                <PanelFieldLabel>Combine Edges Threshold</PanelFieldLabel>
+                <input
+                    defaultValue={options.grouping?.combineSize ?? DEFAULT_GROUPING_OPTIONS.combineSize}
+                    className="form-control"
+                    min={0}
+                    name="combineSize"
+                    onChange={onGroupingChange}
+                    style={{ marginBottom: '16px', maxWidth: '100px' }}
+                    type="number"
+                />
+            </div>
+
+            <div className="job-overview__section">
+                <div className="job-overview__section-header">Filters</div>
+
+                {options.originalFilters?.map(filter => {
+                    return (
+                        <div key={filter.field}>
+                            <input defaultChecked onChange={onFilterChange} name={filter.field} type="checkbox" />
+                            <span style={{ marginLeft: '5px' }}>
+                                {filter.field} = {filter.value.join(' OR ')}
+                            </span>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+});
+
+LineageSettings.displayName = 'LineageSettings';

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, memo, useCallback, useRef, useState } from 'react';
+import React, { ChangeEvent, FC, memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
 
@@ -6,23 +6,6 @@ import { LabelHelpTip } from '../base/LabelHelpTip';
 
 import { LINEAGE_GROUPING_GENERATIONS, LineageFilter, LineageOptions } from './types';
 import { DEFAULT_GROUPING_OPTIONS } from './constants';
-
-const generations: SelectInputOption[] = [
-    { label: 'All', value: LINEAGE_GROUPING_GENERATIONS.All },
-    { label: 'Multi', value: LINEAGE_GROUPING_GENERATIONS.Multi },
-    { label: 'Nearest', value: LINEAGE_GROUPING_GENERATIONS.Nearest },
-    { label: 'Specific', value: LINEAGE_GROUPING_GENERATIONS.Specific },
-];
-
-interface PanelFieldLabelProps {
-    className?: string;
-}
-
-export const PanelFieldLabel: FC<PanelFieldLabelProps> = memo(({ children, className }) => (
-    <div className="panel-field-label">
-        <label className={className}>{children}</label>
-    </div>
-));
 
 interface LineageSettingsOptions extends LineageOptions {
     originalFilters?: LineageFilter[];
@@ -39,6 +22,14 @@ export const LineageSettings: FC<Props> = memo(props => {
         if (props.options) return props.options;
         return { filters: props.filters, grouping: props.grouping, originalFilters: props.filters };
     });
+    const generations = useMemo<SelectInputOption[]>(() => {
+        const generations_ = [];
+        // eslint-disable-next-line guard-for-in
+        for (const value in LINEAGE_GROUPING_GENERATIONS) {
+            generations_.push({ label: value, value: LINEAGE_GROUPING_GENERATIONS[value] });
+        }
+        return generations_;
+    }, []);
     const changeRef = useRef(undefined);
 
     const applyOptions = useCallback(
@@ -99,47 +90,44 @@ export const LineageSettings: FC<Props> = memo(props => {
     );
 
     return (
-        <div>
-            <div style={{ fontSize: 18, fontWeight: 500, marginBottom: '15px' }}>Graph Options</div>
-            <div className="job-overview__section">
-                <div className="job-overview__section-header">Grouping</div>
+        <div className="lineage-settings">
+            <div className="lineage-settings-heading">Graph Options</div>
+            <div className="lineage-settings__section">
+                <div className="lineage-settings__section-header">Grouping</div>
 
-                <PanelFieldLabel>
+                <label>
                     Generations
-                    <LabelHelpTip placement="bottom" title="Generations">
-                        <ul style={{ listStyle: 'none', marginLeft: 0, paddingLeft: 0 }}>
+                    <LabelHelpTip placement="top" title="Generations">
+                        <ul className="lineage-settings__tip-list">
                             <li>
-                                <span style={{ fontWeight: 'bold' }}>All</span> - Include all nodes from the seed
-                                available in the lineage response.
+                                <b>All</b> - Include all nodes from the seed available in the lineage response.
                             </li>
                             <li>
-                                <span style={{ fontWeight: 'bold' }}>Multi</span> - Include all nodes from the seed
-                                until a depth is found that contains multiple nodes..
+                                <b>Multi</b> - Include all nodes from the seed until a depth is found that contains
+                                multiple nodes..
                             </li>
                             <li>
-                                <span style={{ fontWeight: 'bold' }}>Nearest</span> - Include only the immediately
-                                connected nodes from the seed.
+                                <b>Nearest</b> - Include only the immediately connected nodes from the seed.
                             </li>
                             <li>
-                                <span style={{ fontWeight: 'bold' }}>Specific</span> - Include all nodes from the seed
-                                up to the "Parent Generations" or "Child Generations" specified.
+                                <b>Specific</b> - Include all nodes from the seed up to the "Parent Generations" or
+                                "Child Generations" specified.
                             </li>
                         </ul>
                     </LabelHelpTip>
-                </PanelFieldLabel>
+                </label>
                 <SelectInput
                     clearable={false}
                     name="generations"
                     onChange={onGenerationChange}
                     options={generations}
-                    customStyles={{ marginBottom: '16px' }}
                     value={options.grouping?.generations ?? DEFAULT_GROUPING_OPTIONS.generations}
                 />
 
-                <PanelFieldLabel>
+                <label>
                     Child Generations
-                    <LabelHelpTip placement="bottom" title="Child Generations">
-                        <div style={{ maxWidth: '350px' }}>
+                    <LabelHelpTip placement="top" title="Child Generations">
+                        <div className="lineage-settings__tip-body">
                             The number of descendant generations to render from the seed node. Only applies when
                             Generations is set to "Specific".
                             <div>
@@ -148,7 +136,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                             </div>
                         </div>
                     </LabelHelpTip>
-                </PanelFieldLabel>
+                </label>
                 <input
                     defaultValue={options.grouping?.childDepth ?? DEFAULT_GROUPING_OPTIONS.childDepth}
                     className="form-control"
@@ -156,14 +144,13 @@ export const LineageSettings: FC<Props> = memo(props => {
                     min={0}
                     name="childDepth"
                     onChange={onGroupingChange}
-                    style={{ marginBottom: '16px', maxWidth: '100px' }}
                     type="number"
                 />
 
-                <PanelFieldLabel>
+                <label>
                     Parent Generations
-                    <LabelHelpTip placement="bottom" title="Parent Generations">
-                        <div style={{ maxWidth: '350px' }}>
+                    <LabelHelpTip placement="top" title="Parent Generations">
+                        <div className="lineage-settings__tip-body">
                             The number of ancestor generations to render from the seed node. Only applies when
                             Generations is set to "Specific".
                             <div>
@@ -172,7 +159,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                             </div>
                         </div>
                     </LabelHelpTip>
-                </PanelFieldLabel>
+                </label>
                 <input
                     defaultValue={options.grouping?.parentDepth ?? DEFAULT_GROUPING_OPTIONS.parentDepth}
                     className="form-control"
@@ -180,35 +167,33 @@ export const LineageSettings: FC<Props> = memo(props => {
                     min={0}
                     name="parentDepth"
                     onChange={onGroupingChange}
-                    style={{ marginBottom: '16px', maxWidth: '100px' }}
                     type="number"
                 />
 
-                <PanelFieldLabel>
+                <label>
                     Combine Generation Threshold
-                    <LabelHelpTip placement="bottom" title="Combine Generation Threshold">
-                        <div style={{ maxWidth: '350px' }}>
+                    <LabelHelpTip placement="top" title="Combine Generation Threshold">
+                        <div className="lineage-settings__tip-body">
                             If the number of nodes in a generation is greater than or equal to this threshold, then all
                             the nodes in this generation will be combined into a single node.
                         </div>
                     </LabelHelpTip>
-                </PanelFieldLabel>
+                </label>
                 <input
                     defaultValue={options.grouping?.combineSize ?? DEFAULT_GROUPING_OPTIONS.combineSize}
                     className="form-control"
                     min={2}
                     name="combineSize"
                     onChange={onGroupingChange}
-                    style={{ marginBottom: '16px', maxWidth: '100px' }}
                     type="number"
                 />
             </div>
 
-            <div className="job-overview__section">
-                <div className="job-overview__section-header">
+            <div className="lineage-settings__section">
+                <div className="lineage-settings__section-header">
                     Filters
-                    <LabelHelpTip placement="bottom" title="Filters">
-                        <div style={{ maxWidth: '350px' }}>
+                    <LabelHelpTip placement="top" title="Filters">
+                        <div className="lineage-settings__tip-body">
                             Some lineage views provide default filters specified by the application. Toggle filters to
                             change which nodes are displayed in the graph.
                         </div>
@@ -218,7 +203,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                 {options.originalFilters?.map(filter => (
                     <div key={filter.field}>
                         <input defaultChecked onChange={onFilterChange} name={filter.field} type="checkbox" />
-                        <span style={{ marginLeft: '5px' }}>
+                        <span className="lineage-settings__filter-label">
                             {filter.field} = {filter.value.join(' OR ')}
                         </span>
                     </div>

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -203,25 +203,25 @@ export const LineageSettings: FC<Props> = memo(props => {
                     type="number"
                 />
 
-                <PanelFieldLabel>
-                    Combine Type Threshold
-                    <LabelHelpTip placement="bottom" title="Combine Type Threshold">
-                        <div style={{ maxWidth: '350px' }}>
-                            If the number of nodes of a common type in a generation is greater than or equal to this
-                            threshold, then all the nodes of a common type in a generation will be combined into a
-                            single node.
-                        </div>
-                    </LabelHelpTip>
-                </PanelFieldLabel>
-                <input
-                    defaultValue={options.grouping?.combineTypeSize ?? DEFAULT_GROUPING_OPTIONS.combineTypeSize}
-                    className="form-control"
-                    min={2}
-                    name="combineTypeSize"
-                    onChange={onGroupingChange}
-                    style={{ marginBottom: '16px', maxWidth: '100px' }}
-                    type="number"
-                />
+                {/*<PanelFieldLabel>*/}
+                {/*    Combine Type Threshold*/}
+                {/*    <LabelHelpTip placement="bottom" title="Combine Type Threshold">*/}
+                {/*        <div style={{ maxWidth: '350px' }}>*/}
+                {/*            If the number of nodes of a common type in a generation is greater than or equal to this*/}
+                {/*            threshold, then all the nodes of a common type in a generation will be combined into a*/}
+                {/*            single node.*/}
+                {/*        </div>*/}
+                {/*    </LabelHelpTip>*/}
+                {/*</PanelFieldLabel>*/}
+                {/*<input*/}
+                {/*    defaultValue={options.grouping?.combineTypeSize ?? DEFAULT_GROUPING_OPTIONS.combineTypeSize}*/}
+                {/*    className="form-control"*/}
+                {/*    min={2}*/}
+                {/*    name="combineTypeSize"*/}
+                {/*    onChange={onGroupingChange}*/}
+                {/*    style={{ marginBottom: '16px', maxWidth: '100px' }}*/}
+                {/*    type="number"*/}
+                {/*/>*/}
             </div>
 
             <div className="job-overview__section">

--- a/packages/components/src/internal/components/lineage/LineageSummary.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSummary.tsx
@@ -8,7 +8,7 @@ import { List, Map } from 'immutable';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { LINEAGE_DIRECTIONS, LineageOptions } from './types';
-import { createLineageNodeCollections, isAliquotNodeCollection, LineageLink, LineageResult } from './models';
+import { createLineageNodeCollections, isAliquotNode, LineageLink, LineageResult } from './models';
 import { DetailsListNodes } from './node/DetailsList';
 import { InjectedLineage, withLineage } from './withLineage';
 
@@ -39,24 +39,14 @@ class LineageSummaryImpl extends PureComponent<InjectedLineage & LineageSummaryO
 
         return groups.map(groupName => {
             const group = nodesByType[groupName];
-            const groupDisplayName = group.displayType;
-            const isAliquot = isAliquotNodeCollection(group);
             const title =
-                isAliquot && group.nodes.length > 1
+                isAliquotNode(group) && group.nodes.length > 1
                     ? nodeName + ' Aliquots'
-                    : groupDisplayName +
+                    : group.displayType +
                       ' ' +
-                      (suffixes.has(nodesByType[groupName].queryName)
-                          ? suffixes.get(nodesByType[groupName].queryName)
-                          : defaultTitleSuffix);
-            return (
-                <DetailsListNodes
-                    key={groupName}
-                    title={title}
-                    nodes={nodesByType[groupName]}
-                    highlightNode={highlightNode}
-                />
-            );
+                      (suffixes.has(group.queryName) ? suffixes.get(group.queryName) : defaultTitleSuffix);
+
+            return <DetailsListNodes key={groupName} title={title} nodes={group} highlightNode={highlightNode} />;
         });
     };
 

--- a/packages/components/src/internal/components/lineage/constants.tsx
+++ b/packages/components/src/internal/components/lineage/constants.tsx
@@ -23,7 +23,6 @@ export const DEFAULT_LINEAGE_DIRECTION = LINEAGE_DIRECTIONS.Children;
 export const DEFAULT_GROUPING_OPTIONS: LineageGroupingOptions = {
     childDepth: DEFAULT_LINEAGE_DISTANCE,
     combineSize: 6,
-    combineTypeSize: 6,
     generations: LINEAGE_GROUPING_GENERATIONS.All,
     parentDepth: DEFAULT_LINEAGE_DISTANCE + 1,
 };

--- a/packages/components/src/internal/components/lineage/constants.tsx
+++ b/packages/components/src/internal/components/lineage/constants.tsx
@@ -23,6 +23,7 @@ export const DEFAULT_LINEAGE_DIRECTION = LINEAGE_DIRECTIONS.Children;
 export const DEFAULT_GROUPING_OPTIONS: LineageGroupingOptions = {
     childDepth: DEFAULT_LINEAGE_DISTANCE,
     combineSize: 6,
+    combineTypeSize: 6,
     generations: LINEAGE_GROUPING_GENERATIONS.All,
     parentDepth: DEFAULT_LINEAGE_DISTANCE + 1,
 };

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -1345,7 +1345,8 @@ function processNodes(
             });
             queue = [combinedLineageNode.lsid];
         }
-    } else if (grouping.combineTypeSize && edges.size >= grouping.combineTypeSize) {
+        // eslint-disable-next-line no-constant-condition
+    } else if (false /* disabled for now */ && grouping.combineTypeSize && edges.size >= grouping.combineTypeSize) {
         applyCombineTypeSize(lsid, edges, nodes, options, dir, visEdges, visNodes, nodesInCombinedNode);
     } else {
         // create a VisGraph Edge from the current node to the edge's target for each edge

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -721,7 +721,6 @@ function makeEdgeId(fromId: IdType, toId: IdType): string {
     return fromId + EDGE_ID_SEPARATOR + toId;
 }
 
-type CombinedNodeMap = Record<string, VisGraphCombinedNode>;
 type EdgeMap = Record<string, Edge>;
 type LineageNodeMap = Record<string, LineageNode>;
 type VisNodeMap = Record<string, VisGraphNode | VisGraphCombinedNode>;
@@ -1053,7 +1052,6 @@ function applyCombineSize(
     dir: LINEAGE_DIRECTIONS,
     visEdges: EdgeMap,
     visNodes: VisNodeMap,
-    combinedNodes: CombinedNodeMap,
     nodesInCombinedNode: { [key: string]: string[] }
 ): LineageNode {
     let combinedLineageNode: LineageNode;
@@ -1078,7 +1076,6 @@ function applyCombineSize(
 
         combinedAliquotNode = createCombinedVisNode(aliquotNodes, options, node.name);
         visNodes[combinedAliquotNode.id] = combinedAliquotNode;
-        combinedNodes[combinedAliquotNode.id] = combinedAliquotNode;
 
         // create a VisGraph Edge from the current node to the new combined node
         // as well as an edge for each of the combined nodes that one of the edge target nodes may belong to.
@@ -1090,7 +1087,6 @@ function applyCombineSize(
 
         combinedNonAliquotNode = createCombinedVisNode(nonAliquotNodes, options, node.name);
         visNodes[combinedNonAliquotNode.id] = combinedNonAliquotNode;
-        combinedNodes[combinedNonAliquotNode.id] = combinedNonAliquotNode;
         combinedLineageNode = new LineageNode({
             children: nonAliquotNodes.reduce((children, n) => {
                 return children.concat(n.children) as List<LineageLink>;
@@ -1174,7 +1170,6 @@ function applyCombineTypeSize(
     dir: LINEAGE_DIRECTIONS,
     visEdges: EdgeMap,
     visNodes: VisNodeMap,
-    combinedNodes: CombinedNodeMap,
     nodesInCombinedNode: { [key: string]: string[] }
 ): void {
     const node = nodes[lsid];
@@ -1191,7 +1186,6 @@ function applyCombineTypeSize(
                 node.name
             );
             visNodes[combineByTypeNode.id] = combineByTypeNode;
-            combinedNodes[combineByTypeNode.id] = combineByTypeNode;
 
             addEdges(lsid, combineByTypeNode.id, visEdges, List(groupedEdges), nodesInCombinedNode, dir);
 
@@ -1249,7 +1243,6 @@ function processNodes(
     dir: LINEAGE_DIRECTIONS,
     visEdges: EdgeMap,
     visNodes: VisNodeMap,
-    combinedNodes: CombinedNodeMap,
     nodesInCombinedNode: { [key: string]: string[] },
     depth = 0,
     processed: { [key: string]: boolean } = {},
@@ -1343,7 +1336,6 @@ function processNodes(
             dir,
             visEdges,
             visNodes,
-            combinedNodes,
             nodesInCombinedNode
         );
         if (combinedLineageNode) {
@@ -1354,7 +1346,7 @@ function processNodes(
             queue = [combinedLineageNode.lsid];
         }
     } else if (grouping.combineTypeSize && edges.size >= grouping.combineTypeSize) {
-        applyCombineTypeSize(lsid, edges, nodes, options, dir, visEdges, visNodes, combinedNodes, nodesInCombinedNode);
+        applyCombineTypeSize(lsid, edges, nodes, options, dir, visEdges, visNodes, nodesInCombinedNode);
     } else {
         // create a VisGraph Edge from the current node to the edge's target for each edge
         addEdges(lsid, null, visEdges, edges, nodesInCombinedNode, dir);
@@ -1370,7 +1362,6 @@ function processNodes(
             dir,
             visEdges,
             visNodes,
-            combinedNodes,
             nodesInCombinedNode,
             depth + 1,
             processed,
@@ -1455,10 +1446,6 @@ export function generate(result: LineageResult, options?: LineageOptions): VisGr
     const visEdges: EdgeMap = {};
 
     // Intermediate state used by processNodes
-    // combined id -> VisGraphCombinedNode
-    const combinedNodes: CombinedNodeMap = {};
-
-    // Intermediate state used by processNodes
     // lsid -> Array of combined id nodes
     const nodesInCombinedNode: { [key: string]: string[] } = {};
 
@@ -1472,7 +1459,6 @@ export function generate(result: LineageResult, options?: LineageOptions): VisGr
             LINEAGE_DIRECTIONS.Parent,
             visEdges,
             visNodes,
-            combinedNodes,
             nodesInCombinedNode
         );
 
@@ -1485,7 +1471,6 @@ export function generate(result: LineageResult, options?: LineageOptions): VisGr
             LINEAGE_DIRECTIONS.Children,
             visEdges,
             visNodes,
-            combinedNodes,
             nodesInCombinedNode
         );
     });

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -3,7 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { Draft, immerable, produce } from 'immer';
-import { List, Map, Record } from 'immutable';
+import { List, Map, Record as ImmutableRecord } from 'immutable';
 import { Experiment, Utils } from '@labkey/api';
 import { DataSet, Edge, Node } from 'vis-network';
 
@@ -76,7 +76,7 @@ export function applyLineageOptions(options?: LineageOptions): LineageOptions {
     return _options;
 }
 
-export class LineageNodeMetadata extends Record({
+export class LineageNodeMetadata extends ImmutableRecord({
     date: undefined,
     description: undefined,
     aliases: undefined,
@@ -112,7 +112,7 @@ export class LineageNodeMetadata extends Record({
     }
 }
 
-export class LineageLink extends Record({
+export class LineageLink extends ImmutableRecord({
     lsid: undefined,
 }) {
     declare lsid: string;
@@ -248,7 +248,7 @@ interface LineageNodeConfig
 }
 
 export class LineageNode
-    extends Record({
+    extends ImmutableRecord({
         absolutePath: undefined,
         children: undefined,
         container: undefined,
@@ -351,7 +351,7 @@ export class LineageNode
     }
 }
 
-export class LineageResult extends Record({
+export class LineageResult extends ImmutableRecord({
     mergedIn: undefined,
     nodes: undefined,
     seed: undefined,
@@ -722,7 +722,7 @@ interface IVisGraphOptions {
     edges: DataSet<Edge>;
     initialSelection: string[];
     nodes: DataSet<VisGraphNode | VisGraphCombinedNode>;
-    options: { [key: string]: any };
+    options: Record<string, any>;
 }
 
 export class VisGraphOptions implements IVisGraphOptions {
@@ -731,7 +731,7 @@ export class VisGraphOptions implements IVisGraphOptions {
     readonly edges: DataSet<Edge>;
     readonly initialSelection: string[];
     readonly nodes: DataSet<VisGraphNode | VisGraphCombinedNode>;
-    readonly options: { [key: string]: any };
+    readonly options: Record<string, any>;
 
     constructor(config?: Partial<IVisGraphOptions>) {
         Object.assign(this, config);
@@ -748,7 +748,7 @@ function makeEdgeId(fromId, toId): string {
     return fromId + EDGE_ID_SEPARATOR + toId;
 }
 
-type EdgeMap = { [key: string]: Edge };
+type EdgeMap = Record<string, Edge>;
 
 /**
  * Create an edge between fromId -> toId when dir === Child.

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -9,7 +9,7 @@ import { List } from 'immutable';
 import { LineageSummary } from '../LineageSummary';
 import {
     createLineageNodeCollections,
-    isAliquotNodeCollection,
+    isAliquotNode,
     LineageNodeCollectionByType,
     LineageIOWithMetadata,
     LineageNode,
@@ -121,7 +121,7 @@ interface ClusterNodeDetailProps {
 export class ClusterNodeDetail extends PureComponent<ClusterNodeDetailProps> {
     static getGroupDisplayName(nodesByType, groupName, parentNodeName?) {
         const group = nodesByType[groupName];
-        const isAliquot = isAliquotNodeCollection(group);
+        const isAliquot = isAliquotNode(group);
         const aliquotDisplayName = (parentNodeName ? parentNodeName + ' ' : '') + 'Aliquots';
         return isAliquot ? aliquotDisplayName : group.displayType;
     }

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetailFactory.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetailFactory.tsx
@@ -1,8 +1,7 @@
 import React, { PureComponent, ReactNode } from 'react';
 
 import { LineageOptions } from '../types';
-import { Lineage } from '../models';
-import { isBasicNode, isClusterNode, isCombinedNode, VisGraphNodeType } from '../models';
+import { isBasicNode, isClusterNode, isCombinedNode, Lineage, VisGraphNodeType } from '../models';
 
 import { LoadingSpinner } from '../../base/LoadingSpinner';
 
@@ -21,7 +20,9 @@ export class LineageNodeDetailFactory extends PureComponent<LineageNodeDetailFac
 
         if (!lineage || lineage.error) {
             return null;
-        } else if (!lineage.isLoaded()) {
+        }
+
+        if (!lineage.isLoaded()) {
             // Render selected node if seed has been pre-fetched
             if (lineage.isSeedLoaded()) {
                 return (
@@ -35,11 +36,11 @@ export class LineageNodeDetailFactory extends PureComponent<LineageNodeDetailFac
             return <LoadingSpinner msg="Loading details..." />;
         }
 
-        const seed = lineage.seed;
-
-        if (!selectedNodes || selectedNodes.length == 0) {
+        if (!selectedNodes || selectedNodes.length === 0) {
             return <em>Select a node from the graph to view the details.</em>;
-        } else if (selectedNodes.length === 1) {
+        }
+
+        if (selectedNodes.length === 1) {
             const node = selectedNodes[0];
 
             if (isBasicNode(node)) {
@@ -48,7 +49,7 @@ export class LineageNodeDetailFactory extends PureComponent<LineageNodeDetailFac
                         highlightNode={highlightNode}
                         lineageOptions={lineageOptions}
                         node={node.lineageNode}
-                        seed={seed}
+                        seed={lineage.seed}
                     />
                 );
             } else if (isCombinedNode(node)) {
@@ -73,8 +74,8 @@ export class LineageNodeDetailFactory extends PureComponent<LineageNodeDetailFac
             }
 
             throw new Error('unknown node kind');
-        } else {
-            return <div>Multiple selected nodes</div>;
         }
+
+        return <div>Multiple selected nodes</div>;
     }
 }

--- a/packages/components/src/internal/components/lineage/types.ts
+++ b/packages/components/src/internal/components/lineage/types.ts
@@ -66,7 +66,6 @@ export interface LineageOptions {
     // the Map<string, string> should be keyed off of the queryName for the group title suffix being modified
     groupTitles?: Map<LINEAGE_DIRECTIONS, Map<string, string>>;
     grouping?: LineageGroupingOptions;
-    originalFilters?: LineageFilter[];
     request?: Experiment.ExperimentJSONConverterOptions;
     runProtocolLsid?: string;
     urlResolver?: LineageURLResolvers;

--- a/packages/components/src/internal/components/lineage/types.ts
+++ b/packages/components/src/internal/components/lineage/types.ts
@@ -27,14 +27,14 @@ export enum LINEAGE_GROUPING_GENERATIONS {
  * to combine multiple nodes together.
  */
 export interface LineageGroupingOptions {
-    /** Determines when to stop traversing generations of nodes. */
-    generations?: LINEAGE_GROUPING_GENERATIONS;
-    /** When {@link generations} is {@link LINEAGE_GROUPING_GENERATIONS.Specific}, include this many generations along the parent axis. */
-    parentDepth?: number;
     /** When {@link generations} is {@link LINEAGE_GROUPING_GENERATIONS.Specific}, include this many generations along the child axis. */
     childDepth?: number;
     /** When the number of parent or children edges is greater than or equal to this threshold, create a combined node. */
     combineSize?: number;
+    /** Determines when to stop traversing generations of nodes. */
+    generations?: LINEAGE_GROUPING_GENERATIONS;
+    /** When {@link generations} is {@link LINEAGE_GROUPING_GENERATIONS.Specific}, include this many generations along the parent axis. */
+    parentDepth?: number;
 }
 
 export class LineageFilter {
@@ -55,12 +55,12 @@ export enum LineageURLResolvers {
 export interface LineageOptions {
     filterIn?: boolean;
     filters?: LineageFilter[];
-    grouping?: LineageGroupingOptions;
     // the Map<string, string> should be keyed off of the queryName for the group title suffix being modified
     groupTitles?: Map<LINEAGE_DIRECTIONS, Map<string, string>>;
+    grouping?: LineageGroupingOptions;
     request?: Experiment.ExperimentJSONConverterOptions;
-    urlResolver?: LineageURLResolvers;
     runProtocolLsid?: string;
+    urlResolver?: LineageURLResolvers;
 }
 
 export interface LineageIconMetadata {

--- a/packages/components/src/internal/components/lineage/types.ts
+++ b/packages/components/src/internal/components/lineage/types.ts
@@ -58,6 +58,7 @@ export interface LineageOptions {
     // the Map<string, string> should be keyed off of the queryName for the group title suffix being modified
     groupTitles?: Map<LINEAGE_DIRECTIONS, Map<string, string>>;
     grouping?: LineageGroupingOptions;
+    originalFilters?: LineageFilter[];
     request?: Experiment.ExperimentJSONConverterOptions;
     runProtocolLsid?: string;
     urlResolver?: LineageURLResolvers;

--- a/packages/components/src/internal/components/lineage/types.ts
+++ b/packages/components/src/internal/components/lineage/types.ts
@@ -29,8 +29,16 @@ export enum LINEAGE_GROUPING_GENERATIONS {
 export interface LineageGroupingOptions {
     /** When {@link generations} is {@link LINEAGE_GROUPING_GENERATIONS.Specific}, include this many generations along the child axis. */
     childDepth?: number;
-    /** When the number of parent or children edges is greater than or equal to this threshold, create a combined node. */
+    /**
+     * When the number of parent or children edges, for each depth,
+     * is greater than or equal to this threshold, create a combined node.
+     */
     combineSize?: number;
+    /**
+     * When the number of parent or children edges of a common type, for each depth,
+     * is greater than or equal to this threshold, create a combined node.
+     */
+    combineTypeSize?: number;
     /** Determines when to stop traversing generations of nodes. */
     generations?: LINEAGE_GROUPING_GENERATIONS;
     /** When {@link generations} is {@link LINEAGE_GROUPING_GENERATIONS.Specific}, include this many generations along the parent axis. */

--- a/packages/components/src/internal/components/lineage/types.ts
+++ b/packages/components/src/internal/components/lineage/types.ts
@@ -35,7 +35,7 @@ export interface LineageGroupingOptions {
      */
     combineSize?: number;
     /**
-     * When the number of parent or children edges of a common type, for each depth,
+     * (DISABLED) When the number of parent or children edges of a common type, for each depth,
      * is greater than or equal to this threshold, create a combined node.
      */
     combineTypeSize?: number;

--- a/packages/components/src/internal/components/lineage/types.ts
+++ b/packages/components/src/internal/components/lineage/types.ts
@@ -34,11 +34,6 @@ export interface LineageGroupingOptions {
      * is greater than or equal to this threshold, create a combined node.
      */
     combineSize?: number;
-    /**
-     * (DISABLED) When the number of parent or children edges of a common type, for each depth,
-     * is greater than or equal to this threshold, create a combined node.
-     */
-    combineTypeSize?: number;
     /** Determines when to stop traversing generations of nodes. */
     generations?: LINEAGE_GROUPING_GENERATIONS;
     /** When {@link generations} is {@link LINEAGE_GROUPING_GENERATIONS.Specific}, include this many generations along the parent axis. */

--- a/packages/components/src/internal/components/lineage/vis/VisGraph.tsx
+++ b/packages/components/src/internal/components/lineage/vis/VisGraph.tsx
@@ -88,6 +88,7 @@ interface VisGraphProps {
     onNodeDoubleClick?: (clickedNode: VisGraphNodeType) => void;
     onNodeHover?: (node: VisGraphNodeType, coords: HoverNodeCoords) => void;
     onNodeSelect?: (selectedNodes: VisGraphNodeType[]) => void;
+    onToggleSettings: () => void;
     options: VisGraphOptions;
     seed?: string;
 }
@@ -440,7 +441,11 @@ export class VisGraph extends Component<VisGraphProps, VisGraphState> {
         return (
             <div className="lineage-visgraph-ct">
                 <div ref="visgraph" style={{ height: graphHeight }} />
-                <VisGraphControls getNetwork={this.getNetwork} onReset={this.onReset} />
+                <VisGraphControls
+                    getNetwork={this.getNetwork}
+                    onReset={this.onReset}
+                    onToggleSettings={this.props.onToggleSettings}
+                />
             </div>
         );
     }

--- a/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
+++ b/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
@@ -8,6 +8,7 @@ const ZOOM_INCREMENT = 0.05;
 interface GraphControlsProps {
     getNetwork: () => Network;
     onReset: (selectSeed: boolean) => void;
+    onToggleSettings: () => void;
 }
 
 export class VisGraphControls extends PureComponent<GraphControlsProps> {
@@ -55,6 +56,9 @@ export class VisGraphControls extends PureComponent<GraphControlsProps> {
             <div className="lineage-visgraph-controls">
                 <div className="lineage-visgraph-control-settings">
                     <div className="btn-group">
+                        <Button onClick={this.props.onToggleSettings}>
+                            <i className="fa fa-gear" />
+                        </Button>
                         <DropdownButton id="graph-control-dd" title={<i className="fa fa-undo" />} pullRight>
                             <MenuItem onClick={this.resetSelect}>Reset view and select seed</MenuItem>
                             <MenuItem onClick={this.reset}>Reset view</MenuItem>

--- a/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
+++ b/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
@@ -56,9 +56,11 @@ export class VisGraphControls extends PureComponent<GraphControlsProps> {
             <div className="lineage-visgraph-controls">
                 <div className="lineage-visgraph-control-settings">
                     <div className="btn-group">
-                        <Button onClick={this.props.onToggleSettings}>
-                            <i className="fa fa-gear" />
-                        </Button>
+                        {!!this.props.onToggleSettings && (
+                            <Button onClick={this.props.onToggleSettings}>
+                                <i className="fa fa-gear" />
+                            </Button>
+                        )}
                         <DropdownButton id="graph-control-dd" title={<i className="fa fa-undo" />} pullRight>
                             <MenuItem onClick={this.resetSelect}>Reset view and select seed</MenuItem>
                             <MenuItem onClick={this.reset}>Reset view</MenuItem>

--- a/packages/components/src/internal/components/lineage/withLineage.tsx
+++ b/packages/components/src/internal/components/lineage/withLineage.tsx
@@ -4,7 +4,7 @@ import { produce } from 'immer';
 import { LoadingState } from '../../../public/LoadingState';
 
 import { loadLineageResult, loadSampleStats, loadSeedResult } from './actions';
-import { ILineage, Lineage } from './models';
+import { Lineage } from './models';
 import { LineageOptions } from './types';
 import { DEFAULT_LINEAGE_DISTANCE } from './constants';
 
@@ -108,7 +108,7 @@ export function withLineage<Props>(
          * Throws an error if called prior to the state's lineage having been initialized.
          * @param lineageProps The lineage properties to update. Properties not specified will be left unchanged.
          */
-        updateLineage = async (lineageProps: Partial<ILineage>): Promise<void> => {
+        updateLineage = async (lineageProps: Partial<Lineage>): Promise<void> => {
             if (!this.state.lineage) {
                 throw new Error('withLineage: Called "updateLineage" prior to setting lineage.');
             }

--- a/packages/components/src/theme/lineage.scss
+++ b/packages/components/src/theme/lineage.scss
@@ -174,3 +174,44 @@
         border-top: solid 1px $gray-border;
     }
 }
+
+.lineage-settings-heading {
+    font-size: 18px;
+    font-weight: 500;
+    margin-bottom: 16px;
+}
+
+.lineage-settings__section {
+    margin-bottom: 32px;
+}
+
+.lineage-settings__section-header {
+    color: #555555;
+    font-size: 12px;
+    font-weight: bold;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+.lineage-settings__section .form-control {
+    margin-bottom: 16px;
+    max-width: 100px;
+}
+
+.lineage-settings__section label {
+    font-weight: normal;
+}
+
+.lineage-settings__filter-label {
+    margin-left: 5px;
+}
+
+.lineage-settings__tip-body {
+    max-width: 350px;
+}
+
+.lineage-settings__tip-list {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 0;
+}


### PR DESCRIPTION
#### Rationale
This PR contains two lineage-related changes:

1. An update to combine nodes (up/down)stream of other combined nodes to improve readability of graphs with a large number of nodes. This is specifically targeted to address [Issue 47572](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47572). <img width="600" alt="image" src="https://user-images.githubusercontent.com/3926239/228342943-4b3474ef-e49e-41bb-bb2f-c557f531dbc1.png">
2. Adds a new "Graph Options" (a.k.a. `LineageSettings`) pane to give users more fine-grain control over how nodes in the graph are filtered and grouped. This is being made available for advanced preview to allow for exploration of improvements to our default graph rendering against real-world data. As such, it is only available when the URL parameter `lineageSettings=1` is set (e.g. `biologics-app.view?lineageSettings=1#/app`). <img width="600" alt="image" src="https://user-images.githubusercontent.com/3926239/228343185-70881255-fe01-4d95-b855-903ebc928361.png">


#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1155
- https://github.com/LabKey/biologics/pull/2037
- https://github.com/LabKey/sampleManagement/pull/1716
- https://github.com/LabKey/inventory/pull/797

#### Changes
- Graph Options
  - Add `LineageSettings` component that allows for manipulation of settings for the graph.
  - Expose graph options "gear" icon via `LineageGraph` component.
- Combine Nodes
  - Create a `LineageNode` instance that replaces all combined nodes in processing. This node consolidates all edges from combined nodes and
  - Factor out `applyCombineSize` method to encapsulate `combineSize` logic.
  - Factor our `processCombinedNode` method to encapsulate construction of edges from a combined node.
- Miscellaneous
  - Remove superfluous `ILineage` and `ILineageGridModel` interfaces.
  - Refactor away `_processNodes` wrapping method.
  - Remove `combinedNodes` tracking as it is not utilized.
  - Improve typings of lineage model methods.
