### PR TITLE
Issues 47556, 47964, 47960, 47546: small display and messaging updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.2-miscFixes236S.0",
+  "version": "2.341.2-miscFixes236S.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.2-miscFixes236S.1",
+  "version": "2.341.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.1",
+  "version": "2.341.2-miscFixes236S.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Issue 47556: Update color for placeholder text in grids
 * Issue 47964: Adjust `AncestorRenderer` to display field values that are negative
+* Issue 47960: Update messaging about limit on sample creation
 
 ### version 2.341.1
 *Released*: 26 May 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 47556: Update color for placeholder text in grids
+*
+
+
 ### version 2.341.1
 *Released*: 26 May 2023
 * Fix await without try/catch

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 47556: Update color for placeholder text in grids
 * Issue 47964: Adjust `AncestorRenderer` to display field values that are negative
 * Issue 47960: Update messaging about limit on sample creation
+* Issue 47546: Update style for tabs so they don't appear disabled; update font for subnav
 
 ### version 2.341.1
 *Released*: 26 May 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.341.2
+*Released*: 30 May 2023
 * Issue 47556: Update color for placeholder text in grids
 * Issue 47964: Adjust `AncestorRenderer` to display field values that are negative
 * Issue 47960: Update messaging about limit on sample creation

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,8 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 47556: Update color for placeholder text in grids
-*
-
+* Issue 47964: Adjust `AncestorRenderer` to display field values that are negative
 
 ### version 2.341.1
 *Released*: 26 May 2023

--- a/packages/components/src/internal/components/editable/Controls.spec.tsx
+++ b/packages/components/src/internal/components/editable/Controls.spec.tsx
@@ -49,7 +49,7 @@ describe('Controls', () => {
         inputWrapper.simulate('change', { target: { value: 100 } });
         wrapper.update();
         expect(wrapper.find('.text-danger')).toHaveLength(1);
-        expect(wrapper.find('.text-danger').text()).toContain('1-10 rows allowed');
+        expect(wrapper.find('.text-danger').text()).toBe('At most 10 rows can be added at once (10 remaining).');
     });
 
     test('invalid row count with custom invalidCountMsg', () => {
@@ -63,5 +63,16 @@ describe('Controls', () => {
         expect(wrapper.find('.text-danger')).toHaveLength(1);
         expect(wrapper.find('.text-danger').text()).toContain('A max of 10 rows are allowed');
     });
+
+    test('invalid row count with maxTotalCount', () => {
+        const addFn = jest.fn();
+        const wrapper = shallow(<AddRowsControl initialCount={6} maxTotalCount={50} maxCount={10} onAdd={addFn} />);
+        const inputWrapper = wrapper.find('input');
+        inputWrapper.simulate('focus');
+        inputWrapper.simulate('change', { target: { value: 100 } });
+        wrapper.update();
+        expect(wrapper.find('.text-danger')).toHaveLength(1);
+        expect(wrapper.find('.text-danger').text()).toBe('At most 50 rows can be added at once (10 remaining).');
+    })
 
 });

--- a/packages/components/src/internal/components/editable/Controls.tsx
+++ b/packages/components/src/internal/components/editable/Controls.tsx
@@ -147,7 +147,7 @@ export class AddRowsControl extends React.Component<AddRowsControlProps, AddRows
     }
 
     render() {
-        const { disable, minCount, maxTotalCount, nounPlural, nounSingular, placement, wrapperClass, invalidCountMsg, verbPastTense } = this.props;
+        const { disable, minCount, maxCount, maxTotalCount, nounPlural, nounSingular, placement, wrapperClass, invalidCountMsg, verbPastTense } = this.props;
         const { count } = this.state;
 
         const hasError = !disable && this.hasError();
@@ -156,7 +156,8 @@ export class AddRowsControl extends React.Component<AddRowsControlProps, AddRows
             'has-error': hasError,
         });
         const maxToAdd = this.getMaxRowsToAdd();
-        const errorMsg = `At most ${maxTotalCount} ${nounPlural.toLowerCase()} can be ${verbPastTense.toLowerCase()} at once (${maxToAdd} remaining).`;
+        const errorMsg =  `At most ${maxTotalCount ?? maxCount} ${nounPlural.toLowerCase()} can be ${verbPastTense.toLowerCase()} at once (${maxToAdd} remaining).`;
+
         return (
             <div className={wrapperClasses}>
                 <span className="input-group input-group-align">

--- a/packages/components/src/internal/components/editable/Controls.tsx
+++ b/packages/components/src/internal/components/editable/Controls.tsx
@@ -35,6 +35,7 @@ export interface AddRowsControlProps {
     placement?: PlacementType;
     wrapperClass?: string;
     invalidCountMsg?: string;
+    verbPastTense?: string;
 }
 
 interface AddRowsControlState {
@@ -51,6 +52,7 @@ export class AddRowsControl extends React.Component<AddRowsControlProps, AddRows
         nounPlural: 'rows',
         nounSingular: 'row',
         placement: 'bottom',
+        verbPastTense: 'added',
     };
 
     private addCount: React.RefObject<any>;
@@ -145,7 +147,7 @@ export class AddRowsControl extends React.Component<AddRowsControlProps, AddRows
     }
 
     render() {
-        const { disable, minCount, nounPlural, nounSingular, placement, wrapperClass, invalidCountMsg } = this.props;
+        const { disable, minCount, maxTotalCount, nounPlural, nounSingular, placement, wrapperClass, invalidCountMsg, verbPastTense } = this.props;
         const { count } = this.state;
 
         const hasError = !disable && this.hasError();
@@ -154,7 +156,7 @@ export class AddRowsControl extends React.Component<AddRowsControlProps, AddRows
             'has-error': hasError,
         });
         const maxToAdd = this.getMaxRowsToAdd();
-        const errorMsg = minCount == maxToAdd ? `${minCount} ${nounSingular.toLowerCase()} allowed` : `${minCount}-${maxToAdd} ${nounPlural.toLowerCase()} allowed`;
+        const errorMsg = `At most ${maxTotalCount} ${nounPlural.toLowerCase()} can be ${verbPastTense.toLowerCase()} at once (${maxToAdd} remaining).`;
         return (
             <div className={wrapperClasses}>
                 <span className="input-group input-group-align">
@@ -173,7 +175,7 @@ export class AddRowsControl extends React.Component<AddRowsControlProps, AddRows
                     />
                     {this.renderButton()}
                 </span>
-                {hasError && (
+                {hasError && count > 0 && (
                     <span className="text-danger pull-left add-control--error-message">
                         {invalidCountMsg ? invalidCountMsg : errorMsg}
                     </span>

--- a/packages/components/src/internal/renderers/AncestorRenderer.tsx
+++ b/packages/components/src/internal/renderers/AncestorRenderer.tsx
@@ -27,7 +27,7 @@ interface Props {
 export const AncestorRenderer: FC<Props> = memo(({ data }) => {
     if (Map.isMap(data) && data.size > 0) {
         const { displayValue, value } = data.toJS();
-        if (value < 0) {
+        if (value < 0 && displayValue) {
             return (
                 <span className="text-muted" title={`There are ${-value} ancestors of this type.`}>
                     {displayValue}

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -348,7 +348,7 @@ $table-cell-selection-bg-color: #EDF3FF;
     }
 
     .cell-placeholder {
-      color: $light-gray;
+      color: $gray-light;
     }
 
     .cell-read-only {

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -448,7 +448,7 @@
 }
 .container-nav__name {
     float: right;
-    font-size: small;
+    font-size: 14px;
     margin-left: 4px;
     max-width: 165px;
     overflow: hidden;
@@ -473,14 +473,14 @@
 
     li {
       a {
-        color: #222 !important;
-        font-size: small;
+        color: $blue-highlight !important;
+        font-size: 14px;
         padding: 8px 10px 8px 0;
         white-space: nowrap;
       }
 
       i.fa {
-        font-size: smaller;
+        font-size: small;
       }
 
       &:after {
@@ -493,6 +493,13 @@
         top: 50%;
       }
     }
+  }
+  .navbar-nav {
+      li {
+          a {
+              color: $blue-highlight;
+          }
+      }
   }
 
   .tab-scroll-ct {
@@ -508,7 +515,7 @@
 
         & > a {
           border-bottom: 3px solid transparent;
-          font-size: small;
+          font-size: 14px;
           padding: 8px 10px;
 
           &:hover {
@@ -539,7 +546,7 @@
 
     & > .btn {
       border: none;
-      font-size: smaller;
+      font-size: small;
     }
   }
 }

--- a/packages/components/src/theme/section.scss
+++ b/packages/components/src/theme/section.scss
@@ -108,3 +108,7 @@
 .font-large {
     font-size: $font-size-large;
 }
+
+.error-msg {
+    color: $brand-danger;
+}

--- a/packages/components/src/theme/tabs.scss
+++ b/packages/components/src/theme/tabs.scss
@@ -13,7 +13,7 @@
             & > a {
                 background-color: inherit;
                 border: 3px solid transparent;
-                color: $gray-lighten;
+                color: $blue-highlight;
                 font-weight: bold;
                 text-align: center;
                 text-transform: uppercase;


### PR DESCRIPTION
#### Rationale
- [LKSM: Negative field values don't show up in grid when pulling via ancestor field](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47964)
- [LKSM: Need better warning when attempting to create >1000 samples](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47960)
- [LKSM/LKB: [generated ID] text in the sample create grid is too light](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47556)
- [LKSM/LKB: Tabs appear disabled](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47546)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/98
- https://github.com/LabKey/inventory/pull/870
- https://github.com/LabKey/biologics/pull/2153
- https://github.com/LabKey/sampleManagement/pull/1863

#### Changes
* Issue 47556: Update color for placeholder text in grids
* Issue 47964: Adjust `AncestorRenderer` to display field values that are negative
* Issue 47960: Update messaging about limit on sample creation
* Issue 47546: Update style for tabs so they don't appear disabled; update font for subnav
