### PR TITLE
App sample grid and overview menu option to "Move to Project"

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.0-fb-moveSamplesUI.0",
+  "version": "2.328.0-fb-moveSamplesUI.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1-fb-moveSamplesUI.4",
+  "version": "2.329.1-fb-moveSamplesUI.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1-fb-moveSamplesUI.2",
+  "version": "2.329.1-fb-moveSamplesUI.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1-fb-moveSamplesUI.1",
+  "version": "2.329.1-fb-moveSamplesUI.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.0-fb-moveSamplesUI.1",
+  "version": "2.328.0-fb-moveSamplesUI.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1-fb-moveSamplesUI.0",
+  "version": "2.329.1-fb-moveSamplesUI.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1-fb-moveSamplesUI.5",
+  "version": "2.330.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.0",
+  "version": "2.328.0-fb-moveSamplesUI.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1-fb-moveSamplesUI.3",
+  "version": "2.329.1-fb-moveSamplesUI.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.327.0",
+  "version": "2.327.0-fb-moveSamplesUI.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1",
+  "version": "2.329.1-fb-moveSamplesUI.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.328.0-fb-moveSamplesUI.2",
+  "version": "2.328.0-fb-moveSamplesUI.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.330.0
+*Released*: 26 April 2023
 * Move samples between projects UI updates
   * add new SampleMoveMenuItem and EntityMoveModal to be used by the SamplesEditButton
   * add getMoveConfirmationData and moveSamples API action calls

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Move samples between projects UI updates
   * add new SampleMoveMenuItem and EntityMoveModal to be used by the SamplesEditButton
   * add getMoveConfirmationData and moveSamples API action calls
+  * handle selectionKey for useSnapshotSelection case
 
 ### version 2.328.0
 *Released*: 19 April 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Move samples between projects UI updates
+  * add new SampleMoveMenuItem and EntityMoveModal to be used by the SamplesEditButton
+  * add getMoveConfirmationData and moveSamples API action calls
+
 ### version 2.327.0
 *Released*: 18 April 2023
 * Media consistency improvements

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   * add new SampleMoveMenuItem and EntityMoveModal to be used by the SamplesEditButton
   * add getMoveConfirmationData and moveSamples API action calls
   * handle selectionKey for useSnapshotSelection case
+  * add move menu item to sample overview page and usage of EntityMoveModal
 
 ### version 2.328.0
 *Released*: 19 April 2023

--- a/packages/components/src/entities/EntityDeleteConfirmModal.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModal.tsx
@@ -28,6 +28,8 @@ import { setSnapshotSelections } from '../internal/actions';
 import { getDeleteConfirmationData } from '../internal/components/entities/actions';
 import { EntityDataType, OperationConfirmationData } from '../internal/components/entities/models';
 
+import { capitalizeFirstChar } from '../internal/util/utils';
+
 import { EntityDeleteConfirmHandler, EntityDeleteConfirmModalDisplay } from './EntityDeleteConfirmModalDisplay';
 
 interface Props {
@@ -108,8 +110,12 @@ export class EntityDeleteConfirmModal extends PureComponent<Props, State> {
 
         if (this.state.isLoading) {
             return (
-                <ConfirmModal title="Loading confirmation data" onCancel={onCancel} cancelButtonText="Cancel">
-                    <LoadingSpinner />
+                <ConfirmModal
+                    title={'Delete ' + capitalizeFirstChar(entityDataType.nounPlural)}
+                    onCancel={onCancel}
+                    cancelButtonText="Cancel"
+                >
+                    <LoadingSpinner msg="Loading confirmation data..." />
                 </ConfirmModal>
             );
         }

--- a/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -21,9 +21,10 @@ import { isELNEnabled } from '../internal/app/utils';
 import { capitalizeFirstChar } from '../internal/util/utils';
 import { HelpLink } from '../internal/util/helpLinks';
 
-import { DeleteConfirmationModal } from './DeleteConfirmationModal';
-
 import { EntityDataType, OperationConfirmationData } from '../internal/components/entities/models';
+import { Alert } from '../internal/components/base/Alert';
+
+import { DeleteConfirmationModal } from './DeleteConfirmationModal';
 
 export type EntityDeleteConfirmHandler = (rowsToDelete: any[], rowsToKeep: any[], userComment: string) => void;
 
@@ -121,15 +122,17 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
                     </React.Fragment>
                 );
         }
-        const message = (
-            <>
+        const message = numCannotDelete ? (
+            <Alert bsStyle="warning">
                 {text}
                 {numCannotDelete > 0 && deleteHelpLinkTopic && (
                     <>
                         &nbsp;(<HelpLink topic={deleteHelpLinkTopic}>more info</HelpLink>)
                     </>
                 )}
-            </>
+            </Alert>
+        ) : (
+            <>{text}</>
         );
 
         return {

--- a/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -125,7 +125,7 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
         const message = numCannotDelete ? (
             <Alert bsStyle="warning">
                 {text}
-                {numCannotDelete > 0 && deleteHelpLinkTopic && (
+                {deleteHelpLinkTopic && (
                     <>
                         &nbsp;(<HelpLink topic={deleteHelpLinkTopic}>more info</HelpLink>)
                     </>

--- a/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
+++ b/packages/components/src/entities/EntityDeleteConfirmModalDisplay.tsx
@@ -122,18 +122,20 @@ export class EntityDeleteConfirmModalDisplay extends PureComponent<Props, State>
                     </React.Fragment>
                 );
         }
-        const message = numCannotDelete ? (
-            <Alert bsStyle="warning">
+
+        let message = (
+            <>
                 {text}
-                {deleteHelpLinkTopic && (
+                {numCannotDelete > 0 && deleteHelpLinkTopic && (
                     <>
                         &nbsp;(<HelpLink topic={deleteHelpLinkTopic}>more info</HelpLink>)
                     </>
                 )}
-            </Alert>
-        ) : (
-            <>{text}</>
+            </>
         );
+        if (numCanDelete > 0 && numCannotDelete > 0) {
+            message = <Alert bsStyle="warning">{message}</Alert>;
+        }
 
         return {
             message,

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -105,7 +105,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
                 onCancel={onCancel}
                 cancelButtonText="Dismiss"
             >
-                You cannot delete more than {maxSelected} individual {nounPlural} at a time. Please select fewer
+                You cannot delete more than {maxSelected} individual {nounPlural} at a time. Please select fewer{' '}
                 {nounPlural} and try again.
             </ConfirmModal>
         );

--- a/packages/components/src/entities/SampleDetailPage.tsx
+++ b/packages/components/src/entities/SampleDetailPage.tsx
@@ -108,7 +108,7 @@ export const SampleDetailPageBody: FC<SampleDetailPageBodyProps> = memo(props =>
     const sampleType_ = sampleType ?? params?.sampleType;
 
     const containerUser = useContainerUser(sampleModel.getRowValue('Folder'), {
-        includeStandardProperties: true, // need so we get the parentPath to use in EntityMoveConfirmationModal
+        includeStandardProperties: true, // this is needed to get the parentPath to use in EntityMoveConfirmationModal
     });
     const containerUserError = containerUser.error;
     const sampleContainer = containerUser.container;

--- a/packages/components/src/entities/SampleDetailPage.tsx
+++ b/packages/components/src/entities/SampleDetailPage.tsx
@@ -107,10 +107,13 @@ export const SampleDetailPageBody: FC<SampleDetailPageBodyProps> = memo(props =>
     const sampleModel = queryModels[modelId];
     const sampleType_ = sampleType ?? params?.sampleType;
 
-    const containerUser = useContainerUser(sampleModel.getRowValue('Folder'));
+    const containerUser = useContainerUser(sampleModel.getRowValue('Folder'), {
+        includeStandardProperties: true, // need so we get the parentPath to use in EntityMoveConfirmationModal
+    });
     const containerUserError = containerUser.error;
     const sampleContainer = containerUser.container;
     const user = containerUser.user;
+    const containerUserLoading = !containerUser.isLoaded || (user === undefined && containerUserError === undefined);
     const { container } = useServerContext();
     const { SampleStorageMenuComponent, SampleStorageLocationComponent, assayProviderType } = useSampleTypeAppContext();
 
@@ -149,7 +152,7 @@ export const SampleDetailPageBody: FC<SampleDetailPageBodyProps> = memo(props =>
         [sampleContainer, sampleModel, sampleType_, location, user, onDetailUpdate]
     );
 
-    if (!sampleModel || sampleModel.isLoading || (sampleModel.getRow() && !containerUser.isLoaded)) {
+    if (!sampleModel || sampleModel.isLoading || (sampleModel.getRow() && containerUserLoading)) {
         if (sampleModel?.queryInfoError || sampleModel?.rowsError || containerUserError) {
             return <NotFound />;
         }

--- a/packages/components/src/entities/SampleHeader.spec.tsx
+++ b/packages/components/src/entities/SampleHeader.spec.tsx
@@ -5,7 +5,9 @@ import { SCHEMAS } from '../internal/schemas';
 import { makeTestQueryModel } from '../public/QueryModel/testUtils';
 import { LoadingState } from '../public/LoadingState';
 import { mountWithAppServerContext } from '../internal/testHelpers';
-import { TEST_USER_AUTHOR, TEST_USER_READER } from '../internal/userFixtures';
+import { TEST_USER_AUTHOR, TEST_USER_EDITOR, TEST_USER_READER } from '../internal/userFixtures';
+
+import { DisableableMenuItem } from '../internal/components/samples/DisableableMenuItem';
 
 import { SampleHeaderImpl } from './SampleHeader';
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
@@ -119,7 +121,7 @@ describe('SampleHeader', () => {
 
     test('CreateSamplesSubMenu permissions', () => {
         let wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_READER} sampleModel={DATA_MODEL} canDerive={true}/>,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_READER} sampleModel={DATA_MODEL} canDerive={true} />,
             {},
             { user: TEST_USER_READER }
         );
@@ -127,7 +129,7 @@ describe('SampleHeader', () => {
         wrapper.unmount();
 
         wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_AUTHOR} sampleModel={DATA_MODEL} canDerive={true}/>,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_AUTHOR} sampleModel={DATA_MODEL} canDerive={true} />,
             {},
             { user: TEST_USER_AUTHOR }
         );
@@ -137,12 +139,62 @@ describe('SampleHeader', () => {
 
     test('CreateSamplesSubMenu props', () => {
         const wrapper = mountWithAppServerContext(
-            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_AUTHOR} sampleModel={DATA_MODEL} canDerive={true}/>,
+            <SampleHeaderImpl {...DEFAULT_PROPS} user={TEST_USER_AUTHOR} sampleModel={DATA_MODEL} canDerive={true} />,
             {},
             { user: TEST_USER_AUTHOR }
         );
         expect(wrapper.find(CreateSamplesSubMenu).prop('parentType')).toBe('samples');
         expect(wrapper.find(CreateSamplesSubMenu).prop('parentKey')).toBe('samples:testsampletype:123');
+        wrapper.unmount();
+    });
+
+    test('showMoveItem false', () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleHeaderImpl
+                {...DEFAULT_PROPS}
+                user={TEST_USER_EDITOR}
+                sampleModel={DATA_MODEL}
+                showMoveItem={false}
+            />,
+            {},
+            { user: TEST_USER_EDITOR }
+        );
+        expect(wrapper.find(DisableableMenuItem)).toHaveLength(2);
+        expect(wrapper.find(DisableableMenuItem).at(0).text()).toBe('Add to Picklist');
+        expect(wrapper.find(DisableableMenuItem).at(1).text()).toBe('Delete Sample');
+        wrapper.unmount();
+    });
+
+    test('showMoveItem with update perm', () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleHeaderImpl
+                {...DEFAULT_PROPS}
+                user={TEST_USER_EDITOR}
+                sampleModel={DATA_MODEL}
+                showMoveItem={true}
+            />,
+            {},
+            { user: TEST_USER_EDITOR }
+        );
+        expect(wrapper.find(DisableableMenuItem)).toHaveLength(3);
+        expect(wrapper.find(DisableableMenuItem).at(0).text()).toBe('Add to Picklist');
+        expect(wrapper.find(DisableableMenuItem).at(1).text()).toBe('Move to Project');
+        expect(wrapper.find(DisableableMenuItem).at(2).text()).toBe('Delete Sample');
+        wrapper.unmount();
+    });
+
+    test('showMoveItem without update perm', () => {
+        const wrapper = mountWithAppServerContext(
+            <SampleHeaderImpl
+                {...DEFAULT_PROPS}
+                user={TEST_USER_AUTHOR}
+                sampleModel={DATA_MODEL}
+                showMoveItem={true}
+            />,
+            {},
+            { user: TEST_USER_AUTHOR }
+        );
+        expect(wrapper.find(DisableableMenuItem)).toHaveLength(0);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/entities/SampleHeader.tsx
+++ b/packages/components/src/entities/SampleHeader.tsx
@@ -125,11 +125,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                     setCanDelete(confirmationData.allowed.length === 1);
                 }
 
-                if (
-                    showMoveItem &&
-                    user.hasUpdatePermission() &&
-                    isSampleOperationPermitted(sampleStatusType, SampleOperation.Move)
-                ) {
+                if (user.hasUpdatePermission() && isSampleOperationPermitted(sampleStatusType, SampleOperation.Move)) {
                     const confirmationData = await getSampleOperationConfirmationData(SampleOperation.Move, sampleIds);
                     setCanMove(confirmationData.allowed.length === 1);
                 }
@@ -305,11 +301,13 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
 
                             {canPrintLabels && <MenuItem onClick={onPrintLabel}>Print Labels</MenuItem>}
 
-                            <RequiresPermission user={user} perms={PermissionTypes.Update}>
-                                <DisableableMenuItem onClick={onMoveSample} operationPermitted={canMove}>
-                                    Move to Project
-                                </DisableableMenuItem>
-                            </RequiresPermission>
+                            {showMoveItem && (
+                                <RequiresPermission user={user} perms={PermissionTypes.Update}>
+                                    <DisableableMenuItem onClick={onMoveSample} operationPermitted={canMove}>
+                                        Move to Project
+                                    </DisableableMenuItem>
+                                </RequiresPermission>
+                            )}
 
                             <RequiresPermission user={user} perms={PermissionTypes.Delete}>
                                 <DisableableMenuItem

--- a/packages/components/src/entities/SampleHeader.tsx
+++ b/packages/components/src/entities/SampleHeader.tsx
@@ -35,7 +35,7 @@ import { PrintLabelsModal } from '../internal/components/labels/PrintLabelsModal
 
 import { invalidateLineageResults } from '../internal/components/lineage/actions';
 
-import {isAllProductFoldersFilteringEnabled, isAssayEnabled, isWorkflowEnabled} from '../internal/app/utils';
+import { isAllProductFoldersFilteringEnabled, isAssayEnabled, isWorkflowEnabled } from '../internal/app/utils';
 
 import { User } from '../internal/components/base/models/User';
 import { Container } from '../internal/components/base/models/Container';

--- a/packages/components/src/entities/SampleHeader.tsx
+++ b/packages/components/src/entities/SampleHeader.tsx
@@ -77,7 +77,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
         assayProviderType,
         canPrintLabels,
         defaultLabel,
-        entityDataType,
+        entityDataType = SampleTypeDataType,
         iconSrc = 'samples',
         hasActiveJob,
         navigate,
@@ -332,7 +332,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                     onAfterMove={onAfterMove}
                     onCancel={onHideModals}
                     maxSelected={1}
-                    entityDataType={SampleTypeDataType}
+                    entityDataType={entityDataType}
                     moveFn={api.entity.moveSamples}
                     sourceContainer={sampleContainer}
                     targetAppURL={AppURL.create(isMedia ? MEDIA_KEY : SAMPLES_KEY, sampleModel.queryName)}
@@ -345,7 +345,7 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                     beforeDelete={onBeforeDelete}
                     afterDelete={onAfterDelete}
                     onCancel={onHideModals}
-                    entityDataType={entityDataType ?? SampleTypeDataType}
+                    entityDataType={entityDataType}
                     auditBehavior={getSampleAuditBehaviorType()}
                     verb="deleted and removed from storage"
                     containerPath={sampleContainer?.path}

--- a/packages/components/src/entities/SampleMoveMenuItem.spec.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.spec.tsx
@@ -10,8 +10,9 @@ import { mountWithAppServerContext } from '../internal/testHelpers';
 
 import { EntityMoveModal } from '../internal/components/entities/EntityMoveModal';
 
+import { QueryInfo } from '../public/QueryInfo';
+
 import { SampleMoveMenuItem } from './SampleMoveMenuItem';
-import {QueryInfo} from "../public/QueryInfo";
 
 describe('SampleMoveMenuItem', () => {
     const ACTIONS = makeTestActions();

--- a/packages/components/src/entities/SampleMoveMenuItem.spec.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.spec.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { ReactWrapper } from 'enzyme';
+
+import { makeTestActions, makeTestQueryModel } from '../public/QueryModel/testUtils';
+import { SchemaQuery } from '../public/SchemaQuery';
+import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuItem';
+
+import { mountWithAppServerContext } from '../internal/testHelpers';
+
+import { EntityMoveModal } from '../internal/components/entities/EntityMoveModal';
+
+import { SampleMoveMenuItem } from './SampleMoveMenuItem';
+import {QueryInfo} from "../public/QueryInfo";
+
+describe('SampleMoveMenuItem', () => {
+    const ACTIONS = makeTestActions();
+
+    function validate(wrapper: ReactWrapper, moveModalCount = 0) {
+        const menuItem = wrapper.find(SelectionMenuItem);
+
+        expect(menuItem).toHaveLength(1);
+        expect(menuItem.text()).toBe('Move to Project');
+
+        const menuItemComp = wrapper.find('MenuItem a');
+        menuItemComp.simulate('click');
+
+        const modal = wrapper.find(EntityMoveModal);
+        expect(modal).toHaveLength(moveModalCount);
+    }
+
+    test('click menu item with no selection', () => {
+        const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
+        const wrapper = mountWithAppServerContext(<SampleMoveMenuItem actions={ACTIONS} queryModel={queryModel} />);
+        validate(wrapper);
+        wrapper.unmount();
+    });
+
+    test('click menu item', () => {
+        let queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
+        queryModel = queryModel.mutate({ rowCount: 2, selections: new Set(['1', '2']) });
+        const wrapper = mountWithAppServerContext(<SampleMoveMenuItem actions={ACTIONS} queryModel={queryModel} />);
+        validate(wrapper, 1);
+        expect(wrapper.find(EntityMoveModal).prop('targetAppURL').toHref()).toBe('#/samples/query');
+        wrapper.unmount();
+    });
+
+    test('isMedia', () => {
+        let queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'), new QueryInfo({ isMedia: true }));
+        queryModel = queryModel.mutate({ rowCount: 2, selections: new Set(['1', '2']) });
+        const wrapper = mountWithAppServerContext(<SampleMoveMenuItem actions={ACTIONS} queryModel={queryModel} />);
+        validate(wrapper, 1);
+        expect(wrapper.find(EntityMoveModal).prop('targetAppURL').toHref()).toBe('#/media/query');
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/entities/SampleMoveMenuItem.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.tsx
@@ -35,6 +35,10 @@ export const SampleMoveMenuItem: FC<Props> = memo(props => {
         }
     }, [handleClick, queryModel]);
 
+    const onAfterMove = useCallback(() => {
+        actions.loadModel(queryModel.id, true, true);
+    }, [actions, queryModel.id]);
+
     const onClose = useCallback(() => {
         setShowMoveSamplesModal(false);
     }, []);
@@ -51,9 +55,9 @@ export const SampleMoveMenuItem: FC<Props> = memo(props => {
             />
             {showMoveSamplesModal && (
                 <EntityMoveModal
-                    actions={actions}
                     queryModel={queryModel}
                     useSelected
+                    onAfterMove={onAfterMove}
                     onCancel={onClose}
                     maxSelected={maxSelected}
                     entityDataType={SampleTypeDataType}

--- a/packages/components/src/entities/SampleMoveMenuItem.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.tsx
@@ -8,6 +8,8 @@ import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuIte
 import { SampleTypeDataType } from '../internal/components/entities/constants';
 import { EntityMoveModal } from '../internal/components/entities/EntityMoveModal';
 import { useAppContext } from '../internal/AppContext';
+import { AppURL } from '../internal/url/AppURL';
+import { SAMPLES_KEY } from '../internal/app/constants';
 
 const ITEM_TEXT = 'Move to Project';
 
@@ -56,6 +58,7 @@ export const SampleMoveMenuItem: FC<Props> = memo(props => {
                     maxSelected={maxSelected}
                     entityDataType={SampleTypeDataType}
                     moveFn={api.entity.moveSamples}
+                    targetAppURL={AppURL.create(SAMPLES_KEY, queryModel.queryInfo.name)}
                 />
             )}
         </>

--- a/packages/components/src/entities/SampleMoveMenuItem.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.tsx
@@ -11,7 +11,7 @@ import { useAppContext } from '../internal/AppContext';
 import { AppURL } from '../internal/url/AppURL';
 import { MEDIA_KEY, SAMPLES_KEY } from '../internal/app/constants';
 import { EntityDataType } from '../internal/components/entities/models';
-import {capitalizeFirstChar} from "../internal/util/utils";
+import { capitalizeFirstChar } from '../internal/util/utils';
 
 const ITEM_TEXT = 'Move to Project';
 

--- a/packages/components/src/entities/SampleMoveMenuItem.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.tsx
@@ -11,6 +11,7 @@ import { useAppContext } from '../internal/AppContext';
 import { AppURL } from '../internal/url/AppURL';
 import { MEDIA_KEY, SAMPLES_KEY } from '../internal/app/constants';
 import { EntityDataType } from '../internal/components/entities/models';
+import {capitalizeFirstChar} from "../internal/util/utils";
 
 const ITEM_TEXT = 'Move to Project';
 
@@ -31,7 +32,10 @@ export const SampleMoveMenuItem: FC<Props> = memo(props => {
     const onClick = useCallback(() => {
         if (queryModel.hasSelections) {
             if (handleClick) {
-                handleClick(() => setShowMoveSamplesModal(true), 'Cannot Move ' + entityDataType.nounPlural);
+                handleClick(
+                    () => setShowMoveSamplesModal(true),
+                    'Cannot Move ' + capitalizeFirstChar(entityDataType.nounPlural)
+                );
             } else {
                 setShowMoveSamplesModal(true);
             }

--- a/packages/components/src/entities/SampleMoveMenuItem.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.tsx
@@ -9,31 +9,34 @@ import { SampleTypeDataType } from '../internal/components/entities/constants';
 import { EntityMoveModal } from '../internal/components/entities/EntityMoveModal';
 import { useAppContext } from '../internal/AppContext';
 import { AppURL } from '../internal/url/AppURL';
-import { SAMPLES_KEY } from '../internal/app/constants';
+import { MEDIA_KEY, SAMPLES_KEY } from '../internal/app/constants';
+import { EntityDataType } from '../internal/components/entities/models';
 
 const ITEM_TEXT = 'Move to Project';
 
 interface Props {
     actions: Actions;
+    entityDataType?: EntityDataType;
     handleClick?: (cb: () => void, errorMsg?: string) => void;
     maxSelected?: number;
     queryModel: QueryModel;
 }
 
 export const SampleMoveMenuItem: FC<Props> = memo(props => {
-    const { handleClick, maxSelected, queryModel, actions } = props;
+    const { handleClick, maxSelected, queryModel, actions, entityDataType = SampleTypeDataType } = props;
     const [showMoveSamplesModal, setShowMoveSamplesModal] = useState<boolean>(false);
     const { api } = useAppContext();
+    const isMedia = queryModel.queryInfo?.isMedia;
 
     const onClick = useCallback(() => {
         if (queryModel.hasSelections) {
             if (handleClick) {
-                handleClick(() => setShowMoveSamplesModal(true), 'Cannot Move Samples');
+                handleClick(() => setShowMoveSamplesModal(true), 'Cannot Move ' + entityDataType.nounPlural);
             } else {
                 setShowMoveSamplesModal(true);
             }
         }
-    }, [handleClick, queryModel]);
+    }, [entityDataType, handleClick, queryModel]);
 
     const onAfterMove = useCallback(() => {
         actions.loadModel(queryModel.id, true, true);
@@ -51,7 +54,7 @@ export const SampleMoveMenuItem: FC<Props> = memo(props => {
                 onClick={onClick}
                 queryModel={queryModel}
                 maxSelection={maxSelected}
-                nounPlural={SampleTypeDataType.nounPlural}
+                nounPlural={entityDataType.nounPlural.toLowerCase()}
             />
             {showMoveSamplesModal && (
                 <EntityMoveModal
@@ -60,9 +63,9 @@ export const SampleMoveMenuItem: FC<Props> = memo(props => {
                     onAfterMove={onAfterMove}
                     onCancel={onClose}
                     maxSelected={maxSelected}
-                    entityDataType={SampleTypeDataType}
+                    entityDataType={entityDataType}
                     moveFn={api.entity.moveSamples}
-                    targetAppURL={AppURL.create(SAMPLES_KEY, queryModel.queryInfo.name)}
+                    targetAppURL={AppURL.create(isMedia ? MEDIA_KEY : SAMPLES_KEY, queryModel.queryName)}
                 />
             )}
         </>

--- a/packages/components/src/entities/SampleMoveMenuItem.tsx
+++ b/packages/components/src/entities/SampleMoveMenuItem.tsx
@@ -1,0 +1,67 @@
+import React, { FC, memo, useCallback, useState } from 'react';
+
+import { QueryModel } from '../public/QueryModel/QueryModel';
+import { Actions } from '../public/QueryModel/withQueryModels';
+
+import { MAX_EDITABLE_GRID_ROWS } from '../internal/constants';
+import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuItem';
+import { SampleTypeDataType } from '../internal/components/entities/constants';
+import { EntityMoveModal } from '../internal/components/entities/EntityMoveModal';
+import { useAppContext } from '../internal/AppContext';
+
+const ITEM_TEXT = 'Move to Project';
+
+interface Props {
+    actions: Actions;
+    handleClick?: (cb: () => void, errorMsg?: string) => void;
+    maxSelected?: number;
+    queryModel: QueryModel;
+}
+
+export const SampleMoveMenuItem: FC<Props> = memo(props => {
+    const { handleClick, maxSelected, queryModel, actions } = props;
+    const [showMoveSamplesModal, setShowMoveSamplesModal] = useState<boolean>(false);
+    const { api } = useAppContext();
+
+    const onClick = useCallback(() => {
+        if (queryModel.hasSelections) {
+            if (handleClick) {
+                handleClick(() => setShowMoveSamplesModal(true), 'Cannot Move Samples');
+            } else {
+                setShowMoveSamplesModal(true);
+            }
+        }
+    }, [handleClick, queryModel]);
+
+    const onClose = useCallback(() => {
+        setShowMoveSamplesModal(false);
+    }, []);
+
+    return (
+        <>
+            <SelectionMenuItem
+                id="move-samples-menu-item"
+                text={ITEM_TEXT}
+                onClick={onClick}
+                queryModel={queryModel}
+                maxSelection={maxSelected}
+                nounPlural={SampleTypeDataType.nounPlural}
+            />
+            {showMoveSamplesModal && (
+                <EntityMoveModal
+                    actions={actions}
+                    queryModel={queryModel}
+                    useSelected
+                    onCancel={onClose}
+                    maxSelected={maxSelected}
+                    entityDataType={SampleTypeDataType}
+                    moveFn={api.entity.moveSamples}
+                />
+            )}
+        </>
+    );
+});
+
+SampleMoveMenuItem.defaultProps = {
+    maxSelected: MAX_EDITABLE_GRID_ROWS,
+};

--- a/packages/components/src/entities/SamplesEditButton.spec.tsx
+++ b/packages/components/src/entities/SamplesEditButton.spec.tsx
@@ -9,7 +9,7 @@ import {
     TEST_USER_READER,
     TEST_USER_STORAGE_EDITOR,
 } from '../internal/userFixtures';
-import { mountWithServerContext } from '../internal/testHelpers';
+import { mountWithAppServerContext, mountWithServerContext } from '../internal/testHelpers';
 
 import { QueryInfo } from '../public/QueryInfo';
 import { SchemaQuery } from '../public/SchemaQuery';
@@ -24,6 +24,7 @@ import { SamplesEditButtonSections } from '../internal/components/samples/utils'
 import { SampleDeleteMenuItem } from './SampleDeleteMenuItem';
 import { SamplesEditButton } from './SamplesEditButton';
 import { EntityLineageEditMenuItem } from './EntityLineageEditMenuItem';
+import { SampleMoveMenuItem } from './SampleMoveMenuItem';
 
 describe('SamplesEditButton', () => {
     const queryInfo = new QueryInfo({
@@ -39,13 +40,15 @@ describe('SamplesEditButton', () => {
         parentEntityItemCount = 2,
         selMenuItemCount = 5,
         menuItemCount = 8,
-        deleteItemCount = 1
+        deleteItemCount = 1,
+        moveItemCount = 0
     ): void {
         expect(wrapper.find(ManageDropdownButton)).toHaveLength(show ? 1 : 0);
         if (show) {
             expect(wrapper.find(EntityLineageEditMenuItem)).toHaveLength(parentEntityItemCount);
             expect(wrapper.find(SelectionMenuItem)).toHaveLength(selMenuItemCount);
             expect(wrapper.find(SampleDeleteMenuItem)).toHaveLength(deleteItemCount);
+            expect(wrapper.find(SampleMoveMenuItem)).toHaveLength(moveItemCount);
             expect(wrapper.find(MenuItem)).toHaveLength(menuItemCount);
         }
     }
@@ -159,6 +162,32 @@ describe('SamplesEditButton', () => {
                 ]}
             />,
             { user: TEST_USER_EDITOR }
+        );
+        validate(wrapper, true, 0, 0, 0, 0);
+        wrapper.unmount();
+    });
+
+    test('hasProductProjects as editor, includes move', () => {
+        const wrapper = mountWithAppServerContext(
+            <SamplesEditButton {...DEFAULT_PROPS} />,
+            {},
+            {
+                user: TEST_USER_EDITOR,
+                moduleContext: { query: { hasProductProjects: true } },
+            }
+        );
+        validate(wrapper, true, 2, 6, 9, 1, 1);
+        wrapper.unmount();
+    });
+
+    test('hasProductProjects as author', () => {
+        const wrapper = mountWithAppServerContext(
+            <SamplesEditButton {...DEFAULT_PROPS} />,
+            {},
+            {
+                user: TEST_USER_AUTHOR,
+                moduleContext: { query: { hasProductProjects: true } },
+            }
         );
         validate(wrapper, true, 0, 0, 0, 0);
         wrapper.unmount();

--- a/packages/components/src/entities/SamplesEditButton.spec.tsx
+++ b/packages/components/src/entities/SamplesEditButton.spec.tsx
@@ -155,7 +155,7 @@ describe('SamplesEditButton', () => {
                     SamplesEditButtonSections.IMPORT,
                     SamplesEditButtonSections.DELETE,
                     SamplesEditButtonSections.EDIT,
-                    SamplesEditButtonSections.LINKTOSTUDY,
+                    SamplesEditButtonSections.LINK_TO_STUDY,
                 ]}
             />,
             { user: TEST_USER_EDITOR }

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -6,7 +6,7 @@ import { CrossFolderSelectionResult, EntityDataType } from '../internal/componen
 
 import { RequiresModelAndActions } from '../public/QueryModel/withQueryModels';
 
-import { hasModule } from '../internal/app/utils';
+import { hasModule, hasProductProjects } from '../internal/app/utils';
 
 import { useServerContext } from '../internal/components/base/ServerContext';
 import { buildURL, createProductUrlFromParts } from '../internal/url/AppURL';
@@ -32,6 +32,7 @@ import { EntityCrossProjectSelectionConfirmModal } from './EntityCrossProjectSel
 import { shouldIncludeMenuItem } from './utils';
 import { SampleDeleteMenuItem } from './SampleDeleteMenuItem';
 import { EntityLineageEditMenuItem } from './EntityLineageEditMenuItem';
+import { SampleMoveMenuItem } from './SampleMoveMenuItem';
 
 interface OwnProps {
     combineParentTypes?: boolean;
@@ -43,6 +44,7 @@ interface OwnProps {
 
 export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresModelAndActions> = memo(props => {
     const {
+        actions,
         afterSampleDelete,
         afterSampleActionComplete,
         showBulkUpdate,
@@ -124,6 +126,10 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
     const showEditParent =
         shouldIncludeMenuItem(SamplesEditButtonSections.EDIT_PARENT, excludedMenuKeys) &&
         hasAnyPermissions(user, [PermissionTypes.Update]);
+    const showMoveToProject =
+        shouldIncludeMenuItem(SamplesEditButtonSections.MOVETOPROJECT, excludedMenuKeys) &&
+        hasAnyPermissions(user, [PermissionTypes.Update]) &&
+        hasProductProjects(moduleContext);
     const showDelete =
         shouldIncludeMenuItem(SamplesEditButtonSections.DELETE, excludedMenuKeys) &&
         hasAnyPermissions(user, [PermissionTypes.Delete]);
@@ -197,7 +203,10 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
                         )}
                     </RequiresPermission>
                 )}
-                {showEdit && (showDelete || showStudy) && <MenuItem divider />}
+                {showEdit && (showMoveToProject || showDelete || showStudy) && <MenuItem divider />}
+                {showMoveToProject && (
+                    <SampleMoveMenuItem actions={actions} queryModel={model} handleClick={handleMenuClick} />
+                )}
                 {showDelete && (
                     <RequiresPermission perms={PermissionTypes.Delete}>
                         <SampleDeleteMenuItem

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -37,6 +37,7 @@ import { SampleMoveMenuItem } from './SampleMoveMenuItem';
 interface OwnProps {
     combineParentTypes?: boolean;
     currentProductId?: string;
+    entityDataType?: EntityDataType;
     parentEntityDataTypes: EntityDataType[];
     showLinkToStudy?: boolean;
     targetProductId?: string;
@@ -57,6 +58,7 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
         metricFeatureArea,
         currentProductId,
         targetProductId,
+        entityDataType,
     } = props;
     const [crossFolderSelectionResult, setCrossFolderSelectionResult] = useState<CrossFolderSelectionResult>();
     const { user, moduleContext } = useServerContext();
@@ -205,7 +207,12 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
                 )}
                 {showEdit && (showMoveToProject || showDelete || showStudy) && <MenuItem divider />}
                 {showMoveToProject && (
-                    <SampleMoveMenuItem actions={actions} queryModel={model} handleClick={handleMenuClick} />
+                    <SampleMoveMenuItem
+                        actions={actions}
+                        entityDataType={entityDataType}
+                        queryModel={model}
+                        handleClick={handleMenuClick}
+                    />
                 )}
                 {showDelete && (
                     <RequiresPermission perms={PermissionTypes.Delete}>

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -129,7 +129,7 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
         shouldIncludeMenuItem(SamplesEditButtonSections.EDIT_PARENT, excludedMenuKeys) &&
         hasAnyPermissions(user, [PermissionTypes.Update]);
     const showMoveToProject =
-        shouldIncludeMenuItem(SamplesEditButtonSections.MOVETOPROJECT, excludedMenuKeys) &&
+        shouldIncludeMenuItem(SamplesEditButtonSections.MOVE_TO_PROJECT, excludedMenuKeys) &&
         hasAnyPermissions(user, [PermissionTypes.Update]) &&
         hasProductProjects(moduleContext);
     const showDelete =
@@ -138,7 +138,7 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
     const showStudy =
         showLinkToStudy &&
         hasModule('study', moduleContext) &&
-        shouldIncludeMenuItem(SamplesEditButtonSections.LINKTOSTUDY, excludedMenuKeys) &&
+        shouldIncludeMenuItem(SamplesEditButtonSections.LINK_TO_STUDY, excludedMenuKeys) &&
         hasAnyPermissions(user, [PermissionTypes.Insert]);
 
     return (

--- a/packages/components/src/internal/components/base/ConfirmModal.spec.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.spec.tsx
@@ -50,4 +50,19 @@ describe('<ConfirmModal/>', () => {
         expect(modal.find('.btn-danger')).toHaveLength(1);
         expect(modal.find('.btn-danger').prop('disabled')).toBe(true);
     });
+
+    test('canConfirm', () => {
+        const msg = 'testing of canConfirm prop set to false';
+        const modal = mount(
+            <ConfirmModal onConfirm={jest.fn()} onCancel={jest.fn()} canConfirm={false}>
+                {msg}
+            </ConfirmModal>
+        );
+
+        expect(modal.find(Modal)).toHaveLength(1);
+        expect(modal.find('.close')).toHaveLength(1);
+        expect(modal.find('.btn')).toHaveLength(2);
+        expect(modal.find('.btn-danger')).toHaveLength(1);
+        expect(modal.find('.btn-danger').prop('disabled')).toBe(true);
+    });
 });

--- a/packages/components/src/internal/components/base/ConfirmModal.tsx
+++ b/packages/components/src/internal/components/base/ConfirmModal.tsx
@@ -19,6 +19,7 @@ import classNames from 'classnames';
 
 export interface ConfirmModalProps {
     backdrop?: string;
+    canConfirm?: boolean;
     cancelButtonText?: string;
     confirmButtonText?: string;
     confirmVariant?: string;
@@ -35,6 +36,7 @@ export class ConfirmModal extends React.PureComponent<ConfirmModalProps> {
         show: true,
         title: 'Confirm',
         confirmButtonText: 'Yes',
+        canConfirm: true,
         cancelButtonText: 'No', // TODO: 100% of usages override this value, 90% of usages have this set to "Cancel", change the default.
         confirmVariant: 'danger',
     };
@@ -52,6 +54,7 @@ export class ConfirmModal extends React.PureComponent<ConfirmModalProps> {
             confirmVariant,
             size,
             submitting,
+            canConfirm,
         } = this.props;
         const cancelBtnClass = classNames({ 'pull-left': onConfirm !== undefined });
         return (
@@ -69,7 +72,7 @@ export class ConfirmModal extends React.PureComponent<ConfirmModalProps> {
                         </Button>
                     )}
                     {onConfirm && (
-                        <Button bsStyle={confirmVariant} onClick={onConfirm} disabled={submitting}>
+                        <Button bsStyle={confirmVariant} onClick={onConfirm} disabled={!canConfirm || submitting}>
                             {confirmButtonText}
                         </Button>
                     )}

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -6,6 +6,8 @@ import { QueryInfo } from '../../../public/QueryInfo';
 
 import { InsertOptions } from '../../query/api';
 
+import { Container } from '../base/models/Container';
+
 import {
     getDataOperationConfirmationData,
     getEntityTypeData,
@@ -22,7 +24,6 @@ import {
     MoveSamplesResult,
     OperationConfirmationData,
 } from './models';
-import {Container} from "../base/models/Container";
 
 export interface EntityAPIWrapper {
     getDataOperationConfirmationData: (

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -63,10 +63,10 @@ export interface EntityAPIWrapper {
     moveSamples: (
         sourceContainer: Container,
         targetContainer: string,
-        rowIds: number[],
-        selectionKey: string,
-        useSnapshotSelection: boolean,
-        auditUserComment: string
+        rowIds?: number[],
+        selectionKey?: string,
+        useSnapshotSelection?: boolean,
+        auditUserComment?: string
     ) => Promise<MoveSamplesResult>;
 }
 

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -22,6 +22,7 @@ import {
     MoveSamplesResult,
     OperationConfirmationData,
 } from './models';
+import {Container} from "../base/models/Container";
 
 export interface EntityAPIWrapper {
     getDataOperationConfirmationData: (
@@ -59,6 +60,7 @@ export interface EntityAPIWrapper {
     ) => Promise<any>;
     loadNameExpressionOptions: (containerPath?: string) => Promise<GetNameExpressionOptionsResponse>;
     moveSamples: (
+        sourceContainer: Container,
         targetContainer: string,
         rowIds: number[],
         selectionKey: string,

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -11,6 +11,7 @@ import {
     getEntityTypeData,
     getOriginalParentsFromLineage,
     handleEntityFileImport,
+    moveSamples,
 } from './actions';
 import { DataOperation } from './constants';
 import {
@@ -18,6 +19,7 @@ import {
     EntityDataType,
     EntityIdCreationModel,
     IEntityTypeOption,
+    MoveSamplesResult,
     OperationConfirmationData,
 } from './models';
 
@@ -56,6 +58,12 @@ export interface EntityAPIWrapper {
         saveToPipeline?: boolean
     ) => Promise<any>;
     loadNameExpressionOptions: (containerPath?: string) => Promise<GetNameExpressionOptionsResponse>;
+    moveSamples: (
+        targetContainer: string,
+        rowIds: number[],
+        selectionKey: string,
+        auditUserComment: string
+    ) => Promise<MoveSamplesResult>;
 }
 
 export class EntityServerAPIWrapper implements EntityAPIWrapper {
@@ -64,6 +72,7 @@ export class EntityServerAPIWrapper implements EntityAPIWrapper {
     getOriginalParentsFromLineage = getOriginalParentsFromLineage;
     handleEntityFileImport = handleEntityFileImport;
     loadNameExpressionOptions = loadNameExpressionOptions;
+    moveSamples = moveSamples;
 }
 
 /**
@@ -79,6 +88,7 @@ export function getEntityTestAPIWrapper(
         getOriginalParentsFromLineage: mockFn(),
         handleEntityFileImport: mockFn(),
         loadNameExpressionOptions: mockFn(),
+        moveSamples: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -62,6 +62,7 @@ export interface EntityAPIWrapper {
         targetContainer: string,
         rowIds: number[],
         selectionKey: string,
+        useSnapshotSelection: boolean,
         auditUserComment: string
     ) => Promise<MoveSamplesResult>;
 }

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -33,12 +33,6 @@ export interface EntityAPIWrapper {
         selectionKey?: string,
         useSnapshotSelection?: boolean
     ) => Promise<OperationConfirmationData>;
-    getMoveConfirmationData: (
-        dataType: EntityDataType,
-        rowIds: string[] | number[],
-        selectionKey?: string,
-        useSnapshotSelection?: boolean
-    ) => Promise<OperationConfirmationData>;
     getEntityTypeData: (
         model: EntityIdCreationModel,
         entityDataType: EntityDataType,
@@ -48,6 +42,12 @@ export interface EntityAPIWrapper {
         isItemSamples: boolean,
         combineParentTypes: boolean
     ) => Promise<Partial<EntityIdCreationModel>>;
+    getMoveConfirmationData: (
+        dataType: EntityDataType,
+        rowIds: string[] | number[],
+        selectionKey?: string,
+        useSnapshotSelection?: boolean
+    ) => Promise<OperationConfirmationData>;
     getOriginalParentsFromLineage: (
         lineage: Record<string, any>,
         parentDataTypes: EntityDataType[],

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -10,6 +10,7 @@ import { Container } from '../base/models/Container';
 
 import {
     getDataOperationConfirmationData,
+    getMoveConfirmationData,
     getEntityTypeData,
     getOriginalParentsFromLineage,
     handleEntityFileImport,
@@ -28,6 +29,12 @@ import {
 export interface EntityAPIWrapper {
     getDataOperationConfirmationData: (
         operation: DataOperation,
+        rowIds: string[] | number[],
+        selectionKey?: string,
+        useSnapshotSelection?: boolean
+    ) => Promise<OperationConfirmationData>;
+    getMoveConfirmationData: (
+        dataType: EntityDataType,
         rowIds: string[] | number[],
         selectionKey?: string,
         useSnapshotSelection?: boolean
@@ -72,6 +79,7 @@ export interface EntityAPIWrapper {
 
 export class EntityServerAPIWrapper implements EntityAPIWrapper {
     getDataOperationConfirmationData = getDataOperationConfirmationData;
+    getMoveConfirmationData = getMoveConfirmationData;
     getEntityTypeData = getEntityTypeData;
     getOriginalParentsFromLineage = getOriginalParentsFromLineage;
     handleEntityFileImport = handleEntityFileImport;
@@ -88,6 +96,7 @@ export function getEntityTestAPIWrapper(
 ): EntityAPIWrapper {
     return {
         getDataOperationConfirmationData: mockFn(),
+        getMoveConfirmationData: mockFn(),
         getEntityTypeData: mockFn(),
         getOriginalParentsFromLineage: mockFn(),
         handleEntityFileImport: mockFn(),

--- a/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+
+import { PermissionTypes } from '@labkey/api';
+
+import { mountWithAppServerContext, waitForLifecycle } from '../../testHelpers';
+import { ConfirmModal } from '../base/ConfirmModal';
+import { TEST_FOLDER_CONTAINER, TEST_PROJECT_CONTAINER } from '../../../test/data/constants';
+import { getTestAPIWrapper } from '../../APIWrapper';
+import { getSecurityTestAPIWrapper } from '../security/APIWrapper';
+import { Container } from '../base/models/Container';
+import { SelectInput } from '../forms/input/SelectInput';
+
+import { EntityMoveConfirmationModal, EntityMoveConfirmationModalProps } from './EntityMoveConfirmationModal';
+
+describe('EntityMoveConfirmationModal', () => {
+    function getDefaultProps(): EntityMoveConfirmationModalProps {
+        return {
+            nounPlural: 'samples',
+            onConfirm: jest.fn(),
+            sourceContainer: TEST_FOLDER_CONTAINER,
+        };
+    }
+
+    test('loading', () => {
+        const wrapper = mountWithAppServerContext(<EntityMoveConfirmationModal {...getDefaultProps()} />);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(ConfirmModal).text()).toContain('Loading target projects...');
+        wrapper.unmount();
+    });
+
+    test('error', async () => {
+        const wrapper = mountWithAppServerContext(<EntityMoveConfirmationModal {...getDefaultProps()} />, {
+            api: getTestAPIWrapper(jest.fn, {
+                security: getSecurityTestAPIWrapper(jest.fn, {
+                    fetchContainers: () => Promise.reject('This is an error message.'),
+                }),
+            }),
+        });
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(ConfirmModal).text()).toContain('This is an error message.');
+        wrapper.unmount();
+    });
+
+    test('no insert perm to any projects', async () => {
+        const wrapper = mountWithAppServerContext(<EntityMoveConfirmationModal {...getDefaultProps()} />, {
+            api: getTestAPIWrapper(jest.fn, {
+                security: getSecurityTestAPIWrapper(jest.fn, {
+                    fetchContainers: () =>
+                        Promise.resolve([
+                            {
+                                ...TEST_PROJECT_CONTAINER,
+                                effectivePermissions: [PermissionTypes.Read],
+                            } as Container,
+                            {
+                                ...TEST_FOLDER_CONTAINER,
+                                effectivePermissions: [PermissionTypes.Update, PermissionTypes.Insert],
+                            } as Container,
+                        ]),
+                }),
+            }),
+        });
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(ConfirmModal).text()).toContain(
+            'You do not have permission to move samples to any of the available projects.'
+        );
+        wrapper.unmount();
+    });
+
+    test('has perm to move to anothe project', async () => {
+        const wrapper = mountWithAppServerContext(<EntityMoveConfirmationModal {...getDefaultProps()} />, {
+            api: getTestAPIWrapper(jest.fn, {
+                security: getSecurityTestAPIWrapper(jest.fn, {
+                    fetchContainers: () =>
+                        Promise.resolve([
+                            {
+                                ...TEST_PROJECT_CONTAINER,
+                                effectivePermissions: [PermissionTypes.Insert],
+                            } as Container,
+                            {
+                                ...TEST_FOLDER_CONTAINER,
+                                effectivePermissions: [PermissionTypes.Update, PermissionTypes.Insert],
+                            } as Container,
+                        ]),
+                }),
+            }),
+        });
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(SelectInput)).toHaveLength(1);
+        expect(wrapper.find(SelectInput).prop('options').length).toBe(1);
+        expect(wrapper.find(SelectInput).prop('options')[0].value).toBe(TEST_PROJECT_CONTAINER.path);
+        expect(wrapper.find(SelectInput).prop('options')[0].label).toBe(TEST_PROJECT_CONTAINER.title);
+        expect(wrapper.find('textarea')).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    test('can move to home project', async () => {
+        const wrapper = mountWithAppServerContext(<EntityMoveConfirmationModal {...getDefaultProps()} />, {
+            api: getTestAPIWrapper(jest.fn, {
+                security: getSecurityTestAPIWrapper(jest.fn, {
+                    fetchContainers: () =>
+                        Promise.resolve([
+                            {
+                                ...TEST_PROJECT_CONTAINER,
+                                path: '/home',
+                                title: 'home',
+                                effectivePermissions: [PermissionTypes.Insert],
+                            } as Container,
+                            {
+                                ...TEST_FOLDER_CONTAINER,
+                                effectivePermissions: [PermissionTypes.Update, PermissionTypes.Insert],
+                            } as Container,
+                        ]),
+                }),
+            }),
+        });
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(SelectInput)).toHaveLength(1);
+        expect(wrapper.find(SelectInput).prop('options').length).toBe(1);
+        expect(wrapper.find(SelectInput).prop('options')[0].value).toBe('/home');
+        expect(wrapper.find(SelectInput).prop('options')[0].label).toBe('Home Project');
+        expect(wrapper.find('textarea')).toHaveLength(1);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
@@ -2,14 +2,16 @@ import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Security } from '@labkey/api';
 
 import { ConfirmModalProps, ConfirmModal } from '../base/ConfirmModal';
+import { Alert } from '../base/Alert';
+import { useServerContext } from '../base/ServerContext';
+import { LoadingSpinner } from '../base/LoadingSpinner';
+
 import { resolveErrorMessage } from '../../util/messaging';
 import { isLoading, LoadingState } from '../../../public/LoadingState';
 import { isAppHomeFolder } from '../../app/utils';
 import { AppContext, useAppContext } from '../../AppContext';
-import { useServerContext } from '../base/ServerContext';
-import { LoadingSpinner } from '../base/LoadingSpinner';
-import { Alert } from '../base/Alert';
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
+import { HOME_PATH, HOME_TITLE } from '../navigation/constants';
 
 interface Props extends Omit<ConfirmModalProps, 'onConfirm'> {
     nounPlural: string;
@@ -55,7 +57,7 @@ export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
 
                     setContainerOptions(
                         folders.map(f => ({
-                            label: f.title,
+                            label: f.path === HOME_PATH ? HOME_TITLE : f.title,
                             value: f.path,
                             data: f,
                         }))

--- a/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
@@ -12,7 +12,7 @@ import { isAppHomeFolder } from '../../app/utils';
 import { AppContext, useAppContext } from '../../AppContext';
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
 import { HOME_PATH, HOME_TITLE } from '../navigation/constants';
-import {Container} from "../base/models/Container";
+import { Container } from '../base/models/Container';
 
 interface Props extends Omit<ConfirmModalProps, 'onConfirm'> {
     nounPlural: string;

--- a/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
@@ -14,13 +14,13 @@ import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
 import { HOME_PATH, HOME_TITLE } from '../navigation/constants';
 import { Container } from '../base/models/Container';
 
-interface Props extends Omit<ConfirmModalProps, 'onConfirm'> {
+export interface EntityMoveConfirmationModalProps extends Omit<ConfirmModalProps, 'onConfirm'> {
     nounPlural: string;
     onConfirm: (targetContainer: string, targetName: string, userComment: string) => void;
     sourceContainer?: Container;
 }
 
-export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
+export const EntityMoveConfirmationModal: FC<EntityMoveConfirmationModalProps> = memo(props => {
     const { children, onConfirm, nounPlural, sourceContainer, ...confirmModalProps } = props;
     const [error, setError] = useState<string>();
     const [loading, setLoading] = useState<LoadingState>(LoadingState.INITIALIZED);

--- a/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
@@ -12,11 +12,12 @@ import { Alert } from '../base/Alert';
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
 
 interface Props extends Omit<ConfirmModalProps, 'onConfirm'> {
+    nounPlural: string;
     onConfirm: (targetContainer: string, targetName: string, userComment: string) => void;
 }
 
 export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
-    const { children, onConfirm, ...confirmModalProps } = props;
+    const { children, onConfirm, nounPlural, ...confirmModalProps } = props;
     const [error, setError] = useState<string>();
     const [loading, setLoading] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [containerOptions, setContainerOptions] = useState<SelectInputOption[]>();
@@ -47,7 +48,7 @@ export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
                     folders = folders.filter(c => c !== undefined && c.id !== '');
 
                     // filter to folders that the user has InsertPermissions
-                    folders = folders.filter(c => c.effectivePermissions.indexOf(Security.PermissionTypes.Insert));
+                    folders = folders.filter(c => c.effectivePermissions.indexOf(Security.PermissionTypes.Insert) > -1);
 
                     // filter out the current container
                     folders = folders.filter(c => c.id !== container.id);
@@ -108,6 +109,18 @@ export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
                 cancelButtonText="Dismiss"
             >
                 <Alert>{error}</Alert>
+            </ConfirmModal>
+        );
+    }
+
+    if (containerOptions?.length === 0) {
+        return (
+            <ConfirmModal
+                title={confirmModalProps.title}
+                onCancel={confirmModalProps.onCancel}
+                cancelButtonText="Dismiss"
+            >
+                You do not have permission to move {nounPlural} to any of the available projects.
             </ConfirmModal>
         );
     }

--- a/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
@@ -12,14 +12,16 @@ import { isAppHomeFolder } from '../../app/utils';
 import { AppContext, useAppContext } from '../../AppContext';
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
 import { HOME_PATH, HOME_TITLE } from '../navigation/constants';
+import {Container} from "../base/models/Container";
 
 interface Props extends Omit<ConfirmModalProps, 'onConfirm'> {
     nounPlural: string;
     onConfirm: (targetContainer: string, targetName: string, userComment: string) => void;
+    sourceContainer?: Container;
 }
 
 export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
-    const { children, onConfirm, nounPlural, ...confirmModalProps } = props;
+    const { children, onConfirm, nounPlural, sourceContainer, ...confirmModalProps } = props;
     const [error, setError] = useState<string>();
     const [loading, setLoading] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [containerOptions, setContainerOptions] = useState<SelectInputOption[]>();
@@ -27,6 +29,7 @@ export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
     const [auditUserComment, setAuditUserComment] = useState<string>();
     const { api } = useAppContext<AppContext>();
     const { container, moduleContext } = useServerContext();
+    const container_ = sourceContainer ?? container;
 
     useEffect(
         () => {
@@ -36,9 +39,9 @@ export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
 
                 try {
                     let folders = await api.security.fetchContainers({
-                        containerPath: isAppHomeFolder(container, moduleContext)
-                            ? container.path
-                            : container.parentPath,
+                        containerPath: isAppHomeFolder(container_, moduleContext)
+                            ? container_.path
+                            : container_.parentPath,
                         includeEffectivePermissions: true,
                         includeStandardProperties: true, // needed to get the container title
                         includeWorkbookChildren: false,
@@ -53,7 +56,7 @@ export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
                     folders = folders.filter(c => c.effectivePermissions.indexOf(Security.PermissionTypes.Insert) > -1);
 
                     // filter out the current container
-                    folders = folders.filter(c => c.id !== container.id);
+                    folders = folders.filter(c => c.id !== container_.id);
 
                     setContainerOptions(
                         folders.map(f => ({

--- a/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveConfirmationModal.tsx
@@ -141,7 +141,7 @@ export const EntityMoveConfirmationModal: FC<Props> = memo(props => {
             <div className="top-spacing">
                 <SelectInput
                     helpTipRenderer="NONE"
-                    label="Move to Project"
+                    label="Move to"
                     onChange={onContainerChange}
                     options={containerOptions}
                     required

--- a/packages/components/src/internal/components/entities/EntityMoveModal.spec.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.spec.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
+import { SchemaQuery } from '../../../public/SchemaQuery';
+import { mountWithAppServerContext, waitForLifecycle } from '../../testHelpers';
+import { ConfirmModal } from '../base/ConfirmModal';
+import { QueryInfo } from '../../../public/QueryInfo';
+import { getTestAPIWrapper } from '../../APIWrapper';
+
+import { Progress } from '../base/Progress';
+
+import { Alert } from '../base/Alert';
+
+import { getEntityTestAPIWrapper } from './APIWrapper';
+import { EntityMoveConfirmationModal } from './EntityMoveConfirmationModal';
+import { SampleTypeDataType } from './constants';
+import { EntityMoveModal, EntityMoveModalProps, getMoveConfirmationProperties } from './EntityMoveModal';
+import { OperationConfirmationData } from './models';
+
+describe('EntityMoveModal', () => {
+    function getDefaultProps(): EntityMoveModalProps {
+        return {
+            entityDataType: SampleTypeDataType,
+            maxSelected: 1,
+            moveFn: jest.fn(),
+            onAfterMove: jest.fn(),
+            onCancel: jest.fn(),
+            queryModel: makeTestQueryModel(new SchemaQuery('schema', 'query'), new QueryInfo(), { 1: {} }, [1], 1),
+            useSelected: true,
+        };
+    }
+
+    test('loading', () => {
+        const wrapper = mountWithAppServerContext(<EntityMoveModal {...getDefaultProps()} />);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(ConfirmModal).text()).toContain('Loading confirmation data...');
+        wrapper.unmount();
+    });
+
+    test('error', async () => {
+        const wrapper = mountWithAppServerContext(
+            <EntityMoveModal
+                {...getDefaultProps()}
+                api={getTestAPIWrapper(jest.fn, {
+                    entity: getEntityTestAPIWrapper(jest.fn, {
+                        getMoveConfirmationData: () => Promise.reject('I am an error message.'),
+                    }),
+                })}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(ConfirmModal).text()).toContain(
+            'There was a problem retrieving the move confirmation data.'
+        );
+        wrapper.unmount();
+    });
+
+    test('cannot move, no valid selections', async () => {
+        const wrapper = mountWithAppServerContext(
+            <EntityMoveModal
+                {...getDefaultProps()}
+                api={getTestAPIWrapper(jest.fn, {
+                    entity: getEntityTestAPIWrapper(jest.fn, {
+                        getMoveConfirmationData: () =>
+                            Promise.resolve({
+                                allowed: [],
+                                notAllowed: [1],
+                                idMap: { 1: false },
+                            }),
+                    }),
+                })}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(ConfirmModal).text()).toContain(
+            "The sample you've selected cannot be moved because it has a status that prevents moving.   (more info)"
+        );
+        wrapper.unmount();
+    });
+
+    test('can move, valid selection', async () => {
+        const wrapper = mountWithAppServerContext(
+            <EntityMoveModal
+                {...getDefaultProps()}
+                api={getTestAPIWrapper(jest.fn, {
+                    entity: getEntityTestAPIWrapper(jest.fn, {
+                        getMoveConfirmationData: () =>
+                            Promise.resolve({
+                                allowed: [1],
+                                notAllowed: [],
+                                idMap: { 1: true },
+                            }),
+                    }),
+                })}
+            />
+        );
+        await waitForLifecycle(wrapper);
+        expect(wrapper.find(ConfirmModal)).toHaveLength(1);
+        expect(wrapper.find(EntityMoveConfirmationModal)).toHaveLength(1);
+        expect(wrapper.find(Progress)).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    describe('getMoveConfirmationProperties', () => {
+        test('no confirmationData', () => {
+            expect(getMoveConfirmationProperties(undefined, 'sample', 'samples')).toBeUndefined();
+        });
+
+        test('no selection', () => {
+            const props = getMoveConfirmationProperties(
+                { allowed: [], notAllowed: [], idMap: {} } as OperationConfirmationData,
+                'sample',
+                'samples'
+            );
+            expect(props.canMove).toBeFalsy();
+            expect(props.title).toBe('No Samples Can Be Moved');
+            expect(props.message).toBeUndefined();
+        });
+
+        test('single allowed', () => {
+            const props = getMoveConfirmationProperties(
+                { allowed: [1], notAllowed: [], idMap: { 1: true } } as OperationConfirmationData,
+                'sample',
+                'samples'
+            );
+            expect(props.canMove).toBeTruthy();
+            expect(props.title).toBe('Move 1 Sample');
+            expect(props.message).toBeUndefined();
+        });
+
+        test('multiple allowed', () => {
+            const props = getMoveConfirmationProperties(
+                { allowed: [1, 2], notAllowed: [], idMap: { 1: true, 2: true } } as OperationConfirmationData,
+                'sample',
+                'samples'
+            );
+            expect(props.canMove).toBeTruthy();
+            expect(props.title).toBe('Move 2 Samples');
+            expect(props.message).toBeUndefined();
+        });
+
+        test('single not allowed', () => {
+            const props = getMoveConfirmationProperties(
+                { allowed: [], notAllowed: [1], idMap: { 1: false } } as OperationConfirmationData,
+                'sample',
+                'samples'
+            );
+            expect(props.canMove).toBeFalsy();
+            expect(props.title).toBe('Cannot Move Sample');
+
+            const wrapper = mount(props.message);
+            expect(wrapper.find(Alert)).toHaveLength(0);
+            expect(wrapper.first().text()).toBe(
+                "The sample you've selected cannot be moved because it has a status that prevents moving.  "
+            );
+        });
+
+        test('multiple not allowed', () => {
+            const props = getMoveConfirmationProperties(
+                { allowed: [], notAllowed: [1, 2], idMap: { 1: false, 2: false } } as OperationConfirmationData,
+                'sample',
+                'samples'
+            );
+            expect(props.canMove).toBeFalsy();
+            expect(props.title).toBe('No Samples Can Be Moved');
+
+            const wrapper = mount(props.message);
+            expect(wrapper.find(Alert)).toHaveLength(0);
+            expect(wrapper.first().text()).toBe(
+                "Neither of the 2 samples you've selected can be moved because they have a status that prevents moving."
+            );
+        });
+
+        test('single allowed, single not allowed', () => {
+            const props = getMoveConfirmationProperties(
+                { allowed: [1], notAllowed: [2], idMap: { 1: true, 2: false } } as OperationConfirmationData,
+                'sample',
+                'samples'
+            );
+            expect(props.canMove).toBeTruthy();
+            expect(props.title).toBe('Move 1 Sample');
+
+            const wrapper = mount(props.message);
+            expect(wrapper.find(Alert).text()).toBe(
+                "You've selected 2 samples but only 1 can be moved. 1 sample cannot be moved because  it has status that prevents moving. (more info)"
+            );
+        });
+
+        test('multiple allowed, multiple allowed', () => {
+            const props = getMoveConfirmationProperties(
+                {
+                    allowed: [1, 3],
+                    notAllowed: [2, 4],
+                    idMap: { 1: true, 2: false, 3: true, 4: false },
+                } as OperationConfirmationData,
+                'sample',
+                'samples'
+            );
+            expect(props.canMove).toBeTruthy();
+            expect(props.title).toBe('Move 2 Samples');
+
+            const wrapper = mount(props.message);
+            expect(wrapper.find(Alert).text()).toBe(
+                "You've selected 4 samples but only 2 can be moved. 2 samples cannot be moved because  they have status that prevents moving. (more info)"
+            );
+        });
+    });
+});

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -27,7 +27,13 @@ interface Props {
     actions: Actions;
     entityDataType: EntityDataType;
     maxSelected: number;
-    moveFn: (targetContainer: string, rowIds: number[], selectionKey: string, auditUserComment: string) => void;
+    moveFn: (
+        targetContainer: string,
+        rowIds: number[],
+        selectionKey: string,
+        useSnapshotSelection: boolean,
+        auditUserComment: string
+    ) => void;
     onCancel: () => void;
     queryModel: QueryModel;
     useSelected: boolean;
@@ -91,7 +97,8 @@ export const EntityMoveModal: FC<Props> = memo(props => {
                 await moveFn(
                     targetContainer,
                     !movingAll ? confirmationData.allowed.map(a => a.RowId) : undefined,
-                    movingAll ? selectionKey : undefined, // TODO need useSnapshotSelection?
+                    selectionKey,
+                    movingAll && queryModel.filterArray.length > 0, // useSnapshotSelection if grid has filters
                     auditUserComment
                 );
 

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -32,10 +32,10 @@ interface Props {
     moveFn: (
         sourceContainer: Container,
         targetContainerPath: string,
-        rowIds: number[],
-        selectionKey: string,
-        useSnapshotSelection: boolean,
-        auditUserComment: string
+        rowIds?: number[],
+        selectionKey?: string,
+        useSnapshotSelection?: boolean,
+        auditUserComment?: string
     ) => void;
     onAfterMove: () => void;
     onCancel: () => void;
@@ -293,11 +293,9 @@ const getMoveConfirmationProperties = (
         message = (
             <Alert bsStyle="warning">
                 {text}
-                {numCannotMove > 0 && (
-                    <>
-                        &nbsp;(<HelpLink topic={MOVE_SAMPLES_TOPIC}>more info</HelpLink>)
-                    </>
-                )}
+                <>
+                    &nbsp;(<HelpLink topic={MOVE_SAMPLES_TOPIC}>more info</HelpLink>)
+                </>
             </Alert>
         );
     }

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -291,13 +291,16 @@ const getMoveConfirmationProperties = (
     let message;
     if (numCannotMove > 0) {
         message = (
-            <Alert bsStyle="warning">
+            <>
                 {text}
                 <>
                     &nbsp;(<HelpLink topic={MOVE_SAMPLES_TOPIC}>more info</HelpLink>)
                 </>
-            </Alert>
+            </>
         );
+    }
+    if (numCanMove > 0 && numCannotMove > 0) {
+        message = <Alert bsStyle="warning">{message}</Alert>;
     }
 
     return {

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -156,7 +156,7 @@ export const EntityMoveModal: FC<Props> = memo(props => {
     if (isLoading(loading)) {
         return (
             <ConfirmModal title="Move to Project" onCancel={onCancel} cancelButtonText="Cancel">
-                <LoadingSpinner msg="Loading confirmation data" />
+                <LoadingSpinner msg="Loading confirmation data..." />
             </ConfirmModal>
         );
     }
@@ -182,7 +182,7 @@ export const EntityMoveModal: FC<Props> = memo(props => {
                 onCancel={onCancel}
                 cancelButtonText="Dismiss"
             >
-                <Alert>{message}</Alert>
+                {message}
             </ConfirmModal>
         );
     }

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -1,0 +1,267 @@
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
+
+import { Progress } from '../base/Progress';
+import { ConfirmModal } from '../base/ConfirmModal';
+import { LoadingSpinner } from '../base/LoadingSpinner';
+import { Alert } from '../base/Alert';
+
+import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { Actions } from '../../../public/QueryModel/withQueryModels';
+
+import { useNotificationsContext } from '../notifications/NotificationsContext';
+import { capitalizeFirstChar } from '../../util/utils';
+import { setSnapshotSelections } from '../../actions';
+import { HelpLink, MOVE_SAMPLES_TOPIC } from '../../util/helpLinks';
+
+import { isLoading, LoadingState } from '../../../public/LoadingState';
+
+import { getMoveConfirmationData } from './actions';
+import { EntityDataType, OperationConfirmationData } from './models';
+import { getEntityNoun } from './utils';
+import { EntityMoveConfirmationModal } from './EntityMoveConfirmationModal';
+import {buildURL} from "../../url/AppURL";
+import {ActionURL} from "@labkey/api";
+import {getCurrentAppProperties} from "../../app/utils";
+
+interface Props {
+    actions: Actions;
+    entityDataType: EntityDataType;
+    maxSelected: number;
+    moveFn: (targetContainer: string, rowIds: number[], selectionKey: string, auditUserComment: string) => void;
+    onCancel: () => void;
+    queryModel: QueryModel;
+    useSelected: boolean;
+}
+
+export const EntityMoveModal: FC<Props> = memo(props => {
+    const { actions, queryModel, onCancel, useSelected, entityDataType, maxSelected, moveFn } = props;
+    const { nounPlural } = entityDataType;
+    const { createNotification } = useNotificationsContext();
+    const [confirmationData, setConfirmationData] = useState<OperationConfirmationData>();
+    const [loading, setLoading] = useState<LoadingState>(LoadingState.INITIALIZED);
+    const [error, setError] = useState<string>();
+    const [showProgress, setShowProgress] = useState<boolean>(false);
+    const [numConfirmed, setNumConfirmed] = useState<number>(0);
+
+    let rowIds;
+    let numSelected = 0;
+    let selectionKey: string;
+    if (useSelected) {
+        selectionKey = queryModel.selectionKey;
+    } else if (queryModel.hasData) {
+        rowIds = [Object.keys(queryModel.rows)[0]];
+        numSelected = 1;
+    }
+
+    useEffect(
+        () => {
+            (async () => {
+                setLoading(LoadingState.LOADING);
+
+                try {
+                    const useSnapshotSelection = queryModel?.filterArray.length > 0;
+                    if (useSnapshotSelection) await setSnapshotSelections(selectionKey, [...queryModel.selections]);
+                    const confirmationData_ = await getMoveConfirmationData(
+                        entityDataType,
+                        rowIds,
+                        selectionKey,
+                        useSnapshotSelection
+                    );
+                    setConfirmationData(confirmationData_);
+                } catch (e) {
+                    console.error('There was a problem retrieving the move confirmation data.', e);
+                    setError('There was a problem retrieving the move confirmation data.');
+                } finally {
+                    setLoading(LoadingState.LOADED);
+                }
+            })();
+        },
+        [/* on mount only */]
+    );
+
+    const onConfirm = useCallback(
+        async (targetContainer: string, auditUserComment: string) => {
+            const movingAll = confirmationData.notAllowed.length === 0;
+            const count = confirmationData.allowed.length;
+            const noun = getEntityNoun(entityDataType, count);
+            setNumConfirmed(count);
+            setShowProgress(true);
+
+            try {
+                await moveFn(
+                    targetContainer,
+                    !movingAll ? confirmationData.allowed.map(a => a.RowId) : undefined,
+                    movingAll ? selectionKey : undefined, // TODO need useSnapshotSelection?
+                    auditUserComment
+                );
+
+                const projectUrl = buildURL(
+                    getCurrentAppProperties().controllerName,
+                    `${ActionURL.getAction() || 'app'}.view`,
+                    undefined,
+                    { container: targetContainer, returnUrl: false }
+                );
+
+                createNotification({
+                    message: (
+                        <>
+                             Successfully moved {count} {noun}.
+                             Go to <a href={projectUrl}>target project</a>.
+                            {/*TODO go to sample type page, that likely means we need to move this to the SampleMoveMenuItem */}
+                         </>
+                    ),
+                    alertClass: 'success',
+                });
+            } catch (message) {
+                setShowProgress(false);
+                createNotification({
+                    alertClass: 'danger',
+                    message: 'There was a problem moving the ' + noun + '. ' + message,
+                });
+            } finally {
+                actions.loadModel(queryModel.id, true, true);
+                onCancel();
+            }
+        },
+        [actions, confirmationData, createNotification, entityDataType, moveFn, onCancel, queryModel.id, selectionKey]
+    );
+
+    if (useSelected && maxSelected && numSelected > maxSelected) {
+        return (
+            <ConfirmModal
+                title={'Cannot Move ' + capitalizeFirstChar(nounPlural)}
+                onCancel={onCancel}
+                cancelButtonText="Dismiss"
+            >
+                You cannot move more than {maxSelected} individual {nounPlural} at a time. Please select fewer{' '}
+                {nounPlural} and try again.
+            </ConfirmModal>
+        );
+    }
+
+    if (isLoading(loading)) {
+        return (
+            <ConfirmModal title="Move to Project" onCancel={onCancel} cancelButtonText="Cancel">
+                <LoadingSpinner msg="Loading confirmation data" />
+            </ConfirmModal>
+        );
+    }
+
+    if (error) {
+        return (
+            <ConfirmModal title="Move to Project" onCancel={onCancel} cancelButtonText="Dismiss">
+                <Alert>{error}</Alert>
+            </ConfirmModal>
+        );
+    }
+
+    const { canMove, message, title } = getMoveConfirmationProperties(
+        confirmationData,
+        entityDataType.nounSingular,
+        entityDataType.nounPlural
+    );
+
+    if (!canMove) {
+        return (
+            <ConfirmModal
+                title={'Cannot Move ' + capitalizeFirstChar(nounPlural)}
+                onCancel={onCancel}
+                cancelButtonText="Dismiss"
+            >
+                <Alert>{message}</Alert>
+            </ConfirmModal>
+        );
+    }
+
+    return (
+        <>
+            {!showProgress && (
+                <EntityMoveConfirmationModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Move"
+                    onCancel={onCancel}
+                    onConfirm={onConfirm}
+                    title={title}
+                >
+                    {message}
+                </EntityMoveConfirmationModal>
+            )}
+            <Progress
+                modal={true}
+                estimate={numConfirmed * 10} // TODO update estimate accordingly
+                title={`Moving ${numConfirmed} ${getEntityNoun(entityDataType, numConfirmed)}`}
+                toggle={showProgress}
+            />
+        </>
+    );
+});
+
+const getMoveConfirmationProperties = (
+    confirmationData: OperationConfirmationData,
+    nounSingular: string,
+    nounPlural: string
+): { canMove: boolean; message: any; title: string } => {
+    if (!confirmationData) return undefined;
+
+    const capNounSingular = capitalizeFirstChar(nounSingular);
+    const capNounPlural = capitalizeFirstChar(nounPlural);
+    const dependencyText = 'status that prevents moving';
+    const numCanMove = confirmationData.allowed.length;
+    const numCannotMove = confirmationData.notAllowed.length;
+    const canMoveNoun = numCanMove === 1 ? capNounSingular : capNounPlural;
+    const cannotMoveNoun = numCannotMove === 1 ? nounSingular : nounPlural;
+    const totalNum = numCanMove + numCannotMove;
+    const totalNoun = totalNum === 1 ? nounSingular : nounPlural;
+
+    let text;
+    if (totalNum === 0) {
+        text =
+            'Either no ' +
+            nounPlural +
+            ' are selected for moving or the selected ' +
+            nounPlural +
+            ' are no longer valid.';
+    } else if (numCannotMove === 0) {
+        text = totalNum === 1 ? 'The selected ' : totalNum === 2 ? 'Both ' : 'All ' + totalNum + ' ';
+        text += totalNoun + ' will be moved.';
+    } else if (numCanMove === 0) {
+        if (totalNum === 1) {
+            text = 'The ' + totalNoun + " you've selected cannot be moved because it has a " + dependencyText + '.  ';
+        } else {
+            text = numCannotMove === 2 ? 'Neither of' : 'None of';
+            text += ' the ' + totalNum + ' ' + totalNoun + " you've selected can be moved";
+            text += ' because they have a ' + dependencyText + '.';
+        }
+    } else {
+        text = [];
+        let firstText = "You've selected " + totalNum + ' ' + totalNoun + ' but only ' + numCanMove + ' can be moved. ';
+        firstText += numCannotMove + ' ' + cannotMoveNoun + ' cannot be moved because ';
+        firstText += (numCannotMove === 1 ? ' it has ' : ' they have ') + dependencyText + '.';
+        text.push(<React.Fragment key="commonText">{firstText}</React.Fragment>);
+    }
+
+    let message;
+    if (numCannotMove > 0) {
+        message = (
+            <Alert bsStyle="warning">
+                {text}
+                {numCannotMove > 0 && (
+                    <>
+                        &nbsp;(<HelpLink topic={MOVE_SAMPLES_TOPIC}>more info</HelpLink>)
+                    </>
+                )}
+            </Alert>
+        );
+    }
+
+    return {
+        message,
+        title:
+            numCanMove > 0
+                ? 'Move ' + numCanMove + ' ' + canMoveNoun
+                : totalNum === 1
+                ? 'Cannot Move ' + capNounSingular
+                : 'No ' + capNounPlural + ' Can Be Moved',
+        canMove: numCanMove > 0,
+    };
+};

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -107,7 +107,7 @@ export const EntityMoveModal: FC<Props> = memo(props => {
         async (targetContainerPath: string, targetName: string, auditUserComment: string) => {
             const movingAll = confirmationData.notAllowed.length === 0;
             const count = confirmationData.allowed.length;
-            const noun = getEntityNoun(entityDataType, count);
+            const noun = getEntityNoun(entityDataType, count)?.toLowerCase();
             setNumConfirmed(count);
             setShowProgress(true);
 
@@ -179,8 +179,8 @@ export const EntityMoveModal: FC<Props> = memo(props => {
                 onCancel={onCancel}
                 cancelButtonText="Dismiss"
             >
-                You cannot move more than {maxSelected} individual {nounPlural} at a time. Please select fewer{' '}
-                {nounPlural} and try again.
+                You cannot move more than {maxSelected} individual {nounPlural.toLowerCase()} at a time. Please select
+                fewer {nounPlural.toLowerCase()} and try again.
             </ConfirmModal>
         );
     }

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -193,6 +193,7 @@ export const EntityMoveModal: FC<Props> = memo(props => {
                 <EntityMoveConfirmationModal
                     cancelButtonText="Cancel"
                     confirmButtonText="Move"
+                    nounPlural={nounPlural}
                     onCancel={onCancel}
                     onConfirm={onConfirm}
                     title={title}

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -21,12 +21,13 @@ import { AppURL, buildURL } from '../../url/AppURL';
 
 import { getCurrentAppProperties } from '../../app/utils';
 
-import { getMoveConfirmationData } from './actions';
 import { EntityDataType, OperationConfirmationData } from './models';
 import { getEntityNoun } from './utils';
 import { EntityMoveConfirmationModal } from './EntityMoveConfirmationModal';
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
-interface Props {
+export interface EntityMoveModalProps {
+    api?: ComponentsAPIWrapper;
     entityDataType: EntityDataType;
     maxSelected: number;
     moveFn: (
@@ -45,8 +46,9 @@ interface Props {
     useSelected: boolean;
 }
 
-export const EntityMoveModal: FC<Props> = memo(props => {
+export const EntityMoveModal: FC<EntityMoveModalProps> = memo(props => {
     const {
+        api = getDefaultAPIWrapper(),
         onAfterMove,
         sourceContainer,
         queryModel,
@@ -83,7 +85,7 @@ export const EntityMoveModal: FC<Props> = memo(props => {
                 try {
                     const useSnapshotSelection = queryModel?.filterArray.length > 0;
                     if (useSnapshotSelection) await setSnapshotSelections(selectionKey, [...queryModel.selections]);
-                    const confirmationData_ = await getMoveConfirmationData(
+                    const confirmationData_ = await api.entity.getMoveConfirmationData(
                         entityDataType,
                         rowIds,
                         selectionKey,
@@ -244,7 +246,8 @@ export const EntityMoveModal: FC<Props> = memo(props => {
     );
 });
 
-const getMoveConfirmationProperties = (
+// exported for jest testing
+export const getMoveConfirmationProperties = (
     confirmationData: OperationConfirmationData,
     nounSingular: string,
     nounPlural: string

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -21,10 +21,11 @@ import { AppURL, buildURL } from '../../url/AppURL';
 
 import { getCurrentAppProperties } from '../../app/utils';
 
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
+
 import { EntityDataType, OperationConfirmationData } from './models';
 import { getEntityNoun } from './utils';
 import { EntityMoveConfirmationModal } from './EntityMoveConfirmationModal';
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 export interface EntityMoveModalProps {
     api?: ComponentsAPIWrapper;

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -32,6 +32,7 @@ import {
     IParentOption, MoveSamplesResult,
     OperationConfirmationData,
 } from './models';
+import {Container} from "../base/models/Container";
 
 export function getOperationConfirmationData(
     dataType: EntityDataType,
@@ -740,6 +741,7 @@ export function getMoveConfirmationData(
 }
 
 export function moveSamples(
+    sourceContainer: Container,
     targetContainer: string,
     rowIds: number[],
     selectionKey: string,
@@ -761,7 +763,7 @@ export function moveSamples(
         }
 
         return Ajax.request({
-            url: buildURL('experiment', 'moveSamples.api'),
+            url: buildURL('experiment', 'moveSamples.api', undefined, { container: sourceContainer?.path }),
             method: 'POST',
             params,
             success: Utils.getCallbackWrapper(response => {

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1,4 +1,4 @@
-import {ActionURL, Ajax, AuditBehaviorTypes, Filter, Query, Utils} from '@labkey/api';
+import { ActionURL, Ajax, AuditBehaviorTypes, Filter, Query, Utils } from '@labkey/api';
 import { List, Map } from 'immutable';
 
 import { buildURL } from '../../url/AppURL';
@@ -18,6 +18,8 @@ import { Row, selectRows, SelectRowsResponse } from '../../query/selectRows';
 
 import { ViewInfo } from '../../ViewInfo';
 
+import { Container } from '../base/models/Container';
+
 import { getInitialParentChoices, isDataClassEntity, isSampleEntity } from './utils';
 import { DataClassDataType, DataOperation, SampleTypeDataType } from './constants';
 import {
@@ -29,10 +31,10 @@ import {
     EntityParentType,
     EntityTypeOption,
     IEntityTypeOption,
-    IParentOption, MoveSamplesResult,
+    IParentOption,
+    MoveSamplesResult,
     OperationConfirmationData,
 } from './models';
-import {Container} from "../base/models/Container";
 
 export function getOperationConfirmationData(
     dataType: EntityDataType,
@@ -734,8 +736,8 @@ export function getMoveConfirmationData(
         useSnapshotSelection,
         isDataClassEntity(dataType)
             ? {
-                dataOperation: DataOperation.Move,
-            }
+                  dataOperation: DataOperation.Move,
+              }
             : undefined
     );
 }

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -745,10 +745,10 @@ export function getMoveConfirmationData(
 export function moveSamples(
     sourceContainer: Container,
     targetContainer: string,
-    rowIds: number[],
-    selectionKey: string,
-    useSnapshotSelection: boolean,
-    userComment: string
+    rowIds?: number[],
+    selectionKey?: string,
+    useSnapshotSelection?: boolean,
+    userComment?: string
 ): Promise<MoveSamplesResult> {
     return new Promise((resolve, reject) => {
         const params = {

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -743,6 +743,7 @@ export function moveSamples(
     targetContainer: string,
     rowIds: number[],
     selectionKey: string,
+    useSnapshotSelection: boolean,
     userComment: string
 ): Promise<MoveSamplesResult> {
     return new Promise((resolve, reject) => {
@@ -751,8 +752,13 @@ export function moveSamples(
             targetContainer,
             userComment,
         };
-        if (rowIds) params['rowIds'] = rowIds;
-        else if (selectionKey) params['dataRegionSelectionKey'] = selectionKey;
+        if (rowIds) {
+            params['rowIds'] = rowIds;
+        }
+        if (selectionKey) {
+            params['dataRegionSelectionKey'] = selectionKey;
+            params['useSnapshotSelection'] = useSnapshotSelection;
+        }
 
         return Ajax.request({
             url: buildURL('experiment', 'moveSamples.api'),

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -171,4 +171,5 @@ export const ParentEntityRequiredColumns = SCHEMAS.CBMB.concat(
 export enum DataOperation {
     EditLineage,
     Delete,
+    Move,
 }

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -559,7 +559,7 @@ export class OperationConfirmationData {
 
     readonly allowed: any[];
     readonly notAllowed: any[];
-    readonly idMap: { isAllowed: boolean; key: number };
+    readonly idMap: Record<number, boolean>;
 
     constructor(values?: Partial<OperationConfirmationData>) {
         Object.assign(this, values);

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -624,3 +624,8 @@ export interface IParentAlias {
     isDupe?: boolean;
     parentValue: IParentOption;
 }
+
+export interface MoveSamplesResult {
+    containerPath: string;
+    updateCounts: Record<string, number>;
+}

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -627,5 +627,6 @@ export interface IParentAlias {
 
 export interface MoveSamplesResult {
     containerPath: string;
+    success: boolean;
     updateCounts: Record<string, number>;
 }

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -114,8 +114,11 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
     }
 
     getOverlay() {
-        const { column, placement, canMouseOverTooltip } = this.props;
+        const { column, placement, canMouseOverTooltip, helpTipRenderer } = this.props;
         const label = this.props.label ? this.props.label : column ? column.caption : null;
+
+        if (helpTipRenderer === 'NONE') return null;
+
         return !canMouseOverTooltip ? (
             <OverlayTrigger placement={placement} overlay={this.overlayContent()}>
                 <i className="fa fa-question-circle" />

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -66,6 +66,7 @@ export enum SampleOperation {
     AddAssayData,
     LinkToStudy,
     RecallFromStudy,
+    Move,
 }
 
 export enum SampleStateType {

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -92,6 +92,7 @@ export const permittedOps = {
         SampleOperation.AddAssayData,
         SampleOperation.LinkToStudy,
         SampleOperation.RecallFromStudy,
+        SampleOperation.Move,
     ]),
     [SampleStateType.Locked]: new Set([SampleOperation.AddToPicklist]),
 };

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -171,10 +171,7 @@ export const DEFAULT_SAMPLE_FIELD_CONFIG = {
 export const ALIQUOTED_FROM_COL = 'AliquotedFrom';
 const STATUS_COL = 'Status';
 
-export const AMOUNT_AND_UNITS_COLUMNS = [
-    'StoredAmount',
-    'Units'
-];
+export const AMOUNT_AND_UNITS_COLUMNS = ['StoredAmount', 'Units'];
 
 export const AMOUNT_AND_UNITS_COLUMNS_LC = AMOUNT_AND_UNITS_COLUMNS.map(col => col.toLowerCase());
 

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -182,6 +182,7 @@ export enum SamplesEditButtonSections {
     FIND_DERIVATIVES = 'findderivatives',
     IMPORT = 'import',
     LINKTOSTUDY = 'linktostudy',
+    MOVETOPROJECT = 'movetoproject',
 }
 
 export function isSamplesSchema(schemaQuery: SchemaQuery): boolean {

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -182,8 +182,8 @@ export enum SamplesEditButtonSections {
     EDIT_PARENT = 'editparent',
     FIND_DERIVATIVES = 'findderivatives',
     IMPORT = 'import',
-    LINKTOSTUDY = 'linktostudy',
-    MOVETOPROJECT = 'movetoproject',
+    LINK_TO_STUDY = 'linktostudy',
+    MOVE_TO_PROJECT = 'movetoproject',
 }
 
 export function isSamplesSchema(schemaQuery: SchemaQuery): boolean {

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 
 import { Filter, Query } from '@labkey/api';
 
+import { List } from 'immutable';
+
 import { User } from '../base/models/User';
 
 import {
     isFreezerManagementEnabled,
     isProductProjectsEnabled,
     isProjectContainer,
-    isSampleStatusEnabled
+    isSampleStatusEnabled,
 } from '../../app/utils';
 
 import { OperationConfirmationData } from '../entities/models';
@@ -38,7 +40,6 @@ import {
     SampleOperation,
     SampleStateType,
 } from './constants';
-import { List } from 'immutable';
 
 export function getOmittedSampleTypeColumns(user: User, moduleContext?: ModuleContext): string[] {
     let cols: string[] = [];
@@ -260,7 +261,6 @@ export function getSampleDomainDefaultSystemFields(moduleContext?: ModuleContext
         : SAMPLE_DOMAIN_DEFAULT_SYSTEM_FIELDS;
 }
 
-
 export function getStorageItemUpdateData(
     storageRows: any[],
     sampleItems: {},
@@ -303,18 +303,20 @@ export function getStorageItemUpdateData(
     };
 }
 
-export function getSampleStatusLockedMessage(state: SampleState, saving: boolean) : string {
-    let msgs = [];
-    if (state?.inUse || saving)
-        msgs.push('cannot change status type or be deleted because it is in use');
+export function getSampleStatusLockedMessage(state: SampleState, saving: boolean): string {
+    const msgs = [];
+    if (state?.inUse || saving) msgs.push('cannot change status type or be deleted because it is in use');
     if (state && !state.isLocal)
         msgs.push('can be changed only in the ' + state.containerPath.substring(1) + ' project');
-    if (msgs.length > 0)
-        return 'This sample status ' + msgs.join(' and ') + '.'
+    if (msgs.length > 0) return 'This sample status ' + msgs.join(' and ') + '.';
     return undefined;
 }
 
-export function getSampleStatusContainerFilter(forLegend?: boolean, containerPath?: string, moduleContext?: ModuleContext) : Query.ContainerFilter {
+export function getSampleStatusContainerFilter(
+    forLegend?: boolean,
+    containerPath?: string,
+    moduleContext?: ModuleContext
+): Query.ContainerFilter {
     // Check to see if product projects support is enabled.
     if (!isProductProjectsEnabled(moduleContext)) {
         return undefined;

--- a/packages/components/src/internal/util/helpLinks.tsx
+++ b/packages/components/src/internal/util/helpLinks.tsx
@@ -27,6 +27,7 @@ export const DEFINE_ISSUES_LIST_TOPIC = 'adminIssues';
 export const DEFINE_DATASET_TOPIC = 'createDataset';
 export const DATASET_PROPERTIES_TOPIC = 'datasetProperties#advanced';
 
+export const MOVE_SAMPLES_TOPIC = 'viewSampleSets#move';
 export const DELETE_SAMPLES_TOPIC = 'viewSampleSets#delete';
 export const DERIVE_SAMPLES_TOPIC = 'deriveSamples';
 export const DERIVE_SAMPLES_ALIAS_TOPIC = DERIVE_SAMPLES_TOPIC + '#alias';


### PR DESCRIPTION
#### Rationale
We have been working on the backend code for moving samples between projects/containers with the app context. This PR is the initial UI for wiring up that new action API call so that you can move samples from the app sample type grids or from a single sample's overview page.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1180
- https://github.com/LabKey/labkey-ui-premium/pull/82
- https://github.com/LabKey/platform/pull/4343
- https://github.com/LabKey/biologics/pull/2105
- https://github.com/LabKey/inventory/pull/833
- https://github.com/LabKey/sampleManagement/pull/1792

#### Changes
- add new SampleMoveMenuItem and EntityMoveModal to be used by the SamplesEditButton
-  add getMoveConfirmationData and moveSamples API action calls
-  handle selectionKey for useSnapshotSelection case
-  add move menu item to sample overview page and usage of EntityMoveModal
