### PR TITLE
Issue 47756: Use categories to filter search results server-side instead of client-side

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.331.1-searchCategories.3",
+  "version": "2.332.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.331.1-searchCategories.2",
+  "version": "2.331.1-searchCategories.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.329.1",
+  "version": "2.329.2-searchCategories.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.332.0
+*Released*: 27 April 202
 - Issue 47756: Use categories to filter search results server-side instead of client-side
 
 ### version 2.331.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 47756: Use categories to filter search results server-side instead of client-side
+
 ### version 2.329.1
 *Released*: 20 April 2023
 - Support for restricted issue lists

--- a/packages/components/src/entities/EntityInsertPanel.spec.tsx
+++ b/packages/components/src/entities/EntityInsertPanel.spec.tsx
@@ -303,7 +303,7 @@ describe('EntityInsertPanel', () => {
                     )}
                 </div>
             );
-            expect(wrapper.text()).toContain('alsoAllowed cannot be updated and and will be ignored.');
+            expect(wrapper.text()).toContain('alsoAllowed cannot be updated and will be ignored.');
             wrapper.unmount();
         });
     });

--- a/packages/components/src/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/entities/EntityInsertPanel.tsx
@@ -231,7 +231,7 @@ export function getNoUpdateFieldWarnings(
         msg.push(
             <p key="noUpdateFields">
                 <WarningFieldList names={noUpdateFields} />
-                {' cannot be updated and and will be ignored.'}
+                {' cannot be updated and will be ignored.'}
             </p>
         );
     }

--- a/packages/components/src/internal/components/search/SearchPanel.spec.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.spec.tsx
@@ -18,7 +18,7 @@ import { getProcessedSearchHits } from './actions';
 const DEFAULT_PROPS = {
     appName: 'test',
     offset: undefined,
-    onPage: jest.fn(),
+    onPageChange: jest.fn(),
     search: jest.fn(),
     searchResultsModel: undefined,
     searchTerm: undefined,
@@ -64,9 +64,9 @@ describe('<SearchPanelImpl />', () => {
         expect(wrapper.find('.search-form')).toHaveLength(1);
         expect(wrapper.find('HelpLink.search-form__help-link')).toHaveLength(1);
 
-        // No search term set, so no result message or results
+        // Search term set so we have all results
         expect(wrapper.find('.search-panel__no-results')).toHaveLength(0);
-        expect(wrapper.find(SearchResultCard)).toHaveLength(47);
+        expect(wrapper.find(SearchResultCard)).toHaveLength(49);
         expect(wrapper.find(PaginationButtons)).toHaveLength(0);
     });
 
@@ -120,7 +120,7 @@ describe('<SearchPanelImpl />', () => {
 
         // Search term set, so no "no-result" message
         expect(wrapper.find('.search-panel__no-results')).toHaveLength(0);
-        expect(wrapper.find(SearchResultCard)).toHaveLength(47);
+        expect(wrapper.find(SearchResultCard)).toHaveLength(49);
         // All results fit on the page, so no pagination buttons
         expect(wrapper.find(PaginationButtons)).toHaveLength(0);
     });
@@ -149,7 +149,7 @@ describe('<SearchPanelImpl />', () => {
 
         // Search term set, so no "no-results" message
         expect(wrapper.find('.search-panel__no-results')).toHaveLength(0);
-        expect(wrapper.find(SearchResultCard)).toHaveLength(7);
+        expect(wrapper.find(SearchResultCard)).toHaveLength(9);
         expect(wrapper.find(PaginationButtons)).toHaveLength(1);
         expect(wrapper.find('.pagination-buttons__info').text()).toBe('41 - 47 of 47');
     });

--- a/packages/components/src/internal/components/search/SearchPanel.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.tsx
@@ -19,6 +19,7 @@ import { SearchResultsModel } from './models';
 import { SEARCH_HELP_TOPIC, SEARCH_PAGE_DEFAULT_SIZE, SearchScope } from './constants';
 import { GetCardDataFn, searchUsingIndex } from './actions';
 import { getSearchScopeFromContainerFilter } from './utils';
+import { biologicsIsPrimaryApp } from '../../app/utils';
 
 interface SearchPanelProps {
     appName: string;
@@ -145,11 +146,13 @@ export const SearchPanelImpl: FC<Props> = memo(props => {
     );
 });
 
-const SEARCH_CATEGORIES = ['assay', 'data', 'material', 'fileWorkflowJob', 'workflowJob', 'file', 'notebook', 'notebookTemplate'];
+const SEARCH_CATEGORIES = ['assay', 'data', 'material', 'fileWorkflowJob', 'workflowJob', 'file', 'notebook', 'notebookTemplate', 'materialSource', 'dataClass'];
+const MEDIA_SEARCH_CATEGORIES = ['media'];
 
 export const SearchPanel: FC<SearchPanelProps> = memo(props => {
     const { searchTerm, getCardDataFn, search, pageSize = SEARCH_PAGE_DEFAULT_SIZE, offset = 0 } = props;
     const [model, setModel] = useState<SearchResultsModel>(SearchResultsModel.create({ isLoading: true }));
+    const categories = biologicsIsPrimaryApp() ? [...SEARCH_CATEGORIES, ...MEDIA_SEARCH_CATEGORIES] : SEARCH_CATEGORIES;
 
     const loadSearchResults = useCallback(async () => {
         if (searchTerm) {
@@ -161,7 +164,7 @@ export const SearchPanel: FC<SearchPanelProps> = memo(props => {
                         normalizeUrls: true, // this flag will remove the containerID from the returned URL
                         q: searchTerm,
                         scope: getSearchScopeFromContainerFilter(getContainerFilter()),
-                        category: SEARCH_CATEGORIES.join("+"),
+                        category: categories.join("+"),
                         limit: pageSize,
                         offset,
                     },

--- a/packages/components/src/internal/components/search/SearchPanel.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.tsx
@@ -159,6 +159,7 @@ export const SearchPanel: FC<SearchPanelProps> = memo(props => {
                         normalizeUrls: true, // this flag will remove the containerID from the returned URL
                         q: searchTerm,
                         scope: getSearchScopeFromContainerFilter(getContainerFilter()),
+                        category: ['assay', 'data', 'material', 'workflowJob', 'file', 'file workflowJob', 'notebook', 'notebookTemplate'].join("+"),
                         limit: pageSize,
                         offset,
                     },

--- a/packages/components/src/internal/components/search/SearchPanel.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.tsx
@@ -145,6 +145,8 @@ export const SearchPanelImpl: FC<Props> = memo(props => {
     );
 });
 
+const SEARCH_CATEGORIES = ['assay', 'data', 'material', 'workflowJob', 'file', 'file workflowJob', 'notebook', 'notebookTemplate'];
+
 export const SearchPanel: FC<SearchPanelProps> = memo(props => {
     const { searchTerm, getCardDataFn, search, pageSize = SEARCH_PAGE_DEFAULT_SIZE, offset = 0 } = props;
     const [model, setModel] = useState<SearchResultsModel>(SearchResultsModel.create({ isLoading: true }));
@@ -159,7 +161,7 @@ export const SearchPanel: FC<SearchPanelProps> = memo(props => {
                         normalizeUrls: true, // this flag will remove the containerID from the returned URL
                         q: searchTerm,
                         scope: getSearchScopeFromContainerFilter(getContainerFilter()),
-                        category: ['assay', 'data', 'material', 'workflowJob', 'file', 'file workflowJob', 'notebook', 'notebookTemplate'].join("+"),
+                        category: SEARCH_CATEGORIES.join("+"),
                         limit: pageSize,
                         offset,
                     },

--- a/packages/components/src/internal/components/search/SearchPanel.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.tsx
@@ -145,7 +145,7 @@ export const SearchPanelImpl: FC<Props> = memo(props => {
     );
 });
 
-const SEARCH_CATEGORIES = ['assay', 'data', 'material', 'workflowJob', 'file', 'file workflowJob', 'notebook', 'notebookTemplate'];
+const SEARCH_CATEGORIES = ['assay', 'data', 'material', 'fileWorkflowJob', 'workflowJob', 'file', 'notebook', 'notebookTemplate'];
 
 export const SearchPanel: FC<SearchPanelProps> = memo(props => {
     const { searchTerm, getCardDataFn, search, pageSize = SEARCH_PAGE_DEFAULT_SIZE, offset = 0 } = props;

--- a/packages/components/src/internal/components/search/SearchResultsPanel.spec.tsx
+++ b/packages/components/src/internal/components/search/SearchResultsPanel.spec.tsx
@@ -73,7 +73,7 @@ describe('<SearchResultsPanel/>', () => {
         const wrapper = mount(component);
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
         expect(wrapper.find(Alert)).toHaveLength(0);
-        expect(wrapper.find(SearchResultCard)).toHaveLength(47);
+        expect(wrapper.find(SearchResultCard)).toHaveLength(49);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/search/actions.spec.ts
+++ b/packages/components/src/internal/components/search/actions.spec.ts
@@ -154,7 +154,7 @@ describe('getProcessedSearchHits', () => {
         {
             id: 4,
             title: 'Test file workflowJob',
-            category: 'file workflowJob',
+            category: 'fileWorkflowJob',
         },
         {
             id: 5,
@@ -171,23 +171,13 @@ describe('getProcessedSearchHits', () => {
 
     test('default category filters', () => {
         const filteredHits = getProcessedSearchHits(SEARCH_RESULTS);
-        expect(filteredHits).toHaveLength(5);
+        expect(filteredHits).toHaveLength(6);
         expect(filteredHits[0].title).toBe(SEARCH_RESULTS[0].title);
         expect(filteredHits[1].title).toBe(SEARCH_RESULTS[1].title);
         expect(filteredHits[2].title).toBe(SEARCH_RESULTS[2].title);
         expect(filteredHits[3].title).toBe(SEARCH_RESULTS[3].title);
-        expect(filteredHits[4].title).toBe(SEARCH_RESULTS[5].title);
-    });
-
-    test('custom category filters', () => {
-        let filteredHits = getProcessedSearchHits(SEARCH_RESULTS, undefined, ['other']);
-        expect(filteredHits).toHaveLength(2);
-        expect(filteredHits[0].title).toBe(SEARCH_RESULTS[4].title);
-        expect(filteredHits[1].title).toBe(SEARCH_RESULTS[5].title);
-
-        filteredHits = getProcessedSearchHits(SEARCH_RESULTS, undefined, []);
-        expect(filteredHits).toHaveLength(1);
-        expect(filteredHits[0].title).toBe(SEARCH_RESULTS[5].title);
+        expect(filteredHits[4].title).toBe(SEARCH_RESULTS[4].title);
+        expect(filteredHits[5].title).toBe(SEARCH_RESULTS[5].title);
     });
 });
 

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -54,6 +54,9 @@ export function searchUsingIndex(
         containerPath = getProjectPath();
         options.scope = SearchScope.FolderAndSubfoldersAndShared;
     }
+    if (filterCategories) {
+        options.category = filterCategories?.join("+");
+    }
 
     return new Promise((resolve, reject) => {
         Ajax.request({
@@ -64,7 +67,7 @@ export function searchUsingIndex(
             success: Utils.getCallbackWrapper(json => {
                 addDataObjects(json);
                 const results = new URLResolver().resolveSearchUsingIndex(json);
-                const hits = getProcessedSearchHits(results['hits'], getCardDataFn, filterCategories);
+                const hits = getProcessedSearchHits(results['hits'], getCardDataFn);
                 resolve({ ...results, hits });
             }),
             failure: Utils.getCallbackWrapper(json => reject(json), null, false),
@@ -190,11 +193,11 @@ function getCardData(
     return cardData;
 }
 
-// TODO: add categories for other search results so the result['data'] check could be removed.
+// TODO: is the result['data'] check still required?
 export function getProcessedSearchHits(
     hits: any[],
     getCardDataFn?: (data: Map<any, any>, category?: string) => SearchResultCardData,
-    filterCategories = ['assay', 'data', 'material', 'workflowJob', 'file', 'file workflowJob', 'notebook', 'notebookTemplate']
+    filterCategories?: string[]
 ): any[] {
     return hits
         ?.filter(result => {

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -193,17 +193,12 @@ function getCardData(
     return cardData;
 }
 
-// TODO: is the result['data'] check still required?
 export function getProcessedSearchHits(
     hits: any[],
     getCardDataFn?: (data: Map<any, any>, category?: string) => SearchResultCardData,
-    filterCategories?: string[]
 ): any[] {
     return hits
-        ?.filter(result => {
-            return filterCategories?.indexOf(result.category) > -1 || result.data;
-        })
-        .map(result => ({
+        ?.map(result => ({
             ...result,
             cardData: getCardData(result.category, result.data, result.title, getCardDataFn),
         }));


### PR DESCRIPTION
#### Rationale
[Issue 47756](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47756) Before we introduced pagination of results, filtering of results returned from search queries client-side produced no functional difference for users, even if less efficient than having it done server-side, but now that we are paginating results, filtering client-side produces incomplete pages of results.   With this change, we'll likely be eliminating results that don't have categories (depending on the strictness of the "SHOULD" filter for Lucene), but it doesn't seem like that is problematic since all objects of interest to the applications seem to have categories.  If we find there are things that are not returned when searching, we can add a category to the objects in the search index and augment the categories we query for.

#### Related Pull Requests

- https://github.com/LabKey/inventory/pull/835
- https://github.com/LabKey/biologics/pull/2109
- https://github.com/LabKey/sampleManagement/pull/1799
- https://github.com/LabKey/platform/pull/4359
- https://github.com/LabKey/labbook/pull/474

#### Changes
- Pass categories through the search query 
