### PR TITLE
UserDetailsPanel fix for currentProductId vs targetProductId in URL generation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.1-fb-elnHomeNav47376.1",
+  "version": "2.323.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.0",
+  "version": "2.323.0-fb-elnHomeNav47376.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.1-fb-elnHomeNav47376.0",
+  "version": "2.323.1-fb-elnHomeNav47376.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.1",
+  "version": "2.323.1-fb-elnHomeNav47376.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD April 2023
 * UserDetailsPanel fix for currentProductId vs targetProductId in URL generation
+* SampleAssayDetails fix to check for both hasSampleTypeAssayDesigns and hasAssayResults when displaying empty msg
 
 ### version 2.323.1
 *Released*: 4 April 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD April 2023
+### version 2.323.2
+*Released*: 4 April 2023
 * UserDetailsPanel fix for currentProductId vs targetProductId in URL generation
 * SampleAssayDetails fix to check for both hasSampleTypeAssayDesigns and hasAssayResults when displaying empty msg
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD April 2023
+* UserDetailsPanel fix for currentProductId vs targetProductId in URL generation
+
 ### version 2.323.0
 *Released*: 1 April 2023
 * Enable lineage relationship between custom data classes in apps

--- a/packages/components/src/entities/SampleAssayDetail.tsx
+++ b/packages/components/src/entities/SampleAssayDetail.tsx
@@ -271,8 +271,18 @@ export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & Injected
         [activeSampleAliquotType, emptyAliquotViewMsg, emptySampleViewMsg]
     );
 
+    if (!allLoaded || queryModelsWithData === undefined) {
+        return (
+            <AssayResultPanel>
+                <LoadingSpinner />
+            </AssayResultPanel>
+        );
+    }
+
     // always contains the summary grid model, so consider empty if we only have 1
-    if (!hasSampleTypeAssayDesigns) {
+    const hasAssayResults = Object.keys(queryModelsWithData).length > 1;
+
+    if (!hasSampleTypeAssayDesigns && !hasAssayResults) {
         if (emptyAssayDefDisplay) return <>{emptyAssayDefDisplay}</>;
 
         return (
@@ -285,16 +295,7 @@ export const SampleAssayDetailBodyImpl: FC<SampleAssayDetailBodyProps & Injected
         );
     }
 
-    if (!allLoaded || queryModelsWithData === undefined) {
-        return (
-            <AssayResultPanel>
-                <LoadingSpinner />
-            </AssayResultPanel>
-        );
-    }
-
-    // always contains the summary grid model, so consider empty if we only have 1
-    if (Object.keys(queryModelsWithData).length === 1) {
+    if (!hasAssayResults) {
         if (emptyAssayResultDisplay) return <>{emptyAssayResultDisplay}</>;
 
         return (

--- a/packages/components/src/internal/components/permissions/EffectiveRolesList.tsx
+++ b/packages/components/src/internal/components/permissions/EffectiveRolesList.tsx
@@ -8,7 +8,9 @@ import { Map, List } from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 
 import { User } from '../base/models/User';
-import { AppURL } from '../../url/AppURL';
+import { AppURL, createProductUrlFromParts } from '../../url/AppURL';
+
+import { getCurrentAppProperties, getPrimaryAppProperties } from '../../app/utils';
 
 import { SecurityAssignment, SecurityPolicy, SecurityRole } from './models';
 
@@ -24,6 +26,9 @@ interface Props {
 export class EffectiveRolesList extends React.PureComponent<Props> {
     render() {
         const { userId, policy, rootPolicy, rolesByUniqueName, currentUser, showLinks = true } = this.props;
+        const currentProductId = getCurrentAppProperties()?.productId;
+        const targetProductId = getPrimaryAppProperties()?.productId;
+
         let assignments =
             policy && rolesByUniqueName
                 ? policy.assignments.filter(assignment => assignment.userId === userId).toList()
@@ -51,16 +56,18 @@ export class EffectiveRolesList extends React.PureComponent<Props> {
                             {assignments.map(assignment => {
                                 const role = rolesByUniqueName.get(assignment.role);
                                 const roleDisplay = role ? role.displayName : assignment.role;
+                                const url = createProductUrlFromParts(
+                                    targetProductId,
+                                    currentProductId,
+                                    { expand: roleDisplay },
+                                    'admin',
+                                    'permissions'
+                                );
+
                                 return (
                                     <li key={assignment.role} className="principal-detail-li">
                                         {currentUser.isAdmin && showLinks ? (
-                                            <a
-                                                href={AppURL.create('admin', 'permissions')
-                                                    .addParam('expand', roleDisplay)
-                                                    .toHref()}
-                                            >
-                                                {roleDisplay}
-                                            </a>
+                                            <a href={url instanceof AppURL ? url.toHref() : url}>{roleDisplay}</a>
                                         ) : (
                                             roleDisplay
                                         )}

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -20,12 +20,14 @@ import { SCHEMAS } from '../../schemas';
 import { flattenValuesFromRow } from '../../../public/QueryModel/QueryModel';
 
 import { GroupsList } from '../permissions/GroupsList';
-import { AppURL } from '../../url/AppURL';
+import { AppURL, createProductUrlFromParts } from '../../url/AppURL';
 import { User } from '../base/models/User';
 import { getDefaultAPIWrapper } from '../../APIWrapper';
 import { SecurityAPIWrapper } from '../security/APIWrapper';
 import { Container } from '../base/models/Container';
 import { getRolesByUniqueName, processGetRolesResponse } from '../permissions/actions';
+
+import { getCurrentAppProperties, getPrimaryAppProperties } from '../../app/utils';
 
 import { UserResetPasswordConfirmModal } from './UserResetPasswordConfirmModal';
 import { UserDeleteConfirmModal } from './UserDeleteConfirmModal';
@@ -333,9 +335,15 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
         const { showDialog, userProperties } = this.state;
         const { user } = getServerContext();
         const isSelf = userId === user.id;
-        const manageUrl = AppURL.create('admin', 'users')
-            .addParam('usersView', 'all')
-            .addParam('all.UserId~eq', userId);
+        const currentProductId = getCurrentAppProperties()?.productId;
+        const targetProductId = getPrimaryAppProperties()?.productId;
+        const manageUrl = createProductUrlFromParts(
+            targetProductId,
+            currentProductId,
+            { usersView: 'all', 'all.UserId~eq': userId },
+            'admin',
+            'users'
+        );
 
         if (toggleDetailsModal) {
             return (
@@ -346,7 +354,10 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
                     <Modal.Body>{this.renderBody()}</Modal.Body>
                     {user.isAdmin && (
                         <Modal.Footer>
-                            <Button className="pull-right" href={manageUrl.toHref()}>
+                            <Button
+                                className="pull-right"
+                                href={manageUrl instanceof AppURL ? manageUrl.toHref() : manageUrl}
+                            >
                                 Manage
                             </Button>
                         </Modal.Footer>


### PR DESCRIPTION
#### Rationale
We missed adding the UserDetailsPanel modal in the LKFM app grid createdby/modifiedby column renderers when we added it for LKB and LKSM. This PR adds that but also fixes up the URL generation when the currentProductId <> primaryProductId.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/70

#### Changes
- UserDetailsPanel fix for currentProductId vs targetProductId in URL generation
- SampleAssayDetails fix to check for both hasSampleTypeAssayDesigns and hasAssayResults when displaying empty msg
