### PR TITLE
useContainerUser: default to not include subfolders, standard properties

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.18.8",
+    "@labkey/api": "1.19.0",
     "bootstrap": "~3.4.1",
     "classnames": "~2.3.2",
     "enzyme": "~3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.320.1",
+  "version": "2.321.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.321.0
+*Released*: 31 March 2023
+- Allow for specifying other options on requests made by `useContainerUser`.
+- Consolidate usage of `SampleStorageLocationComponentProps` and `SampleStorageMenuComponentProps` types by exporting for external reference.
+
 ### version 2.320.1
 *Released*: 31 March 2023
 - Aliquot panel perf improvements by removing the unnecessary call to get the total row count and extra storage related columns

--- a/packages/components/src/entities/SampleHeader.tsx
+++ b/packages/components/src/entities/SampleHeader.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType, FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { MenuItem } from 'react-bootstrap';
-import { Container, PermissionTypes, User } from '@labkey/api';
+import { Container, PermissionTypes } from '@labkey/api';
 
 import { EntityDataType } from '../internal/components/entities/models';
 import { QueryModel } from '../public/QueryModel/QueryModel';
@@ -38,19 +38,18 @@ import { invalidateLineageResults } from '../internal/components/lineage/actions
 
 import { isAssayEnabled, isWorkflowEnabled } from '../internal/app/utils';
 
+import { User } from '../internal/components/base/models/User';
+
+import { SampleStorageMenuComponentProps } from '../internal/sampleModels';
+
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 import { AssayImportSubMenuItem } from './AssayImportSubMenuItem';
 import { EntityDeleteModal } from './EntityDeleteModal';
 import { createEntityParentKey, getJobCreationHref, getSampleAuditBehaviorType, getSampleDeleteMessage } from './utils';
 import { onSampleChange } from './actions';
 
-interface StorageMenuProps {
-    onUpdate?: (skipChangeCount?: boolean) => any;
-    sampleModel: QueryModel;
-}
-
 interface HeaderProps {
-    StorageMenu?: ComponentType<StorageMenuProps>;
+    StorageMenu?: ComponentType<SampleStorageMenuComponentProps>;
     assayProviderType?: string;
     canDerive?: boolean;
     entityDataType?: EntityDataType;
@@ -87,6 +86,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
         title,
         subtitle,
         StorageMenu,
+        user,
     } = props;
     const { queryInfo } = sampleModel;
     const { createNotification } = useNotificationsContext();
@@ -96,7 +96,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
     const [showPrintDialog, setShowPrintDialog] = useState<boolean>(false);
     const sampleId = useMemo(() => sampleModel.getRowValue('RowId'), [sampleModel]);
     const sampleIds = useMemo(() => [sampleId], [sampleId]);
-    const { moduleContext, user } = useServerContext();
+    const { moduleContext } = useServerContext();
 
     const isMedia = queryInfo?.isMedia;
 
@@ -119,7 +119,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                 setError(true);
             }
         })();
-    }, [sampleIds]);
+    }, [sampleIds, user]);
 
     const onAfterDelete = useCallback((): void => {
         invalidateLineageResults();
@@ -287,7 +287,9 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                                 </RequiresPermission>
                             )}
 
-                            {!isMedia && !!StorageMenu && <StorageMenu onUpdate={onUpdate} sampleModel={sampleModel} />}
+                            {!isMedia && !!StorageMenu && (
+                                <StorageMenu onUpdate={onUpdate} sampleModel={sampleModel} sampleUser={user} />
+                            )}
 
                             {canPrintLabels && <MenuItem onClick={onPrintLabel}>Print Labels</MenuItem>}
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1571,3 +1571,4 @@ export type {
 } from './internal/components/labels/LabelPrintingContextProvider';
 export type { SamplesEditableGridProps } from './internal/sampleModels';
 export type { MeasurementUnit } from './internal/util/measurement';
+export type { SampleStorageLocationComponentProps, SampleStorageMenuComponentProps } from './internal/sampleModels';

--- a/packages/components/src/internal/components/container/actions.ts
+++ b/packages/components/src/internal/components/container/actions.ts
@@ -44,6 +44,7 @@ export interface UseContainerUser extends ContainerUser {
 /**
  * React hook that supplies the container, user, and the container-relative permissions for the user.
  * @param containerIdOrPath The container id or container path to request.
+ * @param includeSubfolders Whether to include subfolders of the requested container.
  * Example:
  * ```tsx
  * const SeeUserPermissions: React.FC = () => {
@@ -75,7 +76,7 @@ export interface UseContainerUser extends ContainerUser {
  * };
  * ```
  */
-export function useContainerUser(containerIdOrPath: string): UseContainerUser {
+export function useContainerUser(containerIdOrPath: string, includeSubfolders = false): UseContainerUser {
     const [container, setContainer] = useState<Container>();
     const [containerUsers, setContainerUsers] = useState<Record<string, ContainerUser>>({});
     const [error, setError] = useState<string>();
@@ -92,7 +93,10 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
             setLoadingState(LoadingState.LOADING);
 
             try {
-                const containers = await api.security.fetchContainers({ containerPath: containerIdOrPath });
+                const containers = await api.security.fetchContainers({
+                    containerPath: containerIdOrPath,
+                    includeSubfolders,
+                });
                 let container_, contextUser_;
 
                 const containerUsers_: Record<string, ContainerUser> = containers.reduce((cu, ct, i) => {
@@ -117,7 +121,7 @@ export function useContainerUser(containerIdOrPath: string): UseContainerUser {
 
             setLoadingState(LoadingState.LOADED);
         })();
-    }, [api, containerIdOrPath, user]);
+    }, [api, containerIdOrPath, includeSubfolders, user]);
 
     return { container, containerUsers, error, isLoaded: !isLoading(loadingState), user: contextUser };
 }

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -129,6 +129,16 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
     };
 
     fetchContainers = (options: FetchContainerOptions): Promise<Container[]> => {
+        // NK: By default the server processes "includeSubfolders=false" as setting the
+        // depth to 1. When the depth is set to 1 the results will include the first level of
+        // subfolders negating the desire to not include subfolders. This endpoint wrapper
+        // works around this by altering requests for "includeSubfolders=false" to be
+        // "includeSubfolders=true&depth=0" so that subfolders are not included.
+        if (options?.includeSubfolders === false && options.depth === undefined) {
+            options.includeSubfolders = true;
+            options.depth = 0;
+        }
+
         return new Promise((resolve, reject) => {
             Security.getContainers({
                 ...options,
@@ -255,7 +265,7 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
 }
 
 function recurseContainerHierarchy(data: Security.ContainerHierarchy, container: Container): Container[] {
-    return data.children.reduce(
+    return (data.children ?? []).reduce(
         (containers, c) => containers.concat(recurseContainerHierarchy(c, new Container(c))),
         [container]
     );

--- a/packages/components/src/internal/sampleModels.ts
+++ b/packages/components/src/internal/sampleModels.ts
@@ -1,8 +1,10 @@
 import { List, Map, OrderedMap } from 'immutable';
 import { ComponentType } from 'react';
+
 import { QueryModel } from '../public/QueryModel/QueryModel';
 import { RequiresModelAndActions } from '../public/QueryModel/withQueryModels';
 import { SchemaQuery } from '../public/SchemaQuery';
+
 import { ComponentsAPIWrapper } from './APIWrapper';
 import { User } from './components/base/models/User';
 import { EntityDataType } from './components/entities/models';
@@ -13,8 +15,7 @@ export interface AssaySampleColumnProp {
     lookupFieldKey: string;
 }
 
-// Note: this should stay in sync with the freezermanager/src/components/SampleStorageLocation.tsx props
-interface SampleStorageLocationComponentProps {
+export interface SampleStorageLocationComponentProps {
     actionChangeCount?: number;
     currentProductId?: string;
     onUpdate?: () => void;
@@ -25,10 +26,10 @@ interface SampleStorageLocationComponentProps {
 
 export type SampleStorageLocation = ComponentType<SampleStorageLocationComponentProps>;
 
-// Note: this should stay in sync with the freezermanager/src/components/SampleStorageMenu.tsx props
-interface SampleStorageMenuComponentProps {
+export interface SampleStorageMenuComponentProps {
     onUpdate?: (skipChangeCount?: boolean) => void;
     sampleModel: QueryModel;
+    sampleUser: User;
 }
 
 export type SampleStorageMenu = ComponentType<SampleStorageMenuComponentProps>;

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1506,10 +1506,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.18.8":
-  version "1.18.8"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz#e7d94c3a1056e8841380f9e7ddbd39568739752c"
-  integrity sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA==
+"@labkey/api@1.19.0":
+  version "1.19.0"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz#b2e3b99f232679e95f273f6a20bfea805a72269e"
+  integrity sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw==
 
 "@labkey/build@6.9.0":
   version "6.9.0"


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 47583](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47583) by defaulting to `includeSubfolders=false` and `includeStandardProperties=false` for `useContainerUser` hook. This hook is used throughout the applications so reducing the payload/processing for each request will improve performance.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1161
- https://github.com/LabKey/labkey-ui-premium/pull/71
- https://github.com/LabKey/biologics/pull/2060
- https://github.com/LabKey/sampleManagement/pull/1727
- https://github.com/LabKey/inventory/pull/805

#### Changes
- Allow for specifying other options on requests made by `useContainerUser`.
- Consolidate usage of `SampleStorageLocationComponentProps` and `SampleStorageMenuComponentProps` types by exporting for external reference.
- Bump `@labkey/api` to include latest properties
