### PR TITLE
Performance Evaluation for Data at Scale - Bulk edit improvements

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.333.3-fb-bulkUpdatePerf.1",
+  "version": "2.333.3-fb-bulkUpdatePerf.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.333.0",
+  "version": "2.333.1-fb-bulkUpdatePerf.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.333.2",
+  "version": "2.333.3-fb-bulkUpdatePerf.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.333.3-fb-bulkUpdatePerf.2",
+  "version": "2.333.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.X
-*Released*: X May 2023
+### version 2.333.3
+*Released*: 7 May 2023
 * Bulk edit improvement
   * limit the number of items that can be edited in Bulk to 1000
   * only select key columns and columns that are editable for bulk edit and edit in grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X May 2023
+* Bulk edit improvement
+  * limit the number of items that can be edited in Bulk to 1000
+  * only select key columns and columns that are editable for bulk edit and edit in grid
+
 ### version 2.333.0
 *Released*: 2 May 2023
 * Add expired sample indicator in UI

--- a/packages/components/src/entities/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/entities/SamplesBulkUpdateForm.tsx
@@ -33,8 +33,9 @@ import {
 
 import { SamplesSelectionProviderProps, SamplesSelectionResultProps } from '../internal/components/samples/models';
 
-import { SamplesSelectionProvider } from './SamplesSelectionContextProvider';
 import { getAltUnitKeys } from '../internal/util/measurement';
+
+import { SamplesSelectionProvider } from './SamplesSelectionContextProvider';
 
 interface OwnProps {
     containerFilter?: Query.ContainerFilter;
@@ -112,12 +113,11 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
     getQueryFilters(): Record<string, List<Filter.IFilter>> {
         const { sampleTypeDomainFields } = this.props;
         const { metricUnit } = sampleTypeDomainFields;
-        if (!metricUnit)
-            return undefined;
+        if (!metricUnit) return undefined;
 
         return {
-            Units: List<Filter.IFilter>([Filter.create('value', getAltUnitKeys(metricUnit), Filter.Types.IN)])
-        }
+            Units: List<Filter.IFilter>([Filter.create('value', getAltUnitKeys(metricUnit), Filter.Types.IN)]),
+        };
     }
 
     getQueryInfo(): QueryInfo {
@@ -132,11 +132,7 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
                 const colLc = column.fieldKey.toLowerCase();
                 const isAliquotField = sampleTypeDomainFields.aliquotFields.indexOf(colLc) > -1;
                 const isIndependentField = sampleTypeDomainFields.independentFields.indexOf(colLc) > -1;
-                if (
-                    COMMON_SYSTEM_FIELDS_FOR_UPDATE.indexOf(colLc) >=0 ||
-                    isAliquotField ||
-                    isIndependentField
-                )
+                if (COMMON_SYSTEM_FIELDS_FOR_UPDATE.indexOf(colLc) >= 0 || isAliquotField || isIndependentField)
                     columns = columns.set(key, column);
             });
             originalQueryInfo.getPkCols().forEach(column => {

--- a/packages/components/src/entities/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/entities/SamplesBulkUpdateForm.tsx
@@ -237,7 +237,6 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
                 queryInfo={this.getQueryInfo()}
                 selectedIds={queryModel.selections}
                 viewName={queryModel.viewName}
-                canSubmitForEdit={hasValidMaxSelection}
                 onCancel={onCancel}
                 onError={onBulkUpdateError}
                 onComplete={this.onComplete}

--- a/packages/components/src/entities/SamplesBulkUpdateForm.tsx
+++ b/packages/components/src/entities/SamplesBulkUpdateForm.tsx
@@ -136,7 +136,7 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
                     columns = columns.set(key, column);
             });
             originalQueryInfo.getPkCols().forEach(column => {
-                columns = columns.set(column.fieldKey, column);
+                columns = columns.set(column.fieldKey.toLowerCase(), column);
             });
         } else {
             // if contains samples, skip aliquot fields
@@ -237,6 +237,7 @@ export class SamplesBulkUpdateFormBase extends React.PureComponent<Props, State>
                 onError={onBulkUpdateError}
                 onComplete={this.onComplete}
                 onSubmitForEdit={editSelectionInGrid}
+                requiredColumns={['lsid']}
                 sortString={queryModel.sorts.join(',')}
                 updateRows={updateRows}
                 header={

--- a/packages/components/src/entities/SamplesEditButton.tsx
+++ b/packages/components/src/entities/SamplesEditButton.tsx
@@ -171,6 +171,7 @@ export const SamplesEditButton: FC<OwnProps & SampleGridButtonProps & RequiresMo
                                 text="Edit in Bulk"
                                 onClick={onShowBulkUpdate}
                                 queryModel={model}
+                                maxSelection={MAX_EDITABLE_GRID_ROWS}
                                 nounPlural={SampleTypeDataType.nounPlural}
                             />
                         )}

--- a/packages/components/src/entities/SamplesTabbedGridPanel.tsx
+++ b/packages/components/src/entities/SamplesTabbedGridPanel.tsx
@@ -168,11 +168,11 @@ export const SamplesTabbedGridPanel: FC<Props> = memo(props => {
     );
 
     const onShowBulkUpdate = useCallback(() => {
-        if (hasSelections) {
+        if (hasSelections && hasValidMaxSelection) {
             dismissNotifications();
             setShowBulkUpdate(true);
         }
-    }, [dismissNotifications, hasSelections]);
+    }, [dismissNotifications, hasSelections, hasValidMaxSelection]);
 
     const onBulkUpdateError = useCallback(
         (message: string) => {

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.spec.tsx
@@ -41,7 +41,6 @@ const QUERY_INFO = QueryInfo.fromJSON({
 });
 
 const DEFAULT_PROPS = {
-    canSubmitForEdit: false,
     onComplete: jest.fn,
     onCancel: jest.fn,
     onSubmitForEdit: jest.fn,

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -14,7 +14,6 @@ import { capitalizeFirstChar, getCommonDataValues, getUpdatedData } from '../../
 import { QueryInfoForm } from './QueryInfoForm';
 
 interface Props {
-    canSubmitForEdit: boolean;
     containerFilter?: Query.ContainerFilter;
     displayValueFields?: string[];
     header?: ReactNode;
@@ -34,7 +33,7 @@ interface Props {
     readOnlyColumns?: List<string>;
     requiredColumns?: string[];
     selectedIds: Set<string>;
-    shownInUpdateColumns?: boolean;
+    getUpdateColumnsOnly?: boolean;
     singularNoun?: string;
     // sortString is used so we render editable grids with the proper sorts when using onSubmitForEdit
     sortString?: string;
@@ -57,6 +56,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
     static defaultProps = {
         pluralNoun: 'rows',
         singularNoun: 'row',
+        getUpdateColumnsOnly: true,
     };
 
     constructor(props) {
@@ -79,14 +79,14 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
             queryInfo,
             readOnlyColumns,
             selectedIds,
-            shownInUpdateColumns,
+            getUpdateColumnsOnly,
             sortString,
             viewName,
             requiredColumns,
         } = this.props;
         // Get all shownInUpdateView and required columns or undefined
         const columns =
-            shownInUpdateColumns || requiredColumns
+            getUpdateColumnsOnly || requiredColumns
                 ? (queryInfo.getPkCols().concat(queryInfo.getUpdateColumns(readOnlyColumns)) as List<QueryColumn>)
                 : undefined;
         let columnString = columns?.map(c => c.fieldKey).join(',');
@@ -217,7 +217,6 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
     render() {
         const { isLoadingDataForSelection, dataForSelection } = this.state;
         const {
-            canSubmitForEdit,
             containerFilter,
             onCancel,
             onComplete,
@@ -233,7 +232,6 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
             <QueryInfoForm
                 allowFieldDisable
                 asModal
-                canSubmitForEdit={canSubmitForEdit}
                 checkRequiredFields={false}
                 columnFilter={this.columnFilter}
                 containerFilter={containerFilter}

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -234,7 +234,6 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                 checkRequiredFields={false}
                 columnFilter={this.columnFilter}
                 containerFilter={containerFilter}
-                disableSubmitForEditMsg={'At most ' + MAX_EDITABLE_GRID_ROWS + ' can be edited with the grid.'}
                 fieldValues={fieldValues}
                 header={this.renderBulkUpdateHeader()}
                 includeCountField={false}

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -1,6 +1,7 @@
 import { Filter, Query, Utils } from '@labkey/api';
 import { List, Map, OrderedMap } from 'immutable';
 import React, { PureComponent, ReactNode } from 'react';
+
 import { Operation, QueryColumn } from '../../../public/QueryColumn';
 
 import { QueryInfo } from '../../../public/QueryInfo';
@@ -16,6 +17,7 @@ import { QueryInfoForm } from './QueryInfoForm';
 interface Props {
     containerFilter?: Query.ContainerFilter;
     displayValueFields?: string[];
+    getUpdateColumnsOnly?: boolean;
     header?: ReactNode;
     itemLabel?: string;
     onAdditionalFormDataChange?: (name: string, value: any) => any;
@@ -29,11 +31,10 @@ interface Props {
     ) => any;
     pluralNoun?: string;
     queryFilters?: Record<string, List<Filter.IFilter>>;
-    queryInfo: QueryInfo;
     readOnlyColumns?: List<string>;
     requiredColumns?: string[];
     selectedIds: Set<string>;
-    getUpdateColumnsOnly?: boolean;
+    queryInfo: QueryInfo;
     singularNoun?: string;
     // sortString is used so we render editable grids with the proper sorts when using onSubmitForEdit
     sortString?: string;
@@ -44,12 +45,12 @@ interface Props {
 }
 
 interface State {
-    originalDataForSelection: Map<string, any>;
     dataForSelection: Map<string, any>;
-    displayFieldUpdates: any;
     dataIdsForSelection: List<any>;
+    displayFieldUpdates: any;
     errorMsg: string;
     isLoadingDataForSelection: boolean;
+    originalDataForSelection: Map<string, any>;
 }
 
 export class BulkUpdateForm extends PureComponent<Props, State> {
@@ -119,21 +120,21 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
         }
     };
 
-    mapDataForDisplayFields(data: Map<string, any>): {data: Map<string, any>, bulkUpdates: OrderedMap<string, any>} {
+    mapDataForDisplayFields(data: Map<string, any>): { bulkUpdates: OrderedMap<string, any>; data: Map<string, any> } {
         const { displayValueFields } = this.props;
         let updates = Map<string, any>();
         let bulkUpdates = OrderedMap<string, any>();
 
-        if (!displayValueFields)
-            return { data, bulkUpdates };
+        if (!displayValueFields) return { data, bulkUpdates };
 
         let conflictKeys = new Set<string>();
         data.forEach((rowData, id) => {
             if (rowData) {
                 let updatedRow = Map<string, any>();
                 rowData.forEach((field, key) => {
-                    if (displayValueFields.includes(key) ) {
-                        const valuesDiffer = field.has('displayValue') && field.get('value') !== field.get('displayValue');
+                    if (displayValueFields.includes(key)) {
+                        const valuesDiffer =
+                            field.has('displayValue') && field.get('value') !== field.get('displayValue');
                         const comparisonValue = field.get('displayValue') ?? field.get('value');
                         if (!conflictKeys.has(key)) {
                             if (!bulkUpdates.has(key)) {
@@ -149,13 +150,11 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                         }
                     }
                 });
-                if (!updatedRow.isEmpty())
-                    updates = updates.set(id, updatedRow);
+                if (!updatedRow.isEmpty()) updates = updates.set(id, updatedRow);
             }
         });
-        if (!updates.isEmpty())
-            return {data: data.merge(updates), bulkUpdates};
-        return {data, bulkUpdates};
+        if (!updates.isEmpty()) return { data: data.merge(updates), bulkUpdates };
+        return { data, bulkUpdates };
     }
 
     getSelectionCount(): number {

--- a/packages/components/src/internal/components/forms/QueryInfoForm.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.tsx
@@ -34,7 +34,6 @@ import { getFieldEnabledFieldName } from './utils';
 
 export interface QueryInfoFormProps extends Omit<QueryFormInputsProps, 'onFieldsEnabledChange'> {
     asModal?: boolean;
-    canSubmitForEdit?: boolean;
     canSubmitNotDirty?: boolean;
     cancelText?: string;
     countText?: string;
@@ -86,7 +85,6 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
     formRef: React.RefObject<Formsy>;
 
     static defaultProps: Partial<QueryInfoFormProps> = {
-        canSubmitForEdit: true,
         canSubmitNotDirty: true,
         includeCountField: true,
         countText: 'Quantity',
@@ -266,7 +264,6 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
         const {
             cancelText,
             canSubmitNotDirty,
-            canSubmitForEdit,
             disableSubmitForEditMsg,
             submitForEditText,
             submitText,
@@ -293,14 +290,14 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
                 <Button
                     className="test-loc-submit-for-edit-button"
                     bsStyle={onSubmit ? 'default' : 'success'}
-                    disabled={isSubmitting || !canSubmitForEdit || !canSubmit || count === 0}
+                    disabled={isSubmitting || !canSubmit || count === 0}
                     onClick={this.setSubmittingForEdit}
                     type="submit"
                 >
                     {submitForEdit && inProgressText ? inProgressText : submitForEditText}
                 </Button>
             );
-            if (!canSubmitForEdit && disableSubmitForEditMsg) {
+            if (disableSubmitForEditMsg) {
                 submitForEditBtn = (
                     <Tip caption={disableSubmitForEditMsg}>
                         <div className="disabled-button-with-tooltip">{btnContent}</div>
@@ -349,7 +346,6 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
         // Include all props to support extraction of queryFormInputProps
         const {
             asModal,
-            canSubmitForEdit,
             canSubmitNotDirty,
             cancelText,
             countText,

--- a/packages/components/src/internal/components/forms/QueryInfoForm.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.tsx
@@ -39,7 +39,6 @@ export interface QueryInfoFormProps extends Omit<QueryFormInputsProps, 'onFields
     cancelText?: string;
     countText?: string;
     creationTypeOptions?: SampleCreationTypeModel[];
-    disableSubmitForEditMsg?: string;
     errorCallback?: (error: any) => void;
     errorMessagePrefix?: string;
     footer?: ReactNode;
@@ -265,7 +264,6 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
         const {
             cancelText,
             canSubmitNotDirty,
-            disableSubmitForEditMsg,
             submitForEditText,
             submitText,
             isSubmittedText,
@@ -287,7 +285,7 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
         let submitForEditBtn;
 
         if (onSubmitForEdit && submitForEditText) {
-            const btnContent = (
+            submitForEditBtn = (
                 <Button
                     className="test-loc-submit-for-edit-button"
                     bsStyle={onSubmit ? 'default' : 'success'}
@@ -298,15 +296,6 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
                     {submitForEdit && inProgressText ? inProgressText : submitForEditText}
                 </Button>
             );
-            if (disableSubmitForEditMsg) {
-                submitForEditBtn = (
-                    <Tip caption={disableSubmitForEditMsg}>
-                        <div className="disabled-button-with-tooltip">{btnContent}</div>
-                    </Tip>
-                );
-            } else {
-                submitForEditBtn = btnContent;
-            }
         }
 
         return (
@@ -351,7 +340,6 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
             cancelText,
             countText,
             creationTypeOptions,
-            disableSubmitForEditMsg,
             errorCallback,
             footer,
             header,

--- a/packages/components/src/internal/components/forms/QueryInfoForm.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.tsx
@@ -18,6 +18,7 @@ import { List, OrderedMap } from 'immutable';
 import { Alert, Button, Modal } from 'react-bootstrap';
 import Formsy from 'formsy-react';
 import { Filter, Utils } from '@labkey/api';
+
 import { Operation } from '../../../public/QueryColumn';
 
 import { MAX_EDITABLE_GRID_ROWS } from '../../constants';
@@ -54,14 +55,14 @@ export interface QueryInfoFormProps extends Omit<QueryFormInputsProps, 'onFields
     // allow passing of full form data, compare with onFormChange
     onFormChangeWithData?: (formData?: any) => void;
     onHide?: () => void;
-    operation?: Operation;
     onSubmit?: (data: OrderedMap<string, any>) => Promise<any>;
     onSubmitForEdit?: (data: OrderedMap<string, any>) => Promise<any>;
     onSuccess?: (data: any, submitForEdit: boolean) => void;
+    operation?: Operation;
     pluralNoun?: string;
+    queryFilters?: Record<string, List<Filter.IFilter>>;
     // required by QueryInfoForm
-    queryInfo: QueryInfo;
-    queryFilters?: Record<string, List<Filter.IFilter>>; // for filtering lookup values in the form
+    queryInfo: QueryInfo; // for filtering lookup values in the form
     showErrorsAtBottom?: boolean;
     singularNoun?: string;
     submitForEditText?: string;

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -580,7 +580,7 @@ export class QueryModel {
     getRequestColumnsString(
         requiredColumns?: string[],
         omittedColumns?: string[],
-        requestUpdateColumns?: boolean
+        isForUpdate?: boolean
     ): string {
         const _requiredColumns = requiredColumns ?? this.requiredColumns;
         const _omittedColumns = omittedColumns ?? this.omittedColumns;
@@ -588,12 +588,15 @@ export class QueryModel {
         // Note: ES6 Set is being used here, not Immutable Set
         const uniqueFieldKeys = new Set(_requiredColumns);
         this.keyColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
-        this.displayColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
+
         this.uniqueIdColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
 
         // Issue 46478: Include update columns in requested columns to ensure values are available
-        if (requestUpdateColumns) {
+        if (isForUpdate) {
             this.updateColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
+        }
+        else {
+            this.displayColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
         }
 
         let fieldKeys = Array.from(uniqueFieldKeys);

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -577,11 +577,7 @@ export class QueryModel {
         return this.getRequestColumnsString();
     }
 
-    getRequestColumnsString(
-        requiredColumns?: string[],
-        omittedColumns?: string[],
-        isForUpdate?: boolean
-    ): string {
+    getRequestColumnsString(requiredColumns?: string[], omittedColumns?: string[], isForUpdate?: boolean): string {
         const _requiredColumns = requiredColumns ?? this.requiredColumns;
         const _omittedColumns = omittedColumns ?? this.omittedColumns;
 
@@ -594,8 +590,7 @@ export class QueryModel {
         // Issue 46478: Include update columns in requested columns to ensure values are available
         if (isForUpdate) {
             this.updateColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
-        }
-        else {
+        } else {
             this.displayColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
         }
 


### PR DESCRIPTION
#### Rationale
Bulk edit form takes a long time to render. Currently, bulk edit form queries for all columns in the grid, but only those columns that are updatable will be used on the bulk form. We want to make the change to only query for the set of columns that are needed for bulk edit as well as editable grid. Additionally, we will limit the max selection allowed for bulk edit to match that of editable grid update.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1189
- https://github.com/LabKey/labkey-ui-premium/pull/89
- https://github.com/LabKey/inventory/pull/846
- https://github.com/LabKey/sampleManagement/pull/1819
- https://github.com/LabKey/biologics/pull/2123

#### Changes
- limit the number of items that can be edited in Bulk to 1000
- only select key columns and columns that are editable for bulk edit and edit in grid
