### PR TITLE
Miscellaneous Bug Fixes for 23.5

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.1-projectSettingsWithoutPremium.0",
+  "version": "2.323.1-projectSettingsWithoutPremium.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.0",
+  "version": "2.323.1-projectSettingsWithoutPremium.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.3-miscFixes235seh.3",
+  "version": "2.323.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.1-projectSettingsWithoutPremium.1",
+  "version": "2.323.1-miscFixes235seh.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.2-miscFixes235seh.1",
+  "version": "2.323.2-miscFixes235seh.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,11 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.323.3
+*Released*: 5 April 2023
 * Issue 47571: Make sure project settings panel shows up even when the premium module is not available.
 * Issue 47544: Don't show [blank] filter option if all distinct values are returned and none is blank.
-* Issue 47532: For the UserProfile form, make sure columns marked as readOnly remain readOnly, regardless of the setting for isUserEditable.
+* Issue 47532: For the UserProfile form, exclude lastActivity column explicitly
 * Issue 47100: Update documentation link for sample ID lookup fields.
 * Issue 47464: Update documentation link for ontology integration from LKSM.
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Issue 47571: Make sure project settings panel shows up even when the premium module is not available.
 * Issue 47544: Don't show [blank] filter option if all distinct values are returned and none is blank.
+* Issue 47532: For the UserProfile form, make sure columns marked as readOnly remain readOnly, regardless of the setting for isUserEditable.
 
 ### version 2.323.0
 *Released*: 1 April 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,11 +6,12 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 47571: Make sure project settings panel shows up even when the premium module is not available.
 * Issue 47544: Don't show [blank] filter option if all distinct values are returned and none is blank.
 * Issue 47532: For the UserProfile form, make sure columns marked as readOnly remain readOnly, regardless of the setting for isUserEditable.
+* Issue 47100: Update documentation link for sample ID lookup fields.
 
 ### version 2.323.0
 *Released*: 1 April 2023
 * Enable lineage relationship between custom data classes in apps
-  * Extract parent alias handling code from SampleTypeDesigner and SampleTypePropertiesPanel to DomianParentAliases and utils
+  * Extract parent alias handling code from SampleTypeDesigner and SampleTypePropertiesPanel to DomainParentAliases and utils
   * Support parent alias for DataClassDesigner
 
 ### version 2.322.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 47544: Don't show [blank] filter option if all distinct values are returned and none is blank.
 * Issue 47532: For the UserProfile form, make sure columns marked as readOnly remain readOnly, regardless of the setting for isUserEditable.
 * Issue 47100: Update documentation link for sample ID lookup fields.
+* Issue 47464: Update documentation link for ontology integration from LKSM.
 
 ### version 2.323.0
 *Released*: 1 April 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 47571: Make sure project settings panel shows up even when the premium module is not available.
+
 ### version 2.323.0
 *Released*: 1 April 2023
 * Enable lineage relationship between custom data classes in apps

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 47571: Make sure project settings panel shows up even when the premium module is not available.
+* Issue 47544: Don't show [blank] filter option if all distinct values are returned and none is blank.
 
 ### version 2.323.0
 *Released*: 1 April 2023

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -81,6 +81,9 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
                 lkVersion={lkVersion}
             >
                 <ActiveUserLimit />
+                {isProductProjectsEnabled(moduleContext) && (
+                    <ProjectSettings onChange={onSettingsChange} onSuccess={onSettingsSuccess} onPageError={onError} />
+                )}
                 <BarTenderSettingsForm
                     onChange={onSettingsChange}
                     onSuccess={onBarTenderSuccess}

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -87,7 +87,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                                 </p>
                                 <p>
                                     Learn more about using{' '}
-                                    {helpLinkNode(FIELD_EDITOR_SAMPLE_TYPES_TOPIC, 'sample types')} in LabKey.
+                                    {helpLinkNode(FIELD_EDITOR_SAMPLE_TYPES_TOPIC, 'sample fields')} in LabKey.
                                 </p>{' '}
                                 {/* TODO: contextualize help link based on app (SM, LKS, etc.)*/}
                             </LabelHelpTip>

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -1,6 +1,12 @@
 import React, { ReactNode, FC, memo, useCallback } from 'react';
 
-import { helpLinkNode, ONTOLOGY_CONCEPT_TOPIC } from '../../util/helpLinks';
+import {
+    ADVANCED_FIELD_EDITOR_TOPIC,
+    HelpLink,
+    helpLinkNode,
+    ONTOLOGY_CONCEPT_TOPIC,
+    ONTOLOGY_LOOKUP_TOPIC
+} from '../../util/helpLinks';
 
 import { DomainField } from '../domainproperties/models';
 
@@ -8,6 +14,7 @@ import { DomainFieldLabel } from '../domainproperties/DomainFieldLabel';
 
 import { ConceptModel, PathModel } from './models';
 import { OntologyConceptSelectButton } from './OntologyConceptSelectButton';
+import { sampleManagerIsPrimaryApp } from '../../app/utils';
 
 interface OntologyConceptAnnotationProps {
     field: DomainField;
@@ -46,7 +53,7 @@ function getOntologyConceptAnnotationHelpTipBody(): ReactNode {
     return (
         <>
             <p>Select an ontology concept to use as an annotation for this field.</p>
-            <p>Learn more about {helpLinkNode(ONTOLOGY_CONCEPT_TOPIC, 'ontology integration')} in LabKey.</p>
+            <p>Learn more about{' '}<HelpLink topic={sampleManagerIsPrimaryApp() ? ADVANCED_FIELD_EDITOR_TOPIC : ONTOLOGY_LOOKUP_TOPIC}>ontology integration</HelpLink>{' '}in LabKey.</p>
         </>
     );
 }

--- a/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyConceptAnnotation.tsx
@@ -1,12 +1,6 @@
-import React, { ReactNode, FC, memo, useCallback } from 'react';
+import React, { FC, memo, ReactNode, useCallback } from 'react';
 
-import {
-    ADVANCED_FIELD_EDITOR_TOPIC,
-    HelpLink,
-    helpLinkNode,
-    ONTOLOGY_CONCEPT_TOPIC,
-    ONTOLOGY_LOOKUP_TOPIC
-} from '../../util/helpLinks';
+import { ADVANCED_FIELD_EDITOR_TOPIC, HelpLink, ONTOLOGY_LOOKUP_TOPIC } from '../../util/helpLinks';
 
 import { DomainField } from '../domainproperties/models';
 

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactNode, FC, memo } from 'react';
 import { Col, FormControl, Row } from 'react-bootstrap';
 import { List } from 'immutable';
 
-import { helpLinkNode, ONTOLOGY_LOOKUP_TOPIC } from '../../util/helpLinks';
+import { ADVANCED_FIELD_EDITOR_TOPIC, HelpLink, helpLinkNode, ONTOLOGY_LOOKUP_TOPIC } from '../../util/helpLinks';
 
 import { isFieldFullyLocked } from '../domainproperties/propertiesUtil';
 import { fetchOntologies } from '../domainproperties/actions';
@@ -23,8 +23,9 @@ import { LabelHelpTip } from '../base/LabelHelpTip';
 import { OntologyModel, PathModel } from './models';
 import { OntologyConceptSelectButton } from './OntologyConceptSelectButton';
 import { fetchParentPaths, getParentsConceptCodePath } from './actions';
+import { isOntologyEnabled, sampleManagerIsPrimaryApp } from '../../app/utils';
 
-const LEARN_MORE = <p>Learn more about {helpLinkNode(ONTOLOGY_LOOKUP_TOPIC, 'ontology integration')} in LabKey.</p>;
+const LEARN_MORE = <p>Learn more about{' '}<HelpLink topic={sampleManagerIsPrimaryApp() ? ADVANCED_FIELD_EDITOR_TOPIC : ONTOLOGY_LOOKUP_TOPIC}>ontology integration</HelpLink>{' '}in LabKey.</p>;
 
 interface Props extends ITypeDependentProps {
     domainContainerPath: string;

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.spec.tsx
@@ -60,6 +60,21 @@ const distinctValuesRespSearch = {
     queryName: 'sampleType1',
 };
 
+const distinctValuesWithoutBlankResp = {
+    values: ['ed', 'ned', 'ted', 'red', 'bed'],
+    schemaName: 'samples',
+    queryName: 'sampleType1',
+};
+
+const largeValues = Array(251).fill('x');
+const largeValuesDisplay = ['[blank]', ...largeValues.slice(1)];
+
+const largeValuesWithoutBlankResp = {
+    values: largeValues, // not distinct, but not required to be for the usage
+    schemaName: 'samples',
+    queryName: 'sampleType1',
+};
+
 const DEFAULT_PROPS = {
     api: getTestAPIWrapper(jest.fn, {
         query: getQueryTestAPIWrapper(jest.fn, {
@@ -141,13 +156,38 @@ describe('FilterFacetedSelector', () => {
     });
 
     test('with no initial filter, not blank', async () => {
-        const wrapper = mount(<FilterFacetedSelector {...{ ...DEFAULT_PROPS, canBeBlank: false }} />);
+        const wrapper = mount(<FilterFacetedSelector {...{ ...DEFAULT_PROPS,
+            api: getTestAPIWrapper(jest.fn, {
+                query: getQueryTestAPIWrapper(jest.fn, {
+                    selectDistinctRows: () => Promise.resolve(distinctValuesWithoutBlankResp),
+                }),
+            }),
+            canBeBlank: false
+        }} />);
 
         expect(wrapper.find(LoadingSpinner).exists()).toEqual(true);
         await waitForLifecycle(wrapper);
         expect(wrapper.find(LoadingSpinner).exists()).toEqual(false);
 
         validate(wrapper, allWithoutBlankDisplayValuesShort, [], allWithoutBlankDisplayValuesShort, false);
+
+        wrapper.unmount();
+    });
+
+    test('with no initial filter, many values, can be blank', async () => {
+        const wrapper = mount(<FilterFacetedSelector {...{ ...DEFAULT_PROPS,
+            api: getTestAPIWrapper(jest.fn, {
+                query: getQueryTestAPIWrapper(jest.fn, {
+                    selectDistinctRows: () => Promise.resolve(largeValuesWithoutBlankResp),
+                }),
+            }),
+        }} />);
+
+        expect(wrapper.find(LoadingSpinner).exists()).toEqual(true);
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(LoadingSpinner).exists()).toEqual(false);
+
+        validate(wrapper, [], [], largeValuesDisplay, true);
 
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
@@ -72,11 +72,15 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
                     return val;
                 });
 
+                let hasBlank = false;
                 // move [blank] to first
                 if (distinctValues.indexOf(EMPTY_VALUE_DISPLAY) >= 0) {
+                    hasBlank = true;
                     distinctValues.splice(distinctValues.indexOf(EMPTY_VALUE_DISPLAY), 1);
                 }
-                if (canBeBlank && toShow.length > 0) distinctValues.unshift(EMPTY_VALUE_DISPLAY);
+                if (toShow.length > 0 && (hasBlank || canBeBlank && result.values.length > MAX_DISTINCT_FILTER_OPTIONS)) {
+                    distinctValues.unshift(EMPTY_VALUE_DISPLAY);
+                }
 
                 // add [All] to first if the total distinct values is < 250
                 const hasAllValues = !searchStr && result.values.length <= MAX_DISTINCT_FILTER_OPTIONS;

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
@@ -78,6 +78,7 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
                     hasBlank = true;
                     distinctValues.splice(distinctValues.indexOf(EMPTY_VALUE_DISPLAY), 1);
                 }
+                // Issue 47544: don't show 'blank' if we have all the values and none are blank
                 if (toShow.length > 0 && (hasBlank || (canBeBlank && result.values.length > MAX_DISTINCT_FILTER_OPTIONS))) {
                     distinctValues.unshift(EMPTY_VALUE_DISPLAY);
                 }

--- a/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
+++ b/packages/components/src/internal/components/search/FilterFacetedSelector.tsx
@@ -78,7 +78,7 @@ export const FilterFacetedSelector: FC<Props> = memo(props => {
                     hasBlank = true;
                     distinctValues.splice(distinctValues.indexOf(EMPTY_VALUE_DISPLAY), 1);
                 }
-                if (toShow.length > 0 && (hasBlank || canBeBlank && result.values.length > MAX_DISTINCT_FILTER_OPTIONS)) {
+                if (toShow.length > 0 && (hasBlank || (canBeBlank && result.values.length > MAX_DISTINCT_FILTER_OPTIONS))) {
                     distinctValues.unshift(EMPTY_VALUE_DISPLAY);
                 }
 

--- a/packages/components/src/internal/components/settings/DeleteProjectModal.spec.tsx
+++ b/packages/components/src/internal/components/settings/DeleteProjectModal.spec.tsx
@@ -142,7 +142,7 @@ describe('ProjectSettings', () => {
         expect(wrapper.find(LoadingSpinner).length).toBe(0);
         expect(wrapper.find(Progress).length).toBe(1);
         expect(
-            wrapper.find({ children: "Please don't close this page until until deletion is complete." }).length
+            wrapper.find({ children: "Please don't close this page until deletion is complete." }).length
         ).toBe(1);
         expect(wrapper.find(Button).length).toBe(0);
 

--- a/packages/components/src/internal/components/settings/DeleteProjectModal.tsx
+++ b/packages/components/src/internal/components/settings/DeleteProjectModal.tsx
@@ -109,7 +109,7 @@ export const BodyDeleting: FC<BodyDeletingProps> = memo(({ totalCountFromSummari
     return (
         <Modal.Body>
             <div className="deleting-project-modal-text">
-                Please don't close this page until until deletion is complete.
+                Please don't close this page until deletion is complete.
             </div>
             <Progress delay={0} estimate={totalCountFromSummaries * 15} toggle={toggle} />
         </Modal.Body>

--- a/packages/components/src/internal/components/user/UserProfile.spec.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.spec.tsx
@@ -20,7 +20,7 @@ describe('<UserProfile/>', () => {
     test('without state, except queryInfo', () => {
         return getQueryDetails(SCHEMAS.CORE_TABLES.USERS).then(queryInfo => {
             const wrapper = mount(
-                <UserProfile user={TEST_USER_READER} userProperties={{}} onSuccess={jest.fn()} onCancel={jest.fn()} />
+                <UserProfile user={TEST_USER_READER} userProperties={{}} onSuccess={jest.fn()} onCancel={jest.fn()} setIsDirty={jest.fn()} getIsDirty={jest.fn()}/>
             );
 
             wrapper.setState({ queryInfo });

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -33,6 +33,7 @@ const FIELDS_TO_EXCLUDE = List<string>([
     'owner',
     'groups',
     'lastlogin',
+    'lastactivity',
     'haspassword',
     'phone',
     'mobile',
@@ -99,10 +100,8 @@ export class UserProfile extends PureComponent<Props, State> {
 
     columnFilter = (col: QueryColumn): boolean => {
         // make sure all columns are set as shownInInsertView and those that are marked as editable are not also readOnly.
-        // It can happen with more frequency than you might think that a column is marked as readOnly but also userEditable.
-        // Here, at least, we want to treat both of these settings as an indication that the column is readOnly. But we let
-        // the email field through so it can be displayed but disabled. Silly hack. Issue 47532
-        const _col = col.mutate({ shownInInsertView: true, readOnly: (col.readOnly && (col.name !== 'Email')) || !col.userEditable  });
+        // Issue 47532 We want users to be able to update the fields on their own profile page, even if only readers
+        const _col = col.mutate({ shownInInsertView: true, readOnly: !col.userEditable  });
         return insertColumnFilter(_col) && !FIELDS_TO_EXCLUDE.contains(_col.fieldKey.toLowerCase());
     };
 

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -101,7 +101,7 @@ export class UserProfile extends PureComponent<Props, State> {
         // make sure all columns are set as shownInInsertView and those that are marked as editable are not also readOnly.
         // It can happen with more frequency than you might think that a column is marked as readOnly but also userEditable.
         // Here, at least, we want to treat both of these settings as an indication that the column is readOnly. But we let
-        // the email field through so it can be displayed but disabled. Silly hack.
+        // the email field through so it can be displayed but disabled. Silly hack. Issue 47532
         const _col = col.mutate({ shownInInsertView: true, readOnly: (col.readOnly && (col.name !== 'Email')) || !col.userEditable  });
         return insertColumnFilter(_col) && !FIELDS_TO_EXCLUDE.contains(_col.fieldKey.toLowerCase());
     };

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -100,8 +100,9 @@ export class UserProfile extends PureComponent<Props, State> {
     columnFilter = (col: QueryColumn): boolean => {
         // make sure all columns are set as shownInInsertView and those that are marked as editable are not also readOnly.
         // It can happen with more frequency than you might think that a column is marked as readOnly but also userEditable.
-        // Here, at least, we want to treat both of these settings as an indication that the column is readOnly.
-        const _col = col.mutate({ shownInInsertView: true, readOnly: col.readOnly || !col.userEditable });
+        // Here, at least, we want to treat both of these settings as an indication that the column is readOnly. But we let
+        // the email field through so it can be displayed but disabled. Silly hack.
+        const _col = col.mutate({ shownInInsertView: true, readOnly: (col.readOnly && (col.name !== 'Email')) || !col.userEditable  });
         return insertColumnFilter(_col) && !FIELDS_TO_EXCLUDE.contains(_col.fieldKey.toLowerCase());
     };
 

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -98,8 +98,10 @@ export class UserProfile extends PureComponent<Props, State> {
     };
 
     columnFilter = (col: QueryColumn): boolean => {
-        // make sure all columns are set as shownInInsertView and those that are marked as editable are not also readOnly
-        const _col = col.mutate({ shownInInsertView: true, readOnly: !col.userEditable });
+        // make sure all columns are set as shownInInsertView and those that are marked as editable are not also readOnly.
+        // It can happen with more frequency than you might think that a column is marked as readOnly but also userEditable.
+        // Here, at least, we want to treat both of these settings as an indication that the column is readOnly.
+        const _col = col.mutate({ shownInInsertView: true, readOnly: col.readOnly || !col.userEditable });
         return insertColumnFilter(_col) && !FIELDS_TO_EXCLUDE.contains(_col.fieldKey.toLowerCase());
     };
 

--- a/packages/components/src/internal/util/helpLinks.tsx
+++ b/packages/components/src/internal/util/helpLinks.tsx
@@ -5,9 +5,10 @@ export const CHART_MEASURES_AND_DIMENSIONS_TOPIC = 'chartTrouble';
 export const MISSING_VALUES_TOPIC = 'manageMissing';
 export const PROPERTY_FIELDS_PHI_TOPIC = 'phiLevels';
 
+export const PROPERTY_FIELDS_TOPIC = 'propertyFields';
 export const FIELD_EDITOR_TOPIC = 'fieldEditor';
 export const ADVANCED_FIELD_EDITOR_TOPIC = FIELD_EDITOR_TOPIC + '#advanced';
-export const FIELD_EDITOR_SAMPLE_TYPES_TOPIC = FIELD_EDITOR_TOPIC + '#samp';
+export const FIELD_EDITOR_SAMPLE_TYPES_TOPIC = PROPERTY_FIELDS_TOPIC + '#samp';
 export const DATE_FORMATS_TOPIC = 'dateFormats#date';
 export const NUMBER_FORMATS_TOPIC = 'dateFormats#number';
 export const ONTOLOGY_LOOKUP_TOPIC = 'ontologyLookup';


### PR DESCRIPTION
#### Rationale
Fixing various bugs
- [LKSM Projects: Deleting and renaming projects panel not showing up on trials](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47571)
- [LKSM: Filter panel shows "blank" values as an option when there are no blanks](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47544)
- [Adjust edit profile page to omit (or disallow editing of) read-only user properties](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47532)
- [Update doc link in Sample field type hovertext](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47100)
- [LKSM: Link to Ontology Integration has no content](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47464)

#### Related Pull Requests

- https://github.com/LabKey/ontology/pull/117
- https://github.com/LabKey/platform/pull/4267
- https://github.com/LabKey/sampleManagement/pull/1731
- https://github.com/LabKey/inventory/pull/806
- https://github.com/LabKey/biologics/pull/2065

#### Changes
* Issue 47571: Make sure project settings panel shows up even when the premium module is not available.
* Issue 47544: Don't show [blank] filter option if all distinct values are returned and none is blank.
* Issue 47532: For the UserProfile form, make sure columns marked as readOnly remain readOnly, regardless of the setting for isUserEditable.
* Issue 47100: Update documentation link for sample ID lookup fields.
* Issue 47464: Update documentation link for ontology integration from LKSM.
