### PR TITLE
Issues 47656 & 47657: add paging metrics and remove ability to create BarTender templates in subfolder projects

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.0",
+  "version": "2.328.1-pagingMetrics.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.1-pagingMetrics.0",
+  "version": "2.328.1-pagingMetrics.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.2-pagingMetrics.2",
+  "version": "2.329.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 47656: Add metrics for pagination usage and page sizing
+* Issue 47657: Remove adding BarTender templates from within subfolder Projects
+
 ### version 2.328.0
 *Released*: 19 April 2023
 - Issue 47509: Better handling of samples with numeric names on assay import

--- a/packages/components/src/internal/components/labels/BarTenderSettingsForm.spec.tsx
+++ b/packages/components/src/internal/components/labels/BarTenderSettingsForm.spec.tsx
@@ -10,6 +10,7 @@ import { getLabelPrintingTestAPIWrapper } from './APIWrapper';
 import { BarTenderSettingsFormImpl } from './BarTenderSettingsForm';
 import { BarTenderConfiguration } from './models';
 import { LabelsConfigurationPanel } from './LabelsConfigurationPanel';
+import { Container } from '../base/models/Container';
 
 describe('BarTenderSettingsForm', () => {
     const DEFAULT_PROPS = {
@@ -22,6 +23,7 @@ describe('BarTenderSettingsForm', () => {
         onSuccess: jest.fn(),
         getIsDirty: jest.fn(),
         setIsDirty: jest.fn(),
+        defaultLabel: 1,
     };
 
     function validate(wrapper: ReactWrapper, withHeading = true): void {
@@ -33,7 +35,11 @@ describe('BarTenderSettingsForm', () => {
     }
 
     test('default props', async () => {
-        const wrapper = mountWithAppServerContext(<BarTenderSettingsFormImpl {...DEFAULT_PROPS} />);
+        const wrapper = mountWithAppServerContext(<BarTenderSettingsFormImpl {...DEFAULT_PROPS} />,
+            undefined,
+            {
+                container: new Container({ path: '/Test' }) ,
+            });
         await waitForLifecycle(wrapper);
         validate(wrapper);
         expect(wrapper.find(FormControl).first().prop('type')).toBe('url');
@@ -58,7 +64,11 @@ describe('BarTenderSettingsForm', () => {
                             ),
                     }),
                 })}
-            />
+            />,
+            undefined,
+            {
+                container: new Container({ path: '/Test' }) ,
+            }
         );
         await waitForLifecycle(wrapper);
         validate(wrapper);

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.spec.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.spec.tsx
@@ -13,6 +13,8 @@ import { ChoicesListItem } from '../base/ChoicesListItem';
 import { getLabelPrintingTestAPIWrapper } from './APIWrapper';
 import { LabelsConfigurationPanel, LabelTemplateDetails, LabelTemplatesList } from './LabelsConfigurationPanel';
 import { LabelTemplate } from './models';
+import { Container } from '../base/models/Container';
+import { AddEntityButton } from '../buttons/AddEntityButton';
 
 jest.mock('react-bootstrap-toggle', () => {
     return props => {
@@ -31,15 +33,54 @@ describe('LabelsConfigurationPanel', () => {
             labelprinting: getLabelPrintingTestAPIWrapper(jest.fn),
         }),
         defaultLabel: undefined,
+        getIsDirty: jest.fn(),
+        setIsDirty: jest.fn(),
     };
 
-    test('default props', async () => {
-        const wrapper = mountWithAppServerContext(<LabelsConfigurationPanel {...DEFAULT_PROPS} />);
+    test('default props, home project', async () => {
+        const wrapper = mountWithAppServerContext(<LabelsConfigurationPanel {...DEFAULT_PROPS} />,
+            undefined,
+            {
+                 container: new Container({ path: '/Test' }) ,
+            });
 
         await waitForLifecycle(wrapper);
 
         expect(wrapper.find(LabelTemplatesList)).toHaveLength(1);
         expect(wrapper.find(LabelTemplateDetails)).toHaveLength(1);
+        expect(wrapper.find(AddEntityButton)).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    test('default props, product project', async () => {
+        const wrapper = mountWithAppServerContext(<LabelsConfigurationPanel {...DEFAULT_PROPS} />,
+            undefined,
+            {
+                container: new Container({ path: '/Test/Folder', type: 'folder' }) ,
+                moduleContext: { query: { isProductProjectsEnabled: true } }
+            });
+
+        await waitForLifecycle(wrapper);
+
+        expect(wrapper.find(LabelTemplatesList)).toHaveLength(1);
+        expect(wrapper.find(LabelTemplateDetails)).toHaveLength(1);
+        expect(wrapper.find(AddEntityButton)).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    test('default props, subfolder without projects', async () => {
+        const wrapper = mountWithAppServerContext(<LabelsConfigurationPanel {...DEFAULT_PROPS} />,
+            undefined,
+            {
+                container: new Container({ path: '/Test/Folder', type: 'folder' }) ,
+                moduleContext: { query: { isProductProjectsEnabled: false } }
+            });
+
+        await waitForLifecycle(wrapper);
+
+        expect(wrapper.find(LabelTemplatesList)).toHaveLength(1);
+        expect(wrapper.find(LabelTemplateDetails)).toHaveLength(1);
+        expect(wrapper.find(AddEntityButton)).toHaveLength(1);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
@@ -28,6 +28,7 @@ import { LabelHelpTip } from '../base/LabelHelpTip';
 
 import { LabelTemplate } from './models';
 import { LABEL_TEMPLATE_SQ } from './constants';
+import { isProductProjectsEnabled } from '../../app/utils';
 
 const TITLE = 'Manage Label Templates';
 const NEW_LABEL_INDEX = -1;
@@ -345,12 +346,13 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
 
 export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props => {
     const { api, setIsDirty, defaultLabel } = props;
-    const { user } = useServerContext();
+    const { user, container } = useServerContext();
     const [templates, setTemplates] = useState<LabelTemplate[]>([]);
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
     const [newDefaultLabel, setNewDefaultLabel] = useState<number>(defaultLabel);
     const addNew = useMemo(() => selected === NEW_LABEL_INDEX, [selected]);
+    const showAdd = container.isProject || !isProductProjectsEnabled();
 
     const queryLabelTemplates = useCallback(
         (newLabelTemplate?: number) => {
@@ -423,7 +425,7 @@ export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props
                                 onSelect={onSetSelected}
                                 defaultLabel={newDefaultLabel}
                             />
-                            <AddEntityButton onClick={onAddLabel} entity="New Label Template" disabled={addNew} />
+                            {showAdd && <AddEntityButton onClick={onAddLabel} entity="New Label Template" disabled={addNew} />}
                         </div>
                         <div className="col-lg-8 col-md-6">
                             <LabelTemplateDetails

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
@@ -28,7 +28,7 @@ import { LabelHelpTip } from '../base/LabelHelpTip';
 
 import { LabelTemplate } from './models';
 import { LABEL_TEMPLATE_SQ } from './constants';
-import { isProductProjectsEnabled } from '../../app/utils';
+import { isAppHomeFolder } from '../../app/utils';
 
 const TITLE = 'Manage Label Templates';
 const NEW_LABEL_INDEX = -1;
@@ -346,13 +346,13 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
 
 export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props => {
     const { api, setIsDirty, defaultLabel } = props;
-    const { user, container } = useServerContext();
+    const { user, container, moduleContext } = useServerContext();
     const [templates, setTemplates] = useState<LabelTemplate[]>([]);
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
     const [newDefaultLabel, setNewDefaultLabel] = useState<number>(defaultLabel);
     const addNew = useMemo(() => selected === NEW_LABEL_INDEX, [selected]);
-    const showAdd = container.isProject || !isProductProjectsEnabled();
+    const showAdd = isAppHomeFolder(container, moduleContext);
 
     const queryLabelTemplates = useCallback(
         (newLabelTemplate?: number) => {

--- a/packages/components/src/internal/components/pagination/Pagination.tsx
+++ b/packages/components/src/internal/components/pagination/Pagination.tsx
@@ -6,6 +6,7 @@ import { LoadingState } from '../../../public/LoadingState';
 import { PaginationButton } from './PaginationButton';
 import { PageMenu } from './PageMenu';
 import { PaginationInfo } from './PaginationInfo';
+import { incrementClientSideMetricCount } from '../../actions';
 
 export interface PaginationData {
     currentPage: number;
@@ -30,10 +31,37 @@ export interface PaginationProps extends PaginationData {
     setPageSize: (pageSize) => void;
 }
 
+const PAGINATION_METRIC_AREA = "pagination";
+
 export class Pagination extends PureComponent<PaginationProps> {
     static defaultProps = {
         pageSizes: [20, 40, 100, 250, 400],
     };
+
+    onLoadFirstPage = () => {
+        incrementClientSideMetricCount(PAGINATION_METRIC_AREA, "loadFirstPage");
+        this.props.loadFirstPage();
+    }
+
+    onLoadLastPage = () => {
+        incrementClientSideMetricCount(PAGINATION_METRIC_AREA, "loadLastPage");
+        this.props.loadLastPage();
+    }
+
+    onLoadPreviousPage = () => {
+        incrementClientSideMetricCount(PAGINATION_METRIC_AREA, "loadPreviousPage");
+        this.props.loadPreviousPage();
+    }
+
+    onLoadNextPage = () => {
+        incrementClientSideMetricCount(PAGINATION_METRIC_AREA, "loadNextPage");
+        this.props.loadNextPage();
+    }
+
+    onSetPageSize = (pageSize: number) => {
+        incrementClientSideMetricCount(PAGINATION_METRIC_AREA, "setPageSize" + pageSize);
+        this.props.setPageSize(pageSize);
+    }
 
     render(): ReactNode {
         const {
@@ -42,16 +70,11 @@ export class Pagination extends PureComponent<PaginationProps> {
             id,
             isFirstPage,
             isLastPage,
-            loadFirstPage,
-            loadLastPage,
-            loadPreviousPage,
-            loadNextPage,
             offset,
             pageSize,
             pageCount,
             pageSizes,
             rowCount,
-            setPageSize,
             totalCountLoadingState,
         } = this.props;
         const showPaginationButtons = rowCount > pageSizes[0];
@@ -73,7 +96,7 @@ export class Pagination extends PureComponent<PaginationProps> {
                             disabled={disabled || isFirstPage}
                             iconClass="fa-chevron-left"
                             tooltip="Previous Page"
-                            onClick={loadPreviousPage}
+                            onClick={this.onLoadPreviousPage}
                         />
 
                         <PageMenu
@@ -83,11 +106,11 @@ export class Pagination extends PureComponent<PaginationProps> {
                             isFirstPage={isFirstPage}
                             isLastPage={isLastPage}
                             pageCount={pageCount}
-                            loadFirstPage={loadFirstPage}
-                            loadLastPage={loadLastPage}
+                            loadFirstPage={this.onLoadFirstPage}
+                            loadLastPage={this.onLoadLastPage}
                             pageSize={pageSize}
                             pageSizes={pageSizes}
-                            setPageSize={setPageSize}
+                            setPageSize={this.onSetPageSize}
                         />
 
                         <PaginationButton
@@ -95,7 +118,7 @@ export class Pagination extends PureComponent<PaginationProps> {
                             disabled={disabled || isLastPage}
                             iconClass="fa-chevron-right"
                             tooltip="Next Page"
-                            onClick={loadNextPage}
+                            onClick={this.onLoadNextPage}
                         />
                     </ButtonGroup>
                 )}


### PR DESCRIPTION
#### Rationale
* [Issue 47656](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47656)
* [Issue 47657](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47657)

#### Related Pull Requests

- https://github.com/LabKey/inventory/pull/832
- https://github.com/LabKey/sampleManagement/pull/1784
- https://github.com/LabKey/labbook/pull/472
- https://github.com/LabKey/biologics/pull/2101

#### Changes
* Add metrics for pagination usage and page sizing
* Remove adding BarTender templates from within subfolder Projects
