### PR TITLE
Issue designer UI to support restricted issue lists

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.326.1-fb-restricted-issue-tracker.0",
+  "version": "2.329.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.326.0",
+  "version": "2.326.1-fb-restricted-issue-tracker.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.19.0",
+    "@labkey/api": "1.19.1",
     "bootstrap": "~3.4.1",
     "classnames": "~2.3.2",
     "enzyme": "~3.11.0",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,15 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.328.1
-*Released*: TBD
+### version 2.329.1
+*Released*: 20 April 2023
 - Support for restricted issue lists
     - Adds configuration to the issue list admin page to enable/disable restricted issue lists.
     - Optional site and project group selection to allow group members to access restricted issues.
     - This feature is controlled via a module property.
 
-### version TBD
-*Released*: TBD
+### version 2.329.0
+*Released*: 20 April 2023
 * Issue 47656: Add metrics for pagination usage and page sizing
 * Issue 47657: Remove adding BarTender templates from within subfolder Projects
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.326.1
+*Released*: TBD
+- Support for restricted issue lists
+    - Adds configuration to the issue list admin page to enable/disable restricted issue lists.
+    - Optional site and project group selection to allow group members to access restricted issues.
+    - This feature is controlled via a module property.
+
 ### version 2.326.0
 *Released*: 15 April 2023
 - Entities subpackage migration

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -335,6 +335,10 @@ export function isCommunityDistribution(moduleContext?: ModuleContext): boolean 
     return !hasModule('SampleManagement', moduleContext) && !hasPremiumModule(moduleContext);
 }
 
+export function isRestrictedIssueListSupported(moduleContext?: ModuleContext): boolean {
+    return resolveModuleContext(moduleContext)?.issues?.hasRestrictedIssueList === true;
+}
+
 export function isProjectContainer(containerPath?: string): boolean {
     return getContainerDepth(containerPath) === 1;
 }

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
@@ -16,8 +16,9 @@ import { HelpTopicURL } from '../HelpTopicURL';
 
 import { DEFINE_ISSUES_LIST_TOPIC } from '../../../util/helpLinks';
 
-import { AssignmentOptions, BasicPropertiesFields } from './IssuesListDefPropertiesPanelFormElements';
+import { AssignmentOptions, BasicPropertiesFields, RestrictedOptions } from './IssuesListDefPropertiesPanelFormElements';
 import { IssuesListDefModel } from './models';
+import { isRestrictedIssueListSupported } from '../../../app/utils';
 
 const PROPERTIES_HEADER_ID = 'issues-properties-hdr';
 
@@ -93,6 +94,19 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
         }
     };
 
+    onCheckChange = e => {
+        const name = e.target.name;
+        let value = e.target.checked;
+
+        if (!value) {
+            // clear out the group dropdown
+            this.onChange(name, value, 'restrictedIssueListGroup');
+        }
+        else {
+            this.onChange(name, value);
+        }
+    };
+
     render() {
         const { model } = this.props;
         const { isValid } = this.state;
@@ -111,11 +125,24 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
                     </Col>
                 </Row>
                 <Form>
-                    <BasicPropertiesFields
-                        model={model}
-                        onInputChange={this.onInputChange}
-                        onSelect={this.onSelectChange}
-                    />
+                    <Col xs={12} md={6}>
+                        <div className="domain-field-padding-bottom">
+                            <BasicPropertiesFields
+                                model={model}
+                                onInputChange={this.onInputChange}
+                                onSelect={this.onSelectChange}
+                            />
+                        </div>
+                        {isRestrictedIssueListSupported() && (
+                            <div className="domain-field-padding-bottom">
+                                <RestrictedOptions
+                                    model={model}
+                                    onCheckChange={this.onCheckChange}
+                                    onSelect={this.onSelectChange}
+                                />
+                            </div>
+                        )}
+                    </Col>
                     <AssignmentOptions model={model} onSelect={this.onSelectChange} />
                 </Form>
             </BasePropertiesPanel>

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
@@ -16,9 +16,14 @@ import { HelpTopicURL } from '../HelpTopicURL';
 
 import { DEFINE_ISSUES_LIST_TOPIC } from '../../../util/helpLinks';
 
-import { AssignmentOptions, BasicPropertiesFields, RestrictedOptions } from './IssuesListDefPropertiesPanelFormElements';
-import { IssuesListDefModel } from './models';
 import { isRestrictedIssueListSupported } from '../../../app/utils';
+
+import {
+    AssignmentOptions,
+    BasicPropertiesFields,
+    RestrictedOptions,
+} from './IssuesListDefPropertiesPanelFormElements';
+import { IssuesListDefModel } from './models';
 
 const PROPERTIES_HEADER_ID = 'issues-properties-hdr';
 
@@ -96,13 +101,12 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
 
     onRestrictedListCheckChange = e => {
         const name = e.target.name;
-        let value = e.target.checked;
+        const value = e.target.checked;
 
         if (!value) {
             // clear out the group dropdown
             this.onChange(name, value, 'restrictedIssueListGroup');
-        }
-        else {
+        } else {
             this.onChange(name, value);
         }
     };

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
@@ -94,7 +94,7 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
         }
     };
 
-    onCheckChange = e => {
+    onRestrictedListCheckChange = e => {
         const name = e.target.name;
         let value = e.target.checked;
 
@@ -137,7 +137,7 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
                             <div className="domain-field-padding-bottom">
                                 <RestrictedOptions
                                     model={model}
-                                    onCheckChange={this.onCheckChange}
+                                    onCheckChange={this.onRestrictedListCheckChange}
                                     onSelect={this.onSelectChange}
                                 />
                             </div>

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -125,22 +125,14 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
 }
 
 export class RestrictedOptions extends PureComponent<RestrictedOptionsProps> {
-
     render() {
         const { model, onCheckChange, onSelect } = this.props;
 
         return (
             <div>
                 <SectionHeading title="Restricted List Options" />
-                <RestrictedIssueInput
-                    model={model}
-                    onCheckChange={onCheckChange}
-                    onSelect={onSelect}
-                />
-                <RestrictedIssueGroupInput
-                    model={model}
-                    onSelect={onSelect}
-                />
+                <RestrictedIssueInput model={model} onCheckChange={onCheckChange} onSelect={onSelect} />
+                <RestrictedIssueGroupInput model={model} onSelect={onSelect} />
             </div>
         );
     }
@@ -349,15 +341,12 @@ export class DefaultRelatedFolderInput extends PureComponent<AssignmentOptionsIn
 
 export class RestrictedIssueInput extends PureComponent<RestrictedOptionsProps> {
     render() {
-        const { model, onCheckChange} = this.props;
+        const { model, onCheckChange } = this.props;
 
         return (
             <Row className="margin-top">
                 <Col xs={3} lg={4}>
-                    <DomainFieldLabel
-                        label="Restrict Issue List"
-                        helpTipBody={ISSUES_LIST_RESTRICTED_TRACKER_TIP}
-                    />
+                    <DomainFieldLabel label="Restrict Issue List" helpTipBody={ISSUES_LIST_RESTRICTED_TRACKER_TIP} />
                 </Col>
                 <Col xs={9} lg={8}>
                     <input
@@ -373,7 +362,7 @@ export class RestrictedIssueInput extends PureComponent<RestrictedOptionsProps> 
 }
 
 export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsProps> {
-    state: Readonly<RestrictedOptionsState> = {coreGroups: undefined,};
+    state: Readonly<RestrictedOptionsState> = { coreGroups: undefined };
 
     componentDidMount = async (): Promise<void> => {
         try {

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -15,11 +15,13 @@ import { SelectInput } from '../../forms/input/SelectInput';
 
 import { IssuesListDefModel, IssuesRelatedFolder } from './models';
 import {
-    ISSUES_LIST_DEF_SORT_DIRECTION_TIP,
     ISSUES_LIST_DEF_SINGULAR_PLURAL_TIP,
+    ISSUES_LIST_DEF_SORT_DIRECTION_TIP,
     ISSUES_LIST_GROUP_ASSIGN_TIP,
-    ISSUES_LIST_USER_ASSIGN_TIP,
     ISSUES_LIST_RELATED_FOLDER_TIP,
+    ISSUES_LIST_RESTRICTED_GROUP_TIP,
+    ISSUES_LIST_RESTRICTED_TRACKER_TIP,
+    ISSUES_LIST_USER_ASSIGN_TIP,
 } from './constants';
 import { getProjectGroups, getRelatedFolders, getUsersForGroup } from './actions';
 
@@ -50,16 +52,27 @@ interface AssignmentOptionsInputProps {
     relatedFolders?: List<IssuesRelatedFolder>;
 }
 
+interface RestrictedOptionsProps {
+    coreGroups?: List<Principal>;
+    model: IssuesListDefModel;
+    onCheckChange?: (any) => void;
+    onSelect: (name: string, value: any) => any;
+}
+
+interface RestrictedOptionsState {
+    coreGroups?: List<Principal>;
+}
+
 export class BasicPropertiesFields extends PureComponent<IssuesListDefBasicPropertiesInputsProps> {
     render() {
         const { model, onInputChange, onSelect } = this.props;
         return (
-            <Col xs={12} md={6}>
+            <div>
                 <SectionHeading title="Basic Properties" />
                 <CommentSortDirectionDropDown model={model} onSelect={onSelect} />
                 <SingularItemNameInput model={model} onInputChange={onInputChange} />
                 <PluralItemNameInput model={model} onInputChange={onInputChange} />
-            </Col>
+            </div>
         );
     }
 }
@@ -108,6 +121,40 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
                 <DefaultUserAssignmentInput model={model} coreUsers={coreUsers} onSelect={onSelect} />
                 <DefaultRelatedFolderInput model={model} relatedFolders={relatedFolders} onSelect={onSelect} />
             </Col>
+        );
+    }
+}
+
+export class RestrictedOptions extends PureComponent<RestrictedOptionsProps, RestrictedOptionsState> {
+    state: Readonly<RestrictedOptionsState> = {coreGroups: undefined,};
+
+    componentDidMount = async (): Promise<void> => {
+        try {
+            const coreGroups = await getProjectGroups();
+            this.setState({ coreGroups });
+        } catch (e) {
+            console.error('RestrictedOptions: failed to load initialize project groups', e);
+        }
+    };
+
+    render() {
+        const { model, onCheckChange, onSelect } = this.props;
+        const { coreGroups } = this.state;
+
+        return (
+            <div>
+                <SectionHeading title="Restricted List Options" />
+                <RestrictedIssueInput
+                    model={model}
+                    onCheckChange={onCheckChange}
+                    onSelect={onSelect}
+                />
+                <RestrictedIssueGroupInput
+                    model={model}
+                    coreGroups={coreGroups}
+                    onSelect={onSelect}
+                />
+            </div>
         );
     }
 }
@@ -305,6 +352,72 @@ export class DefaultRelatedFolderInput extends PureComponent<AssignmentOptionsIn
                             labelKey="displayName"
                             onChange={this.onChange}
                             value={model.relatedFolderName}
+                        />
+                    )}
+                </Col>
+            </Row>
+        );
+    }
+}
+
+export class RestrictedIssueInput extends PureComponent<RestrictedOptionsProps> {
+    render() {
+        const { model, onCheckChange} = this.props;
+
+        return (
+            <Row className="margin-top">
+                <Col xs={3} lg={4}>
+                    <DomainFieldLabel
+                        label="Restrict Issue List"
+                        helpTipBody={ISSUES_LIST_RESTRICTED_TRACKER_TIP}
+                        required={false}
+                    />
+                </Col>
+                <Col xs={9} lg={8}>
+                    <input
+                        type="checkbox"
+                        name="restrictedIssueList"
+                        checked={model.restrictedIssueList}
+                        onChange={onCheckChange}
+                    />
+                </Col>
+            </Row>
+        );
+    }
+}
+
+export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsProps, any> {
+    onChange = (name: string, formValue: any, selected: Principal, ref: any): void => {
+        const groupId = selected ? selected.userId : undefined;
+        this.props.onSelect(name, groupId);
+    };
+
+    render() {
+        const { model, coreGroups } = this.props;
+
+        return (
+            <Row className="margin-top">
+                <Col xs={3} lg={4}>
+                    <DomainFieldLabel
+                        label="Additional Group with Access"
+                        helpTipBody={ISSUES_LIST_RESTRICTED_GROUP_TIP}
+                        required={false}
+                    />
+                </Col>
+                <Col xs={9} lg={8}>
+                    {!coreGroups ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <SelectInput
+                            name="restrictedIssueListGroup"
+                            options={coreGroups?.toArray()}
+                            placeholder="Unassigned"
+                            inputClass="col-xs-12"
+                            valueKey="userId"
+                            labelKey="displayName"
+                            onChange={this.onChange}
+                            value={model.restrictedIssueListGroup ? model.restrictedIssueListGroup : undefined}
+                            disabled={!model.restrictedIssueList}
                         />
                     )}
                 </Col>

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -370,7 +370,6 @@ export class RestrictedIssueInput extends PureComponent<RestrictedOptionsProps> 
                     <DomainFieldLabel
                         label="Restrict Issue List"
                         helpTipBody={ISSUES_LIST_RESTRICTED_TRACKER_TIP}
-                        required={false}
                     />
                 </Col>
                 <Col xs={9} lg={8}>
@@ -386,7 +385,7 @@ export class RestrictedIssueInput extends PureComponent<RestrictedOptionsProps> 
     }
 }
 
-export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsProps, any> {
+export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsProps> {
     onChange = (name: string, formValue: any, selected: Principal, ref: any): void => {
         const groupId = selected ? selected.userId : undefined;
         this.props.onSelect(name, groupId);
@@ -401,7 +400,6 @@ export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsPr
                     <DomainFieldLabel
                         label="Additional Group with Access"
                         helpTipBody={ISSUES_LIST_RESTRICTED_GROUP_TIP}
-                        required={false}
                     />
                 </Col>
                 <Col xs={9} lg={8}>
@@ -416,7 +414,7 @@ export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsPr
                             valueKey="userId"
                             labelKey="displayName"
                             onChange={this.onChange}
-                            value={model.restrictedIssueListGroup ? model.restrictedIssueListGroup : undefined}
+                            value={model.restrictedIssueListGroup}
                             disabled={!model.restrictedIssueList}
                         />
                     )}

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -53,7 +53,6 @@ interface AssignmentOptionsInputProps {
 }
 
 interface RestrictedOptionsProps {
-    coreGroups?: List<Principal>;
     model: IssuesListDefModel;
     onCheckChange?: (any) => void;
     onSelect: (name: string, value: any) => any;
@@ -125,21 +124,10 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
     }
 }
 
-export class RestrictedOptions extends PureComponent<RestrictedOptionsProps, RestrictedOptionsState> {
-    state: Readonly<RestrictedOptionsState> = {coreGroups: undefined,};
-
-    componentDidMount = async (): Promise<void> => {
-        try {
-            const coreGroups = await getProjectGroups();
-            this.setState({ coreGroups });
-        } catch (e) {
-            console.error('RestrictedOptions: failed to load initialize project groups', e);
-        }
-    };
+export class RestrictedOptions extends PureComponent<RestrictedOptionsProps> {
 
     render() {
         const { model, onCheckChange, onSelect } = this.props;
-        const { coreGroups } = this.state;
 
         return (
             <div>
@@ -151,7 +139,6 @@ export class RestrictedOptions extends PureComponent<RestrictedOptionsProps, Res
                 />
                 <RestrictedIssueGroupInput
                     model={model}
-                    coreGroups={coreGroups}
                     onSelect={onSelect}
                 />
             </div>
@@ -386,13 +373,25 @@ export class RestrictedIssueInput extends PureComponent<RestrictedOptionsProps> 
 }
 
 export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsProps> {
+    state: Readonly<RestrictedOptionsState> = {coreGroups: undefined,};
+
+    componentDidMount = async (): Promise<void> => {
+        try {
+            const coreGroups = await getProjectGroups();
+            this.setState({ coreGroups });
+        } catch (e) {
+            console.error('RestrictedOptions: failed to load initialize project groups', e);
+        }
+    };
+
     onChange = (name: string, formValue: any, selected: Principal, ref: any): void => {
         const groupId = selected ? selected.userId : undefined;
         this.props.onSelect(name, groupId);
     };
 
     render() {
-        const { model, coreGroups } = this.props;
+        const { model } = this.props;
+        const { coreGroups } = this.state;
 
         return (
             <Row className="margin-top">

--- a/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefPropertiesPanel.spec.tsx.snap
@@ -49,217 +49,223 @@ exports[`IssuesListDefPropertiesPanel new Issue Def 1`] = `
         className="col-md-6 col-xs-12"
       >
         <div
-          className="domain-field-section-heading"
+          className="domain-field-padding-bottom"
         >
-          Basic Properties
-        </div>
-        <div
-          className="margin-top row"
-        >
-          <div
-            className="col-lg-4 col-xs-3"
-          >
-            Comment Sort 
-            <span
-              className="domain-no-wrap"
-            >
-              Direction
-              <span
-                className="label-help-target"
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-              >
-                <span
-                  className="label-help-icon fa fa-question-circle"
-                />
-              </span>
-              
-            </span>
-          </div>
-          <div
-            className="col-lg-8 col-xs-9"
-          >
+          <div>
             <div
-              className="select-input-container form-group row"
+              className="domain-field-section-heading"
+            >
+              Basic Properties
+            </div>
+            <div
+              className="margin-top row"
             >
               <div
-                className="col-xs-12"
+                className="col-lg-4 col-xs-3"
+              >
+                Comment Sort 
+                <span
+                  className="domain-no-wrap"
+                >
+                  Direction
+                  <span
+                    className="label-help-target"
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <span
+                      className="label-help-icon fa fa-question-circle"
+                    />
+                  </span>
+                  
+                </span>
+              </div>
+              <div
+                className="col-lg-8 col-xs-9"
               >
                 <div
-                  className="select-input css-b62m3t-container"
-                  id="selectinput-0"
-                  onKeyDown={[Function]}
+                  className="select-input-container form-group row"
                 >
-                  <span
-                    className="css-1f43avz-a11yText-A11yText"
-                    id="react-select-2-live-region"
-                  />
-                  <span
-                    aria-atomic="false"
-                    aria-live="polite"
-                    aria-relevant="additions text"
-                    className="css-1f43avz-a11yText-A11yText"
-                  />
                   <div
-                    className="select-input__control css-13cymwt-control"
-                    onMouseDown={[Function]}
-                    onTouchEnd={[Function]}
+                    className="col-xs-12"
                   >
                     <div
-                      className="select-input__value-container select-input__value-container--has-value css-1fdsijx-ValueContainer"
-                    >
-                      <div
-                        className="select-input__single-value css-1dimb5e-singleValue"
-                      >
-                        Oldest first
-                      </div>
-                      <div
-                        className="select-input__input-container css-qbdosj-Input"
-                        data-value=""
-                      >
-                        <input
-                          aria-autocomplete="list"
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          autoCapitalize="none"
-                          autoComplete="off"
-                          autoCorrect="off"
-                          className="select-input__input"
-                          disabled={false}
-                          id="react-select-2-input"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          required={false}
-                          role="combobox"
-                          spellCheck="false"
-                          style={
-                            {
-                              "background": 0,
-                              "border": 0,
-                              "color": "inherit",
-                              "font": "inherit",
-                              "gridArea": "1 / 2",
-                              "label": "input",
-                              "margin": 0,
-                              "minWidth": "2px",
-                              "opacity": 1,
-                              "outline": 0,
-                              "padding": 0,
-                              "width": "100%",
-                            }
-                          }
-                          tabIndex={0}
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="select-input__indicators css-1hb7zxy-IndicatorsContainer"
+                      className="select-input css-b62m3t-container"
+                      id="selectinput-0"
+                      onKeyDown={[Function]}
                     >
                       <span
-                        className="select-input__indicator-separator css-1u9des2-indicatorSeparator"
+                        className="css-1f43avz-a11yText-A11yText"
+                        id="react-select-2-live-region"
+                      />
+                      <span
+                        aria-atomic="false"
+                        aria-live="polite"
+                        aria-relevant="additions text"
+                        className="css-1f43avz-a11yText-A11yText"
                       />
                       <div
-                        aria-hidden="true"
-                        className="select-input__indicator select-input__dropdown-indicator css-1xc3v61-indicatorContainer"
+                        className="select-input__control css-13cymwt-control"
                         onMouseDown={[Function]}
                         onTouchEnd={[Function]}
                       >
-                        <svg
-                          aria-hidden="true"
-                          className="css-tj5bde-Svg"
-                          focusable="false"
-                          height={20}
-                          viewBox="0 0 20 20"
-                          width={20}
+                        <div
+                          className="select-input__value-container select-input__value-container--has-value css-1fdsijx-ValueContainer"
                         >
-                          <path
-                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                          <div
+                            className="select-input__single-value css-1dimb5e-singleValue"
+                          >
+                            Oldest first
+                          </div>
+                          <div
+                            className="select-input__input-container css-qbdosj-Input"
+                            data-value=""
+                          >
+                            <input
+                              aria-autocomplete="list"
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              autoCapitalize="none"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              className="select-input__input"
+                              disabled={false}
+                              id="react-select-2-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              required={false}
+                              role="combobox"
+                              spellCheck="false"
+                              style={
+                                {
+                                  "background": 0,
+                                  "border": 0,
+                                  "color": "inherit",
+                                  "font": "inherit",
+                                  "gridArea": "1 / 2",
+                                  "label": "input",
+                                  "margin": 0,
+                                  "minWidth": "2px",
+                                  "opacity": 1,
+                                  "outline": 0,
+                                  "padding": 0,
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={0}
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                        </div>
+                        <div
+                          className="select-input__indicators css-1hb7zxy-IndicatorsContainer"
+                        >
+                          <span
+                            className="select-input__indicator-separator css-1u9des2-indicatorSeparator"
                           />
-                        </svg>
+                          <div
+                            aria-hidden="true"
+                            className="select-input__indicator select-input__dropdown-indicator css-1xc3v61-indicatorContainer"
+                            onMouseDown={[Function]}
+                            onTouchEnd={[Function]}
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="css-tj5bde-Svg"
+                              focusable="false"
+                              height={20}
+                              viewBox="0 0 20 20"
+                              width={20}
+                            >
+                              <path
+                                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
                       </div>
+                      <input
+                        name="commentSortDirection"
+                        type="hidden"
+                        value="ASC"
+                      />
                     </div>
                   </div>
-                  <input
-                    name="commentSortDirection"
-                    type="hidden"
-                    value="ASC"
-                  />
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div
-          className="margin-top row"
-        >
-          <div
-            className="col-lg-4 col-xs-3"
-          >
-            Singular Item 
-            <span
-              className="domain-no-wrap"
+            <div
+              className="margin-top row"
             >
-              Name
-              <span
-                className="label-help-target"
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
+              <div
+                className="col-lg-4 col-xs-3"
               >
+                Singular Item 
                 <span
-                  className="label-help-icon fa fa-question-circle"
+                  className="domain-no-wrap"
+                >
+                  Name
+                  <span
+                    className="label-help-target"
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <span
+                      className="label-help-icon fa fa-question-circle"
+                    />
+                  </span>
+                  
+                </span>
+              </div>
+              <div
+                className="col-lg-8 col-xs-9"
+              >
+                <input
+                  className="form-control"
+                  id="singularItemName"
+                  onChange={[Function]}
+                  type="text"
+                  value="Issue"
                 />
-              </span>
-              
-            </span>
-          </div>
-          <div
-            className="col-lg-8 col-xs-9"
-          >
-            <input
-              className="form-control"
-              id="singularItemName"
-              onChange={[Function]}
-              type="text"
-              value="Issue"
-            />
-          </div>
-        </div>
-        <div
-          className="margin-top row"
-        >
-          <div
-            className="col-lg-4 col-xs-3"
-          >
-            Plural Items 
-            <span
-              className="domain-no-wrap"
+              </div>
+            </div>
+            <div
+              className="margin-top row"
             >
-              Name
-              <span
-                className="label-help-target"
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
+              <div
+                className="col-lg-4 col-xs-3"
               >
+                Plural Items 
                 <span
-                  className="label-help-icon fa fa-question-circle"
+                  className="domain-no-wrap"
+                >
+                  Name
+                  <span
+                    className="label-help-target"
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <span
+                      className="label-help-icon fa fa-question-circle"
+                    />
+                  </span>
+                  
+                </span>
+              </div>
+              <div
+                className="col-lg-8 col-xs-9"
+              >
+                <input
+                  className="form-control"
+                  id="pluralItemName"
+                  onChange={[Function]}
+                  type="text"
+                  value="Issues"
                 />
-              </span>
-              
-            </span>
-          </div>
-          <div
-            className="col-lg-8 col-xs-9"
-          >
-            <input
-              className="form-control"
-              id="pluralItemName"
-              onChange={[Function]}
-              type="text"
-              value="Issues"
-            />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/components/src/internal/components/domainproperties/issues/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/constants.ts
@@ -10,3 +10,8 @@ export const ISSUES_LIST_USER_ASSIGN_TIP =
     'In some workflows it is useful to have a default user to whom all issues are assigned, such as for initial triage and balancing assignments across a group. If left blank, no user will be assigned by default.';
 export const ISSUES_LIST_RELATED_FOLDER_TIP =
     'A related issue can be created in any issue list that the user can insert into. This setting controls the default folder selection in the related issue dialog box.';
+export const ISSUES_LIST_RESTRICTED_TRACKER_TIP =
+    'A restricted issue list will limit viewing and updating of all issues in the list. When the checkbox is selected only users who are either assigned to the issue or on the notify list ' +
+    'will have access to an issue. An additional group can optionally be configured to provide access to any members of that group.';
+export const ISSUES_LIST_RESTRICTED_GROUP_TIP =
+    'An optional project or site group that can give members of the group access to the issues in a restricted issue list.';

--- a/packages/components/src/internal/components/domainproperties/issues/models.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/models.ts
@@ -20,23 +20,23 @@ import { Record } from 'immutable';
 import { DomainDesign } from '../models';
 
 export interface IssuesListDefOptionsConfig {
-    entityId?: string;
-    issueDefName: string;
-    singularItemName: string;
-    pluralItemName: string;
-    commentSortDirection: string;
     assignedToGroup: number;
     assignedToUser: number;
+    commentSortDirection: string;
+    entityId?: string;
+    issueDefName: string;
+    pluralItemName: string;
     relatedFolderName: string;
     restrictedIssueList: boolean;
     restrictedIssueListGroup: number;
+    singularItemName: string;
 }
 
 interface IssuesListDefModelConfig extends IssuesListDefOptionsConfig {
-    exception: string;
     domain: DomainDesign;
     domainId: number;
     domainKindName: string;
+    exception: string;
 }
 
 export class IssuesListDefModel implements IssuesListDefModelConfig {

--- a/packages/components/src/internal/components/domainproperties/issues/models.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/models.ts
@@ -28,6 +28,8 @@ export interface IssuesListDefOptionsConfig {
     assignedToGroup: number;
     assignedToUser: number;
     relatedFolderName: string;
+    restrictedIssueList: boolean;
+    restrictedIssueListGroup: number;
 }
 
 interface IssuesListDefModelConfig extends IssuesListDefOptionsConfig {
@@ -52,6 +54,8 @@ export class IssuesListDefModel implements IssuesListDefModelConfig {
     readonly assignedToUser: number;
     readonly domainKindName: string;
     readonly relatedFolderName: string;
+    readonly restrictedIssueList: boolean;
+    readonly restrictedIssueListGroup: number;
 
     constructor(values?: Partial<IssuesListDefModelConfig>) {
         Object.assign(this, values);
@@ -89,6 +93,8 @@ export class IssuesListDefModel implements IssuesListDefModelConfig {
             assignedToGroup: this.assignedToGroup,
             assignedToUser: this.assignedToUser,
             relatedFolderName: this.relatedFolderName,
+            restrictedIssueList: this.restrictedIssueList,
+            restrictedIssueListGroup: this.restrictedIssueListGroup,
         };
     }
 }


### PR DESCRIPTION
#### Rationale
To support a client request for a restricted issue list we need to introduce some administrative UI that can be conditionally rendered if a `RestrictedIssueListProvider` is registered.

The new UI elements will be in the properties panel of the issue list designer. Two new form elements are added:
- A checkbox to enable/disable the feature for the issue list
- An optional dropdown with site and project groups to allow access to the selected group.
- 
#### Related Pull Requests
- https://github.com/LabKey/onprcEHRModules/pull/675
- https://github.com/LabKey/platform/pull/4329

#### Changes
- new form elements
- add a utility method to hide or show the new elements based on a issue module property
