### PR TITLE
Sample overview Aliquots panel QueryModel loading improvement

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.320.0-fb-aliquotPanelChanges.0",
+  "version": "2.320.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.319.0",
+  "version": "2.319.0-fb-aliquotPanelChanges.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.320.0",
+  "version": "2.320.0-fb-aliquotPanelChanges.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.320.1
+*Released*: 31 March 2023
 - Aliquot panel perf improvements by removing the unnecessary call to get the total row count and extra storage related columns
 
 ### version 2.320.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Aliquot panel perf improvements by removing the unnecessary call to get the total row count and extra storage related columns
+
 ### version 2.319.0
 *Released*: 30 March 2023
 - Graph Options

--- a/packages/components/src/entities/SampleAliquotsSummary.tsx
+++ b/packages/components/src/entities/SampleAliquotsSummary.tsx
@@ -12,7 +12,7 @@ import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 
 import { InjectedQueryModels, withQueryModels } from '../public/QueryModel/withQueryModels';
 
-import { ALIQUOT_FILTER_MODE } from '../internal/components/samples/constants';
+import { ALIQUOT_FILTER_MODE, SAMPLE_STORAGE_COLUMNS } from '../internal/components/samples/constants';
 
 import { SampleAliquotsStats } from '../internal/components/samples/models';
 import { getSampleAliquotsQueryConfig, getSampleAliquotsStats } from '../internal/components/samples/actions';
@@ -128,7 +128,7 @@ const SampleAliquotsSummaryPanel: FC<OwnProps & PanelProps & InjectedQueryModels
     const { actions, aliquotsModelId, jobsModelId, queryModels, ...ownProps } = props;
     const aliquotsModel = queryModels[aliquotsModelId];
     const jobsModel = queryModels[jobsModelId];
-    const isLoading = aliquotsModel.isLoadingTotalCount || !jobsModel || jobsModel.isLoadingTotalCount;
+    const isLoading = aliquotsModel.isLoading || !jobsModel || jobsModel.isLoadingTotalCount;
 
     return (
         <div className="panel panel-default">
@@ -157,7 +157,7 @@ export const SampleAliquotsSummary: FC<SampleAliquotsSummaryProps> = memo(props 
     const { aliquotJobsQueryConfig, ...ownProps } = props;
     const { sampleId, sampleSet, sampleLsid } = ownProps;
     const aliquotsQueryConfig = useMemo(
-        () => getSampleAliquotsQueryConfig(sampleSet, sampleLsid, false),
+        () => getSampleAliquotsQueryConfig(sampleSet, sampleLsid, false, undefined, SAMPLE_STORAGE_COLUMNS),
         [sampleLsid, sampleSet]
     );
     const queryConfigs = { [aliquotsQueryConfig.id]: aliquotsQueryConfig };

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -819,12 +819,12 @@ export function getSampleAliquotsQueryConfig(
         bindURL: forGridView,
         maxRows: forGridView ? undefined : -1,
         omittedColumns: omitCols ? [...omitCols, omitCol] : [omitCol],
-        requiredColumns: [...SAMPLE_STATUS_REQUIRED_COLUMNS],
+        requiredColumns: forGridView ? [...SAMPLE_STATUS_REQUIRED_COLUMNS] : ['RowId', 'StoredAmount'],
         baseFilters: [
             Filter.create('RootMaterialLSID', aliquotRootLsid ?? sampleLsid),
             Filter.create('Lsid', sampleLsid, Filter.Types.EXP_CHILD_OF),
         ],
-        includeTotalCount: true,
+        includeTotalCount: forGridView,
     };
 }
 


### PR DESCRIPTION
#### Rationale
While investigating performance of the panels on the sample overview page, I noticed that the Aliquots panel QueryModel was doing an extra call to get the totalRows count when it didn't need to and it was also requesting extra storage columns for the rows that weren't needed.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1160
- https://github.com/LabKey/sampleManagement/pull/1724
- https://github.com/LabKey/biologics/pull/2055
- https://github.com/LabKey/inventory/pull/804

#### Changes
- Aliquots QueryModel remove the unnecessary call to get the total row count and extra storage related columns
