### PR TITLE
Issue 47743: Sample Finder mis-renders data cards in queries with both "All Sample Types" and Assay cards

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.1-fb-issue47743.1",
+  "version": "2.328.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.0",
+  "version": "2.328.1-fb-issue47743.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X April 2023
+* Issue 47743: Sample Finder mis-renders data cards in queries with both "All Sample Types" and Assay cards
+
 ### version 2.328.0
 *Released*: 19 April 2023
 - Issue 47509: Better handling of samples with numeric names on assay import

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.X
-*Released*: X April 2023
+### version 2.328.1
+*Released*: 20 April 2023
 * Issue 47743: Sample Finder mis-renders data cards in queries with both "All Sample Types" and Assay cards
 
 ### version 2.328.0

--- a/packages/components/src/entities/EntityFieldFilterModal.tsx
+++ b/packages/components/src/entities/EntityFieldFilterModal.tsx
@@ -117,7 +117,7 @@ export const EntityFieldFilterModal: FC<EntityFieldFilterModalProps> = memo(prop
             const activeDataTypeFilters = {};
 
             cards?.forEach(card => {
-                if (card.entityDataType.instanceSchemaName !== entityDataType.instanceSchemaName) return;
+                if (card.entityDataType.sampleFinderCardType !== entityDataType.sampleFinderCardType) return;
                 let parent = card.schemaQuery.queryName.toLowerCase(); // if is assay, change to datatype
                 if (card.entityDataType.getInstanceDataType) {
                     parent = card.entityDataType.getInstanceDataType(card.schemaQuery, card.altQueryName).toLowerCase();

--- a/packages/components/src/entities/SampleFinderSection.tsx
+++ b/packages/components/src/entities/SampleFinderSection.tsx
@@ -274,7 +274,7 @@ const SampleFinderSectionImpl: FC<Props & InjectedAssayModel> = memo(props => {
             let assayDesignCount = 0;
             let hasWithoutAssayResultFilter = false;
             const newFilterCards = [...filters].filter(filter => {
-                return filter.entityDataType.instanceSchemaName !== chosenEntityType.instanceSchemaName;
+                return filter.entityDataType.sampleFinderCardType !== chosenEntityType.sampleFinderCardType;
             });
             Object.keys(dataTypeFilters).forEach(queryName => {
                 if (isAssay) {


### PR DESCRIPTION
#### Rationale
Assay card and sample property card both uses a function to get schemaName, instead of relying on static instanceSchemaName. Because they both have null instanceSchemaName, instanceSchemaName shouldn't be used to identify a card type.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1179
- https://github.com/LabKey/sampleManagement/pull/1785
- https://github.com/LabKey/biologics/pull/2102

#### Changes
- use sampleFinderCardType property to identify card type
