### PR TITLE
Sample Derivation: limit selected data requests

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.325.0-fb-sample-derive.0",
+  "version": "2.325.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.325.0",
+  "version": "2.325.0-fb-sample-derive.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.325.1
+*Released*: 12 April 2023
+- Sample Derivation: limit selected data requests
+
 ### version 2.325.0
 *Released*: 10 April 2023
 * Follow up consolidation of search pages to a shared component

--- a/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
+++ b/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
@@ -9,9 +9,7 @@ import { AppURL } from '../internal/url/AppURL';
 import { SOURCES_KEY } from '../internal/app/constants';
 import { SCHEMAS } from '../internal/schemas';
 import { getCrossFolderSelectionResult } from '../internal/components/entities/actions';
-import {
-    EntityCrossProjectSelectionConfirmModal
-} from '../internal/components/entities/EntityCrossProjectSelectionConfirmModal';
+import { EntityCrossProjectSelectionConfirmModal } from '../internal/components/entities/EntityCrossProjectSelectionConfirmModal';
 import { isSamplesSchema } from '../internal/components/samples/utils';
 import {
     ALIQUOT_CREATION,
@@ -48,11 +46,11 @@ export interface CreateSamplesSubMenuBaseProps {
     parentType?: string;
     sampleWizardURL?: SampleTypeWizardURLResolver;
     selectedType?: SampleCreationType;
+    selectionData?: Record<any, any>;
     selectionNoun?: string;
     selectionNounPlural?: string;
     skipCrossFolderCheck?: boolean;
     targetProductId?: string;
-    selectionData?: Map<any, any>;
     useSelectionData?: boolean;
 }
 

--- a/packages/components/src/entities/PicklistListing.tsx
+++ b/packages/components/src/entities/PicklistListing.tsx
@@ -49,16 +49,11 @@ interface ButtonProps {
 const PicklistGridButtons: FC<ButtonProps & RequiresModelAndActions> = memo(props => {
     const { onDelete, model } = props;
 
-    const onClickDelete = useCallback(() => {
-        onDelete();
-    }, [onDelete]);
-
     return (
         <RequiresPermission perms={PermissionTypes.ManagePicklists}>
             <DisableableButton
-                bsStyle="default"
-                onClick={onClickDelete}
                 disabledMsg={!model.hasSelections ? 'Select one or more picklists.' : undefined}
+                onClick={onDelete}
             >
                 <span className="fa fa-trash" />
                 <span>&nbsp;Delete</span>

--- a/packages/components/src/entities/RemoveFromPicklistButton.tsx
+++ b/packages/components/src/entities/RemoveFromPicklistButton.tsx
@@ -65,7 +65,6 @@ export const RemoveFromPicklistButton: FC<Props> = memo(props => {
         <RequiresPermission perms={PermissionTypes.ManagePicklists}>
             {picklist.canRemoveItems(user) && (
                 <DisableableButton
-                    bsStyle="default"
                     onClick={onRemoveFromPicklist}
                     disabledMsg={
                         !model.hasSelections ? 'Select one or more ' + SampleTypeDataType.nounPlural + '.' : undefined

--- a/packages/components/src/entities/SampleCreationTypeModal.tsx
+++ b/packages/components/src/entities/SampleCreationTypeModal.tsx
@@ -27,7 +27,7 @@ interface Props {
     onSubmit: (creationType: SampleCreationType, numPerParent?: number) => void;
     options: SampleCreationTypeModel[];
     parentCount: number;
-    selectionData?: Map<any, any>;
+    selectionData?: Record<any, any>;
     selectionKey?: string;
     show: boolean;
     showIcons: boolean;

--- a/packages/components/src/entities/SampleTypeDesignPage.spec.tsx
+++ b/packages/components/src/entities/SampleTypeDesignPage.spec.tsx
@@ -111,7 +111,7 @@ describe('SampleTypeDesignPage', () => {
             { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper);
         expect(wrapper.find('.alert-warning')).toHaveLength(0);
         wrapper.unmount();
@@ -123,7 +123,7 @@ describe('SampleTypeDesignPage', () => {
             { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper, true, false);
         wrapper.unmount();
     });
@@ -138,7 +138,7 @@ describe('SampleTypeDesignPage', () => {
             { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper, true, true, true, true);
         wrapper.unmount();
     });
@@ -163,7 +163,7 @@ describe('SampleTypeDesignPage', () => {
             },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper, false);
         wrapper.unmount();
     });
@@ -180,7 +180,7 @@ describe('SampleTypeDesignPage', () => {
             },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper, true, true, false);
         wrapper.unmount();
     });
@@ -197,7 +197,7 @@ describe('SampleTypeDesignPage', () => {
             },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper, true, true, true, false, true);
         wrapper.unmount();
     });
@@ -214,7 +214,7 @@ describe('SampleTypeDesignPage', () => {
             },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_PROJECT_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper, true, true, true, false, false, true);
         wrapper.unmount();
     });
@@ -225,7 +225,7 @@ describe('SampleTypeDesignPage', () => {
             { sampleType: SAMPLE_TYPE_APP_CONTEXT, api: API },
             { user: TEST_USER_FOLDER_ADMIN, container: TEST_FOLDER_CONTAINER }
         );
-        await waitForLifecycle(wrapper, 1000);
+        await waitForLifecycle(wrapper);
         validate(wrapper);
         expect(wrapper.find('.alert-warning')).toHaveLength(1);
         expect(wrapper.find('.alert-warning').text()).toContain('This is a shared sample type');

--- a/packages/components/src/entities/SamplesAssayButton.tsx
+++ b/packages/components/src/entities/SamplesAssayButton.tsx
@@ -45,19 +45,13 @@ export const SamplesAssayButtonImpl: FC<Props & InjectedAssayModel> = memo(props
         if (disabledMsg) {
             return (
                 <RequiresPermission permissionCheck="any" perms={PermissionTypes.Insert}>
-                    <DisableableButton
-                        bsStyle="default"
-                        className="responsive-menu"
-                        disabledMsg={disabledMsg}
-                        onClick={undefined}
-                    >
+                    <DisableableButton className="responsive-menu" disabledMsg={disabledMsg}>
                         Assay
                     </DisableableButton>
                 </RequiresPermission>
             );
         }
     }
-
 
     let items = (
         <AssayImportSubMenuItem
@@ -75,7 +69,6 @@ export const SamplesAssayButtonImpl: FC<Props & InjectedAssayModel> = memo(props
     if (!isLoading(assayModel?.definitionsLoadingState) && assayModel.definitions.length === 0) {
         items = <MenuItem disabled>No assays defined</MenuItem>;
     }
-
 
     return (
         <RequiresPermission permissionCheck="any" perms={PermissionTypes.Insert}>

--- a/packages/components/src/entities/SamplesDeriveButton.spec.tsx
+++ b/packages/components/src/entities/SamplesDeriveButton.spec.tsx
@@ -10,13 +10,15 @@ import { TEST_USER_EDITOR, TEST_USER_READER } from '../internal/userFixtures';
 
 import { DisableableButton } from '../internal/components/buttons/DisableableButton';
 
+import { QueryInfo } from '../public/QueryInfo';
+
 import { SamplesDeriveButton, SamplesDeriveButtonProps } from './SamplesDeriveButton';
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 
 describe('SamplesDeriveButton', () => {
     function defaultProps(): SamplesDeriveButtonProps {
         return {
-            model: makeTestQueryModel(new SchemaQuery('schema', 'query')),
+            model: makeTestQueryModel(new SchemaQuery('schema', 'query'), new QueryInfo()),
             isSelectingSamples: jest.fn().mockReturnValue(true),
         };
     }
@@ -55,10 +57,11 @@ describe('SamplesDeriveButton', () => {
     });
 
     test('over max selections', () => {
-        const model = makeTestQueryModel(new SchemaQuery('schema', 'query')).mutate({
+        const props = defaultProps();
+        const model = props.model.mutate({
             selections: new Set(Array.from(Array(1001).keys()).map(key => key + '')),
         });
-        const wrapper = mountWithServerContext(<SamplesDeriveButton {...defaultProps()} model={model} />, {
+        const wrapper = mountWithServerContext(<SamplesDeriveButton {...props} model={model} />, {
             user: TEST_USER_EDITOR,
         });
         validate(wrapper, false, false, true);

--- a/packages/components/src/entities/SamplesDeriveButton.tsx
+++ b/packages/components/src/entities/SamplesDeriveButton.tsx
@@ -25,13 +25,16 @@ export const SamplesDeriveButton: FC<SamplesDeriveButtonProps> = memo(props => {
     const { model, asSubMenu, ...createSampleMenuProps } = props;
     const { filterArray, isLoadingSelections, schemaQuery, selections } = model;
     const [selectionData, setSelectionData] = useState<Record<any, any>>();
-    const selectedCount = useMemo(() => selections?.size ?? -1, [selections]);
-    const requestColumns = useMemo(() => model.getRequestColumnsString(), [model]);
+    const selectedCount = useMemo<number>(() => selections?.size ?? -1, [selections]);
+    const requestColumns = useMemo<string>(() => {
+        if (!model.queryInfo) return undefined;
+        return model.getRequestColumnsString();
+    }, [model]);
     const useSelectionData = filterArray.length > 0 && selectedCount > 0 && selectedCount <= MAX_EDITABLE_GRID_ROWS;
 
     useEffect(() => {
         (async () => {
-            if (useSelectionData && !isLoadingSelections) {
+            if (useSelectionData && !isLoadingSelections && requestColumns) {
                 try {
                     const { data } = await getSelectedData(
                         schemaQuery.schemaName,

--- a/packages/components/src/entities/SamplesDeriveButton.tsx
+++ b/packages/components/src/entities/SamplesDeriveButton.tsx
@@ -54,10 +54,8 @@ export const SamplesDeriveButton: FC<SamplesDeriveButtonProps> = memo(props => {
         return (
             <RequiresPermission permissionCheck="any" perms={PermissionTypes.Insert}>
                 <DisableableButton
-                    bsStyle="default"
                     className="responsive-menu"
-                    disabledMsg={'At most ' + MAX_EDITABLE_GRID_ROWS + ' samples can be selected.'}
-                    onClick={undefined}
+                    disabledMsg={`At most ${MAX_EDITABLE_GRID_ROWS} samples can be selected.`}
                 >
                     Derive
                 </DisableableButton>

--- a/packages/components/src/entities/SamplesDeriveButton.tsx
+++ b/packages/components/src/entities/SamplesDeriveButton.tsx
@@ -8,8 +8,9 @@ import { SampleCreationType } from '../internal/components/samples/models';
 import { MAX_EDITABLE_GRID_ROWS } from '../internal/constants';
 import { DisableableButton } from '../internal/components/buttons/DisableableButton';
 
-import { CreateSamplesSubMenu, CreateSamplesSubMenuProps } from './CreateSamplesSubMenu';
 import { getSelectedData } from '../internal/actions';
+
+import { CreateSamplesSubMenu, CreateSamplesSubMenuProps } from './CreateSamplesSubMenu';
 
 export interface SamplesDeriveButtonProps
     extends Omit<
@@ -22,48 +23,32 @@ export interface SamplesDeriveButtonProps
 
 export const SamplesDeriveButton: FC<SamplesDeriveButtonProps> = memo(props => {
     const { model, asSubMenu, ...createSampleMenuProps } = props;
-    const [selectionsAreSet, setSelectionsAreSet] = useState<boolean>(false);
-    const [selectionData, setSelectionData] = useState<Map<any, any>>();
-    const selectedCount = useMemo(() => model?.selections?.size ?? -1, [model?.selections]);
-    const useSelectionData = useMemo(() => model?.filterArray.length > 0 && selectedCount <= MAX_EDITABLE_GRID_ROWS , [model?.filterArray]);
+    const { filterArray, isLoadingSelections, schemaQuery, selections } = model;
+    const [selectionData, setSelectionData] = useState<Record<any, any>>();
+    const selectedCount = useMemo(() => selections?.size ?? -1, [selections]);
+    const requestColumns = useMemo(() => model.getRequestColumnsString(), [model]);
+    const useSelectionData = filterArray.length > 0 && selectedCount > 0 && selectedCount <= MAX_EDITABLE_GRID_ROWS;
 
     useEffect(() => {
         (async () => {
-            if (useSelectionData) {
-                if (!model.isLoadingSelections) {
-                    try {
-                        const { data } = await getSelectedData(
-                            model.schemaName,
-                            model.queryName,
-                            [...model.selections],
-                            model.getRequestColumnsString(),
-                            undefined
-                        );
-                        setSelectionData(data.toJS());
-                        setSelectionsAreSet(true);
-                    } catch (reason) {
-                        console.error(
-                            'There was a problem loading the filtered selection data. Your actions will not obey these filters.',
-                            reason
-                        );
-                        setSelectionsAreSet(true);
-                    }
+            if (useSelectionData && !isLoadingSelections) {
+                try {
+                    const { data } = await getSelectedData(
+                        schemaQuery.schemaName,
+                        schemaQuery.queryName,
+                        [...selections],
+                        requestColumns
+                    );
+                    setSelectionData(data.toJS());
+                } catch (reason) {
+                    console.error(
+                        'There was a problem loading the filtered selection data. Your actions will not obey these filters.',
+                        reason
+                    );
                 }
-            } else {
-                setSelectionsAreSet(true);
             }
         })();
-    }, [
-        useSelectionData,
-        selectionsAreSet,
-        model?.isLoadingSelections,
-        model?.schemaName,
-        model?.queryName,
-        model?.selections,
-        model?.selectionKey,
-        model?.filterArray,
-    ]);
-
+    }, [useSelectionData, isLoadingSelections, schemaQuery, selections, requestColumns]);
 
     if (!asSubMenu && selectedCount > MAX_EDITABLE_GRID_ROWS) {
         return (

--- a/packages/components/src/internal/components/buttons/DisableableButton.spec.tsx
+++ b/packages/components/src/internal/components/buttons/DisableableButton.spec.tsx
@@ -5,7 +5,7 @@ import { Button, OverlayTrigger } from 'react-bootstrap';
 
 import { DisableableButton } from './DisableableButton';
 
-describe('<DisableableButton />', () => {
+describe('DisableableButton', () => {
     test('No disabled message', () => {
         const wrapper = shallow(<DisableableButton bsStyle="primary" onClick={jest.fn()} />);
 

--- a/packages/components/src/internal/components/buttons/DisableableButton.tsx
+++ b/packages/components/src/internal/components/buttons/DisableableButton.tsx
@@ -2,10 +2,10 @@ import React, { memo, FC } from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 interface Props {
-    bsStyle: string;
+    bsStyle?: string;
     className?: string;
     disabledMsg?: string;
-    onClick: () => void;
+    onClick?: () => void;
     title?: string;
 }
 

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
@@ -277,7 +277,6 @@ export const TextChoiceOptionsImpl: FC<ImplProps> = memo(props => {
                                 </div>
                                 <div className="domain-field-padding-bottom">
                                     <DisableableButton
-                                        bsStyle="default"
                                         disabledMsg={currentLocked ? LOCKED_TIP : currentInUse ? IN_USE_TIP : undefined}
                                         onClick={onDelete}
                                         title={currentLocked ? LOCKED_TITLE : IN_USE_TITLE}

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
@@ -306,7 +306,6 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
                     <div>
                         {!isNew && (
                             <DisableableButton
-                                bsStyle="default"
                                 disabledMsg={saving ? SAVING_LOCKED_TIP : undefined}
                                 onClick={onToggleDeleteConfirm}
                                 title={SAVING_LOCKED_TITLE}

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -230,7 +230,6 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     <div>
                         {!addNew && updatedState.isLocal && (
                             <DisableableButton
-                                bsStyle="default"
                                 disabledMsg={disabledMsg}
                                 onClick={onToggleDeleteConfirm}
                                 title={SAMPLE_STATUS_LOCKED_TITLE}

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -24,9 +24,10 @@ import { DisableableButton } from '../buttons/DisableableButton';
 
 import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 
-import { SampleState } from './models';
 import { useServerContext } from '../base/ServerContext';
 import { isProductProjectsEnabled } from '../../app/utils';
+
+import { SampleState } from './models';
 import { getSampleStatusLockedMessage } from './utils';
 
 const TITLE = 'Manage Sample Statuses';
@@ -41,7 +42,6 @@ interface SampleStatusDetailProps {
     onChange: () => void;
     state: SampleState;
 }
-
 
 // exported for jest testing
 export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
@@ -167,7 +167,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
         }
     }, [updatedState, onActionComplete]);
 
-    const disabledMsg = useMemo( () => {
+    const disabledMsg = useMemo(() => {
         return getSampleStatusLockedMessage(updatedState, saving);
     }, [updatedState, saving]);
 
@@ -244,7 +244,12 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                             </Button>
                         )}
                         {updatedState.isLocal && (
-                            <Button bsStyle="success" className="pull-right" disabled={!dirty || saving} onClick={onSave}>
+                            <Button
+                                bsStyle="success"
+                                className="pull-right"
+                                disabled={!dirty || saving}
+                                onClick={onSave}
+                            >
                                 {saving ? 'Saving...' : 'Save'}
                             </Button>
                         )}


### PR DESCRIPTION
#### Rationale
This addresses a performance issue where sample derivation within the application can result in requests for all of the selected data. This type of request does not scale and can result in a degraded/broken experience for the user. This is a follow-on to the work done in #1132 to address [Issue 47224](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47224).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1171
- https://github.com/LabKey/biologics/pull/2089
- https://github.com/LabKey/sampleManagement/pull/1765
- https://github.com/LabKey/inventory/pull/820

#### Changes
- Trim loading of selected data in `SamplesDeriveButton` to only fire in the event that all of the following are true:
  - a filter is applied (not sure why this is strictly necessary but left in because I don't understand).
  - model has at least 1 selected row.
  - model has at max `MAX_EDITABLE_ROWS` selected rows.
- Remove defunct `selectionsAreSet` state tracking in `SamplesDeriveButton`. 
- Consolidate props for `DisableableButton` to remove repetitive declaration of default values.
- Noticed the `SampleTypeDesignPage` test is arbitrarily waiting 8+ seconds for render lifecycle. Removed these and the tests seem to pass just fine.
