### PR TITLE
Project level data type - remove experimental flag

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.3-fb-dataTypeExclusionLookup.2",
+  "version": "2.341.3-fb-dataTypeExclusionLookup.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.1",
+  "version": "2.341.2-fb-dataTypeExclusionLookup.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.3-fb-dataTypeExclusionLookup.3",
+  "version": "2.341.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.3-fb-dataTypeExclusionLookup.1",
+  "version": "2.341.3-fb-dataTypeExclusionLookup.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.2",
+  "version": "2.341.3-fb-dataTypeExclusionLookup.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.X
-*Released*: X May 2023
+### version 2.341.3
+*Released*: 31 May 2023
 * Project level data type - handle lookups and remove experimental flag
   * remove isProductProjectDataTypeSelectionEnabled experimental flag and enable function
   * filter schema and query names for Look Up fields in designer based on selected target container's data type exclusion config

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X May 2023
+* Project level data type - handle lookups and remove experimental flag
+  * TODO
+
 ### version 2.341.1
 *Released*: 26 May 2023
 * Fix await without try/catch

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.X
 *Released*: X May 2023
 * Project level data type - handle lookups and remove experimental flag
-  * TODO
+  * remove isProductProjectDataTypeSelectionEnabled experimental flag and enable function
+  * filter schema and query names for Look Up fields in designer based on selected target container's data type exclusion config
+  * support user supplied lookupValueFilters for LookupCell
 
 ### version 2.341.1
 *Released*: 26 May 2023

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -473,6 +473,7 @@ import {
     getSampleOperationConfirmationData,
     getDeleteConfirmationData,
     getEntityTypeOptions,
+    getExcludedDataTypeNames,
 } from './internal/components/entities/actions';
 import {
     AssayResultDataType,
@@ -676,7 +677,6 @@ import {
     getProjectAssayDesignExclusion,
     getProjectDataClassExclusion,
     getProjectSampleTypeExclusion,
-    isProductProjectDataTypeSelectionEnabled,
     getProjectPath,
     hasModule,
     hasPremiumModule,
@@ -866,7 +866,6 @@ const App = {
     getProjectAssayDesignExclusion,
     getProjectDataClassExclusion,
     getProjectSampleTypeExclusion,
-    isProductProjectDataTypeSelectionEnabled,
     getProjectPath,
     hasPremiumModule,
     hasProductProjects,
@@ -1250,6 +1249,7 @@ export {
     getDeleteConfirmationData,
     getEntityTypeOptions,
     getCrossFolderSelectionResult,
+    getExcludedDataTypeNames,
     getOperationConfirmationData,
     getDataOperationConfirmationData,
     getDataDeleteConfirmationData,

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -95,7 +95,6 @@ export const EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = 'queryProductAllFolderLoo
 export const EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED = 'queryProductProjectDataListingScoped';
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';
 export const EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR = 'experimental-sample-aliquot-selector';
-export const EXPERIMENTAL_PRODUCT_PROJECT_DATA_SELECTION = 'queryProductProjectDataTypeSelection';
 
 export const PROJECT_DATA_TYPE_EXCLUSIONS = 'dataTypeExclusions';
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -24,7 +24,6 @@ import {
     BIOLOGICS_APP_PROPERTIES,
     EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS,
     EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED,
-    EXPERIMENTAL_PRODUCT_PROJECT_DATA_SELECTION,
     EXPERIMENTAL_REQUESTS_MENU,
     EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR,
     FREEZER_MANAGER_APP_PROPERTIES,
@@ -268,10 +267,6 @@ export function isAllProductFoldersFilteringEnabled(moduleContext?: ModuleContex
 
 export function isProductProjectsDataListingScopedToProject(moduleContext?: ModuleContext): boolean {
     return resolveModuleContext(moduleContext)?.query?.[EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED] === true;
-}
-
-export function isProductProjectDataTypeSelectionEnabled(moduleContext?: ModuleContext): boolean {
-    return resolveModuleContext(moduleContext)?.query?.[EXPERIMENTAL_PRODUCT_PROJECT_DATA_SELECTION] === true;
 }
 
 export function getProjectDataExclusion(moduleContext?: ModuleContext): { [key: string]: number[] } {

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -16,7 +16,6 @@ import {
     getProjectDataExclusion,
     isAppHomeFolder,
     isELNEnabled,
-    isProductProjectDataTypeSelectionEnabled,
     isProductProjectsEnabled,
     isSampleStatusEnabled,
 } from '../../app/utils';
@@ -86,7 +85,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
         return (
             <>
                 <ProjectSettings onChange={onSettingsChange} onSuccess={onSettingsSuccess} onPageError={onError} />
-                {isProductProjectDataTypeSelectionEnabled() && !isAppHomeFolder() && (
+                {!isAppHomeFolder() && (
                     <>
                         <ProjectDataTypeSelections
                             entityDataTypes={projectDataTypes}

--- a/packages/components/src/internal/components/domainproperties/Lookup/Context.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Context.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { List } from 'immutable';
 import { Security } from '@labkey/api';
 
-import { fetchContainers, fetchQueries, fetchSchemas } from '../actions';
+import {fetchContainers, fetchQueries, fetchSchemas, getExcludedSchemaQueryNames} from '../actions';
 import { QueryInfoLite } from '../models';
 import { Container } from '../../base/models/Container';
 import { SchemaDetails } from '../../../SchemaDetails';
@@ -12,6 +12,7 @@ export interface ILookupContext {
     fetchContainers: () => Promise<List<Container>>;
     fetchQueries: (containerPath: string, schemaName: string) => Promise<QueryInfoLite[]>;
     fetchSchemas: (containerPath: string) => Promise<SchemaDetails[]>;
+    getExcludedSchemaQueryNames: (schemaName, queryContainerPath?: string) => Promise<string[]>;
 }
 
 const LookupContext = React.createContext<ILookupContext>(undefined);
@@ -28,6 +29,7 @@ export class LookupProvider extends React.Component<any, ILookupContext> {
             fetchContainers,
             fetchQueries,
             fetchSchemas,
+            getExcludedSchemaQueryNames
         };
     }
 

--- a/packages/components/src/internal/components/domainproperties/Lookup/Context.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Context.tsx
@@ -10,8 +10,8 @@ import { SchemaDetails } from '../../../SchemaDetails';
 export interface ILookupContext {
     activeContainer: Container;
     fetchContainers: () => Promise<List<Container>>;
-    fetchQueries: (containerPath: string, schemaName: string) => Promise<List<QueryInfoLite>>;
-    fetchSchemas: (containerPath: string) => Promise<List<SchemaDetails>>;
+    fetchQueries: (containerPath: string, schemaName: string) => Promise<QueryInfoLite[]>;
+    fetchSchemas: (containerPath: string) => Promise<SchemaDetails[]>;
 }
 
 const LookupContext = React.createContext<ILookupContext>(undefined);

--- a/packages/components/src/internal/components/domainproperties/Lookup/Context.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Context.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { List } from 'immutable';
 import { Security } from '@labkey/api';
 
-import {fetchContainers, fetchQueries, fetchSchemas, getExcludedSchemaQueryNames} from '../actions';
+import { fetchContainers, fetchQueries, fetchSchemas, getExcludedSchemaQueryNames } from '../actions';
 import { QueryInfoLite } from '../models';
 import { Container } from '../../base/models/Container';
 import { SchemaDetails } from '../../../SchemaDetails';
@@ -29,7 +29,7 @@ export class LookupProvider extends React.Component<any, ILookupContext> {
             fetchContainers,
             fetchQueries,
             fetchSchemas,
-            getExcludedSchemaQueryNames
+            getExcludedSchemaQueryNames,
         };
     }
 

--- a/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
@@ -11,6 +11,8 @@ import { DOMAIN_FIELD_LOOKUP_CONTAINER, DOMAIN_FIELD_LOOKUP_QUERY, DOMAIN_FIELD_
 import { Container } from '../../base/models/Container';
 import { SchemaDetails } from '../../../SchemaDetails';
 
+import { getExcludedSchemaQueryNames } from '../actions';
+
 import { ILookupContext, LookupContextConsumer } from './Context';
 
 interface ILookupProps {
@@ -131,7 +133,7 @@ export interface ITargetTableSelectImplState {
     loading?: boolean;
     prevPath?: string;
     prevSchemaName?: string;
-    queries?: List<{ name: string; type: PropDescType }>;
+    queries?: { name: string; type: PropDescType }[];
 }
 
 export type TargetTableSelectProps = ITargetTableSelectProps & ILookupProps;
@@ -149,7 +151,7 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
             loading: false,
             prevPath: null,
             prevSchemaName: undefined,
-            queries: List(),
+            queries: undefined,
         };
     }
 
@@ -199,22 +201,31 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
         const queryContainerPath = containerPath === '' ? null : containerPath;
 
         context.fetchQueries(queryContainerPath, schemaName).then(queries => {
-            let infos = List<{ name: string; type: PropDescType }>();
+            let infos: Array<{ name: string; type: PropDescType }> = [];
 
-            queries.forEach(q => {
-                if (q.isIncludedForLookups) infos = infos.concat(q.getLookupInfo(this.props.lookupURI)).toList();
-            });
+            getExcludedSchemaQueryNames(schemaName.toLowerCase(), containerPath)
+                .then(excludedQueries => {
+                    queries.forEach(q => {
+                        if (excludedQueries && excludedQueries?.indexOf(q.name.toLowerCase()) > -1) return;
 
-            const initialQueryName = value ? decodeLookup(value).queryName : undefined;
+                        if (q.isIncludedForLookups) infos.push(...q.getLookupInfo(this.props.lookupURI));
+                    });
 
-            if (!lookupIsValid) infos = infos.unshift({ name: initialQueryName, type: LOOKUP_TYPE }).toList();
+                    const initialQueryName = value ? decodeLookup(value).queryName : undefined;
 
-            this.setState({
-                loading: false,
-                queries: infos,
-                initialQueryName,
-                initialQueryInvalid: !lookupIsValid
-            });
+                    if (!lookupIsValid)
+                        infos.unshift({ name: initialQueryName, type: LOOKUP_TYPE });
+
+                    this.setState({
+                        loading: false,
+                        queries: infos,
+                        initialQueryName,
+                        initialQueryInvalid: !lookupIsValid,
+                    });
+                })
+                .catch(error => {
+                    console.error(error);
+                });
         });
     }
 
@@ -222,14 +233,12 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
         const { id, onChange, value, name, disabled, lookupIsValid, shouldDisableNonExists } = this.props;
         const { loading, queries, initialQueryName, initialQueryInvalid } = this.state;
 
-        const isEmpty = queries.size === 0;
+        const isEmpty = queries?.length === 0;
         const hasValue = !!value;
         const blankOption = !hasValue && !isEmpty;
 
         const queryNameOptionExists =
-            initialQueryName && queries?.size > 0
-                ? queries.find(query => query.name === initialQueryName) !== undefined
-                : true; // default to true without a selected queryName
+            initialQueryName && !isEmpty ? queries.find(query => query.name === initialQueryName) !== undefined : true; // default to true without a selected queryName
 
         // Certain cases disable the lookup field for a valid query that is not in the list of queries
         const disabledField = disabled || (shouldDisableNonExists && !queryNameOptionExists && lookupIsValid);
@@ -254,29 +263,27 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
                     </option>
                 )}
                 {blankOption && <option key="_default" value={undefined} />}
-                {queries
-                    .map(q => {
-                        const encoded = encodeLookup(q.name, q.type);
-                        return (
-                            <option
-                                key={encoded}
-                                value={encoded}
-                                disabled={
-                                    // Disable if it is the initial query and it is an invalid lookup
-                                    initialQueryInvalid &&
-                                    q.name === initialQueryName &&
-                                    decodeLookup(value).queryName !== q.name
-                                }
-                            >
-                                {q.name} (
-                                {!lookupIsValid && q.name === initialQueryName
-                                    ? 'Unknown'
-                                    : q.type.shortDisplay || q.type.display}
-                                )
-                            </option>
-                        );
-                    })
-                    .toArray()}
+                {queries?.map(q => {
+                    const encoded = encodeLookup(q.name, q.type);
+                    return (
+                        <option
+                            key={encoded}
+                            value={encoded}
+                            disabled={
+                                // Disable if it is the initial query and it is an invalid lookup
+                                initialQueryInvalid &&
+                                q.name === initialQueryName &&
+                                decodeLookup(value).queryName !== q.name
+                            }
+                        >
+                            {q.name} (
+                            {!lookupIsValid && q.name === initialQueryName
+                                ? 'Unknown'
+                                : q.type.shortDisplay || q.type.display}
+                            )
+                        </option>
+                    );
+                })}
                 {!loading && isEmpty && (
                     <option disabled key="_empty" value={undefined}>
                         (No tables)
@@ -317,7 +324,7 @@ export interface ISchemaSelectImplState {
     containerPath?: string;
     loading?: boolean;
     prevPath?: string;
-    schemas?: List<SchemaDetails>;
+    schemas?: SchemaDetails[];
 }
 
 class SchemaSelectImpl extends React.Component<SchemaSelectProps, ISchemaSelectImplState> {
@@ -327,7 +334,7 @@ class SchemaSelectImpl extends React.Component<SchemaSelectProps, ISchemaSelectI
         this.state = {
             loading: false,
             prevPath: null,
-            schemas: List(),
+            schemas: undefined,
         };
     }
 
@@ -367,10 +374,26 @@ class SchemaSelectImpl extends React.Component<SchemaSelectProps, ISchemaSelectI
             prevPath: containerPath,
         });
 
-        context.fetchSchemas(containerPath).then(schemas => {
-            this.setState({
-                loading: false,
-                schemas,
+        context.fetchSchemas(containerPath).then(allSchemas => {
+            const schemas = [];
+            getExcludedSchemaQueryNames('assay', containerPath).then(excludedAssayNames => {
+                if (!excludedAssayNames || excludedAssayNames.length === 0) schemas.push(...allSchemas);
+                else {
+                    allSchemas.forEach(schema => {
+                        if (
+                            !(
+                                schema.fullyQualifiedName.indexOf('assay.') === 0 &&
+                                excludedAssayNames.indexOf(schema.schemaName.toLowerCase()) > -1
+                            )
+                        )
+                            schemas.push(schema);
+                    });
+                }
+
+                this.setState({
+                    loading: false,
+                    schemas,
+                });
             });
         });
     }
@@ -379,7 +402,7 @@ class SchemaSelectImpl extends React.Component<SchemaSelectProps, ISchemaSelectI
         const { id, onChange, value, name, disabled } = this.props;
         const { schemas, loading } = this.state;
 
-        const isEmpty = schemas.size === 0;
+        const isEmpty = schemas?.length === 0;
         const hasValue = !!value;
         const blankOption = !hasValue && !isEmpty;
 
@@ -404,13 +427,11 @@ class SchemaSelectImpl extends React.Component<SchemaSelectProps, ISchemaSelectI
                     </option>
                 )}
                 {blankOption && <option key="_default" value={undefined} />}
-                {schemas
-                    .map(s => (
-                        <option key={s.fullyQualifiedName} value={s.fullyQualifiedName}>
-                            {s.fullyQualifiedName}
-                        </option>
-                    ))
-                    .toArray()}
+                {schemas?.map(s => (
+                    <option key={s.fullyQualifiedName} value={s.fullyQualifiedName}>
+                        {s.fullyQualifiedName}
+                    </option>
+                ))}
                 {!loading && isEmpty && (
                     <option disabled key="_empty" value={undefined}>
                         (No schemas)

--- a/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
@@ -11,8 +11,6 @@ import { DOMAIN_FIELD_LOOKUP_CONTAINER, DOMAIN_FIELD_LOOKUP_QUERY, DOMAIN_FIELD_
 import { Container } from '../../base/models/Container';
 import { SchemaDetails } from '../../../SchemaDetails';
 
-import { getExcludedSchemaQueryNames } from '../actions';
-
 import { ILookupContext, LookupContextConsumer } from './Context';
 
 interface ILookupProps {
@@ -203,9 +201,9 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
         context.fetchQueries(queryContainerPath, schemaName).then(queries => {
             const infos: Array<{ name: string; type: PropDescType }> = [];
 
-            getExcludedSchemaQueryNames(schemaName?.toLowerCase(), containerPath)
+            context.getExcludedSchemaQueryNames(schemaName?.toLowerCase(), queryContainerPath)
                 .then(excludedQueries => {
-                    queries.forEach(q => {
+                    queries?.forEach(q => {
                         if (excludedQueries && excludedQueries?.indexOf(q.name.toLowerCase()) > -1) return;
 
                         if (q.isIncludedForLookups) infos.push(...q.getLookupInfo(this.props.lookupURI));
@@ -225,6 +223,8 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
                 .catch(error => {
                     console.error(error);
                 });
+        }).catch(e => {
+            console.error(e);
         });
     }
 
@@ -375,7 +375,7 @@ class SchemaSelectImpl extends React.Component<SchemaSelectProps, ISchemaSelectI
 
         context.fetchSchemas(containerPath).then(allSchemas => {
             const schemas = [];
-            getExcludedSchemaQueryNames('assay', containerPath).then(excludedAssayNames => {
+            context.getExcludedSchemaQueryNames('assay', containerPath).then(excludedAssayNames => {
                 if (!excludedAssayNames || excludedAssayNames.length === 0) schemas.push(...allSchemas);
                 else {
                     allSchemas.forEach(schema => {

--- a/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
@@ -203,7 +203,7 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
         context.fetchQueries(queryContainerPath, schemaName).then(queries => {
             const infos: Array<{ name: string; type: PropDescType }> = [];
 
-            getExcludedSchemaQueryNames(schemaName.toLowerCase(), containerPath)
+            getExcludedSchemaQueryNames(schemaName?.toLowerCase(), containerPath)
                 .then(excludedQueries => {
                     queries.forEach(q => {
                         if (excludedQueries && excludedQueries?.indexOf(q.name.toLowerCase()) > -1) return;

--- a/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
@@ -133,7 +133,7 @@ export interface ITargetTableSelectImplState {
     loading?: boolean;
     prevPath?: string;
     prevSchemaName?: string;
-    queries?: { name: string; type: PropDescType }[];
+    queries?: Array<{ name: string; type: PropDescType }>;
 }
 
 export type TargetTableSelectProps = ITargetTableSelectProps & ILookupProps;
@@ -201,7 +201,7 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
         const queryContainerPath = containerPath === '' ? null : containerPath;
 
         context.fetchQueries(queryContainerPath, schemaName).then(queries => {
-            let infos: Array<{ name: string; type: PropDescType }> = [];
+            const infos: Array<{ name: string; type: PropDescType }> = [];
 
             getExcludedSchemaQueryNames(schemaName.toLowerCase(), containerPath)
                 .then(excludedQueries => {
@@ -213,8 +213,7 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
 
                     const initialQueryName = value ? decodeLookup(value).queryName : undefined;
 
-                    if (!lookupIsValid)
-                        infos.unshift({ name: initialQueryName, type: LOOKUP_TYPE });
+                    if (!lookupIsValid) infos.unshift({ name: initialQueryName, type: LOOKUP_TYPE });
 
                     this.setState({
                         loading: false,

--- a/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
+++ b/packages/components/src/internal/components/domainproperties/Lookup/Fields.tsx
@@ -198,34 +198,38 @@ class TargetTableSelectImpl extends React.Component<TargetTableSelectProps, ITar
         // special case for Current Project/Folder which uses a value of '' (empty string)
         const queryContainerPath = containerPath === '' ? null : containerPath;
 
-        context.fetchQueries(queryContainerPath, schemaName).then(queries => {
-            const infos: Array<{ name: string; type: PropDescType }> = [];
+        context
+            .fetchQueries(queryContainerPath, schemaName)
+            .then(queries => {
+                const infos: Array<{ name: string; type: PropDescType }> = [];
 
-            context.getExcludedSchemaQueryNames(schemaName?.toLowerCase(), queryContainerPath)
-                .then(excludedQueries => {
-                    queries?.forEach(q => {
-                        if (excludedQueries && excludedQueries?.indexOf(q.name.toLowerCase()) > -1) return;
+                context
+                    .getExcludedSchemaQueryNames(schemaName?.toLowerCase(), queryContainerPath)
+                    .then(excludedQueries => {
+                        queries?.forEach(q => {
+                            if (excludedQueries && excludedQueries?.indexOf(q.name.toLowerCase()) > -1) return;
 
-                        if (q.isIncludedForLookups) infos.push(...q.getLookupInfo(this.props.lookupURI));
+                            if (q.isIncludedForLookups) infos.push(...q.getLookupInfo(this.props.lookupURI));
+                        });
+
+                        const initialQueryName = value ? decodeLookup(value).queryName : undefined;
+
+                        if (!lookupIsValid) infos.unshift({ name: initialQueryName, type: LOOKUP_TYPE });
+
+                        this.setState({
+                            loading: false,
+                            queries: infos,
+                            initialQueryName,
+                            initialQueryInvalid: !lookupIsValid,
+                        });
+                    })
+                    .catch(error => {
+                        console.error(error);
                     });
-
-                    const initialQueryName = value ? decodeLookup(value).queryName : undefined;
-
-                    if (!lookupIsValid) infos.unshift({ name: initialQueryName, type: LOOKUP_TYPE });
-
-                    this.setState({
-                        loading: false,
-                        queries: infos,
-                        initialQueryName,
-                        initialQueryInvalid: !lookupIsValid,
-                    });
-                })
-                .catch(error => {
-                    console.error(error);
-                });
-        }).catch(e => {
-            console.error(e);
-        });
+            })
+            .catch(e => {
+                console.error(e);
+            });
     }
 
     render() {

--- a/packages/components/src/internal/components/domainproperties/LookupFieldOptions.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/LookupFieldOptions.spec.tsx
@@ -139,17 +139,17 @@ describe('LookupFieldOptions', () => {
 
             return waitForLoad(schemaField).then(() => {
                 expect(schemaField.props().value).toEqual(_schema);
-                expect(schemaField.state().schemas.size).toEqual(5);
-                expect(schemaField.state().schemas.get(0).schemaName).toEqual(_schema0);
-                expect(schemaField.state().schemas.get(4).schemaName).toEqual(_schema2);
+                expect(schemaField.state().schemas.length).toEqual(5);
+                expect(schemaField.state().schemas[0].schemaName).toEqual(_schema0);
+                expect(schemaField.state().schemas[4].schemaName).toEqual(_schema2);
 
                 // Query
                 const queryField = queryFieldSelector(lookupField, _domainIndex, _index);
 
                 return waitForLoad(queryField).then(() => {
                     expect(queryField.props().value).toEqual(_query);
-                    expect(queryField.state().queries.size).toEqual(3);
-                    expect(queryField.state().queries.get(1).name).toEqual(_queries1);
+                    expect(queryField.state().queries.length).toEqual(3);
+                    expect(queryField.state().queries[1].name).toEqual(_queries1);
 
                     expect(lookupField).toMatchSnapshot();
                     lookupField.unmount();
@@ -207,7 +207,7 @@ describe('LookupFieldOptions', () => {
 
             return waitForLoad(schema).then(() => {
                 expect(schema.props().value).toEqual(_schema);
-                expect(schema.state().schemas.size).toEqual(5);
+                expect(schema.state().schemas.length).toEqual(5);
 
                 lookupField.setProps({
                     children: (
@@ -230,13 +230,15 @@ describe('LookupFieldOptions', () => {
                     ),
                 });
 
-                // Wait for schema to load and verify values updated
-                return waitForLoad(schema).then(() => {
-                    expect(schema.state().schemas.size).toEqual(1);
-                    expect(schema.state().schemas.get(0).schemaName).toEqual(_newSchema);
+                return waitForLoad(container).then(() => {
+                    // Wait for schema to load and verify values updated
+                    return waitForLoad(schema).then(() => {
+                        expect(schema.state().schemas.length).toEqual(1);
+                        expect(schema.state().schemas[0].schemaName).toEqual(_newSchema);
 
-                    expect(lookupField).toMatchSnapshot();
-                    lookupField.unmount();
+                        expect(lookupField).toMatchSnapshot();
+                        lookupField.unmount();
+                    });
                 });
             });
         });
@@ -292,38 +294,44 @@ describe('LookupFieldOptions', () => {
             return waitForLoad(schemaField).then(() => {
                 expect(schemaField.props().value).toEqual(_schema1);
 
-                lookupField.setProps({
-                    children: (
-                        <LookupFieldOptions
-                            field={
-                                new DomainField({
-                                    original: field,
-                                    lookupSchema: _schema2,
-                                    lookupQueryValue: '',
-                                    lookupIsValid: true,
-                                })
-                            }
-                            lookupContainer={_container}
-                            onChange={jest.fn()}
-                            onMultiChange={jest.fn()}
-                            index={_index}
-                            domainIndex={_domainIndex}
-                            label={_label}
-                            lockType={DOMAIN_FIELD_NOT_LOCKED}
-                        />
-                    ),
-                });
-
                 // Query
-                const queryField = queryFieldSelector(lookupField, _domainIndex, _index);
-
+                let queryField = queryFieldSelector(lookupField, _domainIndex, _index);
                 return waitForLoad(queryField).then(() => {
-                    // Verify query field
-                    expect(queryField.state().queries.size).toEqual(1);
-                    expect(queryField.state().queries.get(0).name).toEqual(_query2);
+                    expect(queryField.state().queries.length).toEqual(4);
 
-                    expect(lookupField).toMatchSnapshot();
-                    lookupField.unmount();
+                    lookupField.setProps({
+                        children: (
+                            <LookupFieldOptions
+                                field={
+                                    new DomainField({
+                                        original: field,
+                                        lookupSchema: _schema2,
+                                        lookupQueryValue: '',
+                                        lookupIsValid: true,
+                                    })
+                                }
+                                lookupContainer={_container}
+                                onChange={jest.fn()}
+                                onMultiChange={jest.fn()}
+                                index={_index}
+                                domainIndex={_domainIndex}
+                                label={_label}
+                                lockType={DOMAIN_FIELD_NOT_LOCKED}
+                            />
+                        ),
+                    });
+
+                    queryField = queryFieldSelector(lookupField, _domainIndex, _index);
+                    return waitForLoad(schemaField).then(() => {
+                        return waitForLoad(queryField).then(() => {
+                            // Verify query field
+                            expect(queryField.state().queries.length).toEqual(1);
+                            expect(queryField.state().queries[0].name).toEqual(_query2);
+
+                            expect(lookupField).toMatchSnapshot();
+                            lookupField.unmount();
+                        });
+                    });
                 });
             });
         });
@@ -369,42 +377,49 @@ describe('LookupFieldOptions', () => {
 
         // Folder
         const folderField = folderFieldSelector(lookupField, _domainIndex, _index);
-
+        let queryField = queryFieldSelector(lookupField, _domainIndex, _index);
+        expect(queryField.state().queries).toBeUndefined();
         return waitForLoad(folderField).then(() => {
             expect(folderField.props().value).toEqual(_container1);
 
-            lookupField.setProps({
-                children: (
-                    <LookupFieldOptions
-                        field={
-                            new DomainField({
-                                original: field,
-                                lookupSchema: '',
-                                lookupQueryValue: '',
-                                lookupIsValid: true,
-                            })
-                        }
-                        lookupContainer={_container2}
-                        onChange={jest.fn()}
-                        onMultiChange={jest.fn()}
-                        index={_index}
-                        domainIndex={_domainIndex}
-                        label={_label}
-                        lockType={DOMAIN_FIELD_NOT_LOCKED}
-                    />
-                ),
-            });
-
-            // Query
-            const queryField = queryFieldSelector(lookupField, _domainIndex, _index);
-
             return waitForLoad(queryField).then(() => {
-                // Verify query field
-                expect(queryField.state().queries.size).toEqual(0);
-                expect(queryField.props().value).toEqual('');
+                expect(queryField.state().queries.length).toEqual(3);
 
-                expect(lookupField).toMatchSnapshot();
-                lookupField.unmount();
+                lookupField.setProps({
+                    children: (
+                        <LookupFieldOptions
+                            field={
+                                new DomainField({
+                                    original: field,
+                                    lookupSchema: '',
+                                    lookupQueryValue: '',
+                                    lookupIsValid: true,
+                                })
+                            }
+                            lookupContainer={_container2}
+                            onChange={jest.fn()}
+                            onMultiChange={jest.fn()}
+                            index={_index}
+                            domainIndex={_domainIndex}
+                            label={_label}
+                            lockType={DOMAIN_FIELD_NOT_LOCKED}
+                        />
+                    ),
+                });
+
+                return waitForLoad(folderField).then(() => {
+                    // Query
+                    queryField = queryFieldSelector(lookupField, _domainIndex, _index);
+                    return waitForLoad(queryField).then(() => {
+                        queryField = queryFieldSelector(lookupField, _domainIndex, _index);
+                        // Verify query field
+                        expect(queryField.props().value).toEqual('');
+                        expect(queryField.state().queries.length).toBe(0);
+
+                        expect(lookupField).toMatchSnapshot();
+                        lookupField.unmount();
+                    });
+                });
             });
         });
     });
@@ -476,14 +491,17 @@ describe('LookupFieldOptions', () => {
             </MockLookupProvider>
         );
 
-        // Query
-        const queryField = queryFieldSelector(lookupField, _domainIndex, _index);
+        const folderField = folderFieldSelector(lookupField, _domainIndex, _index);
+        return waitForLoad(folderField).then(() => {
+            // Query
+            const queryField = queryFieldSelector(lookupField, _domainIndex, _index);
 
-        return waitForLoad(queryField).then(() => {
-            // Verify query field
-            expect(queryField.state().queries.size).toEqual(4); // exp queries plus unknown query
-            expect(queryField.props().value).toEqual(_invalidLookup);
-            lookupField.unmount();
+            return waitForLoad(queryField).then(() => {
+                // Verify query field
+                expect(queryField.state().queries.length).toEqual(4); // exp queries plus unknown query
+                expect(queryField.props().value).toEqual(_invalidLookup);
+                lookupField.unmount();
+            });
         });
     });
 });

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -16,6 +16,8 @@ import { ALL_SAMPLES_DISPLAY_TEXT, DOMAIN_FIELD_SAMPLE_TYPE } from './constants'
 import { encodeLookup, IDomainField, ITypeDependentProps, LookupInfo, SAMPLE_TYPE_OPTION_VALUE } from './models';
 
 import { SectionHeading } from './SectionHeading';
+import {getExcludedDataTypeNames} from "../entities/actions";
+import {SCHEMAS} from "../../schemas";
 
 interface SampleFieldProps extends ITypeDependentProps {
     container: string;
@@ -45,10 +47,11 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
 
         try {
             const queries = await fetchQueries(undefined, 'samples');
+            const excludedQueries = await getExcludedDataTypeNames(SCHEMAS.EXP_TABLES.SAMPLE_SETS, 'SampleType'); // TODO Is this needed since data type belongs to home folder
 
             const sampleTypes = queries
                 .reduce((list, q) => list.concat(q.getLookupInfo(original.rangeURI)).toList(), List<LookupInfo>())
-                .filter(st => st.type.isInteger()) // Remove rowId duplicates
+                .filter(st => st.type.isInteger() && excludedQueries.indexOf(st.name.toLowerCase()) === -1) // Remove rowId duplicates
                 .toList();
 
             this.setState({ loadingState: LoadingState.LOADED, sampleTypes });

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -9,6 +9,10 @@ import { isLoading, LoadingState } from '../../../public/LoadingState';
 
 import { LabelHelpTip } from '../base/LabelHelpTip';
 
+import { getExcludedDataTypeNames } from '../entities/actions';
+
+import { SCHEMAS } from '../../schemas';
+
 import { isFieldFullyLocked } from './propertiesUtil';
 import { fetchQueries } from './actions';
 import { createFormInputId, createFormInputName } from './utils';
@@ -16,8 +20,6 @@ import { ALL_SAMPLES_DISPLAY_TEXT, DOMAIN_FIELD_SAMPLE_TYPE } from './constants'
 import { encodeLookup, IDomainField, ITypeDependentProps, LookupInfo, SAMPLE_TYPE_OPTION_VALUE } from './models';
 
 import { SectionHeading } from './SectionHeading';
-import {getExcludedDataTypeNames} from "../entities/actions";
-import {SCHEMAS} from "../../schemas";
 
 interface SampleFieldProps extends ITypeDependentProps {
     container: string;

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -9,10 +9,6 @@ import { isLoading, LoadingState } from '../../../public/LoadingState';
 
 import { LabelHelpTip } from '../base/LabelHelpTip';
 
-import { getExcludedDataTypeNames } from '../entities/actions';
-
-import { SCHEMAS } from '../../schemas';
-
 import { isFieldFullyLocked } from './propertiesUtil';
 import { fetchQueries } from './actions';
 import { createFormInputId, createFormInputName } from './utils';
@@ -49,11 +45,10 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
 
         try {
             const queries = await fetchQueries(undefined, 'samples');
-            const excludedQueries = await getExcludedDataTypeNames(SCHEMAS.EXP_TABLES.SAMPLE_SETS, 'SampleType'); // TODO Is this needed since data type belongs to home folder
 
             const sampleTypes = queries
                 .reduce((list, q) => list.concat(q.getLookupInfo(original.rangeURI)).toList(), List<LookupInfo>())
-                .filter(st => st.type.isInteger() && excludedQueries.indexOf(st.name.toLowerCase()) === -1) // Remove rowId duplicates
+                .filter(st => st.type.isInteger()) // Remove rowId duplicates
                 .toList();
 
             this.setState({ loadingState: LoadingState.LOADED, sampleTypes });

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/LookupFieldOptions.spec.tsx.snap
@@ -239,6 +239,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -278,6 +279,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                         "fetchContainers": [Function],
                         "fetchQueries": [Function],
                         "fetchSchemas": [Function],
+                        "getExcludedSchemaQueryNames": [Function],
                       }
                     }
                     disabled={false}
@@ -316,6 +318,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                           "fetchContainers": [Function],
                           "fetchQueries": [Function],
                           "fetchSchemas": [Function],
+                          "getExcludedSchemaQueryNames": [Function],
                         }
                       }
                       disabled={false}
@@ -388,6 +391,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -483,6 +487,7 @@ exports[`LookupFieldOptions Lookup field options 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -846,6 +851,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -885,6 +891,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                         "fetchContainers": [Function],
                         "fetchQueries": [Function],
                         "fetchSchemas": [Function],
+                        "getExcludedSchemaQueryNames": [Function],
                       }
                     }
                     disabled={false}
@@ -923,6 +930,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                           "fetchContainers": [Function],
                           "fetchQueries": [Function],
                           "fetchSchemas": [Function],
+                          "getExcludedSchemaQueryNames": [Function],
                         }
                       }
                       disabled={false}
@@ -1007,6 +1015,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -1128,6 +1137,7 @@ exports[`LookupFieldOptions Selected container changes queries 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -1535,6 +1545,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -1574,6 +1585,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                         "fetchContainers": [Function],
                         "fetchQueries": [Function],
                         "fetchSchemas": [Function],
+                        "getExcludedSchemaQueryNames": [Function],
                       }
                     }
                     disabled={false}
@@ -1612,6 +1624,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                           "fetchContainers": [Function],
                           "fetchQueries": [Function],
                           "fetchSchemas": [Function],
+                          "getExcludedSchemaQueryNames": [Function],
                         }
                       }
                       disabled={false}
@@ -1696,6 +1709,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -1815,6 +1829,7 @@ exports[`LookupFieldOptions Selected container changes schemas 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -2228,6 +2243,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -2267,6 +2283,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                         "fetchContainers": [Function],
                         "fetchQueries": [Function],
                         "fetchSchemas": [Function],
+                        "getExcludedSchemaQueryNames": [Function],
                       }
                     }
                     disabled={false}
@@ -2305,6 +2322,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                           "fetchContainers": [Function],
                           "fetchQueries": [Function],
                           "fetchSchemas": [Function],
+                          "getExcludedSchemaQueryNames": [Function],
                         }
                       }
                       disabled={false}
@@ -2389,6 +2407,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}
@@ -2507,6 +2526,7 @@ exports[`LookupFieldOptions Selected schema changes queries 1`] = `
                       "fetchContainers": [Function],
                       "fetchQueries": [Function],
                       "fetchSchemas": [Function],
+                      "getExcludedSchemaQueryNames": [Function],
                     }
                   }
                   disabled={false}

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -35,6 +35,8 @@ import { SCHEMAS } from '../../schemas';
 
 import { handleRequestFailure } from '../../util/utils';
 
+import { getExcludedDataTypeNames } from '../entities/actions';
+
 import {
     DOMAIN_FIELD_CLIENT_SIDE_ERROR,
     DOMAIN_FIELD_LOOKUP_CONTAINER,
@@ -84,7 +86,6 @@ import {
     updateSampleField,
 } from './models';
 import { createFormInputId, createFormInputName, getIndexFromId, getNameFromId } from './utils';
-import {getExcludedDataTypeNames} from "../entities/actions";
 
 let sharedCache = Map<string, Promise<any>>();
 
@@ -238,8 +239,7 @@ export function processQueries(payload: any): QueryInfoLite[] {
         return null;
     }
 
-    return payload.queries.map(qi => QueryInfoLite.create(qi, payload.schemaName))
-        .sort(naturalSortByProperty('name'));
+    return payload.queries.map(qi => QueryInfoLite.create(qi, payload.schemaName)).sort(naturalSortByProperty('name'));
 }
 
 export function fetchSchemas(containerPath: string): Promise<SchemaDetails[]> {
@@ -270,7 +270,9 @@ export function getExcludedSchemaQueryNames(schemaName, queryContainerPath?: str
         case 'exp.data':
             return getExcludedDataTypeNames(SCHEMAS.EXP_TABLES.DATA_CLASSES, 'DataClass', queryContainerPath);
     }
-    return new Promise(resolve => {resolve([])});
+    return new Promise(resolve => {
+        resolve([]);
+    });
 }
 
 export function handleSchemas(payload: any): SchemaDetails[] {

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1598,8 +1598,8 @@ export class QueryInfoLite
         );
     }
 
-    getLookupInfo(rangeURI?: string): List<LookupInfo> {
-        let infos = List<LookupInfo>();
+    getLookupInfo(rangeURI?: string): LookupInfo[] {
+        const infos : LookupInfo[] = [];
 
         // allow for queries with only 1 primary key or with 2 primary key columns when one of them is container (see Issue 39879)
         let pkCols =
@@ -1626,7 +1626,7 @@ export class QueryInfoLite
 
                 // if supplied, apply rangeURI matching filter
                 if (type && (rangeURI === undefined || rangeURI === type.rangeURI)) {
-                    infos = infos.push({
+                    infos.push({
                         name: this.name,
                         type,
                     });

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1599,7 +1599,7 @@ export class QueryInfoLite
     }
 
     getLookupInfo(rangeURI?: string): LookupInfo[] {
-        const infos : LookupInfo[] = [];
+        const infos: LookupInfo[] = [];
 
         // allow for queries with only 1 primary key or with 2 primary key columns when one of them is container (see Issue 39879)
         let pkCols =

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { List } from 'immutable';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
-import {Filter, Query} from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { cancelEvent, isCopy, isFillDown, isPaste, isSelectAll } from '../../events';
 
@@ -46,10 +46,10 @@ interface Props {
     focused?: boolean;
     forUpdate: boolean;
     getFilteredLookupKeys?: (linkedValues: any[]) => Promise<List<any>>;
-    lookupValueFilters?: Filter.IFilter[];
     lastSelection?: boolean;
     linkedValues?: any[];
     locked?: boolean;
+    lookupValueFilters?: Filter.IFilter[];
     message?: CellMessage;
     name?: string;
     placeholder?: string;

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -17,13 +17,11 @@ import React from 'react';
 import classNames from 'classnames';
 import { List } from 'immutable';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
-import { Query } from '@labkey/api';
+import {Filter, Query} from '@labkey/api';
 
 import { cancelEvent, isCopy, isFillDown, isPaste, isSelectAll } from '../../events';
 
 import { CELL_SELECTION_HANDLE_CLASSNAME, KEYS, MODIFICATION_TYPES, SELECTION_TYPES } from '../../constants';
-
-import { getQueryColumnRenderers } from '../../global';
 
 import { QueryColumn } from '../../../public/QueryColumn';
 
@@ -48,6 +46,7 @@ interface Props {
     focused?: boolean;
     forUpdate: boolean;
     getFilteredLookupKeys?: (linkedValues: any[]) => Promise<List<any>>;
+    lookupValueFilters?: Filter.IFilter[];
     lastSelection?: boolean;
     linkedValues?: any[];
     locked?: boolean;
@@ -284,6 +283,7 @@ export class Cell extends React.PureComponent<Props, State> {
             selection,
             values,
             filteredLookupValues,
+            lookupValueFilters,
         } = this.props;
 
         const { filteredLookupKeys } = this.state;
@@ -382,6 +382,7 @@ export class Cell extends React.PureComponent<Props, State> {
                     colIdx={colIdx}
                     containerFilter={containerFilter}
                     disabled={this.isReadOnly()}
+                    lookupValueFilters={lookupValueFilters}
                     filteredLookupKeys={filteredLookupKeys}
                     filteredLookupValues={filteredLookupValues}
                     forUpdate={forUpdate}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Query } from '@labkey/api';
+import {Filter, Query} from '@labkey/api';
 import classNames from 'classnames';
 import { List, Map, OrderedMap, Set } from 'immutable';
 import React, { ChangeEvent, MouseEvent, PureComponent, ReactNode, SyntheticEvent } from 'react';
@@ -156,6 +156,7 @@ function inputCellFactory(
                 selection={editorModel ? editorModel.inSelection(colIdx, rn) : false}
                 lastSelection={editorModel ? editorModel.lastSelection(colIdx, rn) : false}
                 values={editorModel ? editorModel.getValue(colIdx, rn) : List<ValueDescriptor>()}
+                lookupValueFilters={columnMetadata?.lookupValueFilters}
                 filteredLookupValues={columnMetadata?.filteredLookupValues}
                 filteredLookupKeys={columnMetadata?.filteredLookupKeys}
                 getFilteredLookupKeys={columnMetadata?.getFilteredLookupKeys}
@@ -177,6 +178,7 @@ function inputCellKey(col: QueryColumn, row: any): string {
 
 export interface EditableColumnMetadata {
     caption?: string;
+    lookupValueFilters?: Filter.IFilter[];
     filteredLookupKeys?: List<any>;
     filteredLookupValues?: List<string>;
     getFilteredLookupKeys?: (linkedValues: any[]) => Promise<List<any>>;

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Filter, Query} from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 import classNames from 'classnames';
 import { List, Map, OrderedMap, Set } from 'immutable';
 import React, { ChangeEvent, MouseEvent, PureComponent, ReactNode, SyntheticEvent } from 'react';
@@ -178,13 +178,13 @@ function inputCellKey(col: QueryColumn, row: any): string {
 
 export interface EditableColumnMetadata {
     caption?: string;
-    lookupValueFilters?: Filter.IFilter[];
     filteredLookupKeys?: List<any>;
     filteredLookupValues?: List<string>;
     getFilteredLookupKeys?: (linkedValues: any[]) => Promise<List<any>>;
     hideTitleTooltip?: boolean;
     isReadOnlyCell?: (rowKey: string) => boolean;
     linkedColInd?: number;
+    lookupValueFilters?: Filter.IFilter[];
     placeholder?: string;
     popoverClassName?: string;
     readOnly?: boolean;
@@ -1022,7 +1022,9 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
     restoreBulkInsertData = (data: Map<string, any>): Map<string, any> => {
         const allInsertCols = OrderedMap<string, any>().asMutable();
-        this.props.queryInfo.getInsertColumns(this.props.bulkAddProps.isIncludedColumn).forEach(col => allInsertCols.set(col.name, undefined));
+        this.props.queryInfo
+            .getInsertColumns(this.props.bulkAddProps.isIncludedColumn)
+            .forEach(col => allInsertCols.set(col.name, undefined));
         return allInsertCols.merge(data).asImmutable();
     };
 

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -44,6 +44,7 @@ export interface LookupCellProps {
     rowIdx: number;
     select: (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES, resetValue?: boolean) => void;
     values: List<ValueDescriptor>;
+    lookupValueFilters?: Filter.IFilter[];
 }
 
 export class LookupCell extends PureComponent<LookupCellProps> {
@@ -57,7 +58,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
     };
 
     render(): ReactNode {
-        const { col, containerFilter, disabled, filteredLookupKeys, filteredLookupValues, forUpdate, values } =
+        const { col, containerFilter, disabled, filteredLookupKeys, filteredLookupValues, forUpdate, values, lookupValueFilters } =
             this.props;
 
         const rawValues = values
@@ -82,6 +83,10 @@ export class LookupCell extends PureComponent<LookupCellProps> {
         const lookup = col.lookup;
         const isMultiple = this.isMultiValue();
         let queryFilters: List<Filter.IFilter> = List();
+
+        if (lookupValueFilters?.length > 0)
+            queryFilters = queryFilters.push(...lookupValueFilters);
+
         if (filteredLookupValues) {
             queryFilters = queryFilters.push(
                 Filter.create(lookup.displayColumn, filteredLookupValues.toArray(), Filter.Types.IN)

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -40,11 +40,11 @@ export interface LookupCellProps {
     filteredLookupKeys?: List<any>;
     filteredLookupValues?: List<string>;
     forUpdate: boolean;
+    lookupValueFilters?: Filter.IFilter[];
     modifyCell: (colIdx: number, rowIdx: number, newValues: ValueDescriptor[], mod: MODIFICATION_TYPES) => void;
     rowIdx: number;
     select: (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES, resetValue?: boolean) => void;
     values: List<ValueDescriptor>;
-    lookupValueFilters?: Filter.IFilter[];
 }
 
 export class LookupCell extends PureComponent<LookupCellProps> {
@@ -58,8 +58,16 @@ export class LookupCell extends PureComponent<LookupCellProps> {
     };
 
     render(): ReactNode {
-        const { col, containerFilter, disabled, filteredLookupKeys, filteredLookupValues, forUpdate, values, lookupValueFilters } =
-            this.props;
+        const {
+            col,
+            containerFilter,
+            disabled,
+            filteredLookupKeys,
+            filteredLookupValues,
+            forUpdate,
+            values,
+            lookupValueFilters,
+        } = this.props;
 
         const rawValues = values
             .filter(vd => vd.raw !== undefined)
@@ -84,8 +92,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
         const isMultiple = this.isMultiValue();
         let queryFilters: List<Filter.IFilter> = List();
 
-        if (lookupValueFilters?.length > 0)
-            queryFilters = queryFilters.push(...lookupValueFilters);
+        if (lookupValueFilters?.length > 0) queryFilters = queryFilters.push(...lookupValueFilters);
 
         if (filteredLookupValues) {
             queryFilters = queryFilters.push(

--- a/packages/components/src/internal/components/entities/DataTypeSelector.tsx
+++ b/packages/components/src/internal/components/entities/DataTypeSelector.tsx
@@ -30,6 +30,8 @@ interface Props {
     uncheckedEntitiesDB: number[];
 
     updateUncheckedTypes: (dataType: string, unchecked: number[]) => void;
+
+    isNewFolder?: boolean;
 }
 
 export const getUncheckedEntityWarning = (
@@ -73,6 +75,7 @@ export const DataTypeSelector: FC<Props> = memo(props => {
         updateUncheckedTypes,
         columns,
         noHeader,
+        isNewFolder,
     } = props;
 
     const [dataTypes, setDataTypes] = useState<DataTypeEntity[]>(undefined);
@@ -111,9 +114,9 @@ export const DataTypeSelector: FC<Props> = memo(props => {
     const ensureCount = useCallback(async () => {
         if (dataCounts) return;
 
-        const results = await getDataTypeDataCount(entityDataType.projectConfigurableDataType, dataTypes);
+        const results = await getDataTypeDataCount(entityDataType.projectConfigurableDataType, dataTypes, isNewFolder);
         setDataCounts(results);
-    }, [dataCounts, dataTypes, entityDataType, allDataTypes]);
+    }, [dataCounts, dataTypes, entityDataType, allDataTypes, isNewFolder]);
 
     const onChange = useCallback(
         (entityRowId: number, toggle: boolean, check?: boolean) => {

--- a/packages/components/src/internal/components/entities/DataTypeSelector.tsx
+++ b/packages/components/src/internal/components/entities/DataTypeSelector.tsx
@@ -23,6 +23,8 @@ interface Props {
     dataTypeLabel?: string;
     disabled?: boolean;
     entityDataType?: EntityDataType;
+    isNewFolder?: boolean;
+
     noHeader?: boolean;
 
     toggleSelectAll?: boolean;
@@ -30,8 +32,6 @@ interface Props {
     uncheckedEntitiesDB: number[];
 
     updateUncheckedTypes: (dataType: string, unchecked: number[]) => void;
-
-    isNewFolder?: boolean;
 }
 
 export const getUncheckedEntityWarning = (

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1,4 +1,4 @@
-import {ActionURL, Ajax, AuditBehaviorTypes, Filter, getServerContext, Query, Utils} from '@labkey/api';
+import { ActionURL, Ajax, AuditBehaviorTypes, Filter, getServerContext, Query, Utils } from '@labkey/api';
 import { List, Map } from 'immutable';
 
 import { buildURL } from '../../url/AppURL';
@@ -21,6 +21,10 @@ import { ViewInfo } from '../../ViewInfo';
 import { Container } from '../base/models/Container';
 
 import { getProjectDataExclusion } from '../../app/utils';
+
+import { resolveErrorMessage } from '../../util/messaging';
+
+import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
 import { getInitialParentChoices, isDataClassEntity, isSampleEntity } from './utils';
 import {
@@ -46,8 +50,6 @@ import {
     OperationConfirmationData,
     ProjectConfigurableDataType,
 } from './models';
-import {resolveErrorMessage} from "../../util/messaging";
-import {SAMPLE_MANAGER_APP_PROPERTIES} from "../../app/constants";
 
 export function getOperationConfirmationData(
     dataType: EntityDataType,
@@ -962,7 +964,11 @@ export const getFolderExcludedDataTypes = (dataType: string, excludedContainer?:
     });
 };
 
-export const getExcludedDataTypeNames = (listingSchemaQuery: SchemaQuery, dataType: string, excludedContainerId?: string): Promise<string[]> => {
+export const getExcludedDataTypeNames = (
+    listingSchemaQuery: SchemaQuery,
+    dataType: string,
+    excludedContainerId?: string
+): Promise<string[]> => {
     return new Promise((resolve, reject) => {
         getFolderExcludedDataTypes(dataType, excludedContainerId)
             .then(excludedRowIds => {

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
@@ -62,7 +62,7 @@ describe('SampleStatusInput', () => {
         const component = mountWithServerContext(<SampleStatusInput {...DEFAULT_PROPS} formsy={false} />, {
             user: TEST_USER_STORAGE_EDITOR,
         });
-        await waitForLifecycle(component);
+        await waitForLifecycle(component, 5);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);
@@ -73,7 +73,7 @@ describe('SampleStatusInput', () => {
             <SampleStatusInput {...DEFAULT_PROPS} formsy={false} value={INIT_CONSUMED} />,
             { user: TEST_USER_STORAGE_EDITOR }
         );
-        await waitForLifecycle(component);
+        await waitForLifecycle(component, 5);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);

--- a/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
@@ -15,9 +15,10 @@ import { AppURL } from '../../url/AppURL';
 
 import { TEST_LIMS_STARTER_MODULE_CONTEXT } from '../../productFixtures';
 
+import { AdminAppContext, AppContext } from '../../AppContext';
+import { getTestAPIWrapper } from '../../APIWrapper';
+
 import { CreateProjectContainer, CreateProjectContainerProps, CreateProjectPage } from './CreateProjectPage';
-import {AdminAppContext, AppContext} from "../../AppContext";
-import {getTestAPIWrapper} from "../../APIWrapper";
 
 describe('CreateProjectPage', () => {
     function getDefaultProps(overrides?: Partial<FolderAPIWrapper>): CreateProjectContainerProps {

--- a/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
@@ -28,9 +28,12 @@ describe('CreateProjectPage', () => {
         };
     }
 
-    function getDefaultAppContext(admin = {}): Partial<AppContext> {
+    function getDefaultAppContext(): Partial<AppContext> {
         return {
-            admin: admin as AdminAppContext,
+            admin: {
+                projectDataTypes: [],
+                ProjectFreezerSelectionComponent: null,
+            } as AdminAppContext,
             api: getTestAPIWrapper(),
         };
     }
@@ -69,6 +72,10 @@ describe('CreateProjectPage', () => {
             name: '',
             nameAsTitle: true,
             title: null,
+            disabledSampleTypes: undefined,
+            disabledDataClasses: undefined,
+            disabledAssayDesigns: undefined,
+            disabledStorageLocations: undefined,
         });
         expect(onCreated).toHaveBeenCalledWith(project);
 

--- a/packages/components/src/internal/components/project/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.tsx
@@ -104,7 +104,9 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                     projectId={null}
                     updateDataTypeExclusions={updateDataTypeExclusions}
                 />
-                {ProjectFreezerSelectionComponent && <ProjectFreezerSelectionComponent updateDataTypeExclusions={updateDataTypeExclusions} />}
+                {ProjectFreezerSelectionComponent && (
+                    <ProjectFreezerSelectionComponent updateDataTypeExclusions={updateDataTypeExclusions} />
+                )}
                 <div className="form-group no-margin-bottom">
                     <div className="pull-left">
                         <button className="project-cancel-button btn btn-default" onClick={onCancel} type="button">

--- a/packages/components/src/internal/components/project/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.tsx
@@ -1,4 +1,4 @@
-import React, {FC, memo, useCallback, useEffect, useState} from 'react';
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { WithRouterProps } from 'react-router';
 import { ActionURL } from '@labkey/api';
 
@@ -12,11 +12,7 @@ import { useNotificationsContext } from '../notifications/NotificationsContext';
 import { Container } from '../base/models/Container';
 import { AppURL } from '../../url/AppURL';
 
-import {
-    getCurrentAppProperties,
-    hasProductProjects,
-    setProductProjects,
-} from '../../app/utils';
+import { getCurrentAppProperties, hasProductProjects, setProductProjects } from '../../app/utils';
 
 import { useFolderMenuContext } from '../navigation/hooks';
 
@@ -24,10 +20,10 @@ import { invalidateFullQueryDetailsCache } from '../../query/api';
 
 import { useAdminAppContext } from '../administration/useAdminAppContext';
 
+import { ProjectConfigurableDataType } from '../entities/models';
+
 import { ProjectProperties } from './ProjectProperties';
 import { ProjectDataTypeSelections } from './ProjectDataTypeSelections';
-import {ProjectConfigurableDataType} from "../entities/models";
-
 
 export interface CreateProjectContainerProps {
     api: FolderAPIWrapper;
@@ -37,10 +33,7 @@ export interface CreateProjectContainerProps {
 
 export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(props => {
     const { api, onCancel, onCreated } = props;
-    const {
-        projectDataTypes,
-        ProjectFreezerSelectionComponent,
-    } = useAdminAppContext();
+    const { projectDataTypes, ProjectFreezerSelectionComponent } = useAdminAppContext();
 
     const [error, setError] = useState<string>();
     const [isSaving, setIsSaving] = useState<boolean>(false);
@@ -48,7 +41,7 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
 
     const updateDataTypeExclusions = useCallback(
         (dataType: ProjectConfigurableDataType, exclusions: number[]) => {
-            setDataTypeExclusion((prevState) => {
+            setDataTypeExclusion(prevState => {
                 const uncheckedUpdates = { ...prevState };
                 uncheckedUpdates[dataType] = exclusions;
                 return uncheckedUpdates;
@@ -71,7 +64,7 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                 disabledSampleTypes: dataTypeExclusion?.['SampleType'],
                 disabledDataClasses: dataTypeExclusion?.['DataClass'],
                 disabledAssayDesigns: dataTypeExclusion?.['AssayDesign'],
-                disabledStorageLocations: dataTypeExclusion?.['StorageLocation']
+                disabledStorageLocations: dataTypeExclusion?.['StorageLocation'],
             };
 
             let project: Container;
@@ -111,9 +104,7 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                     projectId={null}
                     updateDataTypeExclusions={updateDataTypeExclusions}
                 />
-                <ProjectFreezerSelectionComponent
-                    updateDataTypeExclusions={updateDataTypeExclusions}
-                />
+                <ProjectFreezerSelectionComponent updateDataTypeExclusions={updateDataTypeExclusions} />
                 <div className="form-group no-margin-bottom">
                     <div className="pull-left">
                         <button className="project-cancel-button btn btn-default" onClick={onCancel} type="button">

--- a/packages/components/src/internal/components/project/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.tsx
@@ -104,7 +104,7 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                     projectId={null}
                     updateDataTypeExclusions={updateDataTypeExclusions}
                 />
-                <ProjectFreezerSelectionComponent updateDataTypeExclusions={updateDataTypeExclusions} />
+                {ProjectFreezerSelectionComponent && <ProjectFreezerSelectionComponent updateDataTypeExclusions={updateDataTypeExclusions} />}
                 <div className="form-group no-margin-bottom">
                     <div className="pull-left">
                         <button className="project-cancel-button btn btn-default" onClick={onCancel} type="button">

--- a/packages/components/src/internal/components/project/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.tsx
@@ -15,7 +15,6 @@ import { AppURL } from '../../url/AppURL';
 import {
     getCurrentAppProperties,
     hasProductProjects,
-    isProductProjectDataTypeSelectionEnabled,
     setProductProjects,
 } from '../../app/utils';
 
@@ -107,20 +106,14 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                         </div>
                     </div>
                 </div>
-
-                {isProductProjectDataTypeSelectionEnabled() && (
-                    <>
-                        <ProjectDataTypeSelections
-                            entityDataTypes={projectDataTypes}
-                            projectId={null}
-                            updateDataTypeExclusions={updateDataTypeExclusions}
-                        />
-                        <ProjectFreezerSelectionComponent
-                            updateDataTypeExclusions={updateDataTypeExclusions}
-                        />
-                    </>
-                )}
-
+                <ProjectDataTypeSelections
+                    entityDataTypes={projectDataTypes}
+                    projectId={null}
+                    updateDataTypeExclusions={updateDataTypeExclusions}
+                />
+                <ProjectFreezerSelectionComponent
+                    updateDataTypeExclusions={updateDataTypeExclusions}
+                />
                 <div className="form-group no-margin-bottom">
                     <div className="pull-left">
                         <button className="project-cancel-button btn btn-default" onClick={onCancel} type="button">

--- a/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
+++ b/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
@@ -82,6 +82,7 @@ export const ProjectDataTypeSelections: FC<Props> = memo(props => {
                                         uncheckedEntitiesDB={
                                             disabledTypesMap?.[entityDataType.projectConfigurableDataType]
                                         }
+                                        isNewFolder={!projectId}
                                     />
                                 </Col>
                             );

--- a/packages/components/src/internal/components/project/actions.ts
+++ b/packages/components/src/internal/components/project/actions.ts
@@ -4,6 +4,7 @@ import { caseInsensitive } from '../../util/utils';
 import { DataTypeEntity, ProjectConfigurableDataType } from '../entities/models';
 import { getContainerFilterForFolder } from '../../query/api';
 import { SCHEMAS } from '../../schemas';
+import {isProductProjectsDataListingScopedToProject} from "../../app/utils";
 
 export function getProjectDataTypeDataCountSql(dataType: ProjectConfigurableDataType): string {
     if (!dataType) return null;
@@ -30,9 +31,16 @@ export function getProjectDataTypeDataCountSql(dataType: ProjectConfigurableData
 
 export function getDataTypeDataCount(
     dataType: ProjectConfigurableDataType,
-    allDataTypes?: DataTypeEntity[]
+    allDataTypes?: DataTypeEntity[],
+    isNewFolder?: boolean,
 ): Promise<{ [key: string]: number }> {
+
     return new Promise((resolve, reject) => {
+        if (isProductProjectsDataListingScopedToProject() && isNewFolder) {
+            resolve({});
+            return;
+        }
+
         // samples and assay runs reference their data type by lsid, but dataclass data reference by rowid
         const byLsid = dataType === 'SampleType' || dataType === 'AssayDesign';
         const lookup = {};

--- a/packages/components/src/internal/components/project/actions.ts
+++ b/packages/components/src/internal/components/project/actions.ts
@@ -4,7 +4,7 @@ import { caseInsensitive } from '../../util/utils';
 import { DataTypeEntity, ProjectConfigurableDataType } from '../entities/models';
 import { getContainerFilterForFolder } from '../../query/api';
 import { SCHEMAS } from '../../schemas';
-import {isProductProjectsDataListingScopedToProject} from "../../app/utils";
+import { isProductProjectsDataListingScopedToProject } from '../../app/utils';
 
 export function getProjectDataTypeDataCountSql(dataType: ProjectConfigurableDataType): string {
     if (!dataType) return null;
@@ -32,9 +32,8 @@ export function getProjectDataTypeDataCountSql(dataType: ProjectConfigurableData
 export function getDataTypeDataCount(
     dataType: ProjectConfigurableDataType,
     allDataTypes?: DataTypeEntity[],
-    isNewFolder?: boolean,
+    isNewFolder?: boolean
 ): Promise<{ [key: string]: number }> {
-
     return new Promise((resolve, reject) => {
         if (isProductProjectsDataListingScopedToProject() && isNewFolder) {
             resolve({});

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -141,8 +141,7 @@ export class ExperimentRunResolver implements AppRouteResolver {
                 // resolve it
                 this.jobs.add(rowId);
                 return AppURL.create('workflow', rowId);
-            }
-            else {
+            } else {
                 return AppURL.create('rd', 'assayrun', rowId);
             }
         } catch (e) {

--- a/packages/components/src/internal/url/AppURLResolver.ts
+++ b/packages/components/src/internal/url/AppURLResolver.ts
@@ -142,6 +142,9 @@ export class ExperimentRunResolver implements AppRouteResolver {
                 this.jobs.add(rowId);
                 return AppURL.create('workflow', rowId);
             }
+            else {
+                return AppURL.create('rd', 'assayrun', rowId);
+            }
         } catch (e) {
             // skip it
         }

--- a/packages/components/src/test/components/Lookup.tsx
+++ b/packages/components/src/test/components/Lookup.tsx
@@ -24,12 +24,15 @@ export class MockLookupProvider extends React.Component<any, ILookupContext> {
             fetchContainers: () => Promise.resolve<List<Container>>(processContainers(containerData)),
             fetchQueries: (containerPath: string, schemaName: string) => {
                 const data = queryData.queriesBySchema[schemaName];
-                return Promise.resolve<List<QueryInfoLite>>(processQueries(data));
+                return Promise.resolve<QueryInfoLite[]>(processQueries(data));
             },
             fetchSchemas: (containerPath: string) => {
                 const path = containerPath ? containerPath : this.state.activeContainer.path;
                 const data = schemaData.schemasByContainerPath[path];
-                return Promise.resolve<List<SchemaDetails>>(handleSchemas(data));
+                return Promise.resolve<SchemaDetails[]>(handleSchemas(data));
+            },
+            getExcludedSchemaQueryNames: () => {
+                return Promise.resolve<string[]>([]);
             },
         };
     }


### PR DESCRIPTION
#### Rationale
Fix data type exclusion for domain designer lookup fields and remove experimental flag

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1200
- https://github.com/LabKey/labkey-ui-premium/pull/97
- https://github.com/LabKey/platform/pull/4467
- https://github.com/LabKey/inventory/pull/869
- https://github.com/LabKey/sampleManagement/pull/1860
- https://github.com/LabKey/biologics/pull/2152

#### Changes
-  remove isProductProjectDataTypeSelectionEnabled experimental flag and enable function
- filter schema and query names for Look Up fields in designer based on selected target container's data type exclusion config
- support user supplied lookupValueFilters for LookupCell
