### PR TITLE
App assay import / re-import fixes for 23.5

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.332.0-fb-sm235FixesCory.0",
+  "version": "2.332.0-fb-sm235FixesCory.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.331.0",
+  "version": "2.331.0-fb-sm235FixesCory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.332.0-fb-sm235FixesCory.1",
+  "version": "2.332.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.331.0-fb-sm235FixesCory.0",
+  "version": "2.331.0-fb-sm235FixesCory.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.332.0",
+  "version": "2.332.0-fb-sm235FixesCory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD April 2023
+### version 2.332.1
+*Released*: 28 April 202
 * Issue 47749: Assay re-import run from tmp file to use TSV loader for file preview
 * Issue 47576: AssayImportPanels change so that if there are wrapped columns that are marked as userEditable and shownInInsertView, include them in the form / UI
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD April 2023
+* Issue 47749: Assay re-import run from tmp file to use TSV loader for file preview
+
 ### version 2.331.0
 *Released*: 26 April 2023
 * Performance Evaluation for Data at Scale - Improve Insert/UpdateRows calls

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD April 2023
 * Issue 47749: Assay re-import run from tmp file to use TSV loader for file preview
+* Issue 47576: AssayImportPanels change so that if there are wrapped columns that are marked as userEditable and shownInInsertView, include them in the form / UI
 
 ### version 2.331.0
 *Released*: 26 April 2023

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -33,7 +33,7 @@ import { insertColumnFilter, Operation, QueryColumn, QueryLookup } from './publi
 import { QuerySort } from './public/QuerySort';
 import { LastActionStatus, MessageLevel } from './internal/LastActionStatus';
 import { InferDomainResponse } from './public/InferDomainResponse';
-import { getServerFilePreview, inferDomainFromFile } from './internal/components/assay/utils';
+import { inferDomainFromFile } from './internal/components/assay/utils';
 import { ViewInfo } from './internal/ViewInfo';
 import { QueryInfo, QueryInfoStatus } from './public/QueryInfo';
 import { SchemaDetails } from './internal/SchemaDetails';
@@ -1205,7 +1205,6 @@ export {
     DOMAIN_RANGE_VALIDATOR,
     DomainDetails,
     inferDomainFromFile,
-    getServerFilePreview,
     InferDomainResponse,
     BasePropertiesPanel,
     AssayDesignerPanels,

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -5,8 +5,6 @@ import { QueryColumn } from '../public/QueryColumn';
 
 import { SchemaQuery } from '../public/SchemaQuery';
 
-import { QueryInfo } from '../public/QueryInfo';
-
 import { AssayUploadTabs } from './constants';
 
 import { AppURL, createProductUrlFromParts } from './url/AppURL';
@@ -284,7 +282,7 @@ export class AssayDefinitionModel extends Record({
         }
     }
 
-    getDomainColumns(type: AssayDomainTypes, queryInfo?: QueryInfo): OrderedMap<string, QueryColumn> {
+    getDomainColumns(type: AssayDomainTypes): OrderedMap<string, QueryColumn> {
         const columns = OrderedMap<string, QueryColumn>().asMutable();
 
         if (this.domains && this.domains.size) {
@@ -296,12 +294,6 @@ export class AssayDefinitionModel extends Record({
                 });
             }
         }
-
-        // Issue 47576: if there are wrapped columns that are marked as userEditable and shownInInsertView, include them in the form / UI
-        queryInfo?.columns.forEach(c => {
-            const shouldInclude = c.wrappedColumnName && c.userEditable && c.shownInInsertView;
-            if (shouldInclude) columns.set(c.fieldKey.toLowerCase(), c);
-        });
 
         return columns.asImmutable();
     }

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -5,13 +5,14 @@ import { QueryColumn } from '../public/QueryColumn';
 
 import { SchemaQuery } from '../public/SchemaQuery';
 
+import { QueryInfo } from '../public/QueryInfo';
+
 import { AssayUploadTabs } from './constants';
 
 import { AppURL, createProductUrlFromParts } from './url/AppURL';
 
 import { SCHEMAS } from './schemas';
 import { WHERE_FILTER_TYPE } from './url/WhereFilterType';
-import {QueryInfo} from "../public/QueryInfo";
 
 export enum AssayDomainTypes {
     BATCH = 'Batch',

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -59,6 +59,7 @@ import { loadSelectedSamples } from '../samples/actions';
 
 import { SampleOperation, STATUS_DATA_RETRIEVAL_ERROR } from '../samples/constants';
 import { getOperationNotPermittedMessage } from '../samples/utils';
+
 import {
     allowReimportAssayRun,
     checkForDuplicateAssayFiles,

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -15,6 +15,7 @@
  */
 import React, { PureComponent, ReactNode } from 'react';
 import { List, Map } from 'immutable';
+
 import { Operation } from '../../../public/QueryColumn';
 
 import { AssayUploadTabs } from '../../constants';
@@ -59,8 +60,8 @@ interface Props {
         dataKeys?: List<any>,
         data?: Map<any, Map<string, any>>
     ) => void;
-    operation: Operation;
     onTextChange: (value: any) => any;
+    operation: Operation;
     queryModel: QueryModel;
     runPropertiesRow?: Record<string, any>;
     setIsDirty?: (isDirty: boolean) => void;
@@ -294,8 +295,8 @@ export class RunDataPanel extends PureComponent<Props, State> {
                                                     <>
                                                         We recommend dividing your data into smaller files that meet
                                                         this limit. See our{' '}
-                                                        <HelpLink topic={DATA_IMPORT_TOPIC}>help document</HelpLink> for best
-                                                        practices on data import.
+                                                        <HelpLink topic={DATA_IMPORT_TOPIC}>help document</HelpLink> for
+                                                        best practices on data import.
                                                     </>
                                                 }
                                             />

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -132,7 +132,7 @@ export class RunDataPanel extends PureComponent<Props, State> {
                     const outputs = runPropertiesRow['DataOutputs'];
                     this.setState(() => ({ previousRunData: { isLoading: true, isLoaded: false } }));
 
-                    getServerFilePreview(outputs[0].value, PREVIEW_ROW_COUNT)
+                    getServerFilePreview(outputs[0].value, outputs[0].displayValue, PREVIEW_ROW_COUNT)
                         .then(response => {
                             this.setState(() => ({
                                 previousRunData: {

--- a/packages/components/src/internal/components/assay/utils.tsx
+++ b/packages/components/src/internal/components/assay/utils.tsx
@@ -39,9 +39,14 @@ export function inferDomainFromFile(
 /**
  * This is used for retrieving preview data for a file already on the server side
  * @param file  This can be a rowId for the file, or a path to the file
+ * @param file  The file name to be used to check the extension
  * @param numLinesToInclude: the number of lines of data to include (excludes the header)
  */
-export function getServerFilePreview(file: string, numLinesToInclude: number): Promise<InferDomainResponse> {
+export function getServerFilePreview(
+    file: string,
+    fileName: string,
+    numLinesToInclude: number
+): Promise<InferDomainResponse> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL('property', 'getFilePreview.api'),
@@ -49,6 +54,7 @@ export function getServerFilePreview(file: string, numLinesToInclude: number): P
             params: {
                 file,
                 numLinesToInclude: numLinesToInclude ? numLinesToInclude + 1 : undefined, // add one to account for the header
+                guessFormatAsTSV: fileName?.toLowerCase().endsWith('.tmp'), // Issue 47749
             },
             success: Utils.getCallbackWrapper(response => {
                 resolve(InferDomainResponse.create(response));

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -160,6 +160,7 @@ export class QueryColumn {
     declare userEditable: boolean;
     declare validValues: string[];
     // declare versionField: boolean;
+    declare wrappedColumnName: string;
 
     declare cell: Function;
     declare columnRenderer: string;

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -383,7 +383,11 @@ export class QueryColumn {
     }
 }
 
-export function insertColumnFilter(col: QueryColumn, includeFileInputs = true, isIncludedColumn?: (col: QueryColumn) => boolean): boolean {
+export function insertColumnFilter(
+    col: QueryColumn,
+    includeFileInputs = true,
+    isIncludedColumn?: (col: QueryColumn) => boolean
+): boolean {
     return (
         col &&
         col.removeFromViews !== true &&


### PR DESCRIPTION
#### Rationale
Issue [47749](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47749): Assay re-import run from tmp file to use TSV loader for file preview

Issue [47576](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47576): AssayImportPanels change so that if there are wrapped columns that are marked as userEditable and shownInInsertView, include them in the form / UI

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1183
- https://github.com/LabKey/platform/pull/4362
- https://github.com/LabKey/sampleManagement/pull/1805
- https://github.com/LabKey/biologics/pull/2112
- https://github.com/LabKey/inventory/pull/838

#### Changes
- AssayImportPanels update to check for wrapped columns from query info in batch and run insert forms
- getServerFilePreview to set guessFormatAsTSV for tmp file
