### PR TITLE
EntityInsertPanel: move to entities subpackage, utilize API wrappers

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.325.1-fb-entity-insert-api.1",
+  "version": "2.326.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.325.1",
+  "version": "2.325.1-fb-entity-insert-api.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.325.1-fb-entity-insert-api.0",
+  "version": "2.325.1-fb-entity-insert-api.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,24 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.326.0
+*Released*: 15 April 2023
+- Entities subpackage migration
+    - Moved `AssayResultsForSamplesButton`, `EntityCrossProjectSelectionConfirmModal`, `EntityDeleteConfirmModal`, `EntityInsertPanel` and `FindDerivativesButton` to subpackage.
+    - Moved `getOriginalParentsFromLineage` to `@labkey/components` to align endpoint wrappers for use in `EntityAPIWrapper`.
+- `EntityInsertPanel`:
+    - Refactor initialization to separate concerns for initializing import aliases, name expression previews, `insertModel` and editable grid models.
+    - Defer construction of column metadata until after load. Previously results were just thrown away.
+    - Update all direct calls to endpoints to utilize `ComponentAPIWrapper` provided implementations.
+    - `getInferredFieldWarnings` and `getNoUpdateFieldWarnings` are no longer static methods as this served no purpose
+    - Refactored `getWarningFieldList` into `WarningFieldList` component
+    - Remove superfluous render wrapping
+- `ComponentAPIWrapper`:
+    - Add `getEntityTypeData`, `getOriginalParentsFromLineage` and `handleEntityFileImport` to `EntityAPIWrapper`. Update associated usages where possible to use API wrapper.
+    - Add `fetchDomainDetails` to `DomainPropertiesAPIWrapper`
+    - Update `getDefaultAPIWrapper()` for `ComponentAPIWrapper` to instantiate wrappers once. Makes `api` easier for reuse in components to prevent redundant render cycles.
+- Streamline some sample action implementations to use `async/await` and remove redundant error handling wrapping.
+
 ### version 2.325.1
 *Released*: 12 April 2023
 - Sample Derivation: limit selected data requests

--- a/packages/components/src/entities/AssayImportSubMenuItem.tsx
+++ b/packages/components/src/entities/AssayImportSubMenuItem.tsx
@@ -14,9 +14,10 @@ import { InjectedAssayModel, withAssayModels } from '../internal/components/assa
 import { getCrossFolderSelectionResult } from '../internal/components/entities/actions';
 import { MenuOption, SubMenu } from '../internal/components/menus/SubMenu';
 import { isProjectContainer } from '../internal/app/utils';
-import { EntityCrossProjectSelectionConfirmModal } from '../internal/components/entities/EntityCrossProjectSelectionConfirmModal';
 
 import { setSnapshotSelections } from '../internal/actions';
+
+import { EntityCrossProjectSelectionConfirmModal } from './EntityCrossProjectSelectionConfirmModal';
 
 import { getImportItemsForAssayDefinitions } from './utils';
 

--- a/packages/components/src/entities/AssayResultsForSamplesButton.spec.tsx
+++ b/packages/components/src/entities/AssayResultsForSamplesButton.spec.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
-import { SchemaQuery } from '../../../public/SchemaQuery';
-import { mountWithAppServerContext } from '../../testHelpers';
-import { QueryInfo } from '../../../public/QueryInfo';
+import { makeTestQueryModel } from '../public/QueryModel/testUtils';
+import { SchemaQuery } from '../public/SchemaQuery';
+import { mountWithAppServerContext } from '../internal/testHelpers';
+import { QueryInfo } from '../public/QueryInfo';
 
-import { SelectionMenuItem } from '../menus/SelectionMenuItem';
-import { TEST_USER_READER, TEST_USER_STORAGE_EDITOR } from '../../userFixtures';
+import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuItem';
+import { TEST_USER_READER, TEST_USER_STORAGE_EDITOR } from '../internal/userFixtures';
 
 import { AssayResultsForSamplesMenuItem } from './AssayResultsForSamplesButton';
 

--- a/packages/components/src/entities/AssayResultsForSamplesButton.tsx
+++ b/packages/components/src/entities/AssayResultsForSamplesButton.tsx
@@ -1,15 +1,15 @@
 import React, { FC, memo, useCallback, useMemo } from 'react';
 
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
-import { ResponsiveMenuButton } from '../buttons/ResponsiveMenuButton';
-import { SelectionMenuItem } from '../menus/SelectionMenuItem';
-import { SampleTypeDataType } from './constants';
-import { getURLParamsForSampleSelectionKey } from '../samples/utils';
-import { AppURL, createProductUrlFromParts } from '../../url/AppURL';
-import { ASSAYS_KEY } from '../../app/constants';
-import { incrementClientSideMetricCount } from '../../actions';
-import { userCanReadAssays } from '../../app/utils';
-import { User } from '../base/models/User';
+import { QueryModel } from '../public/QueryModel/QueryModel';
+import { ResponsiveMenuButton } from '../internal/components/buttons/ResponsiveMenuButton';
+import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuItem';
+import { SampleTypeDataType } from '../internal/components/entities/constants';
+import { getURLParamsForSampleSelectionKey } from '../internal/components/samples/utils';
+import { AppURL, createProductUrlFromParts } from '../internal/url/AppURL';
+import { ASSAYS_KEY } from '../internal/app/constants';
+import { incrementClientSideMetricCount } from '../internal/actions';
+import { userCanReadAssays } from '../internal/app/utils';
+import { User } from '../internal/components/base/models/User';
 
 function getAssayResultsHref(
     model: QueryModel,

--- a/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
+++ b/packages/components/src/entities/CreateSamplesSubMenuBase.tsx
@@ -9,7 +9,7 @@ import { AppURL } from '../internal/url/AppURL';
 import { SOURCES_KEY } from '../internal/app/constants';
 import { SCHEMAS } from '../internal/schemas';
 import { getCrossFolderSelectionResult } from '../internal/components/entities/actions';
-import { EntityCrossProjectSelectionConfirmModal } from '../internal/components/entities/EntityCrossProjectSelectionConfirmModal';
+
 import { isSamplesSchema } from '../internal/components/samples/utils';
 import {
     ALIQUOT_CREATION,
@@ -28,6 +28,8 @@ import { caseInsensitive } from '../internal/util/utils';
 import { isProjectContainer } from '../internal/app/utils';
 
 import { CrossFolderSelectionResult } from '../internal/components/entities/models';
+
+import { EntityCrossProjectSelectionConfirmModal } from './EntityCrossProjectSelectionConfirmModal';
 
 import { SampleCreationTypeModal } from './SampleCreationTypeModal';
 import { getSampleWizardURL, SampleTypeWizardURLResolver } from './utils';

--- a/packages/components/src/entities/EntityCrossProjectSelectionConfirmModal.tsx
+++ b/packages/components/src/entities/EntityCrossProjectSelectionConfirmModal.tsx
@@ -1,9 +1,9 @@
 import React, { FC, memo } from 'react';
 
-import { ConfirmModal } from '../base/ConfirmModal';
-import { capitalizeFirstChar } from '../../util/utils';
+import { ConfirmModal } from '../internal/components/base/ConfirmModal';
+import { capitalizeFirstChar } from '../internal/util/utils';
 
-import { getCrossFolderSelectionMsg } from '../../../entities/utils';
+import { getCrossFolderSelectionMsg } from './utils';
 
 interface Props {
     crossFolderSelectionCount: number;
@@ -38,3 +38,5 @@ export const EntityCrossProjectSelectionConfirmModal: FC<Props> = memo(props => 
         </ConfirmModal>
     );
 });
+
+EntityCrossProjectSelectionConfirmModal.displayName = 'EntityCrossProjectSelectionConfirmModal';

--- a/packages/components/src/entities/EntityDeleteConfirmModal.spec.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModal.spec.tsx
@@ -21,10 +21,10 @@ import { sleep } from '../internal/testHelpers';
 
 import { ConfirmModal } from '../internal/components/base/ConfirmModal';
 
-import { EntityDeleteConfirmModalDisplay } from '../internal/components/entities/EntityDeleteConfirmModalDisplay';
 import { SampleTypeDataType } from '../internal/components/entities/constants';
 
 import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
+import { EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
 
 beforeAll(() => {
     mock.setup();

--- a/packages/components/src/entities/EntityDeleteConfirmModal.spec.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModal.spec.tsx
@@ -17,13 +17,14 @@ import React from 'react';
 import { mount } from 'enzyme';
 import mock, { proxy } from 'xhr-mock';
 
-import { sleep } from '../../testHelpers';
+import { sleep } from '../internal/testHelpers';
 
-import { ConfirmModal } from '../base/ConfirmModal';
+import { ConfirmModal } from '../internal/components/base/ConfirmModal';
+
+import { EntityDeleteConfirmModalDisplay } from '../internal/components/entities/EntityDeleteConfirmModalDisplay';
+import { SampleTypeDataType } from '../internal/components/entities/constants';
 
 import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
-import { EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
-import { SampleTypeDataType } from './constants';
 
 beforeAll(() => {
     mock.setup();

--- a/packages/components/src/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModal.tsx
@@ -15,19 +15,22 @@
  */
 import React, { PureComponent } from 'react';
 
-import { ConfirmModal } from '../base/ConfirmModal';
+import { ConfirmModal } from '../internal/components/base/ConfirmModal';
 
-import { LoadingSpinner } from '../base/LoadingSpinner';
+import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 
-import { Alert } from '../base/Alert';
+import { Alert } from '../internal/components/base/Alert';
 
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { QueryModel } from '../public/QueryModel/QueryModel';
 
-import { setSnapshotSelections } from '../../actions';
+import { setSnapshotSelections } from '../internal/actions';
 
-import { EntityDeleteConfirmHandler, EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
-import { getDeleteConfirmationData } from './actions';
-import { EntityDataType, OperationConfirmationData } from './models';
+import {
+    EntityDeleteConfirmHandler,
+    EntityDeleteConfirmModalDisplay,
+} from '../internal/components/entities/EntityDeleteConfirmModalDisplay';
+import { getDeleteConfirmationData } from '../internal/components/entities/actions';
+import { EntityDataType, OperationConfirmationData } from '../internal/components/entities/models';
 
 interface Props {
     entityDataType: EntityDataType;

--- a/packages/components/src/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModal.tsx
@@ -25,12 +25,10 @@ import { QueryModel } from '../public/QueryModel/QueryModel';
 
 import { setSnapshotSelections } from '../internal/actions';
 
-import {
-    EntityDeleteConfirmHandler,
-    EntityDeleteConfirmModalDisplay,
-} from '../internal/components/entities/EntityDeleteConfirmModalDisplay';
 import { getDeleteConfirmationData } from '../internal/components/entities/actions';
 import { EntityDataType, OperationConfirmationData } from '../internal/components/entities/models';
+
+import { EntityDeleteConfirmHandler, EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
 
 interface Props {
     entityDataType: EntityDataType;

--- a/packages/components/src/entities/EntityDeleteConfirmModalDisplay.spec.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModalDisplay.spec.tsx
@@ -16,13 +16,14 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT } from '../../productFixtures';
+import { TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT } from '../internal/productFixtures';
+
+import { AssayRunDataType, SampleTypeDataType } from '../internal/components/entities/constants';
+import { OperationConfirmationData } from '../internal/components/entities/models';
 
 import { EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
-import { AssayRunDataType, SampleTypeDataType } from './constants';
-import { OperationConfirmationData } from './models';
 
-describe('<EntityDeleteConfirmModal/>', () => {
+describe('EntityDeleteConfirmModal', () => {
     test('Can delete 1', () => {
         const component = (
             <EntityDeleteConfirmModalDisplay

--- a/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -16,14 +16,14 @@
 import React, { PureComponent } from 'react';
 import { Utils } from '@labkey/api';
 
-import { isELNEnabled } from '../../app/utils';
+import { isELNEnabled } from '../internal/app/utils';
 
-import { capitalizeFirstChar } from '../../util/utils';
-import { HelpLink } from '../../util/helpLinks';
+import { capitalizeFirstChar } from '../internal/util/utils';
+import { HelpLink } from '../internal/util/helpLinks';
 
-import { DeleteConfirmationModal } from '../../../entities/DeleteConfirmationModal';
+import { DeleteConfirmationModal } from './DeleteConfirmationModal';
 
-import { EntityDataType, OperationConfirmationData } from './models';
+import { EntityDataType, OperationConfirmationData } from '../internal/components/entities/models';
 
 export type EntityDeleteConfirmHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => void;
 

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -16,7 +16,7 @@ import { Progress } from '../internal/components/base/Progress';
 import { getEntityNoun } from '../internal/components/entities/utils';
 import { EntityDataType } from '../internal/components/entities/models';
 
-import { EntityDeleteConfirmHandler } from '../internal/components/entities/EntityDeleteConfirmModalDisplay';
+import { EntityDeleteConfirmHandler } from './EntityDeleteConfirmModalDisplay';
 
 import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
 

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -15,8 +15,10 @@ import { Progress } from '../internal/components/base/Progress';
 
 import { getEntityNoun } from '../internal/components/entities/utils';
 import { EntityDataType } from '../internal/components/entities/models';
-import { EntityDeleteConfirmModal } from '../internal/components/entities/EntityDeleteConfirmModal';
+
 import { EntityDeleteConfirmHandler } from '../internal/components/entities/EntityDeleteConfirmModalDisplay';
+
+import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
 
 interface Props {
     afterDelete: (rowsToKeep?: any[]) => void;

--- a/packages/components/src/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
+++ b/packages/components/src/entities/EntityInsertGridRequiredFieldAlert.spec.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { List } from 'immutable';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { QueryColumn } from '../../../public/QueryColumn';
-import { QueryInfo } from '../../../public/QueryInfo';
-import { Alert } from '../base/Alert';
+import { QueryColumn } from '../public/QueryColumn';
+import { QueryInfo } from '../public/QueryInfo';
+import { Alert } from '../internal/components/base/Alert';
 
 import { EntityInsertGridRequiredFieldAlert, getFieldKeysOfRequiredCols } from './EntityInsertGridRequiredFieldAlert';
 

--- a/packages/components/src/entities/EntityInsertGridRequiredFieldAlert.tsx
+++ b/packages/components/src/entities/EntityInsertGridRequiredFieldAlert.tsx
@@ -1,9 +1,9 @@
 import React, { FC, memo, useMemo } from 'react';
 import { List } from 'immutable';
 
-import { QueryInfo } from '../../../public/QueryInfo';
-import { QueryColumn } from '../../../public/QueryColumn';
-import { Alert } from '../base/Alert';
+import { QueryInfo } from '../public/QueryInfo';
+import { QueryColumn } from '../public/QueryColumn';
+import { Alert } from '../internal/components/base/Alert';
 
 interface Props {
     queryInfo: QueryInfo;

--- a/packages/components/src/entities/EntityInsertPanel.spec.tsx
+++ b/packages/components/src/entities/EntityInsertPanel.spec.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { List, Map, OrderedMap } from 'immutable';
 
-import { QueryColumn } from '../../../public/QueryColumn';
-import { DomainDetails } from '../domainproperties/models';
-import { InferDomainResponse } from '../../../public/InferDomainResponse';
-import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../domainproperties/constants';
+import { QueryColumn } from '../public/QueryColumn';
+import { DomainDetails } from '../internal/components/domainproperties/models';
+import { InferDomainResponse } from '../public/InferDomainResponse';
+import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../internal/components/domainproperties/constants';
 
 import { getInferredFieldWarnings, getNoUpdateFieldWarnings, WarningFieldList } from './EntityInsertPanel';
 

--- a/packages/components/src/entities/EntityInsertPanel.spec.tsx
+++ b/packages/components/src/entities/EntityInsertPanel.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { List, Map, OrderedMap } from 'immutable';
 
-import { QueryColumn } from '../public/QueryColumn';
+import { QueryColumn, QueryLookup } from '../public/QueryColumn';
 import { DomainDetails } from '../internal/components/domainproperties/models';
 import { InferDomainResponse } from '../public/InferDomainResponse';
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../internal/components/domainproperties/constants';
@@ -34,7 +34,12 @@ describe('EntityInsertPanel', () => {
     });
 
     describe('getInferredFieldWarnings', () => {
-        const lookup = { containerPath: '/Look', keyColumn: 'Name', displayColumn: 'Name', query: 'LookHere' };
+        const lookup = new QueryLookup({
+            containerPath: '/Look',
+            displayColumn: 'Name',
+            keyColumn: 'Name',
+            query: 'LookHere',
+        });
         const knownColumn = new QueryColumn({
             name: 'known',
         });
@@ -273,7 +278,12 @@ describe('EntityInsertPanel', () => {
     });
 
     describe('getNoUpdateFieldWarnings', () => {
-        const lookup = { containerPath: '/Look', keyColumn: 'Name', displayColumn: 'Name', query: 'LookHere' };
+        const lookup = new QueryLookup({
+            containerPath: '/Look',
+            displayColumn: 'Name',
+            keyColumn: 'Name',
+            query: 'LookHere',
+        });
 
         test('with disallowedUpdateFields', () => {
             const wrapper = mount(

--- a/packages/components/src/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/entities/EntityInsertPanel.tsx
@@ -1558,7 +1558,6 @@ const EntityInsertPanelFormSteps = withFormSteps(EntityInsertPanelImpl, {
     hasDependentSteps: false,
 });
 
-// ideally this would move to the /entities subpackage, but it is used in the core-components.view page
 export const EntityInsertPanel: FC<{ location?: Location } & OwnProps> = memo(props => {
     const { location, ...entityInsertPanelProps } = props;
     const { user } = useServerContext();

--- a/packages/components/src/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/entities/EntityInsertPanel.tsx
@@ -20,68 +20,78 @@ import { AuditBehaviorTypes, Query, Utils } from '@labkey/api';
 
 import { Link } from 'react-router';
 
-import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
+import { MAX_EDITABLE_GRID_ROWS } from '../internal/constants';
 
-import { PlacementType } from '../editable/Controls';
+import { PlacementType } from '../internal/components/editable/Controls';
 
-import { DATA_IMPORT_TOPIC, HelpLink } from '../../util/helpLinks';
+import { DATA_IMPORT_TOPIC, HelpLink } from '../internal/util/helpLinks';
 
-import { BulkAddData, EditableColumnMetadata } from '../editable/EditableGrid';
+import { BulkAddData, EditableColumnMetadata } from '../internal/components/editable/EditableGrid';
 
-import { DERIVATION_DATA_SCOPES } from '../domainproperties/constants';
+import { DERIVATION_DATA_SCOPES } from '../internal/components/domainproperties/constants';
 
-import { getCurrentProductName, isSampleManagerEnabled, sampleManagerIsPrimaryApp } from '../../app/utils';
+import { getCurrentProductName, isSampleManagerEnabled, sampleManagerIsPrimaryApp } from '../internal/app/utils';
 
-import { SAMPLE_STATE_COLUMN_NAME, SAMPLE_UNITS_COLUMN_NAME, SELECTION_KEY_TYPE } from '../samples/constants';
+import {
+    SAMPLE_STATE_COLUMN_NAME,
+    SAMPLE_UNITS_COLUMN_NAME,
+    SELECTION_KEY_TYPE,
+} from '../internal/components/samples/constants';
 
-import { SampleStatusLegend } from '../samples/SampleStatusLegend';
+import { SampleStatusLegend } from '../internal/components/samples/SampleStatusLegend';
 
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../internal/APIWrapper';
 
-import { applyEditableGridChangesToModels, initEditableGridModel } from '../editable/utils';
+import { applyEditableGridChangesToModels, initEditableGridModel } from '../internal/components/editable/utils';
 
-import { EditorMode, EditorModel, EditorModelProps, IEditableGridLoader, IGridResponse } from '../editable/models';
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
-import { SampleCreationType } from '../samples/models';
-import { FormStep, FormTabs, withFormSteps, WithFormStepsProps } from '../forms/FormStep';
-import { User } from '../base/models/User';
-import { QueryInfo } from '../../../public/QueryInfo';
-import { FileSizeLimitProps } from '../../../public/files/models';
-import { capitalizeFirstChar } from '../../util/utils';
-import { getActionErrorMessage, resolveErrorMessage } from '../../util/messaging';
-import { InsertOptions } from '../../query/api';
-import { insertColumnFilter, QueryColumn } from '../../../public/QueryColumn';
-import { SelectInput } from '../forms/input/SelectInput';
-import { Alert } from '../base/Alert';
-import { EditableGridPanel } from '../editable/EditableGridPanel';
-import { LoadingSpinner } from '../base/LoadingSpinner';
-import { Progress } from '../base/Progress';
-import { InferDomainResponse } from '../../../public/InferDomainResponse';
-import { DomainDetails } from '../domainproperties/models';
-import { AppURL } from '../../url/AppURL';
-import { LabelHelpTip } from '../base/LabelHelpTip';
-import { FileAttachmentForm } from '../../../public/files/FileAttachmentForm';
-import { WizardNavButtons } from '../buttons/WizardNavButtons';
-import { useServerContext } from '../base/ServerContext';
-import { getLocation, Location } from '../../util/URL';
-import { SCHEMAS } from '../../schemas';
-import { isSamplesSchema } from '../samples/utils';
-import { SchemaQuery } from '../../../public/SchemaQuery';
+import {
+    EditorMode,
+    EditorModel,
+    EditorModelProps,
+    IEditableGridLoader,
+    IGridResponse,
+} from '../internal/components/editable/models';
+import { QueryModel } from '../public/QueryModel/QueryModel';
+import { SampleCreationType } from '../internal/components/samples/models';
+import { FormStep, FormTabs, withFormSteps, WithFormStepsProps } from '../internal/components/forms/FormStep';
+import { User } from '../internal/components/base/models/User';
+import { QueryInfo } from '../public/QueryInfo';
+import { FileSizeLimitProps } from '../public/files/models';
+import { capitalizeFirstChar } from '../internal/util/utils';
+import { getActionErrorMessage, resolveErrorMessage } from '../internal/util/messaging';
+import { InsertOptions } from '../internal/query/api';
+import { insertColumnFilter, QueryColumn } from '../public/QueryColumn';
+import { SelectInput } from '../internal/components/forms/input/SelectInput';
+import { Alert } from '../internal/components/base/Alert';
+import { EditableGridPanel } from '../internal/components/editable/EditableGridPanel';
+import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
+import { Progress } from '../internal/components/base/Progress';
+import { InferDomainResponse } from '../public/InferDomainResponse';
+import { DomainDetails } from '../internal/components/domainproperties/models';
+import { AppURL } from '../internal/url/AppURL';
+import { LabelHelpTip } from '../internal/components/base/LabelHelpTip';
+import { FileAttachmentForm } from '../public/files/FileAttachmentForm';
+import { WizardNavButtons } from '../internal/components/buttons/WizardNavButtons';
+import { useServerContext } from '../internal/components/base/ServerContext';
+import { getLocation, Location } from '../internal/util/URL';
+import { SCHEMAS } from '../internal/schemas';
+import { isSamplesSchema } from '../internal/components/samples/utils';
+import { SchemaQuery } from '../public/SchemaQuery';
 
-import { getAltUnitKeys } from '../../util/measurement';
+import { getAltUnitKeys } from '../internal/util/measurement';
 
-import { getDataClassDetails } from '../domainproperties/dataclasses/actions';
+import { getDataClassDetails } from '../internal/components/domainproperties/dataclasses/actions';
 
-import { ENTITY_CREATION_METRIC, SampleTypeDataType } from './constants';
+import { ENTITY_CREATION_METRIC, SampleTypeDataType } from '../internal/components/entities/constants';
 import {
     addEntityParentType,
     removeEntityParentType,
     EntityParentTypeSelectors,
     changeEntityParentType,
     EditorModelUpdatesWithParents,
-} from './EntityParentTypeSelectors';
-import { EntityInsertGridRequiredFieldAlert } from './EntityInsertGridRequiredFieldAlert';
-import { getBulkCreationTypeOptions, getUniqueIdColumnMetadata } from './utils';
+} from '../internal/components/entities/EntityParentTypeSelectors';
+
+import { getBulkCreationTypeOptions, getUniqueIdColumnMetadata } from '../internal/components/entities/utils';
 import {
     EntityDataType,
     EntityIdCreationModel,
@@ -89,7 +99,9 @@ import {
     EntityTypeOption,
     IEntityTypeOption,
     IParentOption,
-} from './models';
+} from '../internal/components/entities/models';
+
+import { EntityInsertGridRequiredFieldAlert } from './EntityInsertGridRequiredFieldAlert';
 
 const ENTITY_GRID_ID = 'entity-insert-grid-data';
 const ALIQUOT_FIELD_COLS = [

--- a/packages/components/src/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/entities/EntityLineageEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 
 import { AuditBehaviorTypes, Utils } from '@labkey/api';
 
@@ -172,7 +172,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
         } catch (e) {
             setSubmitting(false);
             setErrorMessage(
-                'There was a fetching parent data for the ' + lcParentNounPlural + '.' + resolveErrorMessage(e)
+                'There was a problem fetching parent data for the ' + lcParentNounPlural + '.' + resolveErrorMessage(e)
             );
             return;
         }

--- a/packages/components/src/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/entities/EntityLineageEditModal.tsx
@@ -21,13 +21,17 @@ import { Alert } from '../internal/components/base/Alert';
 import { Progress } from '../internal/components/base/Progress';
 
 import { DataOperation, ParentEntityLineageColumns } from '../internal/components/entities/constants';
-import { ParentEntityEditPanel } from './ParentEntityEditPanel';
+
 import { getEntityNoun, isSampleEntity } from '../internal/components/entities/utils';
 import { EntityChoice, EntityDataType, OperationConfirmationData } from '../internal/components/entities/models';
-import { getUpdatedLineageRowsForBulkEdit } from './utils';
-import { getOriginalParentsFromLineage } from './actions';
+
 import { setSnapshotSelections } from '../internal/actions';
+
 import { isLoading, LoadingState } from '../public/LoadingState';
+
+import { getUpdatedLineageRowsForBulkEdit } from './utils';
+
+import { ParentEntityEditPanel } from './ParentEntityEditPanel';
 
 interface Props {
     api?: ComponentsAPIWrapper;
@@ -69,15 +73,15 @@ const restrictedDataOperationMsg = (
 export const EntityLineageEditModal: FC<Props> = memo(props => {
     const { api, auditBehavior, queryModel, onCancel, childEntityDataType, onSuccess, parentEntityDataTypes } = props;
     const [submitting, setSubmitting] = useState(false);
-    const [allowedForUpdate, setAllowedForUpdate] = useState<Record<string, any>>(undefined);
-    const [aliquotIds, setAliquotIds] = useState<number[]>(undefined);
-    const [errorMessage, setErrorMessage] = useState<string>(undefined);
+    const [allowedForUpdate, setAllowedForUpdate] = useState<Record<string, any>>();
+    const [aliquotIds, setAliquotIds] = useState<number[]>();
+    const [errorMessage, setErrorMessage] = useState<string>();
     const [hasParentUpdates, setHasParentUpdates] = useState<boolean>(false);
     const parentNounPlural = parentEntityDataTypes[0].nounPlural;
     const parentNounSingular = parentEntityDataTypes[0].nounSingular;
     const lcParentNounPlural = parentNounPlural.toLowerCase();
     const [selectedParents, setSelectedParents] = useState<List<EntityChoice>>(List<EntityChoice>());
-    const [statusData, setStatusData] = useState<OperationConfirmationData>(undefined);
+    const [statusData, setStatusData] = useState<OperationConfirmationData>();
     const [selectionsLoading, setSelectionsLoading] = useState<LoadingState>(LoadingState.INITIALIZED);
     const { createNotification } = useNotificationsContext();
     const useSnapshotSelection = queryModel?.filterArray.length > 0;
@@ -93,7 +97,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                         await setSnapshotSelections(queryModel.id, [...queryModel.selections]);
                         setSelectionsLoading(LoadingState.LOADED);
                     }
-                } else  {
+                } else {
                     setSelectionsLoading(LoadingState.LOADED);
                 }
                 if (!isLoading(selectionsLoading)) {
@@ -113,7 +117,6 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                         );
                     }
 
-
                     // This API will retrieve lineage data for samples or dataclasses
                     const lineageData = await api.samples.getSelectionLineageData(
                         List.of(...queryModel.selections),
@@ -123,7 +126,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                         List.of('RowId', 'Name', 'LSID', IS_ALIQUOT_COL).concat(ParentEntityLineageColumns).toArray()
                     );
 
-                    const {key, models} = lineageData;
+                    const { key, models } = lineageData;
                     const allowedForUpdate = {};
                     const aIds = [];
                     Object.keys(models[key]).forEach(id => {
@@ -156,13 +159,23 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
     const onConfirm = async (): Promise<void> => {
         setSubmitting(true);
 
-        const { originalParents } = await getOriginalParentsFromLineage(allowedForUpdate, parentEntityDataTypes);
-        const rows = getUpdatedLineageRowsForBulkEdit(
-            allowedForUpdate,
-            selectedParents,
-            originalParents,
-            queryModel.queryInfo
-        );
+        let rows: any[];
+
+        try {
+            const parentData = await api.entity.getOriginalParentsFromLineage(allowedForUpdate, parentEntityDataTypes);
+            rows = getUpdatedLineageRowsForBulkEdit(
+                allowedForUpdate,
+                selectedParents,
+                parentData.originalParents,
+                queryModel.queryInfo
+            );
+        } catch (e) {
+            setSubmitting(false);
+            setErrorMessage(
+                'There was a fetching parent data for the ' + lcParentNounPlural + '.' + resolveErrorMessage(e)
+            );
+            return;
+        }
 
         if (rows.length > 0) {
             try {

--- a/packages/components/src/entities/FindDerivativesButton.spec.tsx
+++ b/packages/components/src/entities/FindDerivativesButton.spec.tsx
@@ -4,15 +4,15 @@ import { Filter } from '@labkey/api';
 
 import { fromJS } from 'immutable';
 
-import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
-import { SchemaQuery } from '../../../public/SchemaQuery';
-import { mountWithAppServerContext } from '../../testHelpers';
-import { QueryInfo } from '../../../public/QueryInfo';
-import { ViewInfo } from '../../ViewInfo';
+import { makeTestQueryModel } from '../public/QueryModel/testUtils';
+import { SchemaQuery } from '../public/SchemaQuery';
+import { mountWithAppServerContext } from '../internal/testHelpers';
+import { QueryInfo } from '../public/QueryInfo';
+import { ViewInfo } from '../internal/ViewInfo';
 
-import { DisableableMenuItem } from '../samples/DisableableMenuItem';
+import { DisableableMenuItem } from '../internal/components/samples/DisableableMenuItem';
 
-import { DataClassDataType, SampleTypeDataType } from './constants';
+import { DataClassDataType, SampleTypeDataType } from '../internal/components/entities/constants';
 
 import { FindDerivativesMenuItem, getFieldFilter, getSessionSearchFilterProps } from './FindDerivativesButton';
 

--- a/packages/components/src/entities/FindDerivativesButton.tsx
+++ b/packages/components/src/entities/FindDerivativesButton.tsx
@@ -2,31 +2,32 @@ import React, { FC, memo, useCallback, useMemo } from 'react';
 
 import { Filter } from '@labkey/api';
 
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { QueryModel } from '../public/QueryModel/QueryModel';
 
-import { AppURL } from '../../url/AppURL';
+import { AppURL } from '../internal/url/AppURL';
 
-import { FIND_SAMPLES_BY_FILTER_KEY } from '../../app/constants';
+import { FIND_SAMPLES_BY_FILTER_KEY } from '../internal/app/constants';
 
-import { formatDateTime } from '../../util/Date';
+import { formatDateTime } from '../internal/util/Date';
 
-import { EntityDataType } from './models';
+import { EntityDataType } from '../internal/components/entities/models';
 
-import { ResponsiveMenuButton } from '../buttons/ResponsiveMenuButton';
+import { ResponsiveMenuButton } from '../internal/components/buttons/ResponsiveMenuButton';
 
-import { useAppContext } from '../../AppContext';
+import { useAppContext } from '../internal/AppContext';
 
-import { DisableableMenuItem } from '../samples/DisableableMenuItem';
+import { DisableableMenuItem } from '../internal/components/samples/DisableableMenuItem';
 
-import { isValidFilterFieldSampleFinder, searchFiltersToJson } from '../search/utils';
-import { FieldFilter, FilterProps } from '../search/models';
-import { SAMPLE_FINDER_SESSION_PREFIX } from '../search/constants';
+import { isValidFilterFieldSampleFinder, searchFiltersToJson } from '../internal/components/search/utils';
+import { FieldFilter, FilterProps } from '../internal/components/search/models';
+import { SAMPLE_FINDER_SESSION_PREFIX } from '../internal/components/search/constants';
 
-import { getSampleFinderLocalStorageKey } from '../../../entities/utils';
+import { getSampleFinderLocalStorageKey } from './utils';
 
 const DISABLED_FIND_DERIVATIVES_MSG =
     'Unable to find derivative samples using search filters or filters on multi-valued lookup fields';
 
+// exported for unit test coverage
 export const getFieldFilter = (model: QueryModel, filter: Filter.IFilter): FieldFilter => {
     const colName = filter.getColumnName();
     const column = model.getColumn(colName);
@@ -39,6 +40,7 @@ export const getFieldFilter = (model: QueryModel, filter: Filter.IFilter): Field
     } as FieldFilter;
 };
 
+// exported for unit test coverage
 export const getSessionSearchFilterProps = (
     entityDataType: EntityDataType,
     model: QueryModel,

--- a/packages/components/src/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/entities/ParentEntityEditPanel.tsx
@@ -7,7 +7,7 @@ import { AuditBehaviorTypes, Filter } from '@labkey/api';
 
 import { DetailPanelHeader } from '../internal/components/forms/detail/DetailPanelHeader';
 
-import { getParentTypeDataForLineage, GetParentTypeDataForLineage } from '../internal/components/samples/actions';
+import { getParentTypeDataForLineage, GetParentTypeDataForLineage } from '../internal/components/entities/actions';
 
 import { DELIMITER } from '../internal/components/forms/constants';
 

--- a/packages/components/src/entities/SampleCreatePage.spec.tsx
+++ b/packages/components/src/entities/SampleCreatePage.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ReactWrapper } from 'enzyme';
 
 import { InsufficientPermissionsPage } from '../internal/components/permissions/InsufficientPermissionsPage';
-import { EntityInsertPanel } from '../internal/components/entities/EntityInsertPanel';
 import { mountWithAppServerContext, waitForLifecycle } from '../internal/testHelpers';
 import { TEST_USER_APP_ADMIN, TEST_USER_AUTHOR, TEST_USER_EDITOR, TEST_USER_READER } from '../internal/userFixtures';
 import { createMockWithRouterProps } from '../internal/mockUtils';
@@ -11,6 +10,7 @@ import { BACKGROUND_IMPORT_MIN_FILE_SIZE } from '../internal/components/pipeline
 
 import { SampleTypeAppContext } from '../internal/AppContext';
 
+import { EntityInsertPanel } from './EntityInsertPanel';
 import { SampleCreatePage, SampleCreatePageProps } from './SampleCreatePage';
 import { SampleTypeBasePage } from './SampleTypeBasePage';
 

--- a/packages/components/src/entities/SampleCreatePage.tsx
+++ b/packages/components/src/entities/SampleCreatePage.tsx
@@ -16,7 +16,7 @@ import { SampleTypeDataType } from '../internal/components/entities/constants';
 import { QueryInfo } from '../public/QueryInfo';
 import { BulkAddData } from '../internal/components/editable/EditableGrid';
 import { InsufficientPermissionsPage } from '../internal/components/permissions/InsufficientPermissionsPage';
-import { EntityInsertPanel } from '../internal/components/entities/EntityInsertPanel';
+
 import { ALIQUOTED_FROM_COL, SAMPLE_INSERT_EXTRA_COLUMNS } from '../internal/components/samples/constants';
 import {
     BACKGROUND_IMPORT_MIN_FILE_SIZE,
@@ -25,6 +25,8 @@ import {
 import { HelpLink } from '../internal/util/helpLinks';
 import { CommonPageProps } from '../internal/models';
 import { MAX_EDITABLE_GRID_ROWS } from '../internal/constants';
+
+import { EntityInsertPanel } from './EntityInsertPanel';
 
 import { SampleTypeBasePage } from './SampleTypeBasePage';
 import { onSampleChange } from './actions';

--- a/packages/components/src/entities/SampleDeleteMenuItem.spec.tsx
+++ b/packages/components/src/entities/SampleDeleteMenuItem.spec.tsx
@@ -6,9 +6,9 @@ import { makeTestQueryModel } from '../public/QueryModel/testUtils';
 import { SchemaQuery } from '../public/SchemaQuery';
 import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuItem';
 
-import { EntityDeleteConfirmModal } from '../internal/components/entities/EntityDeleteConfirmModal';
-
 import { mountWithAppServerContext } from '../internal/testHelpers';
+
+import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
 
 import { SampleDeleteMenuItem } from './SampleDeleteMenuItem';
 

--- a/packages/components/src/entities/SampleTypeTemplateDownloadRenderer.tsx
+++ b/packages/components/src/entities/SampleTypeTemplateDownloadRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { FC, memo, useCallback } from 'react';
 import { Map } from 'immutable';
 
 import { SchemaQuery } from '../public/SchemaQuery';
@@ -12,26 +12,6 @@ import { getSampleTypeDetails } from '../internal/components/samples/actions';
 import { downloadAttachment } from '../internal/util/utils';
 
 import { getSampleTypeTemplateUrl } from './utils';
-
-interface Props {
-    excludeColumns?: string[];
-    row?: Map<any, any>;
-}
-
-export class SampleTypeTemplateDownloadRenderer extends React.PureComponent<Props> {
-    onDownload = () => {
-        const { row, excludeColumns } = this.props;
-        const schemaQuery = new SchemaQuery(
-            SCHEMAS.SAMPLE_SETS.SCHEMA,
-            row.getIn(['Name', 'value']) ?? row.getIn(['name', 'value'])
-        );
-        downloadSampleTypeTemplate(schemaQuery, getSampleTypeTemplateUrl, excludeColumns);
-    };
-
-    render(): ReactNode {
-        return <TemplateDownloadButton onClick={this.onDownload} text="Download" className="button-small-padding" />;
-    }
-}
 
 export const downloadSampleTypeTemplate = (
     schemaQuery: SchemaQuery,
@@ -55,3 +35,20 @@ export const downloadSampleTypeTemplate = (
             console.error('Unable to download sample type template', reason);
         });
 };
+
+interface Props {
+    excludeColumns?: string[];
+    row?: Map<any, any>;
+}
+
+export const SampleTypeTemplateDownloadRenderer: FC<Props> = memo(({ excludeColumns, row }) => {
+    const onClick = useCallback(() => {
+        const schemaQuery = new SchemaQuery(
+            SCHEMAS.SAMPLE_SETS.SCHEMA,
+            row.getIn(['Name', 'value']) ?? row.getIn(['name', 'value'])
+        );
+        downloadSampleTypeTemplate(schemaQuery, getSampleTypeTemplateUrl, excludeColumns);
+    }, [excludeColumns, row]);
+
+    return <TemplateDownloadButton className="button-small-padding" onClick={onClick} text="Download" />;
+});

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -19,8 +19,6 @@ import { SampleTypeDataType } from '../internal/components/entities/constants';
 
 import { getCrossFolderSelectionResult } from '../internal/components/entities/actions';
 
-import { EntityCrossProjectSelectionConfirmModal } from '../internal/components/entities/EntityCrossProjectSelectionConfirmModal';
-
 import { SamplesEditButtonSections } from '../internal/components/samples/utils';
 
 import { getSampleTypeRowId } from '../internal/components/samples/actions';
@@ -28,6 +26,8 @@ import { SampleGridButtonProps } from '../internal/components/samples/models';
 import { NEW_SAMPLES_HREF, SAMPLES_KEY } from '../internal/app/constants';
 
 import { setSnapshotSelections } from '../internal/actions';
+
+import { EntityCrossProjectSelectionConfirmModal } from './EntityCrossProjectSelectionConfirmModal';
 
 import { shouldIncludeMenuItem } from './utils';
 import { SampleDeleteMenuItem } from './SampleDeleteMenuItem';

--- a/packages/components/src/entities/SamplesEditableGrid.tsx
+++ b/packages/components/src/entities/SamplesEditableGrid.tsx
@@ -46,8 +46,6 @@ import { SamplesEditableGridPanelForUpdate } from './SamplesEditableGridPanelFor
 import { DiscardConsumedSamplesModal } from './DiscardConsumedSamplesModal';
 import { SamplesSelectionProvider } from './SamplesSelectionContextProvider';
 
-import { getOriginalParentsFromLineage } from './actions';
-
 type Props = SamplesEditableGridProps &
     SamplesSelectionProviderProps &
     SamplesSelectionResultProps &
@@ -175,13 +173,13 @@ class SamplesEditableGridBase extends React.Component<Props, State> {
     };
 
     initLineageEditableGrid = async (): Promise<void> => {
-        const { determineLineage, parentDataTypes } = this.props;
+        const { api, determineLineage, parentDataTypes, sampleLineage } = this.props;
         if (determineLineage && this.hasParentDataTypes()) {
-            const { originalParents, parentTypeOptions } = await getOriginalParentsFromLineage(
-                this.props.sampleLineage,
+            const { originalParents, parentTypeOptions } = await api.entity.getOriginalParentsFromLineage(
+                sampleLineage,
                 parentDataTypes.toArray()
             );
-            this.setState(() => ({ originalParents, parentTypeOptions }));
+            this.setState({ originalParents, parentTypeOptions });
         }
     };
 

--- a/packages/components/src/entities/SamplesSelectionContextProvider.tsx
+++ b/packages/components/src/entities/SamplesSelectionContextProvider.tsx
@@ -19,6 +19,7 @@ import {
     getSelectionLineageData,
 } from '../internal/components/samples/actions';
 import { SampleOperation } from '../internal/components/samples/constants';
+import { resolveErrorMessage } from '../internal/util/messaging';
 
 const Context = React.createContext<SamplesSelectionResultProps>(undefined);
 const SamplesSelectionContextProvider = Context.Provider;
@@ -66,7 +67,9 @@ export function SamplesSelectionProvider<T>(
                     });
                 })
                 .catch(reason => {
-                    this.setState({ selectionInfoError: reason });
+                    this.setState({
+                        selectionInfoError: resolveErrorMessage(reason) ?? 'Failed to load sample type domain',
+                    });
                 });
         }
 
@@ -100,7 +103,7 @@ export function SamplesSelectionProvider<T>(
                     .catch(error => {
                         this.setState({
                             aliquots: undefined,
-                            selectionInfoError: error,
+                            selectionInfoError: resolveErrorMessage(error) ?? 'Failed to load aliquot data',
                         });
                     });
             }
@@ -118,19 +121,18 @@ export function SamplesSelectionProvider<T>(
                     .catch(error => {
                         this.setState({
                             noStorageSamples: undefined,
-                            selectionInfoError: error,
+                            selectionInfoError: resolveErrorMessage(error) ?? 'Failed to load no storage samples',
                         });
                     });
                 getSampleSelectionStorageData(selection)
                     .then(sampleItems => {
-                        this.setState(() => ({
-                            sampleItems,
-                        }));
+                        this.setState({ sampleItems });
                     })
                     .catch(error => {
                         this.setState({
                             sampleItems: undefined,
-                            selectionInfoError: error,
+                            selectionInfoError:
+                                resolveErrorMessage(error) ?? 'Failed to load sample selection storage data',
                         });
                     });
             }
@@ -151,7 +153,7 @@ export function SamplesSelectionProvider<T>(
                         this.setState({
                             sampleLineageKeys: undefined,
                             sampleLineage: undefined,
-                            selectionInfoError: error,
+                            selectionInfoError: resolveErrorMessage(error) ?? 'Failed to load lineage data',
                         });
                     });
             }

--- a/packages/components/src/entities/actions.ts
+++ b/packages/components/src/entities/actions.ts
@@ -1,4 +1,4 @@
-import { fromJS, List, Map, OrderedMap } from 'immutable';
+import { fromJS, Map } from 'immutable';
 import { Query } from '@labkey/api';
 
 import {
@@ -9,15 +9,7 @@ import {
 } from '../internal/query/api';
 import { SCHEMAS } from '../internal/schemas';
 import { resolveErrorMessage } from '../internal/util/messaging';
-import {
-    EntityChoice,
-    EntityDataType,
-    IEntityTypeOption,
-    IParentAlias,
-    IParentOption,
-} from '../internal/components/entities/models';
-import { getParentTypeDataForLineage } from '../internal/components/samples/actions';
-import { getInitialParentChoices } from '../internal/components/entities/utils';
+import { IParentAlias, IParentOption } from '../internal/components/entities/models';
 import { QueryInfo } from '../public/QueryInfo';
 import { invalidateLineageResults } from '../internal/components/lineage/actions';
 import { SchemaQuery } from '../public/SchemaQuery';
@@ -58,64 +50,6 @@ export function getSampleTypes(includeMedia?: boolean): Promise<Array<{ id: numb
             });
     });
 }
-
-export const getOriginalParentsFromLineage = async (
-    lineage: Record<string, any>,
-    parentDataTypes: EntityDataType[],
-    containerPath?: string
-): Promise<{
-    originalParents: Record<string, List<EntityChoice>>;
-    parentTypeOptions: Map<string, List<IEntityTypeOption>>;
-}> => {
-    const originalParents = {};
-    let parentTypeOptions = Map<string, List<IEntityTypeOption>>();
-    const dataClassTypeData = await getParentTypeDataForLineage(
-        parentDataTypes.filter(
-            dataType => dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.DATA_CLASSES.queryName
-        )[0],
-        Object.values(lineage),
-        containerPath
-    );
-    const sampleTypeData = await getParentTypeDataForLineage(
-        parentDataTypes.filter(
-            dataType => dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.SAMPLE_SETS.queryName
-        )[0],
-        Object.values(lineage),
-        containerPath
-    );
-
-    // iterate through both Data Classes and Sample Types for finding sample parents
-    parentDataTypes.forEach(dataType => {
-        const dataTypeOptions =
-            dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.DATA_CLASSES.queryName
-                ? dataClassTypeData.parentTypeOptions
-                : sampleTypeData.parentTypeOptions;
-
-        const parentIdData =
-            dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.DATA_CLASSES.queryName
-                ? dataClassTypeData.parentIdData
-                : sampleTypeData.parentIdData;
-        Object.keys(lineage).forEach(sampleId => {
-            if (!originalParents[sampleId]) originalParents[sampleId] = List<EntityChoice>();
-
-            originalParents[sampleId] = originalParents[sampleId].concat(
-                getInitialParentChoices(dataTypeOptions, dataType, lineage[sampleId], parentIdData)
-            );
-        });
-
-        // filter out the current parent types from the dataTypeOptions
-        const originalParentTypeLsids = [];
-        Object.values(originalParents).forEach((parentTypes: List<EntityChoice>) => {
-            originalParentTypeLsids.push(...parentTypes.map(parentType => parentType.type.lsid).toArray());
-        });
-        parentTypeOptions = parentTypeOptions.set(
-            dataType.typeListingSchemaQuery.queryName,
-            dataTypeOptions.filter(option => originalParentTypeLsids.indexOf(option.lsid) === -1).toList()
-        );
-    });
-
-    return { originalParents, parentTypeOptions };
-};
 
 export const loadSampleTypes = (includeMedia: boolean): Promise<QueryInfo[]> =>
     loadQueriesFromTable(

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -54,6 +54,7 @@ import { useSampleTypeAppContext } from './useSampleTypeAppContext';
 import { SampleTypeDesignPage } from './SampleTypeDesignPage';
 import { SingleParentEntityPanel } from './SingleParentEntityPanel';
 
+import { AssayResultsForSamplesButton, AssayResultsForSamplesMenuItem } from './AssayResultsForSamplesButton';
 import { AssayResultsForSamplesPage, AssayResultsForSamplesSubNav } from './AssayResultsForSamplesPage';
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleDetailContextConsumer, SampleDetailPage } from './SampleDetailPage';
@@ -68,6 +69,8 @@ import { DeleteConfirmationModal } from './DeleteConfirmationModal';
 import { FindDerivativesButton, FindDerivativesMenuItem } from './FindDerivativesButton';
 
 export {
+    AssayResultsForSamplesButton,
+    AssayResultsForSamplesMenuItem,
     createEntityParentKey,
     downloadSampleTypeTemplate,
     filterMediaSampleTypes,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -1,6 +1,5 @@
 import {
     getSampleTypes,
-    getOriginalParentsFromLineage,
     loadSampleTypes,
     onDataClassRename,
     onSampleChange,
@@ -74,7 +73,6 @@ export {
     filterSampleRowsForOperation,
     getDataClassTemplateUrl,
     getJobCreationHref,
-    getOriginalParentsFromLineage,
     getSampleSetMenuItem,
     getSampleDeleteMessage,
     getSampleTypeTemplateUrl,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -65,12 +65,15 @@ import { SamplesCreatedSuccessMessage } from './SamplesCreatedSuccessMessage';
 import { SampleListingPage, SamplesImportSuccessMessage } from './SampleListingPage';
 import { SampleCreatePage } from './SampleCreatePage';
 import { DeleteConfirmationModal } from './DeleteConfirmationModal';
+import { FindDerivativesButton, FindDerivativesMenuItem } from './FindDerivativesButton';
 
 export {
     createEntityParentKey,
     downloadSampleTypeTemplate,
     filterMediaSampleTypes,
     filterSampleRowsForOperation,
+    FindDerivativesButton,
+    FindDerivativesMenuItem,
     getDataClassTemplateUrl,
     getJobCreationHref,
     getSampleSetMenuItem,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -57,6 +57,7 @@ import { SingleParentEntityPanel } from './SingleParentEntityPanel';
 import { AssayResultsForSamplesButton, AssayResultsForSamplesMenuItem } from './AssayResultsForSamplesButton';
 import { AssayResultsForSamplesPage, AssayResultsForSamplesSubNav } from './AssayResultsForSamplesPage';
 import { EntityCrossProjectSelectionConfirmModal } from './EntityCrossProjectSelectionConfirmModal';
+import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleDetailContextConsumer, SampleDetailPage } from './SampleDetailPage';
 import { SampleAssaysPage } from './SampleAssaysPage';
@@ -75,6 +76,7 @@ export {
     createEntityParentKey,
     downloadSampleTypeTemplate,
     EntityCrossProjectSelectionConfirmModal,
+    EntityDeleteConfirmModal,
     filterMediaSampleTypes,
     filterSampleRowsForOperation,
     FindDerivativesButton,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -58,6 +58,7 @@ import { AssayResultsForSamplesButton, AssayResultsForSamplesMenuItem } from './
 import { AssayResultsForSamplesPage, AssayResultsForSamplesSubNav } from './AssayResultsForSamplesPage';
 import { EntityCrossProjectSelectionConfirmModal } from './EntityCrossProjectSelectionConfirmModal';
 import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
+import { EntityInsertPanel } from './EntityInsertPanel';
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleDetailContextConsumer, SampleDetailPage } from './SampleDetailPage';
 import { SampleAssaysPage } from './SampleAssaysPage';
@@ -77,6 +78,7 @@ export {
     downloadSampleTypeTemplate,
     EntityCrossProjectSelectionConfirmModal,
     EntityDeleteConfirmModal,
+    EntityInsertPanel,
     filterMediaSampleTypes,
     filterSampleRowsForOperation,
     FindDerivativesButton,

--- a/packages/components/src/entities/index.ts
+++ b/packages/components/src/entities/index.ts
@@ -56,6 +56,7 @@ import { SingleParentEntityPanel } from './SingleParentEntityPanel';
 
 import { AssayResultsForSamplesButton, AssayResultsForSamplesMenuItem } from './AssayResultsForSamplesButton';
 import { AssayResultsForSamplesPage, AssayResultsForSamplesSubNav } from './AssayResultsForSamplesPage';
+import { EntityCrossProjectSelectionConfirmModal } from './EntityCrossProjectSelectionConfirmModal';
 import { SampleOverviewPanel } from './SampleOverviewPanel';
 import { SampleDetailContextConsumer, SampleDetailPage } from './SampleDetailPage';
 import { SampleAssaysPage } from './SampleAssaysPage';
@@ -73,6 +74,7 @@ export {
     AssayResultsForSamplesMenuItem,
     createEntityParentKey,
     downloadSampleTypeTemplate,
+    EntityCrossProjectSelectionConfirmModal,
     filterMediaSampleTypes,
     filterSampleRowsForOperation,
     FindDerivativesButton,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -428,7 +428,6 @@ import {
 } from './internal/components/entities/constants';
 import { getUniqueIdColumnMetadata } from './internal/components/entities/utils';
 import { EntityInsertPanel } from './internal/components/entities/EntityInsertPanel';
-import { EntityCrossProjectSelectionConfirmModal } from './internal/components/entities/EntityCrossProjectSelectionConfirmModal';
 import { EntityDeleteConfirmModal } from './internal/components/entities/EntityDeleteConfirmModal';
 import { SampleTypeModel } from './internal/components/domainproperties/samples/models';
 
@@ -1056,7 +1055,6 @@ export {
     getParentTypeDataForLineage,
     getSelectedSampleIdsFromSelectionKey,
     EntityInsertPanel,
-    EntityCrossProjectSelectionConfirmModal,
     EntityDeleteConfirmModal,
     SampleTypeDataType,
     SamplePropertyDataType,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -427,7 +427,6 @@ import {
     SamplePropertyDataType,
 } from './internal/components/entities/constants';
 import { getUniqueIdColumnMetadata } from './internal/components/entities/utils';
-import { EntityInsertPanel } from './internal/components/entities/EntityInsertPanel';
 import { SampleTypeModel } from './internal/components/domainproperties/samples/models';
 
 import { EditableDetailPanel } from './public/QueryModel/EditableDetailPanel';
@@ -1053,7 +1052,6 @@ export {
     getSelectionLineageData,
     getParentTypeDataForLineage,
     getSelectedSampleIdsFromSelectionKey,
-    EntityInsertPanel,
     SampleTypeDataType,
     SamplePropertyDataType,
     DataClassDataType,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -506,7 +506,6 @@ import {
     AssayResultsForSamplesButton,
     AssayResultsForSamplesMenuItem,
 } from './internal/components/entities/AssayResultsForSamplesButton';
-import { FindDerivativesButton, FindDerivativesMenuItem } from './internal/components/entities/FindDerivativesButton';
 import {
     makeQueryInfo,
     mountWithAppServerContext,
@@ -1102,8 +1101,6 @@ export {
     getStoredAmountDisplay,
     isValuePrecisionValid,
     // search related items
-    FindDerivativesMenuItem,
-    FindDerivativesButton,
     FIND_SAMPLE_BY_ID_METRIC_AREA,
     BaseSearchPage,
     SearchResultsModel,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -503,10 +503,6 @@ import { RangeValidationOptionsModal } from './internal/components/domainpropert
 import { AssayImportPanels } from './internal/components/assay/AssayImportPanels';
 import { AssayDesignEmptyAlert } from './internal/components/assay/AssayDesignEmptyAlert';
 import {
-    AssayResultsForSamplesButton,
-    AssayResultsForSamplesMenuItem,
-} from './internal/components/entities/AssayResultsForSamplesButton';
-import {
     makeQueryInfo,
     mountWithAppServerContext,
     mountWithAppServerContextOptions,
@@ -1133,8 +1129,6 @@ export {
     AssayDomainTypes,
     AssayLink,
     AssayDesignEmptyAlert,
-    AssayResultsForSamplesButton,
-    AssayResultsForSamplesMenuItem,
     allowReimportAssayRun,
     clearAssayDefinitionCache,
     fetchAllAssays,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -428,7 +428,6 @@ import {
 } from './internal/components/entities/constants';
 import { getUniqueIdColumnMetadata } from './internal/components/entities/utils';
 import { EntityInsertPanel } from './internal/components/entities/EntityInsertPanel';
-import { EntityDeleteConfirmModal } from './internal/components/entities/EntityDeleteConfirmModal';
 import { SampleTypeModel } from './internal/components/domainproperties/samples/models';
 
 import { EditableDetailPanel } from './public/QueryModel/EditableDetailPanel';
@@ -1055,7 +1054,6 @@ export {
     getParentTypeDataForLineage,
     getSelectedSampleIdsFromSelectionKey,
     EntityInsertPanel,
-    EntityDeleteConfirmModal,
     SampleTypeDataType,
     SamplePropertyDataType,
     DataClassDataType,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -322,7 +322,6 @@ import {
     getSampleTypeDetails,
     getSelectedSampleIdsFromSelectionKey,
     getSelectionLineageData,
-    getParentTypeDataForLineage,
 } from './internal/components/samples/actions';
 import { SampleEmptyAlert, SampleTypeEmptyAlert } from './internal/components/samples/SampleEmptyAlert';
 import { SampleAmountEditModal } from './internal/components/samples/SampleAmountEditModal';
@@ -415,6 +414,7 @@ import {
     getDataDeleteConfirmationData,
     getDataOperationConfirmationData,
     getOperationConfirmationData,
+    getParentTypeDataForLineage,
     getSampleOperationConfirmationData,
 } from './internal/components/entities/actions';
 import {

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -43,18 +43,24 @@ export interface ComponentsAPIWrapper {
     security: SecurityAPIWrapper;
 }
 
+let DEFAULT_WRAPPER: ComponentsAPIWrapper;
+
 export function getDefaultAPIWrapper(): ComponentsAPIWrapper {
-    return {
-        domain: new DomainPropertiesAPIWrapper(),
-        entity: new EntityServerAPIWrapper(),
-        folder: new ServerFolderAPIWrapper(),
-        query: new QueryServerAPIWrapper(),
-        labelprinting: new LabelPrintingServerAPIWrapper(),
-        navigation: new ServerNavigationAPIWrapper(),
-        picklist: new PicklistServerAPIWrapper(),
-        samples: new SamplesServerAPIWrapper(),
-        security: new ServerSecurityAPIWrapper(),
-    };
+    if (!DEFAULT_WRAPPER) {
+        DEFAULT_WRAPPER = {
+            domain: new DomainPropertiesAPIWrapper(),
+            entity: new EntityServerAPIWrapper(),
+            folder: new ServerFolderAPIWrapper(),
+            query: new QueryServerAPIWrapper(),
+            labelprinting: new LabelPrintingServerAPIWrapper(),
+            navigation: new ServerNavigationAPIWrapper(),
+            picklist: new PicklistServerAPIWrapper(),
+            samples: new SamplesServerAPIWrapper(),
+            security: new ServerSecurityAPIWrapper(),
+        };
+    }
+
+    return DEFAULT_WRAPPER;
 }
 
 /**

--- a/packages/components/src/internal/components/domainproperties/APIWrapper.ts
+++ b/packages/components/src/internal/components/domainproperties/APIWrapper.ts
@@ -6,38 +6,46 @@ import {
     getGenId,
     setGenId,
     hasExistingDomainData,
+    fetchDomainDetails,
 } from './actions';
-import { DomainDesign, NameExpressionsValidationResults } from './models';
+import { DomainDesign, DomainDetails, NameExpressionsValidationResults } from './models';
 
 export interface DomainPropertiesAPIWrapper {
+    fetchDomainDetails: (
+        domainId: number,
+        schemaName: string,
+        queryName: string,
+        domainKind?: string
+    ) => Promise<DomainDetails>;
     getDomainNamePreviews: (schemaQuery?: SchemaQuery, domainId?: number, containerPath?: string) => Promise<string[]>;
-    validateDomainNameExpressions: (
-        domain: DomainDesign,
-        kind?: string,
-        options?: any,
-        includeNamePreview?: boolean
-    ) => Promise<NameExpressionsValidationResults>;
     getGenId: (rowId: number, kindName: 'SampleSet' | 'DataClass', containerPath?: string) => Promise<number>;
-    setGenId: (
-        rowId: number,
-        kindName: 'SampleSet' | 'DataClass',
-        genId: number,
-        containerPath?: string
-    ) => Promise<any>;
     hasExistingDomainData: (
         kindName: 'SampleSet' | 'DataClass',
         dataTypeLSID?: string,
         rowId?: number,
         containerPath?: string
     ) => Promise<boolean>;
+    setGenId: (
+        rowId: number,
+        kindName: 'SampleSet' | 'DataClass',
+        genId: number,
+        containerPath?: string
+    ) => Promise<any>;
+    validateDomainNameExpressions: (
+        domain: DomainDesign,
+        kind?: string,
+        options?: any,
+        includeNamePreview?: boolean
+    ) => Promise<NameExpressionsValidationResults>;
 }
 
 export class DomainPropertiesAPIWrapper implements DomainPropertiesAPIWrapper {
+    fetchDomainDetails = fetchDomainDetails;
     getDomainNamePreviews = getDomainNamePreviews;
-    validateDomainNameExpressions = validateDomainNameExpressions;
     getGenId = getGenId;
-    setGenId = setGenId;
     hasExistingDomainData = hasExistingDomainData;
+    setGenId = setGenId;
+    validateDomainNameExpressions = validateDomainNameExpressions;
 }
 
 /**
@@ -48,11 +56,12 @@ export function getDomainPropertiesTestAPIWrapper(
     overrides: Partial<DomainPropertiesAPIWrapper> = {}
 ): DomainPropertiesAPIWrapper {
     return {
+        fetchDomainDetails: mockFn(),
         getDomainNamePreviews: mockFn(),
-        validateDomainNameExpressions: mockFn(),
         getGenId: mockFn(),
-        setGenId: mockFn(),
         hasExistingDomainData: mockFn(),
+        setGenId: mockFn(),
+        validateDomainNameExpressions: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -33,6 +33,8 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SCHEMAS } from '../../schemas';
 
+import { handleRequestFailure } from '../../util/utils';
+
 import {
     DOMAIN_FIELD_CLIENT_SIDE_ERROR,
     DOMAIN_FIELD_LOOKUP_CONTAINER,
@@ -219,7 +221,7 @@ export function fetchQueries(containerPath: string, schemaName: string): Promise
 }
 
 // This looks hacky, but it's actually the recommended way to download a file using raw JS
-export function downloadJsonFile(content: string, fileName: string) {
+export function downloadJsonFile(content: string, fileName: string): void {
     const downloadLink = document.createElement('a');
     downloadLink.href = 'data:application/json;charset=utf-8,' + encodeURIComponent(content);
     downloadLink.download = fileName;
@@ -340,9 +342,7 @@ export function getMaxPhiLevel(containerPath?: string): Promise<string> {
             success: Utils.getCallbackWrapper(response => {
                 resolve(response.maxPhiLevel);
             }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
+            failure: handleRequestFailure(reject),
         });
     });
 }
@@ -1133,6 +1133,7 @@ export function getDomainNamePreviews(
                 resolve(response['previews']);
             },
             failure: response => {
+                console.error('Failed to retrieve name expression previews', response);
                 reject(response);
             },
         });

--- a/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
@@ -22,6 +22,8 @@ import { deleteEntityType } from '../../entities/actions';
 import { SchemaQuery } from '../../../../public/SchemaQuery';
 import { DomainDetails } from '../models';
 
+import { handleRequestFailure } from '../../../util/utils';
+
 import { DataClassModel } from './models';
 
 export function fetchDataClass(queryName?: string, rowId?: number, containerPath?: string): Promise<DataClassModel> {
@@ -95,9 +97,7 @@ function fetchDataClassProperties(rowId: number, containerPath?: string): Promis
             success: Utils.getCallbackWrapper(data => {
                 resolve(data);
             }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
+            failure: handleRequestFailure(reject, 'Failed to get data class properties'),
         });
     });
 }

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -1,8 +1,25 @@
+import { List, Map } from 'immutable';
+
 import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../settings/actions';
 
-import { getDataOperationConfirmationData } from './actions';
+import { QueryInfo } from '../../../public/QueryInfo';
+
+import { InsertOptions } from '../../query/api';
+
+import {
+    getDataOperationConfirmationData,
+    getEntityTypeData,
+    getOriginalParentsFromLineage,
+    handleEntityFileImport,
+} from './actions';
 import { DataOperation } from './constants';
-import { OperationConfirmationData } from './models';
+import {
+    EntityChoice,
+    EntityDataType,
+    EntityIdCreationModel,
+    IEntityTypeOption,
+    OperationConfirmationData,
+} from './models';
 
 export interface EntityAPIWrapper {
     getDataOperationConfirmationData: (
@@ -11,12 +28,41 @@ export interface EntityAPIWrapper {
         selectionKey?: string,
         useSnapshotSelection?: boolean
     ) => Promise<OperationConfirmationData>;
-
+    getEntityTypeData: (
+        model: EntityIdCreationModel,
+        entityDataType: EntityDataType,
+        parentSchemaQueries: Map<string, EntityDataType>,
+        targetQueryName: string,
+        allowParents: boolean,
+        isItemSamples: boolean,
+        combineParentTypes: boolean
+    ) => Promise<Partial<EntityIdCreationModel>>;
+    getOriginalParentsFromLineage: (
+        lineage: Record<string, any>,
+        parentDataTypes: EntityDataType[],
+        containerPath?: string
+    ) => Promise<{
+        originalParents: Record<string, List<EntityChoice>>;
+        parentTypeOptions: Map<string, List<IEntityTypeOption>>;
+    }>;
+    handleEntityFileImport: (
+        importAction: string,
+        queryInfo: QueryInfo,
+        file: File,
+        insertOption: InsertOptions,
+        useAsync: boolean,
+        importParameters?: Record<string, any>,
+        importFileController?: string,
+        saveToPipeline?: boolean
+    ) => Promise<any>;
     loadNameExpressionOptions: (containerPath?: string) => Promise<GetNameExpressionOptionsResponse>;
 }
 
 export class EntityServerAPIWrapper implements EntityAPIWrapper {
     getDataOperationConfirmationData = getDataOperationConfirmationData;
+    getEntityTypeData = getEntityTypeData;
+    getOriginalParentsFromLineage = getOriginalParentsFromLineage;
+    handleEntityFileImport = handleEntityFileImport;
     loadNameExpressionOptions = loadNameExpressionOptions;
 }
 
@@ -29,6 +75,9 @@ export function getEntityTestAPIWrapper(
 ): EntityAPIWrapper {
     return {
         getDataOperationConfirmationData: mockFn(),
+        getEntityTypeData: mockFn(),
+        getOriginalParentsFromLineage: mockFn(),
+        handleEntityFileImport: mockFn(),
         loadNameExpressionOptions: mockFn(),
         ...overrides,
     };

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.spec.tsx
@@ -8,295 +8,293 @@ import { DomainDetails } from '../domainproperties/models';
 import { InferDomainResponse } from '../../../public/InferDomainResponse';
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../domainproperties/constants';
 
-import { EntityInsertPanelImpl } from './EntityInsertPanel';
+import { getInferredFieldWarnings, getNoUpdateFieldWarnings, WarningFieldList } from './EntityInsertPanel';
 
-describe('EntityInsertPanel.getWarningFieldList', () => {
-    test('no fields', () => {
-        expect(EntityInsertPanelImpl.getWarningFieldList([])).toStrictEqual([]);
-    });
+describe('EntityInsertPanel', () => {
+    describe('WarningFieldList', () => {
+        test('no fields', () => {
+            const wrapper = mount(<WarningFieldList names={[]} />);
+            expect(wrapper.isEmptyRender()).toBe(true);
+        });
 
-    test('one field', () => {
-        const wrapper = mount(<div>{EntityInsertPanelImpl.getWarningFieldList(['one'])}</div>);
-        expect(wrapper.text()).toBe('one');
-        wrapper.unmount();
-    });
+        test('one field', () => {
+            const wrapper = mount(<WarningFieldList names={['one']} />);
+            expect(wrapper.text()).toBe('one');
+        });
 
-    test('two fields', () => {
-        const wrapper = mount(<div>{EntityInsertPanelImpl.getWarningFieldList(['one', 'two'])}</div>);
-        expect(wrapper.text()).toBe('one and two');
-        wrapper.unmount();
-    });
+        test('two fields', () => {
+            const wrapper = mount(<WarningFieldList names={['one', 'two']} />);
+            expect(wrapper.text()).toBe('one and two');
+        });
 
-    test('multiple fields', () => {
-        const wrapper = mount(
-            <div>{EntityInsertPanelImpl.getWarningFieldList(['one', 'two', 'three', 'four', 'five'])}</div>
-        );
-        expect(wrapper.text()).toBe('one, two, three, four, and five');
-        wrapper.unmount();
-    });
-});
-
-describe('EntityInsertPanel.getInferredFieldWarnings', () => {
-    const lookup = { containerPath: '/Look', keyColumn: 'Name', displayColumn: 'Name', query: 'LookHere' };
-    const knownColumn = new QueryColumn({
-        name: 'known',
-    });
-    const alsoKnownColumn = new QueryColumn({
-        name: 'alsoKnown',
-    });
-    const aliasedColumn = new QueryColumn({
-        name: 'aliased',
+        test('multiple fields', () => {
+            const wrapper = mount(<WarningFieldList names={['one', 'two', 'three', 'four', 'five']} />);
+            expect(wrapper.text()).toBe('one, two, three, four, and five');
+        });
     });
 
-    const domainDetails = DomainDetails.create(
-        Map<string, any>({
-            domainDesign: {
-                fields: [{ name: 'known' }, { name: 'aliased', importAliases: 'aliasName,otherAlias' }],
-            },
-            options: {
-                importAliases: {
-                    parentA: 'materialInputs/P',
-                    parentB: 'dataInputs/B',
+    describe('getInferredFieldWarnings', () => {
+        const lookup = { containerPath: '/Look', keyColumn: 'Name', displayColumn: 'Name', query: 'LookHere' };
+        const knownColumn = new QueryColumn({
+            name: 'known',
+        });
+        const alsoKnownColumn = new QueryColumn({
+            name: 'alsoKnown',
+        });
+        const aliasedColumn = new QueryColumn({
+            name: 'aliased',
+        });
+
+        const domainDetails = DomainDetails.create(
+            Map<string, any>({
+                domainDesign: {
+                    fields: [{ name: 'known' }, { name: 'aliased', importAliases: 'aliasName,otherAlias' }],
                 },
-            },
-        })
-    );
-
-    const baseColumns = OrderedMap<string, QueryColumn>({
-        known: knownColumn,
-        alsoKnown: alsoKnownColumn,
-        aliased: aliasedColumn,
-    });
-
-    test('none unknown, none unique', () => {
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getInferredFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'aliasName' }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
-                    }),
-                    domainDetails,
-                    baseColumns
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toHaveLength(0);
-        wrapper.unmount();
-    });
-
-    test('none unknown, one unique', () => {
-        const columns = baseColumns.set(
-            'barcode1',
-            new QueryColumn({
-                name: 'barcode1',
-                caption: 'Barcode 1',
-                conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
+                options: {
+                    importAliases: {
+                        parentA: 'materialInputs/P',
+                        parentB: 'dataInputs/B',
+                    },
+                },
             })
         );
 
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getInferredFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'barcode1' }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
-                    }),
-                    domainDetails,
-                    columns
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toContain(
-            'barcode1 is a unique ID field. It will not be imported and will be managed by LabKey Server.'
-        );
-        wrapper.unmount();
-    });
+        const baseColumns = OrderedMap<string, QueryColumn>({
+            known: knownColumn,
+            alsoKnown: alsoKnownColumn,
+            aliased: aliasedColumn,
+        });
 
-    test('none unknown, multiple unique', () => {
-        const columns = baseColumns.merge(
-            OrderedMap<string, QueryColumn>({
-                barcode1: new QueryColumn({
+        test('none unknown, none unique', () => {
+            const wrapper = mount(
+                <div>
+                    {getInferredFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'aliasName' }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        domainDetails,
+                        baseColumns
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toHaveLength(0);
+            wrapper.unmount();
+        });
+
+        test('none unknown, one unique', () => {
+            const columns = baseColumns.set(
+                'barcode1',
+                new QueryColumn({
                     name: 'barcode1',
                     caption: 'Barcode 1',
                     conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
-                }),
-                otherCode: new QueryColumn({
-                    name: 'otherCode',
-                    caption: 'Other Code',
-                    conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
-                }),
-            })
-        );
+                })
+            );
 
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getInferredFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'barcode1' }),
-                            new QueryColumn({ name: 'Other Code' }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
+            const wrapper = mount(
+                <div>
+                    {getInferredFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'barcode1' }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        domainDetails,
+                        columns
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toContain(
+                'barcode1 is a unique ID field. It will not be imported and will be managed by LabKey Server.'
+            );
+            wrapper.unmount();
+        });
+
+        test('none unknown, multiple unique', () => {
+            const columns = baseColumns.merge(
+                OrderedMap<string, QueryColumn>({
+                    barcode1: new QueryColumn({
+                        name: 'barcode1',
+                        caption: 'Barcode 1',
+                        conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
                     }),
-                    domainDetails,
-                    columns
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toContain(
-            'barcode1 and Other Code are unique ID fields. They will not be imported and will be managed by LabKey Server.'
-        );
-        wrapper.unmount();
+                    otherCode: new QueryColumn({
+                        name: 'otherCode',
+                        caption: 'Other Code',
+                        conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
+                    }),
+                })
+            );
+
+            const wrapper = mount(
+                <div>
+                    {getInferredFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'barcode1' }),
+                                new QueryColumn({ name: 'Other Code' }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        domainDetails,
+                        columns
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toContain(
+                'barcode1 and Other Code are unique ID fields. They will not be imported and will be managed by LabKey Server.'
+            );
+            wrapper.unmount();
+        });
+
+        test('one unknown, none unique', () => {
+            const wrapper = mount(
+                <div>
+                    {getInferredFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'Nonesuch' }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        domainDetails,
+                        baseColumns
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toContain('Nonesuch is an unknown field and will be ignored.');
+            wrapper.unmount();
+        });
+
+        test('multiple unknown, multiple unique', () => {
+            const columns = baseColumns.merge(
+                OrderedMap<string, QueryColumn>({
+                    bcode: new QueryColumn({
+                        name: 'bcode',
+                        caption: 'Barcode',
+                        conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
+                    }),
+                    otherCode: new QueryColumn({
+                        name: 'otherCode',
+                        caption: 'Other Code',
+                        conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
+                    }),
+                })
+            );
+
+            const wrapper = mount(
+                <div>
+                    {getInferredFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'Nonesuch' }),
+                                new QueryColumn({ name: 'Nonesuch' }),
+                                new QueryColumn({ name: 'Not Again' }),
+                                new QueryColumn({ name: 'bcode' }),
+                                new QueryColumn({ name: 'OtherCode' }),
+                                new QueryColumn({ name: 'OtherCode' }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        domainDetails,
+                        columns
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toContain('Nonesuch and Not Again are unknown fields and will be ignored.');
+            expect(wrapper.text()).toContain(
+                'bcode and OtherCode are unique ID fields. They will not be imported and will be managed by LabKey Server.'
+            );
+            wrapper.unmount();
+        });
+
+        test('with parent import aliases', () => {
+            const wrapper = mount(
+                <div>
+                    {getInferredFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'parentA' }),
+                                new QueryColumn({ name: 'parentB' }),
+                                new QueryColumn({ name: 'parentc' }),
+                                new QueryColumn({ name: 'materialInputs/X', lookup }),
+                                new QueryColumn({ name: 'dataInputs/Y', lookup }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        domainDetails,
+                        baseColumns
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toContain('parentc is an unknown field and will be ignored.');
+            wrapper.unmount();
+        });
+
+        test('with other allowed fields', () => {
+            const wrapper = mount(
+                <div>
+                    {getInferredFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'alsoAllowed' }),
+                                new QueryColumn({ name: 'materialInputs/X', lookup }),
+                                new QueryColumn({ name: 'dataInputs/Y', lookup }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        domainDetails,
+                        baseColumns,
+                        ['otherAllowed', 'alsoAllowed']
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toHaveLength(0);
+            wrapper.unmount();
+        });
     });
 
-    test('one unknown, none unique', () => {
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getInferredFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'Nonesuch' }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
-                    }),
-                    domainDetails,
-                    baseColumns
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toContain('Nonesuch is an unknown field and will be ignored.');
-        wrapper.unmount();
-    });
+    describe('getNoUpdateFieldWarnings', () => {
+        const lookup = { containerPath: '/Look', keyColumn: 'Name', displayColumn: 'Name', query: 'LookHere' };
 
-    test('multiple unknown, multiple unique', () => {
-        const columns = baseColumns.merge(
-            OrderedMap<string, QueryColumn>({
-                bcode: new QueryColumn({
-                    name: 'bcode',
-                    caption: 'Barcode',
-                    conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
-                }),
-                otherCode: new QueryColumn({
-                    name: 'otherCode',
-                    caption: 'Other Code',
-                    conceptURI: STORAGE_UNIQUE_ID_CONCEPT_URI,
-                }),
-            })
-        );
-
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getInferredFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'Nonesuch' }),
-                            new QueryColumn({ name: 'Nonesuch' }),
-                            new QueryColumn({ name: 'Not Again' }),
-                            new QueryColumn({ name: 'bcode' }),
-                            new QueryColumn({ name: 'OtherCode' }),
-                            new QueryColumn({ name: 'OtherCode' }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
-                    }),
-                    domainDetails,
-                    columns
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toContain('Nonesuch and Not Again are unknown fields and will be ignored.');
-        expect(wrapper.text()).toContain(
-            'bcode and OtherCode are unique ID fields. They will not be imported and will be managed by LabKey Server.'
-        );
-        wrapper.unmount();
-    });
-
-    test('with parent import aliases', () => {
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getInferredFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'parentA' }),
-                            new QueryColumn({ name: 'parentB' }),
-                            new QueryColumn({ name: 'parentc' }),
-                            new QueryColumn({ name: 'materialInputs/X', lookup }),
-                            new QueryColumn({ name: 'dataInputs/Y', lookup }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
-                    }),
-                    domainDetails,
-                    baseColumns
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toContain('parentc is an unknown field and will be ignored.');
-        wrapper.unmount();
-    });
-
-    test('with other allowed fields', () => {
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getInferredFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'alsoAllowed' }),
-                            new QueryColumn({ name: 'materialInputs/X', lookup }),
-                            new QueryColumn({ name: 'dataInputs/Y', lookup }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
-                    }),
-                    domainDetails,
-                    baseColumns,
-                    ['otherAllowed', 'alsoAllowed']
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toHaveLength(0);
-        wrapper.unmount();
-    });
-});
-
-describe('EntityInsertPanel.getNoUpdateFieldWarnings', () => {
-    const lookup = { containerPath: '/Look', keyColumn: 'Name', displayColumn: 'Name', query: 'LookHere' };
-
-    test('with disallowedUpdateFields', () => {
-        const wrapper = mount(
-            <div>
-                {EntityInsertPanelImpl.getNoUpdateFieldWarnings(
-                    new InferDomainResponse({
-                        data: List<any>(),
-                        fields: List<QueryColumn>([
-                            new QueryColumn({ name: 'known' }),
-                            new QueryColumn({ name: 'alsoAllowed' }),
-                            new QueryColumn({ name: 'materialInputs/X', lookup }),
-                            new QueryColumn({ name: 'dataInputs/Y', lookup }),
-                        ]),
-                        reservedFields: List<QueryColumn>(),
-                    }),
-                    ['alsoAllowed']
-                )}
-            </div>
-        );
-        expect(wrapper.text()).toContain('alsoAllowed cannot be updated and and will be ignored.');
-        wrapper.unmount();
+        test('with disallowedUpdateFields', () => {
+            const wrapper = mount(
+                <div>
+                    {getNoUpdateFieldWarnings(
+                        new InferDomainResponse({
+                            data: List<any>(),
+                            fields: List<QueryColumn>([
+                                new QueryColumn({ name: 'known' }),
+                                new QueryColumn({ name: 'alsoAllowed' }),
+                                new QueryColumn({ name: 'materialInputs/X', lookup }),
+                                new QueryColumn({ name: 'dataInputs/Y', lookup }),
+                            ]),
+                            reservedFields: List<QueryColumn>(),
+                        }),
+                        ['alsoAllowed']
+                    )}
+                </div>
+            );
+            expect(wrapper.text()).toContain('alsoAllowed cannot be updated and and will be ignored.');
+            wrapper.unmount();
+        });
     });
 });

--- a/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/internal/components/entities/EntityInsertPanel.tsx
@@ -24,7 +24,7 @@ import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
 
 import { PlacementType } from '../editable/Controls';
 
-import { DATA_IMPORT_TOPIC, helpLinkNode } from '../../util/helpLinks';
+import { DATA_IMPORT_TOPIC, HelpLink } from '../../util/helpLinks';
 
 import { BulkAddData, EditableColumnMetadata } from '../editable/EditableGrid';
 
@@ -32,11 +32,7 @@ import { DERIVATION_DATA_SCOPES } from '../domainproperties/constants';
 
 import { getCurrentProductName, isSampleManagerEnabled, sampleManagerIsPrimaryApp } from '../../app/utils';
 
-import { fetchDomainDetails, getDomainNamePreviews } from '../domainproperties/actions';
-
 import { SAMPLE_STATE_COLUMN_NAME, SAMPLE_UNITS_COLUMN_NAME, SELECTION_KEY_TYPE } from '../samples/constants';
-
-import { loadNameExpressionOptions } from '../settings/actions';
 
 import { SampleStatusLegend } from '../samples/SampleStatusLegend';
 
@@ -53,8 +49,7 @@ import { QueryInfo } from '../../../public/QueryInfo';
 import { FileSizeLimitProps } from '../../../public/files/models';
 import { capitalizeFirstChar } from '../../util/utils';
 import { getActionErrorMessage, resolveErrorMessage } from '../../util/messaging';
-import { getQueryDetails, InsertOptions } from '../../query/api';
-import { getSampleTypeDetails } from '../samples/actions';
+import { InsertOptions } from '../../query/api';
 import { insertColumnFilter, QueryColumn } from '../../../public/QueryColumn';
 import { SelectInput } from '../forms/input/SelectInput';
 import { Alert } from '../base/Alert';
@@ -87,7 +82,6 @@ import {
 } from './EntityParentTypeSelectors';
 import { EntityInsertGridRequiredFieldAlert } from './EntityInsertGridRequiredFieldAlert';
 import { getBulkCreationTypeOptions, getUniqueIdColumnMetadata } from './utils';
-import { getEntityTypeData, handleEntityFileImport } from './actions';
 import {
     EntityDataType,
     EntityIdCreationModel,
@@ -109,6 +103,129 @@ const ALIQUOT_FIELD_COLS = [
 ];
 const ALIQUOT_NOUN_SINGULAR = 'Aliquot';
 const ALIQUOT_NOUN_PLURAL = 'Aliquots';
+
+interface WarningFieldListProps {
+    names: string[];
+}
+
+// exported for unit tests
+export const WarningFieldList: FC<WarningFieldListProps> = memo(props => {
+    const { names } = props;
+    if (!names || names.length === 0) {
+        return null;
+    }
+
+    const oxfordComma = names.length > 2 ? ',' : '';
+
+    return (
+        <>
+            {names.map((name, index) => (
+                <span key={name}>
+                    <b>{name}</b>
+                    {index === names.length - 2 ? oxfordComma + ' and ' : index < names.length - 2 ? ', ' : ''}
+                </span>
+            ))}
+        </>
+    );
+});
+
+// exported for unit tests
+export function getInferredFieldWarnings(
+    inferred: InferDomainResponse,
+    domainDetails: DomainDetails,
+    columns: OrderedMap<string, QueryColumn>,
+    otherAllowedFields?: string[]
+): ReactNode[] {
+    const uniqueIdFields = [];
+    const unknownFields = [];
+    const { domainDesign } = domainDetails;
+    let allowedFields = [];
+    if (domainDetails.options.has('importAliases')) {
+        allowedFields = Object.keys(domainDetails.options.get('importAliases')).map(key => key.toLowerCase());
+    }
+    if (otherAllowedFields) {
+        allowedFields = allowedFields.concat(otherAllowedFields.map(field => field.toLowerCase()));
+    }
+
+    inferred.fields.forEach(field => {
+        const lcName = field.name.toLowerCase();
+
+        if (!field.isExpInput(false) && allowedFields.indexOf(lcName) < 0) {
+            const aliasField = domainDesign.fields.find(
+                domainField => domainField.importAliases?.toLowerCase().indexOf(lcName) >= 0
+            );
+            const columnName = aliasField ? aliasField.name : field.name;
+            const column = columns.find(c => c.isImportColumn(columnName));
+
+            if (!column) {
+                if (unknownFields.indexOf(field.name) < 0) {
+                    unknownFields.push(field.name);
+                }
+            } else if (column.isUniqueIdColumn) {
+                if (uniqueIdFields.indexOf(field.name) < 0) {
+                    // duplicate fields are handled as errors during import; we do not issue warnings about that here.
+                    uniqueIdFields.push(field.name);
+                }
+            }
+        }
+    });
+
+    const msg = [];
+
+    if (unknownFields.length > 0) {
+        msg.push(
+            <p key="unknownFields">
+                <WarningFieldList names={unknownFields} />
+                {(unknownFields.length === 1 ? ' is an unknown field' : ' are unknown fields') +
+                    ' and will be ignored.'}
+            </p>
+        );
+    }
+    if (uniqueIdFields.length > 0) {
+        msg.push(
+            <p key="uniqueIdFields">
+                <WarningFieldList names={uniqueIdFields} />
+                {(uniqueIdFields.length === 1 ? ' is a unique ID field. It' : ' are unique ID fields. They') +
+                    ' will not be imported and will be managed by ' +
+                    getCurrentProductName() +
+                    '.'}
+            </p>
+        );
+    }
+    return msg;
+}
+
+// exported for unit tests
+export function getNoUpdateFieldWarnings(
+    inferred: InferDomainResponse,
+    disallowedUpdateFields?: string[]
+): ReactNode[] {
+    const noUpdateFields = [];
+    let lcDisallowedUdateFields = [];
+    if (disallowedUpdateFields) {
+        lcDisallowedUdateFields = disallowedUpdateFields.map(field => field.toLowerCase());
+    }
+
+    inferred.fields.forEach(field => {
+        const lcName = field.name.toLowerCase();
+
+        if (lcDisallowedUdateFields.indexOf(lcName) >= 0) {
+            noUpdateFields.push(field.name);
+        }
+    });
+
+    const msg = [];
+    if (noUpdateFields.length > 0) {
+        msg.push(
+            <p key="noUpdateFields">
+                <WarningFieldList names={noUpdateFields} />
+                {' cannot be updated and and will be ignored.'}
+            </p>
+        );
+    }
+
+    return msg;
+}
 
 class EntityGridLoader implements IEditableGridLoader {
     id: string;
@@ -137,12 +254,10 @@ interface OwnProps {
     afterEntityCreation?: (entityTypeName, filter, entityCount, actionStr, transactionAuditId?, response?) => void;
     allowedNonDomainFields?: string[];
     api?: ComponentsAPIWrapper;
-    asyncSize?: number;
-    // the file size cutoff to enable async import. If undefined, async is not supported
+    asyncSize?: number; // the file size cutoff to enable async import. If undefined, async is not supported
     auditBehavior?: AuditBehaviorTypes;
     canEditEntityTypeDetails?: boolean;
-    combineParentTypes?: boolean;
-    // Puts all parent types in one parent button. Name on the button will be the first parent type listed
+    combineParentTypes?: boolean; // Puts all parent types in one parent button. Name on the button will be the first parent type listed
     containerFilter?: Query.ContainerFilter;
     disableMerge?: boolean;
     disallowedUpdateFields?: string[];
@@ -195,7 +310,7 @@ interface FromLocationProps {
 
 type Props = FromLocationProps & OwnProps & WithFormStepsProps;
 
-interface StateProps {
+interface State {
     allowUserSpecifiedNames: boolean;
     creationType: SampleCreationType;
     dataModel: QueryModel;
@@ -220,7 +335,7 @@ enum EntityInsertPanelTabs {
     Second = 2,
 }
 
-export class EntityInsertPanelImpl extends Component<Props, StateProps> {
+export class EntityInsertPanelImpl extends Component<Props, State> {
     static defaultProps = {
         numPerParent: 1,
         tab: EntityInsertPanelTabs.First,
@@ -284,8 +399,9 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             this.init();
         }
 
-        if ((this.props.importOnly || this.props.gridInsertOnly) && this.props.tab !== EntityInsertPanelTabs.First)
+        if ((this.props.importOnly || this.props.gridInsertOnly) && this.props.tab !== EntityInsertPanelTabs.First) {
             this.props.selectStep(EntityInsertPanelTabs.First);
+        }
     }
 
     allowParents = (): boolean => {
@@ -295,7 +411,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     getTabs = (): string[] => {
         const { isEditMode, importOnly, gridInsertOnly } = this.props;
         const importTabTitle = (isEditMode ? 'Update' : 'Import') + ' ' + this.capNounPlural + ' from File';
-        const gridTabTitle = 'Create ' + this.capNounPlural + ' from Grid';
+        const gridTabTitle = `Create ${this.capNounPlural} from Grid`;
 
         if (importOnly || isEditMode) {
             return [importTabTitle];
@@ -310,6 +426,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
     init = async (): Promise<void> => {
         const {
+            api,
             auditBehavior,
             entityDataType,
             numPerParent,
@@ -334,7 +451,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
         if (isSampleManagerEnabled()) {
             try {
-                const nameIdSettings = await loadNameExpressionOptions();
+                const nameIdSettings = await api.entity.loadNameExpressionOptions();
                 this.setState({ allowUserSpecifiedNames: nameIdSettings.allowUserSpecifiedNames });
             } catch (error) {
                 this.setState({
@@ -377,7 +494,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         });
 
         try {
-            const partialModel = await getEntityTypeData(
+            const partialModel = await api.entity.getEntityTypeData(
                 insertModel,
                 entityDataType,
                 parentSchemaQueries,
@@ -387,7 +504,9 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                 combineParentTypes
             );
 
-            if (selectedParents) partialModel['entityParents'] = selectedParents;
+            if (selectedParents) {
+                partialModel.entityParents = selectedParents;
+            }
 
             this.gridInit(insertModel.merge(partialModel) as EntityIdCreationModel);
         } catch {
@@ -400,81 +519,97 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         }
     };
 
-    gridInit = (insertModel: EntityIdCreationModel): void => {
-        const { shouldGetParentAlias } = this.props;
+    gridInit = async (insertModel: EntityIdCreationModel): Promise<void> => {
+        const { api } = this.props;
         const schemaQuery = insertModel.getSchemaQuery();
+
         if (schemaQuery) {
-            // only query for the importAliases for Sample Types (i.e. not sources)
-            if (insertModel.entityDataType.insertColumnNamePrefix === SampleTypeDataType.insertColumnNamePrefix) {
-                getSampleTypeDetails(schemaQuery).then(domainDetails => {
-                    this.setState(() => ({
-                        importAliases: domainDetails.options?.get('importAliases'),
-                        metricUnit: domainDetails.options?.get('metricUnit'),
-                    }));
-                });
-            } else if (shouldGetParentAlias?.(schemaQuery)) {
-                getDataClassDetails(schemaQuery).then(domainDetails => {
-                    this.setState(() => ({
-                        importAliases: domainDetails.options?.get('importAliases'),
-                    }));
+            this.initImportAliases(insertModel);
+            this.initNameExpressionPreviews(schemaQuery);
+
+            try {
+                const originalQueryInfo = await api.query.getQueryDetails(schemaQuery);
+                this.setState({ insertModel, originalQueryInfo }, this.gridInitModel);
+            } catch (e) {
+                this.setState({
+                    insertModel: insertModel.merge({
+                        isError: true,
+                        errors: `Problem retrieving data for ${
+                            this.typeTextSingular
+                        } '${insertModel.getTargetEntityTypeLabel()}'.`,
+                    }) as EntityIdCreationModel,
                 });
             }
-
-            getQueryDetails(schemaQuery)
-                .then(originalQueryInfo => {
-                    this.setState(
-                        () => ({ insertModel, originalQueryInfo }),
-                        async () => {
-                            getDomainNamePreviews(schemaQuery)
-                                .then(previews => {
-                                    if (previews?.length > 0) {
-                                        this.setState(() => ({
-                                            previewName: previews[0],
-                                            previewAliquotName: previews.length > 1 ? previews[1] : null,
-                                        }));
-                                    }
-                                })
-                                .catch(errors => {
-                                    console.error('Unable to retrieve name expression previews ', errors);
-                                    this.setState(() => ({
-                                        previewName: null,
-                                        previewAliquotName: null,
-                                    }));
-                                });
-
-                            const queryModel = new QueryModel({ id: ENTITY_GRID_ID, schemaQuery }).mutate({
-                                queryInfo: this.getGridQueryInfo(),
-                            });
-                            const { dataModel, editorModel } = await initEditableGridModel(
-                                queryModel,
-                                new EditorModel({ id: ENTITY_GRID_ID }),
-                                new EntityGridLoader(insertModel, queryModel.queryInfo),
-                                queryModel,
-                                this.isIncludedColumn
-                            );
-                            this.setState({ dataModel, editorModel });
-                        }
-                    );
-                })
-                .catch(() => {
-                    this.setState({
-                        insertModel: insertModel.merge({
-                            isError: true,
-                            errors:
-                                'Problem retrieving data for ' +
-                                this.typeTextSingular +
-                                " '" +
-                                insertModel.getTargetEntityTypeLabel() +
-                                "'.",
-                        }) as EntityIdCreationModel,
-                    });
-                });
         } else {
-            this.setState(() => ({ insertModel, dataModel: undefined, editorModel: undefined }));
+            this.setState({ insertModel, dataModel: undefined, editorModel: undefined });
         }
     };
 
-    isAliquotField = (column): boolean => {
+    gridInitModel = async (): Promise<void> => {
+        const { insertModel } = this.state;
+        const schemaQuery = insertModel.getSchemaQuery();
+        const queryModel = new QueryModel({ id: ENTITY_GRID_ID, schemaQuery }).mutate({
+            queryInfo: this.getGridQueryInfo(),
+        });
+        const { dataModel, editorModel } = await initEditableGridModel(
+            queryModel,
+            new EditorModel({ id: ENTITY_GRID_ID }),
+            new EntityGridLoader(insertModel, queryModel.queryInfo),
+            queryModel,
+            this.isIncludedColumn
+        );
+        this.setState({ dataModel, editorModel });
+    };
+
+    initImportAliases = async (insertModel: EntityIdCreationModel): Promise<void> => {
+        const { api, shouldGetParentAlias } = this.props;
+        const schemaQuery = insertModel.getSchemaQuery();
+
+        // only query for the importAliases for Sample Types (i.e. not sources)
+        if (insertModel.entityDataType.insertColumnNamePrefix === SampleTypeDataType.insertColumnNamePrefix) {
+            try {
+                const domainDetails = await api.samples.getSampleTypeDetails(schemaQuery);
+
+                this.setState({
+                    importAliases: domainDetails.options?.get('importAliases'),
+                    metricUnit: domainDetails.options?.get('metricUnit'),
+                });
+            } catch (e) {
+                this.setState({ importAliases: undefined, metricUnit: undefined });
+            }
+        } else if (shouldGetParentAlias?.(schemaQuery)) {
+            try {
+                const domainDetails = await getDataClassDetails(schemaQuery);
+                this.setState({
+                    importAliases: domainDetails.options?.get('importAliases'),
+                    metricUnit: undefined,
+                });
+            } catch (e) {
+                this.setState({ importAliases: undefined, metricUnit: undefined });
+            }
+        } else {
+            this.setState({ importAliases: undefined, metricUnit: undefined });
+        }
+    };
+
+    initNameExpressionPreviews = async (schemaQuery: SchemaQuery): Promise<void> => {
+        try {
+            const previews = await this.props.api.domain.getDomainNamePreviews(schemaQuery);
+
+            if (previews?.length > 0) {
+                this.setState({
+                    previewAliquotName: previews.length > 1 ? previews[1] : undefined,
+                    previewName: previews[0],
+                });
+            } else {
+                this.setState({ previewAliquotName: undefined, previewName: undefined });
+            }
+        } catch (errors) {
+            this.setState({ previewAliquotName: undefined, previewName: undefined });
+        }
+    };
+
+    isAliquotField = (column: QueryColumn): boolean => {
         return (
             ALIQUOT_FIELD_COLS.indexOf(column.fieldKey.toLowerCase()) > -1 ||
             column.derivationDataScope === DERIVATION_DATA_SCOPES.CHILD_ONLY ||
@@ -483,17 +618,20 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     };
 
     getAliquotCreationColumns = (allColumns: OrderedMap<string, QueryColumn>): OrderedMap<string, QueryColumn> => {
-        let columns = OrderedMap<string, QueryColumn>();
+        const columns = OrderedMap<string, QueryColumn>().asMutable();
 
         allColumns.forEach((column, key) => {
             if (this.isAliquotField(column)) {
                 let col = column;
                 // Aliquot name can be auto generated, regardless of sample name expression config
-                if (column.fieldKey.toLowerCase() === 'name') col = col.mutate({ required: false });
-                columns = columns.set(key, col);
+                if (column.fieldKey.toLowerCase() === 'name') {
+                    col = col.mutate({ required: false });
+                }
+                columns.set(key, col);
             }
         });
-        return columns;
+
+        return columns.asImmutable();
     };
 
     getGridQueryInfo = (): QueryInfo => {
@@ -507,21 +645,23 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                     .toList()
                     .findIndex(column => column.fieldKey === entityDataType.uniqueFieldKey)
             );
-            const newColumnIndex = nameIndex + insertModel.getParentCount();
             let columns = originalQueryInfo.insertColumns(
-                newColumnIndex,
+                nameIndex + insertModel.getParentCount(),
                 insertModel.getParentColumns(entityDataType.uniqueFieldKey)
             );
-            if (creationType === SampleCreationType.Aliquots) columns = this.getAliquotCreationColumns(columns);
+            if (creationType === SampleCreationType.Aliquots) {
+                columns = this.getAliquotCreationColumns(columns);
+            }
 
             return originalQueryInfo.merge({ columns }) as QueryInfo;
         }
+
         return undefined;
     };
 
     changeTargetEntityType = (fieldName: string, formValue: any, selectedOption: IEntityTypeOption): void => {
         const { setIsDirty, navigate } = this.props;
-        const { insertModel, creationType } = this.state;
+        const { creationType } = this.state;
 
         // if creating aliquots and we change the targetEntityType, update params to get the component to re-render
         if (creationType === SampleCreationType.Aliquots && navigate) {
@@ -535,30 +675,32 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             return;
         }
 
-        let updatedModel = insertModel.merge({
-            targetEntityType: new EntityTypeOption(selectedOption),
-            isError: false,
-            errors: undefined,
-        }) as EntityIdCreationModel;
-
-        if (!selectedOption) {
-            updatedModel = updatedModel.merge({
-                entityParents: insertModel.getClearedEntityParents(),
-            }) as EntityIdCreationModel;
-        }
-
         this.setState(
-            () => ({
-                originalQueryInfo: undefined,
-                importAliases: undefined,
-                insertModel: updatedModel,
-            }),
+            state => {
+                const { insertModel } = state;
+                let updatedModel = insertModel.merge({
+                    targetEntityType: new EntityTypeOption(selectedOption),
+                    isError: false,
+                    errors: undefined,
+                }) as EntityIdCreationModel;
+
+                if (!selectedOption) {
+                    updatedModel = updatedModel.merge({
+                        entityParents: insertModel.getClearedEntityParents(),
+                    }) as EntityIdCreationModel;
+                }
+
+                return {
+                    importAliases: undefined,
+                    insertModel: updatedModel,
+                    originalQueryInfo: undefined,
+                };
+            },
             () => {
-                this.gridInit(updatedModel);
+                this.gridInit(this.state.insertModel);
+                this.props.onTargetChange?.(selectedOption?.value);
             }
         );
-
-        this.props.onTargetChange?.(selectedOption?.value);
     };
 
     addParent = (queryName: string): void => {
@@ -636,36 +778,9 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         );
     }
 
-    renderParentTypesAndButtons = (): ReactNode => {
-        const { insertModel } = this.state;
-        const { parentDataTypes, combineParentTypes, hideParentEntityButtons } = this.props;
-
-        if (insertModel) {
-            const { isInit, targetEntityType } = insertModel;
-
-            if (!hideParentEntityButtons && isInit && targetEntityType && parentDataTypes) {
-                return (
-                    <EntityParentTypeSelectors
-                        parentDataTypes={parentDataTypes}
-                        parentOptionsMap={insertModel.parentOptions}
-                        entityParentsMap={insertModel.entityParents}
-                        combineParentTypes={combineParentTypes}
-                        onAdd={this.addParent}
-                        onChange={this.changeParent}
-                        onRemove={this.removeParent}
-                    />
-                );
-            }
-        }
-
-        return null;
-    };
-
-    renderMergeOption = (isGrid: boolean): ReactNode => {
+    renderMergeOption = (): ReactNode => {
         const { disableMerge, user, nounPlural, isEditMode } = this.props;
         const { insertModel, allowUserSpecifiedNames, isMerge, originalQueryInfo } = this.state;
-
-        if (isGrid) return null;
 
         const allowMerge =
             isEditMode &&
@@ -674,21 +789,28 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             allowUserSpecifiedNames &&
             originalQueryInfo?.supportMerge;
 
-        const entityTypeName = insertModel.getTargetEntityTypeLabel();
-        if (!allowMerge || !entityTypeName) return null;
-
-        const mergeMsg = `Allow new ${nounPlural}`;
+        if (!allowMerge || !insertModel.getTargetEntityTypeLabel()) {
+            return null;
+        }
 
         return (
             <div className="col-sm-3">
                 <div className="pull-right">
                     <input type="checkbox" checked={isMerge} onChange={this.toggleInsertOptionChange} />
                     <span className="entity-mergeoption-checkbox" onClick={this.toggleInsertOptionChange}>
-                        {mergeMsg}
+                        Allow new {nounPlural}
                     </span>
                     &nbsp;
                     <LabelHelpTip title="Import Options" placement="top">
-                        {this.renderUpdateTooltipText()}
+                        <p>
+                            By default, import will update existing {nounPlural} based on the file provided. The
+                            operation will fail if there are new {this.capIdsText} being imported.
+                        </p>
+                        <p>
+                            When the "Allow new {nounPlural}" checkbox is checked, data will be updated for matching{' '}
+                            {this.capIdsText}, and new {nounPlural} will be created for any new {this.capIdsText}{' '}
+                            provided. Data will not be changed for any columns not in the imported file.
+                        </p>
                         <p>
                             For more information on import options for {nounPlural}, see the{' '}
                             {this.props.importHelpLinkNode} documentation page.
@@ -699,29 +821,9 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         );
     };
 
-    renderTargetEntitySelect = (): ReactNode => {
-        const { insertModel } = this.state;
-        const hasTargetEntityType = insertModel?.hasTargetEntityType();
-
-        return (
-            <SelectInput
-                autoValue={false}
-                inputClass="col-sm-5"
-                label={this.capTypeTextSingular}
-                labelClass="col-sm-3 col-xs-12 entity-insert--parent-label"
-                name="targetEntityType"
-                placeholder={'Select a ' + this.capTypeTextSingular + '...'}
-                onChange={this.changeTargetEntityType}
-                options={insertModel.entityTypeOptions.toArray()}
-                required
-                selectedOptions={hasTargetEntityType ? insertModel?.targetEntityType : undefined}
-            />
-        );
-    };
-
     renderHeader = (isGrid: boolean): ReactNode => {
+        const { parentDataTypes, combineParentTypes, hideParentEntityButtons } = this.props;
         const { insertModel, creationType } = this.state;
-
         if (!insertModel) return null;
 
         const hasTargetEntityType = insertModel.hasTargetEntityType();
@@ -730,8 +832,21 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             <>
                 {insertModel.isInit && (
                     <div className="row">
-                        <div className={isGrid ? 'col-sm-12' : 'col-sm-9'}>{this.renderTargetEntitySelect()}</div>
-                        {this.renderMergeOption(isGrid)}
+                        <div className={isGrid ? 'col-sm-12' : 'col-sm-9'}>
+                            <SelectInput
+                                autoValue={false}
+                                inputClass="col-sm-5"
+                                label={this.capTypeTextSingular}
+                                labelClass="col-sm-3 col-xs-12 entity-insert--parent-label"
+                                name="targetEntityType"
+                                placeholder={`Select a ${this.capTypeTextSingular}...`}
+                                onChange={this.changeTargetEntityType}
+                                options={insertModel.entityTypeOptions.toArray()}
+                                required
+                                selectedOptions={hasTargetEntityType ? insertModel.targetEntityType : undefined}
+                            />
+                        </div>
+                        {!isGrid && this.renderMergeOption()}
                     </div>
                 )}
                 {insertModel.isError && (
@@ -741,39 +856,40 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                     </Alert>
                 )}
                 {!insertModel.isError &&
+                    insertModel.isInit &&
+                    !hideParentEntityButtons &&
                     isGrid &&
                     hasTargetEntityType &&
                     creationType !== SampleCreationType.Aliquots &&
-                    this.renderParentTypesAndButtons()}
-                {!insertModel.isError &&
-                    isGrid &&
-                    creationType === SampleCreationType.Aliquots &&
-                    this.renderAliquotResetMsg()}
+                    parentDataTypes && (
+                        <EntityParentTypeSelectors
+                            parentDataTypes={parentDataTypes}
+                            parentOptionsMap={insertModel.parentOptions}
+                            entityParentsMap={insertModel.entityParents}
+                            combineParentTypes={combineParentTypes}
+                            onAdd={this.addParent}
+                            onChange={this.changeParent}
+                            onRemove={this.removeParent}
+                        />
+                    )}
+                {!insertModel.isError && isGrid && creationType === SampleCreationType.Aliquots && (
+                    <Alert bsStyle="info" className="notification-container">
+                        Parent {sampleManagerIsPrimaryApp() ? 'and source' : ''} types cannot be changed when creating
+                        aliquots.{' '}
+                        <a className="pull-right" onClick={this.resetCreationType}>
+                            Clear Aliquots and Reset.
+                        </a>
+                    </Alert>
+                )}
             </>
         );
     };
 
     resetCreationType = (): void => {
-        this.setState(
-            () => ({
-                creationType: SampleCreationType.Independents,
-            }),
-            () => {
-                this.changeTargetEntityType(null, null, null);
-                this.props.setIsDirty?.(false);
-            }
-        );
-    };
-
-    renderAliquotResetMsg = (): ReactNode => {
-        return (
-            <Alert bsStyle="info" className="notification-container">
-                Parent {sampleManagerIsPrimaryApp() ? 'and source' : ''} types cannot be changed when creating aliquots.{' '}
-                <a className="pull-right" onClick={this.resetCreationType}>
-                    Clear Aliquots and Reset.
-                </a>
-            </Alert>
-        );
+        this.setState({ creationType: SampleCreationType.Independents }, () => {
+            this.changeTargetEntityType(null, null, null);
+            this.props.setIsDirty?.(false);
+        });
     };
 
     onGridChange = (
@@ -914,34 +1030,30 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
 
     renderGridButtons = (): ReactNode => {
         const { insertModel, isSubmitting, creationType, editorModel } = this.state;
-        if (insertModel?.isInit) {
-            const isAliquotCreation = creationType === SampleCreationType.Aliquots;
+        const isAliquotCreation = creationType === SampleCreationType.Aliquots;
+        const nounSingle = isAliquotCreation ? capitalizeFirstChar(ALIQUOT_NOUN_SINGULAR) : this.capNounSingular;
+        const nounPlural = isAliquotCreation ? capitalizeFirstChar(ALIQUOT_NOUN_PLURAL) : this.capNounPlural;
+        const noun = insertModel.entityCount === 1 ? nounSingle : nounPlural;
 
-            const nounSingle = isAliquotCreation ? capitalizeFirstChar(ALIQUOT_NOUN_SINGULAR) : this.capNounSingular;
-            const nounPlural = isAliquotCreation ? capitalizeFirstChar(ALIQUOT_NOUN_PLURAL) : this.capNounPlural;
-            const noun = insertModel.entityCount === 1 ? nounSingle : nounPlural;
-
-            return (
-                <div className="form-group no-margin-bottom">
-                    <div className="pull-left">
-                        <Button className="test-loc-cancel-button" onClick={this.onCancel}>
-                            Cancel
-                        </Button>
-                    </div>
-                    <div className="btn-group pull-right">
-                        <Button
-                            className="test-loc-submit-button"
-                            bsStyle="success"
-                            disabled={isSubmitting || insertModel.entityCount === 0 || !editorModel}
-                            onClick={this.insertRowsFromGrid}
-                        >
-                            {isSubmitting ? 'Creating...' : 'Finish Creating ' + insertModel.entityCount + ' ' + noun}
-                        </Button>
-                    </div>
+        return (
+            <div className="form-group no-margin-bottom">
+                <div className="pull-left">
+                    <Button className="test-loc-cancel-button" onClick={this.onCancel}>
+                        Cancel
+                    </Button>
                 </div>
-            );
-        }
-        return null;
+                <div className="btn-group pull-right">
+                    <Button
+                        className="test-loc-submit-button"
+                        bsStyle="success"
+                        disabled={isSubmitting || insertModel.entityCount === 0 || !editorModel}
+                        onClick={this.insertRowsFromGrid}
+                    >
+                        {isSubmitting ? 'Creating...' : 'Finish Creating ' + insertModel.entityCount + ' ' + noun}
+                    </Button>
+                </div>
+            </div>
+        );
     };
 
     getBulkAddFormValues = (): Record<string, any> | null => {
@@ -979,18 +1091,22 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     };
 
     isIncludedColumn = (column: QueryColumn): boolean => {
-        const { creationType } = this.state;
-
-        if (creationType === SampleCreationType.Aliquots) return this.isAliquotField(column);
+        if (this.state.creationType === SampleCreationType.Aliquots) {
+            return this.isAliquotField(column);
+        }
         return column.derivationDataScope !== DERIVATION_DATA_SCOPES.CHILD_ONLY;
     };
 
     getInsertColumns = (): List<QueryColumn> => {
         const { queryInfo } = this.state.dataModel;
-        let columns: List<QueryColumn> = queryInfo.getInsertColumns().filter(this.isIncludedColumn).toList();
-        // we add the UniqueId columns, which will be displayed as read-only fields
-        columns = columns.concat(queryInfo.getUniqueIdColumns()).toList();
-        return columns;
+        return (
+            queryInfo
+                .getInsertColumns()
+                .filter(this.isIncludedColumn)
+                // Add the UniqueId columns which will be displayed as read-only fields
+                .concat(queryInfo.getUniqueIdColumns())
+                .toList()
+        );
     };
 
     columnFilter = (col: QueryColumn): boolean => {
@@ -1003,7 +1119,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
     getColumnMetadata(): Map<string, EditableColumnMetadata> {
         const { entityDataType, nounSingular, nounPlural } = this.props;
         const { creationType, previewName, previewAliquotName, metricUnit } = this.state;
-        let columnMetadata = getUniqueIdColumnMetadata(this.getGridQueryInfo());
+        const columnMetadata = getUniqueIdColumnMetadata(this.getGridQueryInfo()).asMutable();
         if (creationType === SampleCreationType.Aliquots) {
             let toolTip =
                 "A generated Aliquot ID will be provided for Aliquots that don't have a user-provided ID in the grid.";
@@ -1014,7 +1130,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                 toolTip +=
                     ' For example, if the original sample is S1, aliquots of that sample will be named S1-1, S1-2, etc.';
 
-            columnMetadata = columnMetadata.set(entityDataType.uniqueFieldKey, {
+            columnMetadata.set(entityDataType.uniqueFieldKey, {
                 caption: 'Aliquot ID',
                 readOnly: false,
                 placeholder: '[generated id]',
@@ -1024,39 +1140,38 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         } else if (!this.isNameRequired()) {
             let toolTip = `A generated ${nounSingular} ID will be provided for ${nounPlural} that don't have a user-provided ID in the grid.`;
             if (previewName) toolTip += ' Example name that will be generated from the current pattern: ' + previewName;
-            columnMetadata = columnMetadata.set(entityDataType.uniqueFieldKey, {
+            columnMetadata.set(entityDataType.uniqueFieldKey, {
                 readOnly: false,
                 placeholder: '[generated id]',
                 toolTip,
                 hideTitleTooltip: true,
             });
         } else {
-            columnMetadata = columnMetadata.set(entityDataType.uniqueFieldKey, {
+            columnMetadata.set(entityDataType.uniqueFieldKey, {
                 hideTitleTooltip: true,
                 toolTip: `A ${nounSingular} ID is required for each ${nounSingular} since this ${this.typeTextSingular} has no naming pattern. You can provide a naming pattern by editing the ${this.typeTextSingular} design.`,
             });
         }
 
-        columnMetadata = columnMetadata.set(SAMPLE_STATE_COLUMN_NAME, {
+        columnMetadata.set(SAMPLE_STATE_COLUMN_NAME, {
             hideTitleTooltip: true,
             toolTip: <SampleStatusLegend />,
             popoverClassName: 'label-help-arrow-left',
         });
 
         if (metricUnit) {
-            columnMetadata = columnMetadata.set(SAMPLE_UNITS_COLUMN_NAME, {
+            columnMetadata.set(SAMPLE_UNITS_COLUMN_NAME, {
                 linkedColInd: 0,
                 filteredLookupKeys: List<string>(getAltUnitKeys(metricUnit)),
             });
         }
 
-        return columnMetadata;
+        return columnMetadata.asImmutable();
     }
 
     renderCreateFromGrid = (): ReactNode => {
         const { insertModel, creationType, dataModel, editorModel } = this.state;
         const { containerFilter, maxEntities, nounPlural, onBulkAdd, getIsDirty, setIsDirty } = this.props;
-        const columnMetadata = this.getColumnMetadata();
         const isLoaded = (dataModel && !dataModel?.isLoading) ?? false;
 
         const isAliquotCreation = creationType === SampleCreationType.Aliquots;
@@ -1114,7 +1229,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                                     isIncludedColumn: this.isIncludedColumn,
                                 }}
                                 bulkRemoveText={'Remove ' + gridNounPluralCap}
-                                columnMetadata={columnMetadata}
+                                columnMetadata={this.getColumnMetadata()}
                                 containerFilter={containerFilter}
                                 editorModel={editorModel}
                                 emptyGridMsg={`Start by adding the quantity of ${gridNounPlural} you want to create.`}
@@ -1134,65 +1249,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         );
     };
 
-    renderUpdateTooltipTextDeprecated = (): ReactNode => {
-        const { nounPlural } = this.props;
-        const { allowUserSpecifiedNames } = this.state;
-
-        if (nounPlural === 'Samples' && !allowUserSpecifiedNames) {
-            return (
-                <>
-                    <p>
-                        When "Update data for existing samples during this file import" is unchecked, import will insert
-                        new samples based on the file provided. This Sample Type has been configured to not accept
-                        user-defined Sample IDs or Names. Providing a Sample ID or Name column in your file will result
-                        in an error.
-                    </p>
-                    <p>
-                        When "Update data for existing samples during this file import" is checked, the Sample ID or
-                        Name column must be provided. All Sample IDs or Names provided must already exist in the system.
-                        Encountering a new Sample ID or Name will result in an error.
-                    </p>
-                </>
-            );
-        }
-
-        return (
-            <>
-                <p>
-                    By default, import will insert new {nounPlural} based on the file provided. The operation will fail
-                    if there are existing {this.capIdsText} that match those being imported.
-                </p>
-                <p>
-                    When update is selected, data will be updated for matching {this.capIdsText}, and new {nounPlural}{' '}
-                    will be created for any new {this.capIdsText} provided. Data will not be changed for any columns not
-                    in the imported file.
-                </p>
-            </>
-        );
-    };
-
-    renderUpdateTooltipText = (): ReactNode => {
-        const { nounPlural } = this.props;
-
-        return (
-            <>
-                <p>
-                    By default, import will update existing {nounPlural} based on the file provided. The operation will
-                    fail if there are new {this.capIdsText} being imported.
-                </p>
-                <p>
-                    When the "Allow new {nounPlural}" checkbox is checked, data will be updated for matching{' '}
-                    {this.capIdsText}, and new {nounPlural} will be created for any new {this.capIdsText} provided. Data
-                    will not be changed for any columns not in the imported file.
-                </p>
-            </>
-        );
-    };
-
     toggleInsertOptionChange = (): void => {
-        const { onChangeInsertOption } = this.props;
-
-        if (onChangeInsertOption) onChangeInsertOption(!this.state.isMerge);
+        this.props.onChangeInsertOption?.(!this.state.isMerge);
 
         this.setState(state => ({ isMerge: !state.isMerge }));
     };
@@ -1245,7 +1303,7 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         const importOption = isEditMode ? (isMerge ? InsertOptions.MERGE : InsertOptions.UPDATE) : InsertOptions.IMPORT;
 
         try {
-            const response = await handleEntityFileImport(
+            const response = await api.entity.handleEntityFileImport(
                 entityDataType.importFileAction,
                 originalQueryInfo,
                 file,
@@ -1302,180 +1360,47 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
             : undefined;
     };
 
-    isGridStep = (): boolean => {
-        return (
-            this.props.currentStep === EntityInsertPanelTabs.First && !this.props.importOnly && !this.props.isEditMode
-        );
-    };
-
-    renderProgress = (): ReactNode => {
-        const { insertModel, isSubmitting, file } = this.state;
-
-        return this.isGridStep() ? (
-            <Progress
-                estimate={insertModel.entityCount * 20}
-                modal
-                title={'Generating ' + this.props.nounPlural}
-                toggle={isSubmitting}
-            />
-        ) : (
-            <Progress
-                estimate={file ? file.size * 0.1 : undefined}
-                modal
-                title={'Importing ' + this.props.nounPlural + ' from file'}
-                toggle={isSubmitting}
-            />
-        );
-    };
-
-    static getWarningFieldList(names: string[]): ReactNode {
-        const oxfordComma = names.length > 2 ? ',' : '';
-        return names.map((name, index) => (
-            <span key={name}>
-                <b>{name}</b>
-                {index === names.length - 2 ? oxfordComma + ' and ' : index < names.length - 2 ? ', ' : ''}
-            </span>
-        ));
-    }
-
-    static getInferredFieldWarnings(
-        inferred: InferDomainResponse,
-        domainDetails: DomainDetails,
-        columns: OrderedMap<string, QueryColumn>,
-        otherAllowedFields?: string[]
-    ): React.ReactNode[] {
-        const uniqueIdFields = [];
-        const unknownFields = [];
-        const { domainDesign } = domainDetails;
-        let allowedFields = [];
-        if (domainDetails.options.has('importAliases')) {
-            allowedFields = Object.keys(domainDetails.options.get('importAliases')).map(key => key.toLowerCase());
-        }
-        if (otherAllowedFields) {
-            allowedFields = allowedFields.concat(otherAllowedFields.map(field => field.toLowerCase()));
-        }
-
-        inferred.fields.forEach(field => {
-            const lcName = field.name.toLowerCase();
-
-            if (!field.isExpInput(false) && allowedFields.indexOf(lcName) < 0) {
-                const aliasField = domainDesign.fields.find(
-                    domainField => domainField.importAliases?.toLowerCase().indexOf(lcName) >= 0
-                );
-                const columnName = aliasField ? aliasField.name : field.name;
-                const column = columns.find(column => column.isImportColumn(columnName));
-
-                if (!column) {
-                    if (unknownFields.indexOf(field.name) < 0) {
-                        unknownFields.push(field.name);
-                    }
-                } else if (column.isUniqueIdColumn) {
-                    if (uniqueIdFields.indexOf(field.name) < 0) {
-                        // duplicate fields are handled as errors during import; we do not issue warnings about that here.
-                        uniqueIdFields.push(field.name);
-                    }
-                }
-            }
-        });
-
-        const msg = [];
-
-        if (unknownFields.length > 0) {
-            msg.push(
-                <p key="unknownFields">
-                    {EntityInsertPanelImpl.getWarningFieldList(unknownFields)}
-                    {(unknownFields.length === 1 ? ' is an unknown field' : ' are unknown fields') +
-                        ' and will be ignored.'}
-                </p>
-            );
-        }
-        if (uniqueIdFields.length > 0) {
-            msg.push(
-                <p key="uniqueIdFields">
-                    {EntityInsertPanelImpl.getWarningFieldList(uniqueIdFields)}
-                    {(uniqueIdFields.length === 1 ? ' is a unique ID field. It' : ' are unique ID fields. They') +
-                        ' will not be imported and will be managed by ' +
-                        getCurrentProductName() +
-                        '.'}
-                </p>
-            );
-        }
-        return msg;
-    }
-
-    static getNoUpdateFieldWarnings(
-        inferred: InferDomainResponse,
-        disallowedUpdateFields?: string[]
-    ): React.ReactNode[] {
-        const noUpdateFields = [];
-        let lcDisallowedUdateFields = [];
-        if (disallowedUpdateFields) {
-            lcDisallowedUdateFields = disallowedUpdateFields.map(field => field.toLowerCase());
-        }
-
-        inferred.fields.forEach(field => {
-            const lcName = field.name.toLowerCase();
-
-            if (lcDisallowedUdateFields.indexOf(lcName) >= 0) {
-                noUpdateFields.push(field.name);
-            }
-        });
-
-        const msg = [];
-        if (noUpdateFields.length > 0) {
-            msg.push(
-                <p key="noUpdateFields">
-                    {EntityInsertPanelImpl.getWarningFieldList(noUpdateFields)}
-                    {' cannot be updated and and will be ignored.'}
-                </p>
-            );
-        }
-
-        return msg;
-    }
-
-    onPreviewLoad = (inferred: InferDomainResponse): any => {
-        const { allowedNonDomainFields, disallowedUpdateFields, isEditMode } = this.props;
+    onPreviewLoad = async (inferred: InferDomainResponse): Promise<void> => {
+        const { allowedNonDomainFields, api, disallowedUpdateFields, isEditMode } = this.props;
         const { insertModel, originalQueryInfo } = this.state;
-        fetchDomainDetails(undefined, insertModel.getSchemaQuery().schemaName, insertModel.getSchemaQuery().queryName)
-            .then(domainDetails => {
-                const msg = EntityInsertPanelImpl.getInferredFieldWarnings(
-                    inferred,
-                    domainDetails,
-                    originalQueryInfo.columns,
-                    allowedNonDomainFields
-                );
+        const { schemaName, queryName } = insertModel.getSchemaQuery();
 
-                let updateMsg: React.ReactNode[] = null;
-                if (isEditMode) {
-                    updateMsg = EntityInsertPanelImpl.getNoUpdateFieldWarnings(inferred, disallowedUpdateFields);
-                }
+        try {
+            const domainDetails = await api.domain.fetchDomainDetails(undefined, schemaName, queryName);
 
-                this.setState({
-                    fieldsWarningMsg: msg?.length > 0 ? <>{msg}</> : undefined,
-                    fieldsUpdateWarningMsg: updateMsg?.length > 0 ? <>{updateMsg}</> : undefined,
-                });
-            })
-            .catch(reason => {
-                console.error('Unable to retrieve domain ', reason);
+            const msg = getInferredFieldWarnings(
+                inferred,
+                domainDetails,
+                originalQueryInfo.columns,
+                allowedNonDomainFields
+            );
+
+            let updateMsg: React.ReactNode[] = null;
+            if (isEditMode) {
+                updateMsg = getNoUpdateFieldWarnings(inferred, disallowedUpdateFields);
+            }
+
+            this.setState({
+                fieldsWarningMsg: msg?.length > 0 ? <>{msg}</> : undefined,
+                fieldsUpdateWarningMsg: updateMsg?.length > 0 ? <>{updateMsg}</> : undefined,
             });
-    };
-
-    shouldShowGrid = (): boolean => {
-        const { importOnly, isEditMode } = this.props;
-
-        return !importOnly && !isEditMode;
+        } catch (e) {
+            console.error('Unable to retrieve domain ', e);
+        }
     };
 
     render() {
         const {
             acceptedFormats,
             canEditEntityTypeDetails,
+            currentStep,
             fileSizeLimits,
             entityDataType,
             filePreviewFormats,
             gridInsertOnly,
+            importOnly,
             isEditMode,
+            nounPlural,
         } = this.props;
         const {
             error,
@@ -1491,21 +1416,19 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
         if (!insertModel) {
             if (error) {
                 return <Alert>{error}</Alert>;
-            } else {
-                return <LoadingSpinner wrapperClassName="loading-data-message" />;
             }
+
+            return <LoadingSpinner wrapperClassName="loading-data-message" />;
         }
 
-        const isGridStep = this.isGridStep();
+        const showGrid = !importOnly && !isEditMode;
+        const isGridStep = currentStep === EntityInsertPanelTabs.First && showGrid;
         const entityTypeName = insertModel.getTargetEntityTypeLabel();
         const isFromSharedContainer = insertModel.isFromSharedContainer();
-
         const editEntityTypeDetailsLink =
             entityTypeName && entityDataType?.editTypeAppUrlPrefix && !isFromSharedContainer
                 ? AppURL.create(entityDataType.editTypeAppUrlPrefix, entityTypeName)
                 : undefined;
-
-        const showGrid = this.shouldShowGrid();
 
         let filePreviewWarningMsg;
         if (!!fieldsWarningMsg || (isEditMode && !isMerge && !!fieldsUpdateWarningMsg)) {
@@ -1570,8 +1493,8 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                                                     <>
                                                         We recommend dividing your data into smaller files that meet
                                                         this limit. See our{' '}
-                                                        {helpLinkNode(DATA_IMPORT_TOPIC, 'help article')} for best
-                                                        practices on data import.
+                                                        <HelpLink topic={DATA_IMPORT_TOPIC}>help article</HelpLink> for
+                                                        best practices on data import.
                                                     </>
                                                 }
                                             />
@@ -1596,7 +1519,22 @@ export class EntityInsertPanelImpl extends Component<Props, StateProps> {
                         isFinishingText="Importing..."
                     />
                 )}
-                {this.renderProgress()}
+                {isGridStep && (
+                    <Progress
+                        estimate={insertModel.entityCount * 20}
+                        modal
+                        title={`Generating ${nounPlural}`}
+                        toggle={isSubmitting}
+                    />
+                )}
+                {!isGridStep && (
+                    <Progress
+                        estimate={file ? file.size * 0.1 : undefined}
+                        modal
+                        title={`Importing ${nounPlural} from file`}
+                        toggle={isSubmitting}
+                    />
+                )}
             </>
         );
     }

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -6,7 +6,7 @@ import { SampleOperation } from '../samples/constants';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { getFilterForSampleOperation, isSamplesSchema } from '../samples/utils';
 import { importData, InsertOptions } from '../../query/api';
-import { caseInsensitive } from '../../util/utils';
+import { caseInsensitive, handleRequestFailure } from '../../util/utils';
 import { SampleCreationType } from '../samples/models';
 import { getSelected, getSelectedData } from '../../actions';
 import { SHARED_CONTAINER_PATH } from '../../constants';
@@ -16,11 +16,14 @@ import { SCHEMAS } from '../../schemas';
 
 import { Row, selectRows, SelectRowsResponse } from '../../query/selectRows';
 
-import { isDataClassEntity, isSampleEntity } from './utils';
+import { getParentTypeDataForLineage } from '../samples/actions';
+
+import { getInitialParentChoices, isDataClassEntity, isSampleEntity } from './utils';
 import { DataClassDataType, DataOperation, SampleTypeDataType } from './constants';
 import {
     CrossFolderSelectionResult,
     DisplayObject,
+    EntityChoice,
     EntityDataType,
     EntityIdCreationModel,
     EntityParentType,
@@ -490,9 +493,7 @@ export function deleteEntityType(
             success: Utils.getCallbackWrapper(response => {
                 resolve(response);
             }),
-            failure: Utils.getCallbackWrapper(response => {
-                reject(response);
-            }),
+            failure: handleRequestFailure(reject, 'Failed to delete entity type.'),
         });
     });
 }
@@ -595,3 +596,61 @@ export function getCrossFolderSelectionResult(
         });
     });
 }
+
+export const getOriginalParentsFromLineage = async (
+    lineage: Record<string, any>,
+    parentDataTypes: EntityDataType[],
+    containerPath?: string
+): Promise<{
+    originalParents: Record<string, List<EntityChoice>>;
+    parentTypeOptions: Map<string, List<IEntityTypeOption>>;
+}> => {
+    const originalParents = {};
+    let parentTypeOptions = Map<string, List<IEntityTypeOption>>();
+    const dataClassTypeData = await getParentTypeDataForLineage(
+        parentDataTypes.filter(
+            dataType => dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.DATA_CLASSES.queryName
+        )[0],
+        Object.values(lineage),
+        containerPath
+    );
+    const sampleTypeData = await getParentTypeDataForLineage(
+        parentDataTypes.filter(
+            dataType => dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.SAMPLE_SETS.queryName
+        )[0],
+        Object.values(lineage),
+        containerPath
+    );
+
+    // iterate through both Data Classes and Sample Types for finding sample parents
+    parentDataTypes.forEach(dataType => {
+        const dataTypeOptions =
+            dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.DATA_CLASSES.queryName
+                ? dataClassTypeData.parentTypeOptions
+                : sampleTypeData.parentTypeOptions;
+
+        const parentIdData =
+            dataType.typeListingSchemaQuery.queryName === SCHEMAS.EXP_TABLES.DATA_CLASSES.queryName
+                ? dataClassTypeData.parentIdData
+                : sampleTypeData.parentIdData;
+        Object.keys(lineage).forEach(sampleId => {
+            if (!originalParents[sampleId]) originalParents[sampleId] = List<EntityChoice>();
+
+            originalParents[sampleId] = originalParents[sampleId].concat(
+                getInitialParentChoices(dataTypeOptions, dataType, lineage[sampleId], parentIdData)
+            );
+        });
+
+        // filter out the current parent types from the dataTypeOptions
+        const originalParentTypeLsids = [];
+        Object.values(originalParents).forEach((parentTypes: List<EntityChoice>) => {
+            originalParentTypeLsids.push(...parentTypes.map(parentType => parentType.type.lsid).toArray());
+        });
+        parentTypeOptions = parentTypeOptions.set(
+            dataType.typeListingSchemaQuery.queryName,
+            dataTypeOptions.filter(option => originalParentTypeLsids.indexOf(option.lsid) === -1).toList()
+        );
+    });
+
+    return { originalParents, parentTypeOptions };
+};

--- a/packages/components/src/internal/components/entities/utils.spec.ts
+++ b/packages/components/src/internal/components/entities/utils.spec.ts
@@ -2,24 +2,22 @@ import { List } from 'immutable';
 
 import { SampleCreationType } from '../samples/models';
 
+import {
+    TEST_LKS_STARTER_MODULE_CONTEXT,
+    TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
+    TEST_LKSM_STARTER_AND_WORKFLOW_MODULE_CONTEXT,
+    TEST_LKSM_STARTER_MODULE_CONTEXT,
+} from '../../productFixtures';
+
 import { IEntityTypeOption } from './models';
 import {
     getBulkCreationTypeOptions,
     getEntityDescription,
     getEntityNoun,
     getInitialParentChoices,
-    sampleDeleteDependencyText
+    sampleDeleteDependencyText,
 } from './utils';
 import { DataClassDataType, SampleTypeDataType } from './constants';
-import {
-    TEST_LKS_STARTER_MODULE_CONTEXT,
-    TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
-    TEST_LKSM_STARTER_AND_WORKFLOW_MODULE_CONTEXT, TEST_LKSM_STARTER_MODULE_CONTEXT
-} from '../../productFixtures';
-import { mount } from 'enzyme';
-import { getSampleDeleteMessage } from '../../../entities/index';
-import { LoadingSpinner } from '../base/LoadingSpinner';
-import React from 'react';
 
 describe('getInitialParentChoices', () => {
     const parentTypeOptions = List<IEntityTypeOption>([
@@ -260,32 +258,30 @@ describe('getBulkCreationTypeOptions', () => {
     });
 });
 
-describe("sampleDeleteDependencyText", () => {
+describe('sampleDeleteDependencyText', () => {
     test('cannot delete, professional', () => {
-        LABKEY.moduleContext = {...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT};
+        LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
         expect(sampleDeleteDependencyText()).toBe(
             'either derived sample, job, or assay data dependencies, status that prevents deletion, or references in one or more active notebooks'
         );
     });
 
     test('cannot delete, no workflow', () => {
-        LABKEY.moduleContext = {...TEST_LKS_STARTER_MODULE_CONTEXT};
+        LABKEY.moduleContext = { ...TEST_LKS_STARTER_MODULE_CONTEXT };
         expect(sampleDeleteDependencyText()).toBe(
             'either derived sample or assay data dependencies, or status that prevents deletion'
         );
     });
 
     test('cannot delete, workflow no assay', () => {
-        LABKEY.moduleContext = {...TEST_LKSM_STARTER_AND_WORKFLOW_MODULE_CONTEXT};
+        LABKEY.moduleContext = { ...TEST_LKSM_STARTER_AND_WORKFLOW_MODULE_CONTEXT };
         expect(sampleDeleteDependencyText()).toBe(
             'either derived sample or job dependencies, or status that prevents deletion'
         );
     });
 
     test('cannot delete no workflow or assay', () => {
-        LABKEY.moduleContext = {...TEST_LKSM_STARTER_MODULE_CONTEXT};
-        expect(sampleDeleteDependencyText()).toBe(
-            'derived sample dependencies or status that prevents deletion'
-        );
+        LABKEY.moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT };
+        expect(sampleDeleteDependencyText()).toBe('derived sample dependencies or status that prevents deletion');
     });
 });

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -19,18 +19,17 @@ import {
 
 import { EntityChoice, EntityDataType, IEntityTypeOption } from './models';
 
-export function sampleDeleteDependencyText() {
+export function sampleDeleteDependencyText(): string {
     let deleteMsg = '';
     if (isWorkflowEnabled()) {
         if (isAssayEnabled()) {
-            deleteMsg += 'either derived sample, job, or assay data dependencies, '
-        }
-        else {
-            deleteMsg += 'either derived sample or job dependencies, '
+            deleteMsg += 'either derived sample, job, or assay data dependencies, ';
+        } else {
+            deleteMsg += 'either derived sample or job dependencies, ';
         }
     } else {
         if (isAssayEnabled()) {
-            deleteMsg += 'either derived sample or assay data dependencies, '
+            deleteMsg += 'either derived sample or assay data dependencies, ';
         } else {
             deleteMsg += 'derived sample dependencies ';
         }
@@ -41,7 +40,6 @@ export function sampleDeleteDependencyText() {
         deleteMsg += 'or status that prevents deletion';
     }
     return deleteMsg;
-
 }
 
 export function getInitialParentChoices(
@@ -114,11 +112,11 @@ export function getEntityDescription(entityDataType: EntityDataType, quantity: n
     return quantity === 1 ? entityDataType.descriptionSingular : entityDataType.descriptionPlural;
 }
 
-export function isSampleEntity(dataType: EntityDataType) {
+export function isSampleEntity(dataType: EntityDataType): boolean {
     return dataType.instanceSchemaName === SCHEMAS.SAMPLE_SETS.SCHEMA;
 }
 
-export function isDataClassEntity(dataType: EntityDataType) {
+export function isDataClassEntity(dataType: EntityDataType): boolean {
     return dataType.instanceSchemaName === SCHEMAS.DATA_CLASSES.SCHEMA;
 }
 

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -2,8 +2,6 @@ import { List, Map } from 'immutable';
 
 import { getCurrentProductName, isAssayEnabled, isELNEnabled, isWorkflowEnabled } from '../../app/utils';
 
-import { ParentIdData } from '../samples/actions';
-
 import { naturalSort } from '../../../public/sort';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { EditableColumnMetadata } from '../editable/EditableGrid';
@@ -16,6 +14,8 @@ import {
     POOLED_SAMPLE_CREATION,
     SampleCreationTypeModel,
 } from '../samples/models';
+
+import { ParentIdData } from './actions';
 
 import { EntityChoice, EntityDataType, IEntityTypeOption } from './models';
 

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -10,12 +10,13 @@ import { Experiment, Filter, getServerContext, Query } from '@labkey/api';
 import { SAMPLES_KEY } from '../../app/constants';
 
 import { ISelectRowsResult, selectRowsDeprecated } from '../../query/api';
-import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SCHEMAS } from '../../schemas';
 import { caseInsensitive } from '../../util/utils';
 import { AppURL } from '../../url/AppURL';
 import { naturalSort } from '../../../public/sort';
 import { Location } from '../../util/URL';
+
+import { ViewInfo } from '../../ViewInfo';
 
 import { getURLResolver, LineageURLResolver } from './LineageURLResolvers';
 import { getLineageDepthFirstNodeList, resolveIconAndShapeForNode } from './utils';
@@ -32,7 +33,6 @@ import {
     LineageResult,
     LineageRunStep,
 } from './models';
-import { ViewInfo } from '../../ViewInfo';
 
 const LINEAGE_METADATA_COLUMNS = OrderedSet<string>(['LSID', 'Name', 'Description', 'Alias', 'RowId', 'Created']);
 

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -17,6 +17,7 @@ import { SchemaQuery } from '../../../public/SchemaQuery';
 import { DomainDetails } from '../domainproperties/models';
 
 import {
+    getGroupedSampleDomainFields,
     getSampleAliquotRows,
     getSampleAssayResultViewConfigs,
     getFieldLookupFromSelection,
@@ -29,7 +30,7 @@ import {
     createSessionAssayRunSummaryQuery,
     getDistinctAssaysPerSample,
 } from './actions';
-import { SampleState } from './models';
+import { GroupedSampleFields, SampleState } from './models';
 import { SampleOperation } from './constants';
 
 export interface SamplesAPIWrapper {
@@ -43,6 +44,8 @@ export interface SamplesAPIWrapper {
         selected: any[],
         fieldKey: string
     ) => Promise<string[]>;
+
+    getGroupedSampleDomainFields: (sampleType: string) => Promise<GroupedSampleFields>;
 
     getSampleAliquotRows: (sampleId: number | string) => Promise<Array<Record<string, any>>>;
 
@@ -81,6 +84,7 @@ export interface SamplesAPIWrapper {
 
 export class SamplesServerAPIWrapper implements SamplesAPIWrapper {
     createSessionAssayRunSummaryQuery = createSessionAssayRunSummaryQuery;
+    getGroupedSampleDomainFields = getGroupedSampleDomainFields;
     getSampleAliquotRows = getSampleAliquotRows;
     getSampleAssayResultViewConfigs = getSampleAssayResultViewConfigs;
     getSelectionLineageData = getSelectionLineageData;
@@ -103,6 +107,7 @@ export function getSamplesTestAPIWrapper(
 ): SamplesAPIWrapper {
     return {
         createSessionAssayRunSummaryQuery: mockFn(),
+        getGroupedSampleDomainFields: mockFn(),
         getSampleAliquotRows: mockFn(),
         getSampleAssayResultViewConfigs: mockFn(),
         getSelectionLineageData: mockFn(),

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -16,8 +16,8 @@
 import { List, Map, OrderedMap } from 'immutable';
 import { ActionURL, Ajax, Domain, Filter, Query, Utils } from '@labkey/api';
 
-import { EntityDataType, IEntityTypeDetails, IEntityTypeOption } from '../entities/models';
-import { deleteEntityType, getEntityTypeOptions, getSelectedItemSamples } from '../entities/actions';
+import { IEntityTypeDetails } from '../entities/models';
+import { deleteEntityType, getSelectedItemSamples } from '../entities/actions';
 
 import { Location } from '../../util/URL';
 import { getSelectedData, getSelection, getSnapshotSelections } from '../../actions';
@@ -49,8 +49,6 @@ import { QueryConfig } from '../../../public/QueryModel/QueryModel';
 import { naturalSort, naturalSortByProperty } from '../../../public/sort';
 import { AssayStateModel } from '../assay/models';
 import { TimelineEventModel } from '../auditlog/models';
-
-import { ViewInfo } from '../../ViewInfo';
 
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -78,6 +78,7 @@ const INVENTORY_SCHEMA = 'inventory';
 export const INVENTORY = {
     SCHEMA: INVENTORY_SCHEMA,
     ITEMS: new SchemaQuery(INVENTORY_SCHEMA, 'Item'),
+    ITEM_SAMPLES: new SchemaQuery(INVENTORY_SCHEMA, 'ItemSamples'),
     SAMPLE_ITEMS: new SchemaQuery(INVENTORY_SCHEMA, 'SampleItems'),
     CHECKED_OUT_BY_FIELD: 'checkedOutBy',
     INVENTORY_COLS: [


### PR DESCRIPTION
#### Rationale
This set of PRs moves the `EntityInsertPanel` (EIP) and it's related components to the `@labkey/components/entities` subpackage. Additionally, the initialization of the EIP has been refactored to more clearly delineate initialization/loading of different features.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1173
- https://github.com/LabKey/labkey-ui-premium/pull/78
- https://github.com/LabKey/sampleManagement/pull/1770
- https://github.com/LabKey/biologics/pull/2093
- https://github.com/LabKey/inventory/pull/823
- https://github.com/LabKey/platform/pull/4301

#### Changes
- Entities subpackage migration
	- Moved `AssayResultsForSamplesButton`, `EntityCrossProjectSelectionConfirmModal`, `EntityDeleteConfirmModal`, `EntityInsertPanel` and `FindDerivativesButton` to subpackage.
	- Moved `getOriginalParentsFromLineage` to `@labkey/components` to align endpoint wrappers for use in `EntityAPIWrapper`.
- `EntityInsertPanel`:
  - Refactor initialization to separate concerns for initializing import aliases, name expression previews, `insertModel` and editable grid models.
  - Defer construction of column metadata until after load. Previously results were just thrown away.
  - Update all direct calls to endpoints to utilize `ComponentAPIWrapper` provided implementations.
  - `getInferredFieldWarnings` and `getNoUpdateFieldWarnings` are no longer static methods as this served no purpose
  - Refactored `getWarningFieldList` into `WarningFieldList` component
  - Remove superfluous render wrapping
- `ComponentAPIWrapper`:
  - Add `getEntityTypeData`, `getOriginalParentsFromLineage` and `handleEntityFileImport` to `EntityAPIWrapper`. Update associated usages where possible to use API wrapper.
  - Add `fetchDomainDetails` to `DomainPropertiesAPIWrapper`
  - Update `getDefaultAPIWrapper()` for `ComponentAPIWrapper` to instantiate wrappers once. Makes `api` easier for reuse in components to prevent redundant render cycles.
- Streamline some sample action implementations to use `async/await` and remove redundant error handling wrapping.
