### PR TITLE
Issue 47648: Make "Contains" the default filter

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.7",
+  "version": "2.323.8-defaultFilter.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.323.8-defaultFilter.0",
+  "version": "2.324.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-* Issue 47648: Make "Conatins" the default filter
+* Issue 47648: Make "Contains" the default filter
 
 ### version 2.323.7
 *Released*: 10 April 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 47648: Make "Conatins" the default filter
+
 ### version 2.323.7
 *Released*: 10 April 2023
 * Issue 47647: App permissions page needs to check for project container perm when loading group memberships

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.324.0
+*Released*: 10 April 2023
 * Issue 47648: Make "Contains" the default filter
 
 ### version 2.323.7

--- a/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
@@ -142,7 +142,7 @@ describe('FilterExpressionView', () => {
         const options = selectInput.props()['options'];
         const selectedFilter = selectInput.props()['value'];
         if (selectedOp) expect(selectedFilter).toEqual(selectedOp);
-        else expect(selectedFilter == null).toBeTruthy();
+        else expect(selectedFilter).toEqual("contains");
 
         const ops = [];
         options.map(op => ops.push(op['value']));

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -1039,7 +1039,7 @@ export function getFilterSelections(
         }
     });
     if (filters.length == 0) {
-        const filterOption = filterOptions.find(option => {
+        const filterOption = filterOptions?.find(option => {
             return isFilterUrlSuffixMatch(option.value, Filter.Types.CONTAINS);
         });
         if (filterOption) {

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -1038,6 +1038,16 @@ export function getFilterSelections(
             filters.push(filter);
         }
     });
+    if (filters.length == 0) {
+        const filterOption = filterOptions.find(option => {
+            return isFilterUrlSuffixMatch(option.value, Filter.Types.CONTAINS);
+        });
+        if (filterOption) {
+            filters.push({
+                filterType: filterOption,
+            });
+        }
+    }
     return filters;
 }
 


### PR DESCRIPTION
#### Rationale
When the filter dropdown is empty, users interpret that as a place to enter a string value to filter on. This PR changes the Filter expression panel so it defaults to the "Contains" filter instead of the empty value in the dropdown.

#### Related Pull Requests

- https://github.com/LabKey/biologics/pull/2085
- https://github.com/LabKey/sampleManagement/pull/1755
- https://github.com/LabKey/inventory/pull/817


#### Changes
- Update `FilterExpressionView` to default to the "Contains" filter as the first filter
