### PR TITLE
Issue 47502: ProductMenu should use isAppHomeFolder to determine containerPath for fetchContainers call

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.302.3-fb-productMenuIssue47502.0",
+  "version": "2.302.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.302.3",
+  "version": "2.302.3-fb-productMenuIssue47502.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.302.TBD
-*Released*: TBD
+### version 2.302.4
+*Released*: 30 March 2023
 - Issue 47502: ProductMenu should use isAppHomeFolder to determine containerPath for fetchContainers call
 
 ### version 2.302.3

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.302.TBD
+*Released*: TBD
+- Issue 47502: ProductMenu should use isAppHomeFolder to determine containerPath for fetchContainers call
+
 ### version 2.302.3
 *Released*: 27 March 2023
 - Issue 47569: Remove setting for inheriting permissions for the Site Roles and Assignments


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47502

The app ProductMenu makes a call to fetchContainers so that it can get the current container and any child containers, for the app projects listing in the mega menu. The containerPath being used for that API call was only using the LK container depth to determine if it should consider the current container an "App home project". This wasn't correct for the LK subfolder scenario in all cases. This PR changes that check to use the existing isAppHomeFolder() helper instead.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1156
- https://github.com/LabKey/sampleManagement/pull/1719
- https://github.com/LabKey/biologics/pull/2048
- https://github.com/LabKey/inventory/pull/799

#### Changes
- use isAppHomeFolder() to determine containerPath to use for fetchContainers API call
