### PR TITLE
Adjust usages of auditBehavior to always use AuditBehaviorTypes.DETAILED

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.333.0",
+  "version": "2.333.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.332.3",
+  "version": "2.332.3-fb-auditBehaviorDetailed.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD May 2023
+### version 2.333.1
+*Released*: 3 May 2023
 * Adjust usages of auditBehavior to always use AuditBehaviorTypes.DETAILED
   * remove auditBehavior optional props since they were always passed in as DETAILED
   * remove getSampleAuditBehavior() since it was always using DETAILED

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD May 2023
+* Adjust usages of auditBehavior to always use AuditBehaviorTypes.DETAILED
+  * remove auditBehavior optional props since they were always passed in as DETAILED
+  * remove getSampleAuditBehavior() since it was always using DETAILED
+
 ### version 2.332.3
 *Released*: 1 May 2023
 * Move samples between project updates and containerFilter changes

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -22,7 +22,6 @@ import { EntityDeleteConfirmModal } from './EntityDeleteConfirmModal';
 
 interface Props {
     afterDelete: (rowsToKeep?: any[]) => void;
-    auditBehavior?: AuditBehaviorTypes;
     beforeDelete?: () => void;
     containerPath?: string;
     entityDataType: EntityDataType;
@@ -35,7 +34,6 @@ interface Props {
 
 export const EntityDeleteModal: FC<Props> = memo(props => {
     const {
-        auditBehavior,
         containerPath,
         queryModel,
         onCancel,
@@ -69,7 +67,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
 
             try {
                 await deleteRows({
-                    auditBehavior,
+                    auditBehavior: AuditBehaviorTypes.DETAILED,
                     auditUserComment,
                     containerPath,
                     rows: rowsToDelete,
@@ -86,16 +84,7 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
                 onCancel(); // close the modal so the error notification is more apparent.
             }
         },
-        [
-            afterDelete,
-            auditBehavior,
-            beforeDelete,
-            containerPath,
-            createNotification,
-            entityDataType,
-            onCancel,
-            queryModel.schemaQuery,
-        ]
+        [afterDelete, beforeDelete, containerPath, createNotification, entityDataType, onCancel, queryModel.schemaQuery]
     );
 
     if (useSelected && maxSelected && numSelected > maxSelected) {
@@ -135,6 +124,5 @@ export const EntityDeleteModal: FC<Props> = memo(props => {
 });
 
 EntityDeleteModal.defaultProps = {
-    auditBehavior: AuditBehaviorTypes.DETAILED,
     maxSelected: MAX_SELECTED_SAMPLES,
 };

--- a/packages/components/src/entities/EntityDeleteModal.tsx
+++ b/packages/components/src/entities/EntityDeleteModal.tsx
@@ -33,16 +33,8 @@ interface Props {
 }
 
 export const EntityDeleteModal: FC<Props> = memo(props => {
-    const {
-        containerPath,
-        queryModel,
-        onCancel,
-        afterDelete,
-        beforeDelete,
-        useSelected,
-        entityDataType,
-        maxSelected,
-    } = props;
+    const { containerPath, queryModel, onCancel, afterDelete, beforeDelete, useSelected, entityDataType, maxSelected } =
+        props;
     const { nounPlural } = entityDataType;
     const { createNotification } = useNotificationsContext();
     const [showProgress, setShowProgress] = useState<boolean>(false);

--- a/packages/components/src/entities/EntityInsertPanel.tsx
+++ b/packages/components/src/entities/EntityInsertPanel.tsx
@@ -16,7 +16,7 @@
 import React, { Component, FC, memo, ReactNode, useMemo } from 'react';
 import { Button } from 'react-bootstrap';
 import { List, Map, OrderedMap, fromJS } from 'immutable';
-import { AuditBehaviorTypes, Query, Utils } from '@labkey/api';
+import { Query, Utils } from '@labkey/api';
 
 import { Link } from 'react-router';
 
@@ -267,7 +267,6 @@ interface OwnProps {
     allowedNonDomainFields?: string[];
     api?: ComponentsAPIWrapper;
     asyncSize?: number; // the file size cutoff to enable async import. If undefined, async is not supported
-    auditBehavior?: AuditBehaviorTypes;
     canEditEntityTypeDetails?: boolean;
     combineParentTypes?: boolean; // Puts all parent types in one parent button. Name on the button will be the first parent type listed
     containerFilter?: Query.ContainerFilter;
@@ -347,7 +346,7 @@ enum EntityInsertPanelTabs {
     Second = 2,
 }
 
-export class EntityInsertPanelImpl extends Component<Props, State> {
+class EntityInsertPanelImpl extends Component<Props, State> {
     static defaultProps = {
         numPerParent: 1,
         tab: EntityInsertPanelTabs.First,
@@ -439,7 +438,6 @@ export class EntityInsertPanelImpl extends Component<Props, State> {
     init = async (): Promise<void> => {
         const {
             api,
-            auditBehavior,
             entityDataType,
             numPerParent,
             parentDataTypes,
@@ -489,7 +487,6 @@ export class EntityInsertPanelImpl extends Component<Props, State> {
         }
 
         insertModel = new EntityIdCreationModel({
-            auditBehavior,
             creationType,
             entityCount: 0,
             entityDataType,

--- a/packages/components/src/entities/EntityLineageEditMenuItem.tsx
+++ b/packages/components/src/entities/EntityLineageEditMenuItem.tsx
@@ -6,6 +6,7 @@ import { QueryModel } from '../public/QueryModel/QueryModel';
 import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuItem';
 
 import { EntityDataType } from '../internal/components/entities/models';
+
 import { EntityLineageEditModal } from './EntityLineageEditModal';
 
 interface Props {

--- a/packages/components/src/entities/EntityLineageEditMenuItem.tsx
+++ b/packages/components/src/entities/EntityLineageEditMenuItem.tsx
@@ -1,8 +1,6 @@
 import React, { FC, memo, useCallback, useState } from 'react';
 import { MenuItem } from 'react-bootstrap';
 
-import { AuditBehaviorTypes } from '@labkey/api';
-
 import { QueryModel } from '../public/QueryModel/QueryModel';
 
 import { SelectionMenuItem } from '../internal/components/menus/SelectionMenuItem';
@@ -11,7 +9,6 @@ import { EntityDataType } from '../internal/components/entities/models';
 import { EntityLineageEditModal } from './EntityLineageEditModal';
 
 interface Props {
-    auditBehavior?: AuditBehaviorTypes;
     childEntityDataType: EntityDataType;
     handleClick?: (cb: () => void, errorMsg?: string) => void;
     onSuccess?: () => void;
@@ -20,7 +17,7 @@ interface Props {
 }
 
 export const EntityLineageEditMenuItem: FC<Props> = memo(props => {
-    const { childEntityDataType, parentEntityDataTypes, queryModel, auditBehavior, onSuccess, handleClick } = props;
+    const { childEntityDataType, parentEntityDataTypes, queryModel, onSuccess, handleClick } = props;
     const parentNounPlural = parentEntityDataTypes[0].nounPlural;
     const itemText = 'Edit ' + parentNounPlural;
     const [showEditModal, setShowEditModal] = useState<boolean>(false);
@@ -61,7 +58,6 @@ export const EntityLineageEditMenuItem: FC<Props> = memo(props => {
                     queryModel={queryModel}
                     onCancel={onCancel}
                     childEntityDataType={childEntityDataType}
-                    auditBehavior={auditBehavior}
                     parentEntityDataTypes={parentEntityDataTypes}
                     onSuccess={_onSuccess}
                 />
@@ -69,7 +65,3 @@ export const EntityLineageEditMenuItem: FC<Props> = memo(props => {
         </>
     );
 });
-
-EntityLineageEditMenuItem.defaultProps = {
-    auditBehavior: AuditBehaviorTypes.DETAILED,
-};

--- a/packages/components/src/entities/EntityLineageEditModal.tsx
+++ b/packages/components/src/entities/EntityLineageEditModal.tsx
@@ -35,7 +35,6 @@ import { ParentEntityEditPanel } from './ParentEntityEditPanel';
 
 interface Props {
     api?: ComponentsAPIWrapper;
-    auditBehavior?: AuditBehaviorTypes;
     childEntityDataType: EntityDataType;
     onCancel: () => void;
     onSuccess: () => void;
@@ -71,7 +70,7 @@ const restrictedDataOperationMsg = (
 };
 
 export const EntityLineageEditModal: FC<Props> = memo(props => {
-    const { api, auditBehavior, queryModel, onCancel, childEntityDataType, onSuccess, parentEntityDataTypes } = props;
+    const { api, queryModel, onCancel, childEntityDataType, onSuccess, parentEntityDataTypes } = props;
     const [submitting, setSubmitting] = useState(false);
     const [allowedForUpdate, setAllowedForUpdate] = useState<Record<string, any>>();
     const [aliquotIds, setAliquotIds] = useState<number[]>();
@@ -182,7 +181,7 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
                 await updateRows({
                     schemaQuery: queryModel.schemaQuery,
                     rows,
-                    auditBehavior,
+                    auditBehavior: AuditBehaviorTypes.DETAILED,
                 });
                 onSuccess();
                 createNotification(
@@ -288,7 +287,6 @@ export const EntityLineageEditModal: FC<Props> = memo(props => {
 
                         <Progress modal={false} estimate={numAllowed * 10} toggle={submitting} />
                         <ParentEntityEditPanel
-                            auditBehavior={auditBehavior}
                             canUpdate={true}
                             childSchemaQuery={queryModel.schemaQuery}
                             parentDataTypes={parentEntityDataTypes}

--- a/packages/components/src/entities/FindSamplesByIdsPageBase.tsx
+++ b/packages/components/src/entities/FindSamplesByIdsPageBase.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType, FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { WithRouterProps } from 'react-router';
-import { ActionURL, Ajax, AuditBehaviorTypes, Filter, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Filter, Utils } from '@labkey/api';
 
 import {
     FIND_BY_IDS_QUERY_PARAM,
@@ -63,8 +63,6 @@ const FindSamplesByIdsTabbedGridPanelImpl: FC<FindSamplesByIdsTabProps> = memo(p
         actions.loadAllModels(true);
     }, [actions]);
 
-    const getSampleAuditBehaviorType = useCallback(() => AuditBehaviorTypes.DETAILED, []);
-
     const getAdvancedExportOptions = useCallback((tabId: string): { [key: string]: any } => {
         return SAMPLE_DATA_EXPORT_CONFIG;
     }, []);
@@ -94,7 +92,6 @@ const FindSamplesByIdsTabbedGridPanelImpl: FC<FindSamplesByIdsTabProps> = memo(p
                 withTitle={false}
                 afterSampleActionComplete={afterSampleActionComplete}
                 actions={actions}
-                getSampleAuditBehaviorType={getSampleAuditBehaviorType}
                 samplesEditableGridProps={samplesEditableGridProps}
                 gridButtons={gridButtons}
                 gridButtonProps={{

--- a/packages/components/src/entities/ParentEntityEditPanel.tsx
+++ b/packages/components/src/entities/ParentEntityEditPanel.tsx
@@ -36,7 +36,6 @@ import { SingleParentEntityPanel } from './SingleParentEntityPanel';
 import { parentValuesDiffer, getUpdatedRowForParentChanges } from './utils';
 
 export interface ParentEntityEditPanelProps {
-    auditBehavior?: AuditBehaviorTypes;
     canUpdate: boolean;
     cancelText?: string;
     childContainerPath?: string;
@@ -259,7 +258,7 @@ export class ParentEntityEditPanel extends Component<ParentEntityEditPanelProps,
 
         this.setState({ submitting: true });
 
-        const { auditBehavior, childContainerPath, onUpdate } = this.props;
+        const { childContainerPath, onUpdate } = this.props;
         const { childData, childQueryInfo, currentParents, originalParents } = this.state;
 
         const schemaQuery = childQueryInfo.schemaQuery;
@@ -268,7 +267,7 @@ export class ParentEntityEditPanel extends Component<ParentEntityEditPanelProps,
             containerPath: childContainerPath,
             schemaQuery,
             rows: [getUpdatedRowForParentChanges(originalParents, currentParents, childData, childQueryInfo)],
-            auditBehavior,
+            auditBehavior: AuditBehaviorTypes.DETAILED,
         })
             .then(() => {
                 this.setState(

--- a/packages/components/src/entities/PicklistOverview.tsx
+++ b/packages/components/src/entities/PicklistOverview.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { MenuItem } from 'react-bootstrap';
-import { AuditBehaviorTypes, Filter, Utils } from '@labkey/api';
+import { Filter, Utils } from '@labkey/api';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../internal/APIWrapper';
 
@@ -176,8 +176,6 @@ export const PicklistOverviewImpl: FC<Props> = memo(props => {
         loadPicklist(true);
     }, [loadPicklist]);
 
-    const getSampleAuditBehaviorType = useCallback(() => AuditBehaviorTypes.DETAILED, []);
-
     const gridButtonProps = {
         user,
         picklist,
@@ -219,7 +217,6 @@ export const PicklistOverviewImpl: FC<Props> = memo(props => {
                 gridButtonProps={gridButtonProps}
                 getIsDirty={getIsDirty}
                 setIsDirty={setIsDirty}
-                getSampleAuditBehaviorType={getSampleAuditBehaviorType}
                 afterSampleActionComplete={afterSampleActionComplete}
                 samplesEditableGridProps={samplesEditableGridProps}
                 tabbedGridPanelProps={{

--- a/packages/components/src/entities/SampleAliquotsGridPanel.tsx
+++ b/packages/components/src/entities/SampleAliquotsGridPanel.tsx
@@ -18,7 +18,6 @@ import { SAMPLE_DATA_EXPORT_CONFIG } from '../internal/components/samples/consta
 import { getContainerFilterForLookups } from '../internal/query/api';
 
 import { useSampleTypeAppContext } from './useSampleTypeAppContext';
-import { getSampleAuditBehaviorType } from './utils';
 import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 
 // We are only looking at single model here
@@ -91,7 +90,6 @@ export const SampleAliquotsGridPanelImpl: FC<Props & InjectedQueryModels> = memo
                 afterSampleActionComplete={afterAction}
                 containerFilter={containerFilter}
                 getIsDirty={getIsDirty}
-                getSampleAuditBehaviorType={getSampleAuditBehaviorType}
                 gridButtonProps={{
                     metricFeatureArea,
                     subMenuWidth: SUB_MENU_WIDTH,

--- a/packages/components/src/entities/SampleCreatePage.tsx
+++ b/packages/components/src/entities/SampleCreatePage.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useMemo } from 'react';
 import { WithRouterProps } from 'react-router';
 import { OrderedMap } from 'immutable';
-import { Filter } from '@labkey/api';
+import { AuditBehaviorTypes, Filter } from '@labkey/api';
 
 import { InjectedRouteLeaveProps, useRouteLeave } from '../internal/util/RouteLeave';
 import { useServerContext } from '../internal/components/base/ServerContext';
@@ -30,7 +30,7 @@ import { EntityInsertPanel } from './EntityInsertPanel';
 
 import { SampleTypeBasePage } from './SampleTypeBasePage';
 import { onSampleChange } from './actions';
-import { getSampleAuditBehaviorType, getSampleTypeTemplateUrl, processSampleBulkAdd } from './utils';
+import { getSampleTypeTemplateUrl, processSampleBulkAdd } from './utils';
 import { useSampleTypeAppContext } from './useSampleTypeAppContext';
 
 const TITLE = 'Sample Type';
@@ -47,15 +47,14 @@ export const SampleCreatePage: FC<SampleCreatePageProps> = memo(props => {
     const { combineParentTypes, controllerName, downloadTemplateExcludeColumns, importHelpLinkTopic, parentDataTypes } =
         useSampleTypeAppContext();
     const [getIsDirty, setIsDirty] = useRouteLeave(router, routes);
-    const auditBehavior = getSampleAuditBehaviorType();
 
     const fileImportParameters = useMemo(
         () => ({
-            auditBehavior,
+            auditBehavior: AuditBehaviorTypes.DETAILED,
             pipelineProvider: 'Samples Import',
             pipelineNotificationProvider: controllerName,
         }),
-        [auditBehavior, controllerName]
+        [controllerName]
     );
 
     const entityDataType = useMemo(() => {
@@ -147,7 +146,6 @@ export const SampleCreatePage: FC<SampleCreatePageProps> = memo(props => {
                 allowedNonDomainFields={SAMPLE_INSERT_EXTRA_COLUMNS}
                 disallowedUpdateFields={[ALIQUOTED_FROM_COL]}
                 asyncSize={useAsync === 'true' ? 1 : BACKGROUND_IMPORT_MIN_FILE_SIZE}
-                auditBehavior={auditBehavior}
                 combineParentTypes={combineParentTypes}
                 containerFilter={getContainerFilterForLookups()}
                 entityDataType={entityDataType}

--- a/packages/components/src/entities/SampleDeleteMenuItem.tsx
+++ b/packages/components/src/entities/SampleDeleteMenuItem.tsx
@@ -1,8 +1,6 @@
 import React, { FC, memo, useCallback, useState } from 'react';
 import { MenuItem } from 'react-bootstrap';
 
-import { AuditBehaviorTypes } from '@labkey/api';
-
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../internal/APIWrapper';
 
 import { QueryModel } from '../public/QueryModel/QueryModel';
@@ -17,7 +15,6 @@ import { EntityDeleteModal } from './EntityDeleteModal';
 interface Props {
     afterSampleDelete?: (rowsToKeep?: any[]) => void;
     api?: ComponentsAPIWrapper;
-    auditBehavior?: AuditBehaviorTypes;
     beforeSampleDelete?: () => void;
     handleClick?: (cb: () => void, errorMsg?: string) => void;
     itemText?: string;
@@ -35,7 +32,6 @@ export const SampleDeleteMenuItem: FC<Props> = memo(props => {
         verb,
         beforeSampleDelete,
         afterSampleDelete,
-        auditBehavior,
         maxDeleteRows,
         selectionMenuId,
         metricFeatureArea,
@@ -88,7 +84,6 @@ export const SampleDeleteMenuItem: FC<Props> = memo(props => {
                     onCancel={onClose}
                     maxSelected={maxDeleteRows}
                     entityDataType={SampleTypeDataType}
-                    auditBehavior={auditBehavior}
                     verb={verb}
                 />
             )}
@@ -98,7 +93,6 @@ export const SampleDeleteMenuItem: FC<Props> = memo(props => {
 
 SampleDeleteMenuItem.defaultProps = {
     api: getDefaultAPIWrapper(),
-    auditBehavior: AuditBehaviorTypes.DETAILED,
     itemText: 'Delete',
     maxDeleteRows: MAX_SELECTED_SAMPLES,
     selectionMenuId: 'delete-samples-menu-item',

--- a/packages/components/src/entities/SampleFinderSection.tsx
+++ b/packages/components/src/entities/SampleFinderSection.tsx
@@ -1,7 +1,5 @@
 import React, { ComponentType, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { AuditBehaviorTypes } from '@labkey/api';
-
 import { Location } from '../internal/util/URL';
 import { capitalizeFirstChar } from '../internal/util/utils';
 import { EntityDataType } from '../internal/components/entities/models';
@@ -36,7 +34,7 @@ import { InjectedAssayModel, withAssayModels } from '../internal/components/assa
 
 import { isLoading } from '../public/LoadingState';
 
-import { AssayResultDataType, SamplePropertyDataType } from '../internal/components/entities/constants';
+import { AssayResultDataType } from '../internal/components/entities/constants';
 
 import {
     getSampleFinderTabRowCounts,
@@ -49,7 +47,6 @@ import { FilterCards } from '../internal/components/search/FilterCards';
 import {
     getFinderStartText,
     getSampleFinderColumnNames,
-    getSampleFinderCommonConfigs,
     getSampleFinderQueryConfigs,
     getSearchFilterObjs,
     SAMPLE_FILTER_METRIC_AREA,
@@ -79,7 +76,6 @@ import { SamplesTabbedGridPanel } from './SamplesTabbedGridPanel';
 
 interface SampleFinderSamplesGridProps {
     getIsDirty?: () => boolean;
-    getSampleAuditBehaviorType: () => AuditBehaviorTypes;
     gridButtonProps?: SampleGridButtonProps;
     gridButtons?: ComponentType<SampleGridButtonProps & RequiresModelAndActions>;
     sampleTypeNames: string[];

--- a/packages/components/src/entities/SampleHeader.tsx
+++ b/packages/components/src/entities/SampleHeader.tsx
@@ -49,7 +49,7 @@ import { useAppContext } from '../internal/AppContext';
 import { CreateSamplesSubMenu } from './CreateSamplesSubMenu';
 import { AssayImportSubMenuItem } from './AssayImportSubMenuItem';
 import { EntityDeleteModal } from './EntityDeleteModal';
-import { createEntityParentKey, getJobCreationHref, getSampleAuditBehaviorType, getSampleDeleteMessage } from './utils';
+import { createEntityParentKey, getJobCreationHref, getSampleDeleteMessage } from './utils';
 import { onSampleChange } from './actions';
 
 interface HeaderProps {
@@ -356,7 +356,6 @@ export const SampleHeaderImpl: FC<Props> = memo(props => {
                     afterDelete={onAfterDelete}
                     onCancel={onHideModals}
                     entityDataType={entityDataType}
-                    auditBehavior={getSampleAuditBehaviorType()}
                     verb="deleted and removed from storage"
                     containerPath={sampleContainer?.path}
                 />

--- a/packages/components/src/entities/SampleListingPage.tsx
+++ b/packages/components/src/entities/SampleListingPage.tsx
@@ -47,7 +47,7 @@ import { SampleTypeBasePage } from './SampleTypeBasePage';
 import { downloadSampleTypeTemplate } from './SampleTypeTemplateDownloadRenderer';
 import { useSampleTypeAppContext } from './useSampleTypeAppContext';
 import { onSampleChange, onSampleTypeChange } from './actions';
-import { getSampleAuditBehaviorType, getSampleTypeTemplateUrl } from './utils';
+import { getSampleTypeTemplateUrl } from './utils';
 
 const DETAIL_GRID_ID = 'samples-details';
 const SAMPLES_LISTING_GRID_ID = 'samples-listing';
@@ -416,7 +416,6 @@ export const SampleListingPageBody: FC<SampleListingPageBodyProps> = props => {
                     afterSampleActionComplete={afterSampleActionComplete}
                     containerFilter={containerFilter}
                     getIsDirty={getIsDirty}
-                    getSampleAuditBehaviorType={getSampleAuditBehaviorType}
                     gridButtonProps={{
                         metricFeatureArea: 'sampleListingGrid',
                         subMenuWidth: SUB_MENU_WIDTH,

--- a/packages/components/src/entities/SampleOverviewPanel.tsx
+++ b/packages/components/src/entities/SampleOverviewPanel.tsx
@@ -17,7 +17,6 @@ import { useServerContext } from '../internal/components/base/ServerContext';
 import { SampleAliquotsSummary } from './SampleAliquotsSummary';
 import { SampleDetailEditing } from './SampleDetailEditing';
 
-import { getSampleAuditBehaviorType } from './utils';
 import { SampleStorageLocation } from '../internal/sampleModels';
 import { useSampleTypeAppContext } from './useSampleTypeAppContext';
 
@@ -52,7 +51,6 @@ export const SampleOverviewPanel: FC<Props> = memo(props => {
         return !sampleModel.isLoading ? sampleModel.getRow() : undefined;
     }, [sampleModel]);
 
-    const auditBehavior = getSampleAuditBehaviorType();
     const sampleStatusType = getSampleStatusType(row);
     const _canUpdate = !isEditing && canUpdate;
     const aliquotedFrom = sampleModel.getRowValue('AliquotedFromLSID/Name');
@@ -132,7 +130,6 @@ export const SampleOverviewPanel: FC<Props> = memo(props => {
                 <div className={`col-md-${isMedia ? '7' : '12'}`}>
                     <SampleDetailEditing
                         actions={actions}
-                        auditBehavior={auditBehavior}
                         canUpdate={_canUpdate}
                         containerFilter={getContainerFilterForLookups()}
                         containerPath={sampleContainer.path}

--- a/packages/components/src/entities/SampleOverviewPanel.tsx
+++ b/packages/components/src/entities/SampleOverviewPanel.tsx
@@ -14,10 +14,11 @@ import { LoadingSpinner } from '../internal/components/base/LoadingSpinner';
 
 import { useServerContext } from '../internal/components/base/ServerContext';
 
+import { SampleStorageLocation } from '../internal/sampleModels';
+
 import { SampleAliquotsSummary } from './SampleAliquotsSummary';
 import { SampleDetailEditing } from './SampleDetailEditing';
 
-import { SampleStorageLocation } from '../internal/sampleModels';
 import { useSampleTypeAppContext } from './useSampleTypeAppContext';
 
 interface Props {

--- a/packages/components/src/entities/SamplesTabbedGridPanel.spec.tsx
+++ b/packages/components/src/entities/SamplesTabbedGridPanel.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { fromJS } from 'immutable';
 import { ReactWrapper } from 'enzyme';
-import { AuditBehaviorTypes } from '@labkey/api';
 
 import { mountWithAppServerContext, waitForLifecycle } from '../internal/testHelpers';
 
@@ -32,7 +31,6 @@ const DEFAULT_PROPS = {
     actions: makeTestActions(),
     samplesEditableGridProps: {},
     gridButtons: undefined,
-    getSampleAuditBehaviorType: () => AuditBehaviorTypes.DETAILED,
     isAllSamplesTab: () => false,
 };
 
@@ -44,7 +42,6 @@ const SINGLE_TAB_PROPS = {
     actions: makeTestActions(),
     samplesEditableGridProps: {},
     gridButtons: undefined,
-    getSampleAuditBehaviorType: () => AuditBehaviorTypes.DETAILED,
 };
 
 describe('SamplesTabbedGridPanel', () => {

--- a/packages/components/src/entities/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/entities/SamplesTabbedGridPanel.tsx
@@ -41,7 +41,6 @@ interface Props extends InjectedQueryModels {
     createBtnParentKey?: string;
     createBtnParentType?: string;
     getIsDirty?: () => boolean;
-    getSampleAuditBehaviorType: () => AuditBehaviorTypes;
     gridButtonProps?: any;
     gridButtons?: ComponentType<SampleGridButtonProps & RequiresModelAndActions>;
     // use if you have multiple tabs but want to start on something other than the first one
@@ -77,7 +76,6 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
         samplesEditableGridProps = {},
         gridButtons,
         gridButtonProps,
-        getSampleAuditBehaviorType,
         getIsDirty,
         onSampleTabSelect,
         setIsDirty,
@@ -251,7 +249,7 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             return updateRows({
                 schemaQuery,
                 rows,
-                auditBehavior: getSampleAuditBehaviorType(),
+                auditBehavior: AuditBehaviorTypes.DETAILED,
             }).then(result => {
                 invalidateLineageResults();
                 dismissNotifications(); // get rid of any error notifications that have already been created
@@ -261,7 +259,7 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
             });
             // catch block intentionally absent so callers can handle the errors appropriately
         },
-        [createNotification, dismissNotifications, getSampleAuditBehaviorType]
+        [createNotification, dismissNotifications]
     );
 
     const onPrintLabel = useCallback(

--- a/packages/components/src/entities/utils.tsx
+++ b/packages/components/src/entities/utils.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { fromJS, List, OrderedMap, Set } from 'immutable';
-import { ActionURL, AuditBehaviorTypes, Filter, getServerContext, Utils } from '@labkey/api';
+import { ActionURL, Filter, getServerContext, Utils } from '@labkey/api';
 
 import {
     getOperationNotPermittedMessage,
@@ -561,10 +561,6 @@ export function getImportItemsForAssayDefinitions(
             );
             return items.set(assay, href);
         }, OrderedMap<AssayDefinitionModel, string>());
-}
-
-export function getSampleAuditBehaviorType() {
-    return AuditBehaviorTypes.DETAILED;
 }
 
 export function getJobCreationHref(

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -208,7 +208,6 @@ export class EntityIdCreationModel extends Record({
     targetEntityType: undefined,
     entityCount: 0,
     entityDataType: undefined,
-    auditBehavior: undefined,
     creationType: undefined,
     numPerParent: 1,
 }) {
@@ -225,7 +224,6 @@ export class EntityIdCreationModel extends Record({
     declare targetEntityType: EntityTypeOption; // the target entity Type
     declare entityCount: number; // how many rows are in the grid
     declare entityDataType: EntityDataType; // target entity data type
-    declare auditBehavior: AuditBehaviorTypes;
     declare creationType: SampleCreationType;
     declare numPerParent: number;
 
@@ -373,7 +371,7 @@ export class EntityIdCreationModel extends Record({
             }, List<Map<string, any>>());
 
         return insertRows({
-            auditBehavior: this.auditBehavior,
+            auditBehavior: AuditBehaviorTypes.DETAILED,
             fillEmptyFields: true,
             rows,
             schemaQuery: this.getSchemaQuery(),

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -20,7 +20,6 @@ import { DetailPanel, DetailPanelWithModel } from './DetailPanel';
 export interface EditableDetailPanelProps extends RequiresModelAndActions {
     appEditable?: boolean;
     asSubPanel?: boolean;
-    auditBehavior?: AuditBehaviorTypes;
     canUpdate: boolean;
     cancelText?: string;
     containerFilter?: Query.ContainerFilter;
@@ -86,7 +85,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleSubmit = async (values: Record<string, any>): Promise<void> => {
-        const { auditBehavior, containerPath, model, onEditToggle, onUpdate } = this.props;
+        const { containerPath, model, onEditToggle, onUpdate } = this.props;
         const { queryInfo } = model;
         const row = model.getRow();
         const updatedValues = extractChanges(queryInfo, fromJS(model.getRow()), values);
@@ -114,7 +113,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
         try {
             await updateRows({
-                auditBehavior,
+                auditBehavior: AuditBehaviorTypes.DETAILED,
                 containerPath,
                 rows: [updatedValues],
                 schemaQuery: queryInfo.schemaQuery,


### PR DESCRIPTION
#### Rationale
The apps always use AuditBehaviorTypes.DETAILED for inserts/updates but we still pass around this as an optional prop in various places. This PR refactors that so that we just use AuditBehaviorTypes.DETAILED directly instead of having to have each usage of various components pass this in as a prop.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1188
- https://github.com/LabKey/labkey-ui-premium/pull/87
- https://github.com/LabKey/sampleManagement/pull/1812
- https://github.com/LabKey/inventory/pull/844
- https://github.com/LabKey/biologics/pull/2120

#### Changes
- remove auditBehavior optional props since they were always passed in as DETAILED
- remove getSampleAuditBehavior() since it was always using DETAILED
