### PR TITLE
Issue 47633: display project data in home folder when "queryProductProjectDataListingScoped" experimental flag is enabled

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.4-fb-fix-47633.0",
+  "version": "2.323.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.4",
+  "version": "2.323.4-fb-fix-47633.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.323.5
+*Released*: 7 April 2023
+* Issue 47633: display project data in home folder when "queryProductProjectDataListingScoped" experimental flag is enabled.
+
 ### version 2.323.4
 *Released*: 5 April 2023
 * Add loading state to domain designer initialization.

--- a/packages/components/src/internal/query/api.spec.ts
+++ b/packages/components/src/internal/query/api.spec.ts
@@ -14,6 +14,7 @@ import {
     getContainerFilter,
     getContainerFilterForFolder,
     getContainerFilterForLookups,
+    ISelectRowsResult,
     quoteValueColumnWithDelimiters,
     Renderers,
 } from './api';
@@ -115,7 +116,7 @@ describe('api', () => {
                 )
             ).toEqual(Query.ContainerFilter.allInProjectPlusShared);
             expect(getContainerFilterForFolder(topFolderPath, moduleContext({ projectDataScoped: true }))).toEqual(
-                Query.ContainerFilter.currentPlusProjectAndShared
+                Query.ContainerFilter.currentAndSubfoldersPlusShared
             );
             expect(getContainerFilterForFolder(subFolderPath, moduleContext({ projectDataScoped: true }))).toEqual(
                 Query.ContainerFilter.current
@@ -134,7 +135,7 @@ describe('api', () => {
     });
 
     describe('quoteValueColumnWithDelimiters', () => {
-        const results = {
+        const results: ISelectRowsResult = {
             key: 'test',
             models: {
                 test: {
@@ -147,6 +148,7 @@ describe('api', () => {
             },
             orderedModels: List([1, 2, 3, 4, 5]),
             queries: {},
+            rowCount: 5,
         };
         test('encode', () => {
             expect(quoteValueColumnWithDelimiters(results, 'Name', ',')).toStrictEqual({
@@ -174,6 +176,7 @@ describe('api', () => {
                 },
                 orderedModels: List([1, 2, 3, 4, 5]),
                 queries: {},
+                rowCount: 5,
             });
         });
     });

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1007,7 +1007,7 @@ export function getContainerFilterForFolder(
             if (isAllProductFoldersFilteringEnabled(moduleContext)) {
                 return Query.ContainerFilter.allInProjectPlusShared;
             }
-            return Query.ContainerFilter.currentPlusProjectAndShared;
+            return Query.ContainerFilter.currentAndSubfoldersPlusShared;
         }
 
         // When listing data in a folder scope returned data to the current


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47633](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47633) by adjusting the container filter supplied when the `queryProductProjectDataListingScoped` experimental feature is enabled.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1166
- https://github.com/LabKey/biologics/pull/2078
- https://github.com/LabKey/sampleManagement/pull/1746
- https://github.com/LabKey/inventory/pull/811

#### Changes
- Change container filter supplied by `getContainerFilterForFolder()` from `currentPlusProjectAndShared` to `currentAndSubfoldersPlusShared` when in the top-level folder and the `queryProductProjectDataListingScoped` experimental flag is enabled.
- Miscellaneous: fix typings/test for `quoteValueColumnWithDelimiters`.
