### PR TITLE
Issue 46747: Update lookup resolver to go to LKS when lookup is defined outside the app

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.333.2-lookupContainerResolution.1",
+  "version": "2.333.2-lookupContainerResolution.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.332.0",
+  "version": "2.332.1-lookupContainerResolution.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.333.2-lookupContainerResolution.2",
+  "version": "2.333.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### Version TBD
+#Released*: TBD
+- Issue 46747: Update lookup resolver to go to LKS when lookup is defined outside the app
+
 ### version 2.332.0
 *Released*: 27 April 202
 - Issue 47756: Use categories to filter search results server-side instead of client-side

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### Version TBD
-#Released*: TBD
+### Version 2.333.2
+#Released*: 3 May 2023
 - Issue 46747: Update lookup resolver to go to LKS when lookup is defined outside the app
 
 ### version 2.333.1

--- a/packages/components/src/internal/url/URLResolver.spec.ts
+++ b/packages/components/src/internal/url/URLResolver.spec.ts
@@ -8,7 +8,8 @@ import { registerDefaultURLMappers } from '../testHelpers';
 
 import { initUnitTestMocks } from '../../test/testHelperMocks';
 
-import { URLResolver } from './URLResolver';
+import { LookupMapper, URLResolver } from './URLResolver';
+import { AppURL } from './AppURL';
 
 beforeAll(() => {
     initUnitTestMocks();
@@ -25,6 +26,26 @@ describe('resolveSearchUsingIndex', () => {
         expect(resolved).toHaveProperty(['hits', 0]);
         expect(resolved).toHaveProperty(['hits', 0, 'url'], '#/samples/Molecule');
         expect(resolved).toHaveProperty(['hits', 0, 'data', 'name'], 'Molecule'); // not sure if this is best place to check this...
+    });
+});
+
+describe("LookupMapper", () => {
+    test('resolve without lookup container', () => {
+        const mapper = new LookupMapper('test', undefined);
+        const resolved = mapper.resolve("#/list/a", fromJS({value: 1}), fromJS({lookup: {schemaName: "list", queryName: "testing"}}));
+        expect(resolved).toStrictEqual(AppURL.create('test', "list", "testing", 1))
+    });
+
+    test('resolve with lookup container same as current', () => {
+        const mapper = new LookupMapper('test', undefined);
+        const resolved = mapper.resolve("#/list/a", fromJS({value: 1}), fromJS({lookup: {schemaName: "list", queryName: "testing", containerPath: LABKEY.container.path}}));
+        expect(resolved).toStrictEqual(AppURL.create('test', "list", "testing", 1))
+    });
+
+    test('resolve with different lookup container', () => {
+        const mapper = new LookupMapper('test', undefined);
+        const resolved = mapper.resolve("#/list/a", fromJS({value: 1}), fromJS({lookup: {schemaName: "list", queryName: "testing", containerPath: "/other/path"}}));
+        expect(resolved).toBeUndefined();
     });
 });
 

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -160,7 +160,8 @@ interface MapURLOptions {
     url: string;
 }
 
-class LookupMapper implements URLMapper {
+// exported for jest tests
+export class LookupMapper implements URLMapper {
     defaultPrefix: string;
     lookupResolvers: any;
 
@@ -188,7 +189,7 @@ class LookupMapper implements URLMapper {
             }
 
             // Issue 46747: When the lookup goes to a different container, don't rewrite the URL
-            const containerPath = ActionURL.getContainer();
+            const containerPath = getServerContext().container.path;
             if (lookupContainerPath && lookupContainerPath !== containerPath)
                 return undefined;
 

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -187,6 +187,7 @@ class LookupMapper implements URLMapper {
                 }
             }
 
+            // Issue 46747: When the lookup goes to a different container, don't rewrite the URL
             const containerPath = ActionURL.getContainer();
             if (lookupContainerPath && lookupContainerPath !== containerPath)
                 return undefined;

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -169,11 +169,12 @@ class LookupMapper implements URLMapper {
         this.lookupResolvers = lookupResolvers;
     }
 
-    resolve(url, row, column, schema, query): AppURL {
+    resolve(url, row, column): AppURL {
         if (column.has('lookup')) {
             var lookup = column.get('lookup'),
                 schema = lookup.get('schemaName'),
                 query = lookup.get('queryName'),
+                lookupContainerPath = lookup.get('containerPath'),
                 queryKey = [schema, query].join('-').toLowerCase(),
                 schemaKey = schema.toLowerCase();
 
@@ -185,6 +186,10 @@ class LookupMapper implements URLMapper {
                     return this.lookupResolvers[schemaKey](row, column, schema, query);
                 }
             }
+
+            const containerPath = ActionURL.getContainer();
+            if (lookupContainerPath && lookupContainerPath !== containerPath)
+                return undefined;
 
             const parts = [
                 this.defaultPrefix,


### PR DESCRIPTION
#### Rationale
[Issue 46747](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46747).  When a lookup references data in a different container, the `q` view within the application won't show the data. We opt to not resolve the URL so it will link out to the LKS detail for that lookup instead.

#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/2119
- https://github.com/LabKey/inventory/pull/843
- https://github.com/LabKey/sampleManagement/pull/1811
- https://github.com/LabKey/inventory/pull/843

#### Changes
- Update `LookupMapper` to compare container paths. 
