### PR TITLE
Update shouldShowProductNavigation() to include check for LKB app instead of just hasPremiumModule

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.336.1-fb-showProductNavLKB.0",
+  "version": "2.336.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.336.1",
+  "version": "2.336.1-fb-showProductNavLKB.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released* : TBD May 2023
+### version 2.336.2
+*Released* : 15 May 2023
 * Update shouldShowProductNavigation() to include check for LKB app instead of just hasPremiumModule
 
 ### version 2.336.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released* : TBD May 2023
+* Update shouldShowProductNavigation() to include check for LKB app instead of just hasPremiumModule
+
 ### version 2.336.1
 *Released* : 12 May 2023
 * Issue 47794: App sample type assay button to show assay submenu items in disabled state

--- a/packages/components/src/internal/components/productnavigation/utils.spec.tsx
+++ b/packages/components/src/internal/components/productnavigation/utils.spec.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { TEST_USER_APP_ADMIN, TEST_USER_EDITOR } from '../../userFixtures';
+import { TEST_LIMS_STARTER_MODULE_CONTEXT, TEST_LKSM_STARTER_MODULE_CONTEXT } from '../../productFixtures';
+
+import { shouldShowProductNavigation } from './utils';
+
+describe('shouldShowProductNavigation', () => {
+    test('LKB non-premium admin user', () => {
+        let moduleContext = { ...TEST_LIMS_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ADMIN' } };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeTruthy();
+
+        moduleContext = { ...TEST_LIMS_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ALWAYS' } };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeTruthy();
+    });
+    test('LKB non-premium non-admin user', () => {
+        let moduleContext = { ...TEST_LIMS_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ADMIN' } };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeFalsy();
+
+        moduleContext = { ...TEST_LIMS_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ALWAYS' } };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeTruthy();
+    });
+
+    test('LKB premium admin user', () => {
+        let moduleContext = {
+            ...TEST_LIMS_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ADMIN', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeTruthy();
+
+        moduleContext = {
+            ...TEST_LIMS_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ALWAYS', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeTruthy();
+    });
+
+    test('LKB premium non-admin user', () => {
+        let moduleContext = {
+            ...TEST_LIMS_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ADMIN', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeFalsy();
+
+        moduleContext = {
+            ...TEST_LIMS_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ALWAYS', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeTruthy();
+    });
+
+    test('LKSM non-premium admin user', () => {
+        let moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ADMIN' } };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeFalsy();
+
+        moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ALWAYS' } };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeFalsy();
+    });
+
+    test('LKSM non-premium non-admin user', () => {
+        let moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ADMIN' } };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeFalsy();
+
+        moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT, api: { applicationMenuDisplayMode: 'ALWAYS' } };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeFalsy();
+    });
+
+    test('LKSM premium admin user', () => {
+        let moduleContext = {
+            ...TEST_LKSM_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ADMIN', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeTruthy();
+
+        moduleContext = {
+            ...TEST_LKSM_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ALWAYS', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_APP_ADMIN, moduleContext)).toBeTruthy();
+    });
+
+    test('LKSM premium non-admin user', () => {
+        let moduleContext = {
+            ...TEST_LKSM_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ADMIN', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeFalsy();
+
+        moduleContext = {
+            ...TEST_LKSM_STARTER_MODULE_CONTEXT,
+            api: { applicationMenuDisplayMode: 'ALWAYS', moduleNames: ['premium'] },
+        };
+        expect(shouldShowProductNavigation(TEST_USER_EDITOR, moduleContext)).toBeTruthy();
+    });
+});

--- a/packages/components/src/internal/components/productnavigation/utils.ts
+++ b/packages/components/src/internal/components/productnavigation/utils.ts
@@ -1,10 +1,14 @@
 import { User } from '../base/models/User';
-import { hasPremiumModule, resolveModuleContext } from '../../app/utils';
+import { hasPremiumModule, isBiologicsEnabled, resolveModuleContext } from '../../app/utils';
 import { ModuleContext } from '../base/ServerContext';
 
+/**
+ * Returns true for the LKB app or the LKSM app w/ premium module when the user isAdmin or the Look and Feel Setting
+ * for applicationMenuDisplayMode is set to ALWAYS.
+ */
 export function shouldShowProductNavigation(user?: User, moduleContext?: ModuleContext): boolean {
     return (
-        hasPremiumModule(moduleContext) &&
+        (isBiologicsEnabled(moduleContext) || hasPremiumModule(moduleContext)) &&
         (user?.isAdmin ||
             resolveModuleContext(moduleContext)?.api?.applicationMenuDisplayMode?.toLowerCase() === 'always')
     );


### PR DESCRIPTION
#### Rationale
AppsMenuNavigationTest.testBackNavigationFromLabkeyPanel and other tests started failing on the lims_starter distribution because the check for shouldShowProductNavigation() was returning false if the premium module was not present. This check makes sense in the LKSM case, but for LKB it should always return true.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1195
- https://github.com/LabKey/inventory/pull/858
- https://github.com/LabKey/biologics/pull/2135
- https://github.com/LabKey/sampleManagement/pull/1835

#### Changes
- Update shouldShowProductNavigation() to include check for LKB app instead of just hasPremiumModule
