### PR TITLE
Issue 47660: QueryModel with bindURL isn't reloading totalCount on URL filter change

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.4",
+  "version": "2.323.4-fb-bindUrlTotalCount47660.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.5",
+  "version": "2.323.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD April 2023
+* Issue 47660: QueryModel with bindURL isn't reloading totalCount on URL filter change
+
 ### version 2.323.4
 *Released*: 5 April 2023
 * Add loading state to domain designer initialization.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD April 2023
+### version 2.323.6
+*Released*: 10 April 2023
 * Issue 47660: QueryModel with bindURL isn't reloading totalCount on URL filter change
 
 ### version 2.323.5

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -291,6 +291,9 @@ export function withQueryModels<Props>(
                     // If we have selections or previously attempted to load them we'll want to reload them when the
                     // model is updated from the URL because it can affect selections.
                     loadSelections = !!model.selections || !!model.selectionsError;
+
+                    // since URL param changes could change the filterArray, need to reload the totalCount (issue 47660)
+                    model.totalCountLoadingState = LoadingState.INITIALIZED;
                 }),
                 () => {
                     this.maybeLoad(id, false, true, loadSelections);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47660

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1168
- https://github.com/LabKey/sampleManagement/pull/1748
- https://github.com/LabKey/biologics/pull/2082
- https://github.com/LabKey/inventory/pull/813

#### Changes
- reset totalCountLoadingState in updateModelFromURL
