### PR TITLE
Issue 47647: App permissions page needs to check for project container perm when loading group memberships

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.4-fb-appSubfolderAdminPerm47641.1",
+  "version": "2.323.4-fb-appSubfolderAdminPerm47641.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.4-fb-appSubfolderAdminPerm47641.0",
+  "version": "2.323.4-fb-appSubfolderAdminPerm47641.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.6",
+  "version": "2.323.6-fb-appSubfolderAdminPerm47641.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.4",
+  "version": "2.323.4-fb-appSubfolderAdminPerm47641.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.6-fb-appSubfolderAdminPerm47641.0",
+  "version": "2.323.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD April 2023
 * Issue 47647: App permissions page needs to check for project container perm when loading group memberships
-* ResponsiveMenuButtonGroup add disabled prop, defaults to false
 
 ### version 2.323.4
 *Released*: 5 April 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD April 2023
 * Issue 47647: App permissions page needs to check for project container perm when loading group memberships
+* ResponsiveMenuButtonGroup add disabled prop, defaults to false
 
 ### version 2.323.4
 *Released*: 5 April 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD April 2023
+* Issue 47647: App permissions page needs to check for project container perm when loading group memberships
+
 ### version 2.323.4
 *Released*: 5 April 2023
 * Add loading state to domain designer initialization.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD April 2023
+### version 2.323.7
+*Released*: 10 April 2023
 * Issue 47647: App permissions page needs to check for project container perm when loading group memberships
 
 ### version 2.323.6

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -10,13 +10,14 @@ interface ResponsiveMenuItem {
 
 interface Props {
     asSubMenu?: boolean;
+    disabled?: boolean;
     items: ResponsiveMenuItem[];
     subMenuWidth?: number;
     user: User;
 }
 
 export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
-    const { items, user, subMenuWidth = 1600, asSubMenu = true } = props;
+    const { items, user, subMenuWidth = 1600, asSubMenu = true, disabled = false } = props;
     const [width, setWidth] = useState<number>(window.innerWidth);
     useEffect(() => {
         function handleResize() {
@@ -37,7 +38,12 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
         <>
             {!_asSubMenu && buttons}
             {_asSubMenu && (
-                <DropdownButton id="responsive-menu-button-group" title="More" className="responsive-menu">
+                <DropdownButton
+                    id="responsive-menu-button-group"
+                    title="More"
+                    className="responsive-menu"
+                    disabled={disabled}
+                >
                     {buttons.map((item, index) => {
                         return (
                             <React.Fragment key={index}>

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -10,14 +10,13 @@ interface ResponsiveMenuItem {
 
 interface Props {
     asSubMenu?: boolean;
-    disabled?: boolean;
     items: ResponsiveMenuItem[];
     subMenuWidth?: number;
     user: User;
 }
 
 export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
-    const { items, user, subMenuWidth = 1600, asSubMenu = true, disabled = false } = props;
+    const { items, user, subMenuWidth = 1600, asSubMenu = true } = props;
     const [width, setWidth] = useState<number>(window.innerWidth);
     useEffect(() => {
         function handleResize() {
@@ -38,12 +37,7 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
         <>
             {!_asSubMenu && buttons}
             {_asSubMenu && (
-                <DropdownButton
-                    id="responsive-menu-button-group"
-                    title="More"
-                    className="responsive-menu"
-                    disabled={disabled}
-                >
+                <DropdownButton id="responsive-menu-button-group" title="More" className="responsive-menu">
                     {buttons.map((item, index) => {
                         return (
                             <React.Fragment key={index}>

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.spec.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.spec.tsx
@@ -233,7 +233,7 @@ describe('PermissionAssignments', () => {
 
         wrapper.setProps({ showDetailsPanel: true });
 
-        let onShowDetails = wrapper.find(PermissionsRole).at(0).prop('onClickAssignment');
+        const onShowDetails = wrapper.find(PermissionsRole).at(0).prop('onClickAssignment');
         act(() => {
             onShowDetails(USER.userId);
         });
@@ -243,17 +243,6 @@ describe('PermissionAssignments', () => {
         expect(wrapper.find(GroupDetailsPanel).exists()).toEqual(false);
         expect(wrapper.find(UserDetailsPanel).exists()).toEqual(true);
         expect(wrapper.find(UserDetailsPanel).prop('userId')).toEqual(USER.userId);
-
-        onShowDetails = wrapper.find(PermissionsRole).at(0).prop('onClickAssignment');
-        act(() => {
-            onShowDetails(GROUP.userId);
-        });
-
-        await waitForLifecycle(wrapper);
-
-        expect(wrapper.find(GroupDetailsPanel).exists()).toEqual(true);
-        expect(wrapper.find(UserDetailsPanel).exists()).toEqual(false);
-        expect(wrapper.find(GroupDetailsPanel).prop('principal')).toEqual(GROUP);
 
         wrapper.unmount();
     });


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47641

The group membership information query executes at the current container's project containerPath. A user can get to the App permissions page if they are a folder admin, but we need to check their permissions in the project containerPath to determine if they can view group membership details.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1169
- https://github.com/LabKey/sampleManagement/pull/1749
- https://github.com/LabKey/biologics/pull/2083
- https://github.com/LabKey/inventory/pull/814 

#### Changes
- check if userCanReadGroupDetails at the project container before trying to query for group membership information
