### PR TITLE
Projects: Selection of data structures to be shown in Projects - Designer UI updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.1-fb-hideDataTypeProjects.2",
+  "version": "2.341.1-fb-hideDataTypeProjects.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.2",
+  "version": "2.341.2-fb-hideDataTypeProjects.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.1",
+  "version": "2.341.1-fb-hideDataTypeProjects.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.2-fb-hideDataTypeProjects.0",
+  "version": "2.341.2-fb-hideDataTypeProjects.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.1-fb-hideDataTypeProjects.3",
+  "version": "2.341.1-fb-hideDataTypeProjects.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.3",
+  "version": "2.341.3-fb-hideDataTypeProjects.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.1-fb-hideDataTypeProjects.1",
+  "version": "2.341.1-fb-hideDataTypeProjects.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.2-fb-hideDataTypeProjects.1",
+  "version": "2.341.2-fb-hideDataTypeProjects.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.3-fb-hideDataTypeProjects.0",
+  "version": "2.342.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.2-fb-hideDataTypeProjects.2",
+  "version": "2.341.2-fb-hideDataTypeProjects.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.341.1-fb-hideDataTypeProjects.0",
+  "version": "2.341.1-fb-hideDataTypeProjects.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Data type domain exclude projects
   * Add DataTypeProjectsPanel to show panel in field editor for selecting excluded projects for a given data type domain
+  * Misc updates to admin panel titles for consistency
 
 ### version 2.341.1
 *Released*: 26 May 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,7 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Data type domain exclude projects
   * Add DataTypeProjectsPanel to show panel in field editor for selecting excluded projects for a given data type domain
-    * implement for Sample Type designer, Data Class designer (sources and non-built in registry), ...
+    * implement for Sample Type designer, Data Class designer (sources and non-built in registry), Assay Designer
   * Misc updates to admin panel titles for consistency
 
 ### version 2.341.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Data type domain exclude projects
   * Add DataTypeProjectsPanel to show panel in field editor for selecting excluded projects for a given data type domain
+    * implement for Sample Type designer, ...
   * Misc updates to admin panel titles for consistency
 
 ### version 2.341.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Data type domain exclude projects
+  * Add DataTypeProjectsPanel to show panel in field editor for selecting excluded projects for a given data type domain
+
 ### version 2.341.1
 *Released*: 26 May 2023
 * Fix await without try/catch

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,7 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 * Data type domain exclude projects
   * Add DataTypeProjectsPanel to show panel in field editor for selecting excluded projects for a given data type domain
-    * implement for Sample Type designer, ...
+    * implement for Sample Type designer, Data Class designer (sources and non-built in registry), ...
   * Misc updates to admin panel titles for consistency
 
 ### version 2.341.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.342.0
+*Released*: 31 May 2023
 * Data type domain exclude projects
   * Add DataTypeProjectsPanel to show panel in field editor for selecting excluded projects for a given data type domain
     * implement for Sample Type designer, Data Class designer (sources and non-built in registry), Assay Designer

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -571,6 +571,7 @@ import {
 import { DesignerDetailPanel } from './internal/components/domainproperties/DesignerDetailPanel';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { RangeValidationOptionsModal } from './internal/components/domainproperties/validation/RangeValidationOptions';
+import { DataTypeProjectsPanel } from './internal/components/domainproperties/DataTypeProjectsPanel';
 
 import { AssayImportPanels } from './internal/components/assay/AssayImportPanels';
 import { AssayDesignEmptyAlert } from './internal/components/assay/AssayDesignEmptyAlert';
@@ -1417,6 +1418,7 @@ export {
     IssuesListDefModel,
     IssuesListDefDesignerPanels,
     fetchIssuesListDefDesign,
+    DataTypeProjectsPanel,
     // file / webdav related items
     DEFAULT_FILE,
     FilesListing,

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { ReactWrapper } from 'enzyme';
+
+import { mountWithAppServerContext, waitForLifecycle } from '../../testHelpers';
+import { TEST_USER_EDITOR, TEST_USER_FOLDER_ADMIN } from '../../userFixtures';
+import { TEST_FOLDER_CONTAINER, TEST_PROJECT_CONTAINER } from '../../containerFixtures';
+import { ProjectSettings } from '../project/ProjectSettings';
+import { ProjectDataTypeSelections } from '../project/ProjectDataTypeSelections';
+
+import { ActiveUserLimit } from '../settings/ActiveUserLimit';
+import { BarTenderSettingsForm } from '../labels/BarTenderSettingsForm';
+import { NameIdSettings } from '../settings/NameIdSettings';
+import { ManageSampleStatusesPanel } from '../samples/ManageSampleStatusesPanel';
+import { BasePermissionsCheckPage } from '../permissions/BasePermissionsCheckPage';
+import { TEST_LKS_STARTER_MODULE_CONTEXT, TEST_LKSM_STARTER_MODULE_CONTEXT } from '../../productFixtures';
+import { getTestAPIWrapper } from '../../APIWrapper';
+import { getSecurityTestAPIWrapper } from '../security/APIWrapper';
+
+import policyJSON from '../../../test/data/security-getPolicy.json';
+import { SecurityPolicy } from '../permissions/models';
+import { initBrowserHistoryState } from '../../util/global';
+
+import { InsufficientPermissionsPage } from '../permissions/InsufficientPermissionsPage';
+
+import { BasePermissions } from './BasePermissions';
+import { AdminSettingsPageImpl } from './AdminSettingsPage';
+
+const TEST_POLICY = SecurityPolicy.create(policyJSON);
+
+beforeAll(() => {
+    initBrowserHistoryState();
+});
+
+describe('AdminSettingsPageImpl', () => {
+    const APP_CONTEXT = {
+        admin: {},
+        api: getTestAPIWrapper(jest.fn, {
+            security: getSecurityTestAPIWrapper(jest.fn, {
+                fetchPolicy: jest.fn().mockResolvedValue(TEST_POLICY),
+            }),
+        }),
+    };
+
+    const SERVER_CONTEXT = {
+        user: TEST_USER_FOLDER_ADMIN,
+        project: TEST_PROJECT_CONTAINER,
+        container: TEST_FOLDER_CONTAINER,
+        moduleContext: TEST_LKS_STARTER_MODULE_CONTEXT,
+    };
+
+    function validatePremium(wrapper: ReactWrapper, projectSettingsCount = 0, manageSampleStatusCount = 1): void {
+        expect(wrapper.find(InsufficientPermissionsPage)).toHaveLength(0);
+        expect(wrapper.find(ProjectSettings)).toHaveLength(projectSettingsCount);
+        expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(0);
+        expect(wrapper.find(BasePermissions)).toHaveLength(0);
+        expect(wrapper.find(BasePermissionsCheckPage)).toHaveLength(1);
+        expect(wrapper.find(ActiveUserLimit)).toHaveLength(1);
+        expect(wrapper.find(BarTenderSettingsForm)).toHaveLength(1);
+        expect(wrapper.find(NameIdSettings)).toHaveLength(1);
+        expect(wrapper.find(ManageSampleStatusesPanel)).toHaveLength(manageSampleStatusCount);
+    }
+
+    function validateNonPremium(wrapper: ReactWrapper): void {
+        expect(wrapper.find(InsufficientPermissionsPage)).toHaveLength(0);
+        expect(wrapper.find(ProjectSettings)).toHaveLength(0);
+        expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(0);
+        expect(wrapper.find(BasePermissions)).toHaveLength(1);
+        expect(wrapper.find(BasePermissionsCheckPage)).toHaveLength(1);
+        expect(wrapper.find(ActiveUserLimit)).toHaveLength(1);
+        expect(wrapper.find(BarTenderSettingsForm)).toHaveLength(1);
+        expect(wrapper.find(NameIdSettings)).toHaveLength(1);
+        expect(wrapper.find(ManageSampleStatusesPanel)).toHaveLength(1);
+    }
+
+    test('showPremiumFeatures, isAppHomeFolder subfolder', async () => {
+        const wrapper = mountWithAppServerContext(<AdminSettingsPageImpl />, APP_CONTEXT, SERVER_CONTEXT);
+        await waitForLifecycle(wrapper, 50);
+        validatePremium(wrapper);
+        expect(wrapper.find(BasePermissionsCheckPage).prop('title')).toBe('Settings');
+        expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBeUndefined();
+        wrapper.unmount();
+    });
+
+    test('showPremiumFeatures, isAppHomeFolder LK project', async () => {
+        const wrapper = mountWithAppServerContext(<AdminSettingsPageImpl />, APP_CONTEXT, {
+            ...SERVER_CONTEXT,
+            container: TEST_PROJECT_CONTAINER,
+        });
+        await waitForLifecycle(wrapper, 50);
+        validatePremium(wrapper);
+        expect(wrapper.find(BasePermissionsCheckPage).prop('title')).toBe('Settings');
+        expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBeUndefined();
+        wrapper.unmount();
+    });
+
+    test('not showPremiumFeatures, isAppHomeFolder subfolder', async () => {
+        const wrapper = mountWithAppServerContext(<AdminSettingsPageImpl />, APP_CONTEXT, {
+            ...SERVER_CONTEXT,
+            moduleContext: TEST_LKSM_STARTER_MODULE_CONTEXT,
+        });
+        await waitForLifecycle(wrapper, 50);
+        validateNonPremium(wrapper);
+        expect(wrapper.find(BasePermissionsCheckPage).prop('title')).toBe('Settings');
+        expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBeUndefined();
+        wrapper.unmount();
+    });
+
+    test('isProductProjectsEnabled, LK project', async () => {
+        const wrapper = mountWithAppServerContext(<AdminSettingsPageImpl />, APP_CONTEXT, {
+            ...SERVER_CONTEXT,
+            container: TEST_PROJECT_CONTAINER,
+            moduleContext: { ...TEST_LKS_STARTER_MODULE_CONTEXT, query: { isProductProjectsEnabled: true } },
+        });
+        await waitForLifecycle(wrapper, 50);
+        validatePremium(wrapper, 1);
+        expect(wrapper.find(BasePermissionsCheckPage).prop('title')).toBe('Settings');
+        expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBeUndefined();
+        wrapper.unmount();
+    });
+
+    test('isProductProjectsEnabled, subfolder', async () => {
+        const wrapper = mountWithAppServerContext(<AdminSettingsPageImpl />, APP_CONTEXT, {
+            ...SERVER_CONTEXT,
+            moduleContext: { ...TEST_LKS_STARTER_MODULE_CONTEXT, query: { isProductProjectsEnabled: true } },
+        });
+        await waitForLifecycle(wrapper, 50);
+        validatePremium(wrapper, 1);
+        expect(wrapper.find(BasePermissionsCheckPage).prop('title')).toBe('Project Settings');
+        expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBe('/TestProjectContainer/TestFolderContainer');
+        wrapper.unmount();
+    });
+
+    test('not isSampleStatusEnabled', async () => {
+        const wrapper = mountWithAppServerContext(<AdminSettingsPageImpl />, APP_CONTEXT, {
+            ...SERVER_CONTEXT,
+            moduleContext: {
+                ...TEST_LKS_STARTER_MODULE_CONTEXT,
+                api: { moduleNames: ['inventory', 'assay', 'premium'] },
+            },
+        });
+        await waitForLifecycle(wrapper, 50);
+        validatePremium(wrapper, 0, 0);
+        wrapper.unmount();
+    });
+
+    test('non admin', async () => {
+        const wrapper = mountWithAppServerContext(<AdminSettingsPageImpl />, APP_CONTEXT, {
+            ...SERVER_CONTEXT,
+            user: TEST_USER_EDITOR,
+        });
+        await waitForLifecycle(wrapper, 50);
+        expect(wrapper.find(InsufficientPermissionsPage)).toHaveLength(1);
+        expect(wrapper.find(BasePermissions)).toHaveLength(0);
+        expect(wrapper.find(BasePermissionsCheckPage)).toHaveLength(0);
+        wrapper.unmount();
+    });
+});

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
@@ -126,7 +126,9 @@ describe('AdminSettingsPageImpl', () => {
         await waitForLifecycle(wrapper, 50);
         validatePremium(wrapper, 1);
         expect(wrapper.find(BasePermissionsCheckPage).prop('title')).toBe('Project Settings');
-        expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBe('/TestProjectContainer/TestFolderContainer');
+        expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBe(
+            '/TestProjectContainer/TestFolderContainer'
+        );
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
@@ -48,7 +48,12 @@ describe('AdminSettingsPageImpl', () => {
         moduleContext: TEST_LKS_STARTER_MODULE_CONTEXT,
     };
 
-    function validatePremium(wrapper: ReactWrapper, projectSettingsCount = 0, manageSampleStatusCount = 1, projectDataTypeCount = 0): void {
+    function validatePremium(
+        wrapper: ReactWrapper,
+        projectSettingsCount = 0,
+        manageSampleStatusCount = 1,
+        projectDataTypeCount = 0
+    ): void {
         expect(wrapper.find(InsufficientPermissionsPage)).toHaveLength(0);
         expect(wrapper.find(ProjectSettings)).toHaveLength(projectSettingsCount);
         expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(projectDataTypeCount);

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.spec.tsx
@@ -48,10 +48,10 @@ describe('AdminSettingsPageImpl', () => {
         moduleContext: TEST_LKS_STARTER_MODULE_CONTEXT,
     };
 
-    function validatePremium(wrapper: ReactWrapper, projectSettingsCount = 0, manageSampleStatusCount = 1): void {
+    function validatePremium(wrapper: ReactWrapper, projectSettingsCount = 0, manageSampleStatusCount = 1, projectDataTypeCount = 0): void {
         expect(wrapper.find(InsufficientPermissionsPage)).toHaveLength(0);
         expect(wrapper.find(ProjectSettings)).toHaveLength(projectSettingsCount);
-        expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(0);
+        expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(projectDataTypeCount);
         expect(wrapper.find(BasePermissions)).toHaveLength(0);
         expect(wrapper.find(BasePermissionsCheckPage)).toHaveLength(1);
         expect(wrapper.find(ActiveUserLimit)).toHaveLength(1);
@@ -124,7 +124,7 @@ describe('AdminSettingsPageImpl', () => {
             moduleContext: { ...TEST_LKS_STARTER_MODULE_CONTEXT, query: { isProductProjectsEnabled: true } },
         });
         await waitForLifecycle(wrapper, 50);
-        validatePremium(wrapper, 1);
+        validatePremium(wrapper, 1, 1, 1);
         expect(wrapper.find(BasePermissionsCheckPage).prop('title')).toBe('Project Settings');
         expect(wrapper.find(BasePermissionsCheckPage).prop('description')).toBe(
             '/TestProjectContainer/TestFolderContainer'

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -29,14 +29,11 @@ import { Alert } from '../base/Alert';
 
 import { ProjectDataTypeSelections } from '../project/ProjectDataTypeSelections';
 import { AppContext, useAppContext } from '../../AppContext';
-import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { useAdminAppContext } from './useAdminAppContext';
 import { showPremiumFeatures } from './utils';
 import { BasePermissions } from './BasePermissions';
 import { SITE_SECURITY_ROLES } from './constants';
-
-const TITLE = 'Settings';
 
 // export for jest testing
 export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
@@ -86,7 +83,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
         return (
             <>
                 <ProjectSettings onChange={onSettingsChange} onSuccess={onSettingsSuccess} onPageError={onError} />
-                {isProductProjectDataTypeSelectionEnabled() && !isAppHomeFolder() && (
+                {isProductProjectDataTypeSelectionEnabled() && !isAppHomeFolder(container, moduleContext) && (
                     <>
                         <ProjectDataTypeSelections
                             entityDataTypes={projectDataTypes}
@@ -109,14 +106,16 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
         );
     }, [moduleContext, projectDataTypes, disabledTypesMap, container]);
 
+    const _title = isAppHomeFolder(container, moduleContext) ? 'Settings' : 'Project Settings';
+
     if (!user.isAdmin) {
-        return <InsufficientPermissionsPage title={TITLE} />;
+        return <InsufficientPermissionsPage title={_title} />;
     }
 
     if (!showPremiumFeatures(moduleContext)) {
         return (
             <BasePermissions
-                pageTitle={TITLE}
+                pageTitle={_title}
                 panelTitle="Site Roles and Assignments"
                 containerId={project.rootId}
                 hasPermission={user.isAdmin}
@@ -142,7 +141,13 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
     return (
         <>
             {error && <Alert className="admin-settings-error"> {error} </Alert>}
-            <BasePermissionsCheckPage user={user} title={TITLE} hasPermission={user.isAdmin} renderButtons={lkVersion}>
+            <BasePermissionsCheckPage
+                user={user}
+                title={_title}
+                description={!isAppHomeFolder(container, moduleContext) ? container.path : undefined}
+                hasPermission={user.isAdmin}
+                renderButtons={lkVersion}
+            >
                 <ActiveUserLimit />
                 {projectSettings}
                 {biologicsIsPrimaryApp(moduleContext) && isELNEnabled(moduleContext) && (

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -93,12 +93,14 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
                             api={api.folder}
                             onSuccess={onSettingsSuccess}
                         />
-                        <ProjectFreezerSelectionComponent
-                            projectId={container.id}
-                            updateDataTypeExclusions={onSettingsChange}
-                            disabledTypesMap={disabledTypesMap}
-                            onSuccess={onSettingsSuccess}
-                        />
+                        {!!ProjectFreezerSelectionComponent && (
+                            <ProjectFreezerSelectionComponent
+                                projectId={container.id}
+                                updateDataTypeExclusions={onSettingsChange}
+                                disabledTypesMap={disabledTypesMap}
+                                onSuccess={onSettingsSuccess}
+                            />
+                        )}
                     </>
                 )}
             </>

--- a/packages/components/src/internal/components/domainproperties/BasePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/BasePropertiesPanel.tsx
@@ -25,6 +25,7 @@ interface OwnProps {
     isValid: boolean;
     title: string;
     titlePrefix?: string;
+    todoIconHelpMsg?: string;
     updateValidStatus: (model?: any) => void;
 }
 
@@ -70,6 +71,7 @@ export class BasePropertiesPanel extends React.PureComponent<Props> {
             isValid,
             children,
             warning,
+            todoIconHelpMsg,
         } = this.props;
 
         return (
@@ -86,6 +88,7 @@ export class BasePropertiesPanel extends React.PureComponent<Props> {
                         panelStatus={panelStatus}
                         isValid={isValid}
                         iconHelpMsg={PROPERTIES_PANEL_ERROR_MSG}
+                        todoIconHelpMsg={todoIconHelpMsg}
                         useTheme={useTheme}
                     />
                     <Panel.Body collapsible={collapsible || controlledCollapse}>{children}</Panel.Body>

--- a/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
@@ -15,8 +15,6 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { DataTypeSelector } from '../entities/DataTypeSelector';
 
-import { SchemaQuery } from '../../../public/SchemaQuery';
-
 import { BasePropertiesPanel } from './BasePropertiesPanel';
 import {
     InjectedDomainPropertiesPanelCollapseProps,
@@ -28,7 +26,6 @@ interface OwnProps {
     dataTypeName?: string;
     dataTypeRowId?: number;
     entityDataType: EntityDataType;
-    noun: string;
     onUpdateExcludedProjects: (excludedProjects: string[]) => void;
 }
 
@@ -37,7 +34,6 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
         collapsed,
         togglePanel,
         controlledCollapse,
-        noun,
         dataType,
         dataTypeRowId,
         dataTypeName,
@@ -53,10 +49,6 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
     const [allProjects, setAllProjects] = useState<DataTypeEntity[]>();
     const [excludedProjectIdsDB, setExcludedProjectIdsDB] = useState<string[]>();
     const [excludedProjectIds, setExcludedProjectIds] = useState<string[]>();
-    const schemaQuery = useMemo(
-        () => new SchemaQuery(entityDataType.instanceSchemaName, dataTypeName),
-        [dataType, dataTypeName]
-    );
 
     useEffect(
         () => {
@@ -92,7 +84,7 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
                     setExcludedProjectIdsDB(excludedProjectIds_);
                     setExcludedProjectIds(excludedProjectIds_);
 
-                    const allDataCounts_ = await api.query.getDataTypeProjectDataCount(schemaQuery);
+                    const allDataCounts_ = await api.query.getDataTypeProjectDataCount(entityDataType, dataTypeRowId, dataTypeName);
                     setAllDataCounts(allDataCounts_);
                 } catch (e) {
                     setError(`Error: ${resolveErrorMessage(e)}`);
@@ -137,15 +129,19 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
             panelStatus={collapsed && isValid ? 'COMPLETE' : isValid ? 'INPROGRESS' : 'TODO'}
             updateValidStatus={updateValidStatus}
             todoIconHelpMsg={
-                'This section defines which projects use this ' + noun.toLowerCase() + '. You may want to review.'
+                'This section defines which projects use this ' +
+                entityDataType.typeNounSingular.toLowerCase() +
+                '. You may want to review.'
             }
             togglePanel={togglePanel}
         >
-            <div className="bottom-spacing">Select which projects use this {noun.toLowerCase()}.</div>
+            <div className="bottom-spacing">
+                Select which projects use this {entityDataType.typeNounSingular.toLowerCase()}.
+            </div>
             {!!allProjects && allProjects?.length === excludedProjectIds?.length && (
                 <Alert bsStyle="warning">
-                    Note that this {noun.toLowerCase()} can be re-enabled in the Project Settings page for individual
-                    projects.
+                    Note that this {entityDataType.typeNounSingular.toLowerCase()} can be re-enabled in the Project
+                    Settings page for individual projects.
                 </Alert>
             )}
             {error && <Alert>{error}</Alert>}

--- a/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
@@ -142,7 +142,7 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
             togglePanel={togglePanel}
         >
             <div className="bottom-spacing">Select which projects use this {noun.toLowerCase()}.</div>
-            {allProjects?.length === excludedProjectIds?.length && (
+            {!!allProjects && allProjects?.length === excludedProjectIds?.length && (
                 <Alert bsStyle="warning">
                     Note that this {noun.toLowerCase()} can be re-enabled in the Project Settings page for individual
                     projects.

--- a/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
 
-import { hasProductProjects, isAppHomeFolder, isProductProjectDataTypeSelectionEnabled } from '../../app/utils';
+import { hasProductProjects, isAppHomeFolder } from '../../app/utils';
 
 import { useServerContext } from '../base/ServerContext';
 
@@ -120,7 +120,7 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
         [onUpdateExcludedProjects]
     );
 
-    if (!isProductProjectDataTypeSelectionEnabled(moduleContext) || !hasProductProjects(moduleContext)) {
+    if (!hasProductProjects(moduleContext)) {
         return null;
     }
 

--- a/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
@@ -7,15 +7,13 @@ import { useServerContext } from '../base/ServerContext';
 
 import { isLoading, LoadingState } from '../../../public/LoadingState';
 import { AppContext, useAppContext } from '../../AppContext';
-import { DataTypeEntity, ProjectConfigurableDataType } from '../entities/models';
+import { DataTypeEntity, EntityDataType, ProjectConfigurableDataType } from '../entities/models';
 
 import { resolveErrorMessage } from '../../util/messaging';
 import { Alert } from '../base/Alert';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { DataTypeSelector } from '../entities/DataTypeSelector';
-
-import { SCHEMAS } from '../../schemas';
 
 import { SchemaQuery } from '../../../public/SchemaQuery';
 
@@ -29,6 +27,7 @@ interface OwnProps {
     dataType?: ProjectConfigurableDataType;
     dataTypeName?: string;
     dataTypeRowId?: number;
+    entityDataType: EntityDataType;
     noun: string;
     onUpdateExcludedProjects: (excludedProjects: string[]) => void;
 }
@@ -43,6 +42,7 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
         dataTypeRowId,
         dataTypeName,
         onUpdateExcludedProjects,
+        entityDataType,
     } = props;
     const { moduleContext, container } = useServerContext();
     const { api } = useAppContext<AppContext>();
@@ -53,10 +53,10 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
     const [allProjects, setAllProjects] = useState<DataTypeEntity[]>();
     const [excludedProjectIdsDB, setExcludedProjectIdsDB] = useState<string[]>();
     const [excludedProjectIds, setExcludedProjectIds] = useState<string[]>();
-    const schemaQuery = useMemo(() => {
-        const schema = dataType === 'SampleType' ? SCHEMAS.SAMPLE_SETS.SCHEMA : 'tbd'; // TODO other types
-        return new SchemaQuery(schema, dataTypeName);
-    }, [dataType, dataTypeName]);
+    const schemaQuery = useMemo(
+        () => new SchemaQuery(entityDataType.instanceSchemaName, dataTypeName),
+        [dataType, dataTypeName]
+    );
 
     useEffect(
         () => {
@@ -155,6 +155,7 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
                 <Row>
                     <Col xs={12} className="bottom-spacing">
                         <DataTypeSelector
+                            entityDataType={entityDataType}
                             allDataCounts={allDataCounts}
                             allDataTypes={allProjects}
                             updateUncheckedTypes={updateExcludedProjects}

--- a/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
@@ -1,0 +1,152 @@
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
+import { Col, Row } from 'react-bootstrap';
+
+import { hasProductProjects, isAppHomeFolder, isProductProjectDataTypeSelectionEnabled } from '../../app/utils';
+
+import { useServerContext } from '../base/ServerContext';
+
+import { isLoading, LoadingState } from '../../../public/LoadingState';
+import { AppContext, useAppContext } from '../../AppContext';
+import { DataTypeEntity, ProjectConfigurableDataType } from '../entities/models';
+
+import { resolveErrorMessage } from '../../util/messaging';
+import { Alert } from '../base/Alert';
+import { LoadingSpinner } from '../base/LoadingSpinner';
+
+import { DataTypeSelector } from '../entities/DataTypeSelector';
+
+import { BasePropertiesPanel } from './BasePropertiesPanel';
+import {
+    InjectedDomainPropertiesPanelCollapseProps,
+    withDomainPropertiesPanelCollapse,
+} from './DomainPropertiesPanelCollapse';
+
+interface OwnProps {
+    dataType?: ProjectConfigurableDataType;
+    dataTypeRowId?: number;
+    isNew: boolean;
+    noun: string;
+    onUpdateExcludedProjects: (excludedProjects: string[]) => void;
+}
+
+const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelCollapseProps> = memo(props => {
+    const {
+        collapsed,
+        togglePanel,
+        controlledCollapse,
+        isNew,
+        noun,
+        dataType,
+        dataTypeRowId,
+        onUpdateExcludedProjects,
+    } = props;
+    const { moduleContext, container } = useServerContext();
+    const { api } = useAppContext<AppContext>();
+    const [isValid, setIsValid] = useState<boolean>(!collapsed || !isNew);
+    const [error, setError] = useState<string>();
+    const [loading, setLoading] = useState<LoadingState>(LoadingState.INITIALIZED);
+    const [allProjects, setAllProjects] = useState<DataTypeEntity[]>();
+    const [excludedProjectIds, setExcludedProjectIds] = useState<string[]>();
+
+    useEffect(
+        () => {
+            (async () => {
+                setLoading(LoadingState.LOADING);
+                setError(undefined);
+
+                try {
+                    const containers = await api.security.fetchContainers({
+                        containerPath: isAppHomeFolder(container, moduleContext)
+                            ? container.path
+                            : container.parentPath,
+                        includeEffectivePermissions: false,
+                        includeStandardProperties: true, // needed to get the container title
+                        includeWorkbookChildren: false,
+                        includeSubfolders: true,
+                        depth: 1,
+                    });
+
+                    const allProjects_ = containers
+                        // if user doesn't have permissions to the parent/project, the response will come back with an empty Container object
+                        .filter(c => c !== undefined && c.id !== '')
+                        // filter out the Home project container (i.e. the type = "project")
+                        .filter(c => c.type === 'folder')
+                        // convert to an array of DataTypeEntity
+                        .map(project => {
+                            return { label: project.title, lsid: project.id, type: 'Project' } as DataTypeEntity;
+                        });
+
+                    setAllProjects(allProjects_);
+
+                    const excludedProjectIds_ = await api.folder.getDataTypeExcludedProjects(dataType, dataTypeRowId);
+                    setExcludedProjectIds(excludedProjectIds_);
+                } catch (e) {
+                    setError(`Error: ${resolveErrorMessage(e)}`);
+                } finally {
+                    setLoading(LoadingState.LOADED);
+                }
+            })();
+        },
+        [
+            /* on mount only */
+        ]
+    );
+
+    useEffect(() => {
+        // consider the panel valid once the user has expanded/opened it at least once
+        if (!collapsed && !isValid) setIsValid(true);
+    }, [collapsed, isValid]);
+
+    const updateValidStatus = useCallback(() => {
+        /* no-op */
+    }, []);
+
+    const updateExcludedProjects = useCallback(
+        (_: ProjectConfigurableDataType, exclusions: string[]) => {
+            onUpdateExcludedProjects(exclusions);
+        },
+        [onUpdateExcludedProjects]
+    );
+
+    if (!isProductProjectDataTypeSelectionEnabled(moduleContext) || !hasProductProjects(moduleContext)) {
+        return null;
+    }
+
+    return (
+        <BasePropertiesPanel
+            headerId="domain-projects-hdr"
+            title="Projects"
+            collapsed={collapsed}
+            controlledCollapse={controlledCollapse}
+            isValid
+            panelStatus={collapsed && isValid ? 'COMPLETE' : isValid ? 'INPROGRESS' : 'TODO'}
+            updateValidStatus={updateValidStatus}
+            todoIconHelpMsg={
+                'This section defines which projects use this ' + noun.toLowerCase() + '. You may want to review.'
+            }
+            togglePanel={togglePanel}
+        >
+            <div className="bottom-spacing">Select which projects use this {noun.toLowerCase()}.</div>
+            {error && <Alert>{error}</Alert>}
+            {isLoading(loading) ? (
+                <LoadingSpinner />
+            ) : (
+                <Row>
+                    <Col xs={12} className="bottom-spacing">
+                        <DataTypeSelector
+                            allDataCounts={{}} // TODO
+                            allDataTypes={allProjects}
+                            updateUncheckedTypes={updateExcludedProjects}
+                            uncheckedEntitiesDB={excludedProjectIds}
+                            dataTypeLabel="projects"
+                            noHeader={true}
+                            columns={2}
+                        />
+                    </Col>
+                </Row>
+            )}
+        </BasePropertiesPanel>
+    );
+});
+
+export const DataTypeProjectsPanel = withDomainPropertiesPanelCollapse<OwnProps>(DataTypeProjectsPanelImpl);

--- a/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeProjectsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
 
 import { hasProductProjects, isAppHomeFolder, isProductProjectDataTypeSelectionEnabled } from '../../app/utils';
@@ -22,7 +22,6 @@ import {
 } from './DomainPropertiesPanelCollapse';
 
 interface OwnProps {
-    dataType?: ProjectConfigurableDataType;
     dataTypeName?: string;
     dataTypeRowId?: number;
     entityDataType: EntityDataType;
@@ -34,7 +33,6 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
         collapsed,
         togglePanel,
         controlledCollapse,
-        dataType,
         dataTypeRowId,
         dataTypeName,
         onUpdateExcludedProjects,
@@ -80,11 +78,18 @@ const DataTypeProjectsPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelColl
 
                     setAllProjects(allProjects_);
 
-                    const excludedProjectIds_ = await api.folder.getDataTypeExcludedProjects(dataType, dataTypeRowId);
+                    const excludedProjectIds_ = await api.folder.getDataTypeExcludedProjects(
+                        entityDataType.projectConfigurableDataType,
+                        dataTypeRowId
+                    );
                     setExcludedProjectIdsDB(excludedProjectIds_);
                     setExcludedProjectIds(excludedProjectIds_);
 
-                    const allDataCounts_ = await api.query.getDataTypeProjectDataCount(entityDataType, dataTypeRowId, dataTypeName);
+                    const allDataCounts_ = await api.query.getDataTypeProjectDataCount(
+                        entityDataType,
+                        dataTypeRowId,
+                        dataTypeName
+                    );
                     setAllDataCounts(allDataCounts_);
                 } catch (e) {
                     setError(`Error: ${resolveErrorMessage(e)}`);

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesPanelCollapse.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesPanelCollapse.tsx
@@ -29,7 +29,7 @@ export function withDomainPropertiesPanelCollapse<Props>(
             super(props);
 
             this.state = {
-                collapsed: false,
+                collapsed: props.initCollapsed,
             };
         }
 

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesPanelCollapse.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesPanelCollapse.tsx
@@ -1,15 +1,15 @@
 import React, { PureComponent, ComponentType } from 'react';
 
 export interface InjectedDomainPropertiesPanelCollapseProps {
-    controlledCollapse: boolean;
-    collapsible?: boolean;
     collapsed: boolean;
+    collapsible?: boolean;
+    controlledCollapse: boolean;
     togglePanel: (collapsed?: boolean) => void;
 }
 
 export interface MakeDomainPropertiesPanelCollapseProps {
-    controlledCollapse: boolean;
     collapsible?: boolean;
+    controlledCollapse: boolean;
     initCollapsed: boolean;
     onToggle?: (collapsed: boolean, callback: () => any) => any;
 }

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -300,7 +300,6 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                 {appPropertiesOnly && (
                     <DataTypeProjectsPanel
                         controlledCollapse
-                        dataType="AssayDesign"
                         dataTypeRowId={protocolModel?.protocolId}
                         dataTypeName={protocolModel?.name}
                         entityDataType={AssayRunDataType}

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -12,11 +12,13 @@ import { DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS } from '../constants';
 
 import { GENERAL_ASSAY_PROVIDER_NAME } from '../../assay/constants';
 
+import { DataTypeProjectsPanel } from '../DataTypeProjectsPanel';
+
+import { AssayRunDataType } from '../../entities/constants';
+
 import { saveAssayDesign } from './actions';
 import { AssayProtocolModel } from './models';
 import { AssayPropertiesPanel } from './AssayPropertiesPanel';
-import { DataTypeProjectsPanel } from '../DataTypeProjectsPanel';
-import { AssayRunDataType } from '../../entities/constants';
 
 const PROPERTIES_PANEL_INDEX = 0;
 const DOMAIN_PANEL_INDEX = 1;
@@ -269,7 +271,12 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                             validate={validatePanel === i + DOMAIN_PANEL_INDEX}
                             panelStatus={
                                 protocolModel.isNew()
-                                    ? getDomainPanelStatus(i + DOMAIN_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState)
+                                    ? getDomainPanelStatus(
+                                          i + DOMAIN_PANEL_INDEX,
+                                          currentPanelIndex,
+                                          visitedPanels,
+                                          firstState
+                                      )
                                     : 'COMPLETE'
                             }
                             helpTopic={null} // null so that we don't show the "learn more about this tool" link for these domains

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -15,6 +15,11 @@ import { GENERAL_ASSAY_PROVIDER_NAME } from '../../assay/constants';
 import { saveAssayDesign } from './actions';
 import { AssayProtocolModel } from './models';
 import { AssayPropertiesPanel } from './AssayPropertiesPanel';
+import { DataTypeProjectsPanel } from '../DataTypeProjectsPanel';
+import { AssayRunDataType } from '../../entities/constants';
+
+const PROPERTIES_PANEL_INDEX = 0;
+const DOMAIN_PANEL_INDEX = 1;
 
 export interface AssayDesignerPanelsProps {
     appDomainHeaders?: Map<string, HeaderRenderer>;
@@ -23,6 +28,7 @@ export interface AssayDesignerPanelsProps {
     beforeFinish?: (model: AssayProtocolModel) => void;
     containerTop?: number; // This sets the top of the sticky header, default is 0
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
+    hideAdvancedProperties?: boolean;
     hideEmptyBatchDomain?: boolean;
     initModel: AssayProtocolModel;
     onCancel: () => void;
@@ -174,9 +180,16 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
         return appDomainHeaders.filter((v, k) => domain.isNameSuffixMatch(k)).first();
     };
 
+    onUpdateExcludedProjects = (excludedContainerIds: string[]): void => {
+        const { protocolModel } = this.state;
+        const newModel = protocolModel.merge({ excludedContainerIds }) as AssayProtocolModel;
+        this.onAssayPropertiesChange(newModel);
+    };
+
     render() {
         const {
             appPropertiesOnly,
+            hideAdvancedProperties,
             domainFormDisplayOptions,
             useTheme,
             successBsStyle,
@@ -208,18 +221,18 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                 <AssayPropertiesPanel
                     model={protocolModel}
                     onChange={this.onAssayPropertiesChange}
-                    controlledCollapse={true}
-                    initCollapsed={currentPanelIndex !== 0}
+                    controlledCollapse
+                    initCollapsed={currentPanelIndex !== PROPERTIES_PANEL_INDEX}
                     panelStatus={
                         protocolModel.isNew()
-                            ? getDomainPanelStatus(0, currentPanelIndex, visitedPanels, firstState)
+                            ? getDomainPanelStatus(PROPERTIES_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState)
                             : 'COMPLETE'
                     }
-                    validate={validatePanel === 0}
-                    appPropertiesOnly={appPropertiesOnly}
+                    validate={validatePanel === PROPERTIES_PANEL_INDEX}
+                    appPropertiesOnly={hideAdvancedProperties}
                     hideStudyProperties={!!domainFormDisplayOptions && domainFormDisplayOptions.hideStudyPropertyTypes}
                     onToggle={(collapsed, callback) => {
-                        onTogglePanel(0, collapsed, callback);
+                        onTogglePanel(PROPERTIES_PANEL_INDEX, collapsed, callback);
                     }}
                     useTheme={useTheme}
                 />
@@ -251,12 +264,12 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                             domainIndex={i}
                             domain={domain}
                             headerPrefix={protocolModel.name}
-                            controlledCollapse={true}
-                            initCollapsed={currentPanelIndex !== i + 1}
-                            validate={validatePanel === i + 1}
+                            controlledCollapse
+                            initCollapsed={currentPanelIndex !== i + DOMAIN_PANEL_INDEX}
+                            validate={validatePanel === i + DOMAIN_PANEL_INDEX}
                             panelStatus={
                                 protocolModel.isNew()
-                                    ? getDomainPanelStatus(i + 1, currentPanelIndex, visitedPanels, firstState)
+                                    ? getDomainPanelStatus(i + DOMAIN_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState)
                                     : 'COMPLETE'
                             }
                             helpTopic={null} // null so that we don't show the "learn more about this tool" link for these domains
@@ -264,12 +277,12 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                                 this.onDomainChange(i, updatedDomain, dirty);
                             }}
                             onToggle={(collapsed, callback) => {
-                                onTogglePanel(i + 1, collapsed, callback);
+                                onTogglePanel(i + DOMAIN_PANEL_INDEX, collapsed, callback);
                             }}
                             appDomainHeaderRenderer={appDomainHeaderRenderer}
                             modelDomains={protocolModel.domains}
                             useTheme={useTheme}
-                            appPropertiesOnly={appPropertiesOnly}
+                            appPropertiesOnly={hideAdvancedProperties}
                             successBsStyle={successBsStyle}
                             testMode={testMode}
                             domainFormDisplayOptions={{
@@ -284,6 +297,20 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                         </DomainForm>
                     );
                 })}
+                {appPropertiesOnly && (
+                    <DataTypeProjectsPanel
+                        controlledCollapse
+                        dataType="AssayDesign"
+                        dataTypeRowId={protocolModel?.protocolId}
+                        dataTypeName={protocolModel?.name}
+                        entityDataType={AssayRunDataType}
+                        initCollapsed={currentPanelIndex !== protocolModel.domains.size + 1}
+                        onToggle={(collapsed, callback) => {
+                            onTogglePanel(protocolModel.domains.size + 1, collapsed, callback);
+                        }}
+                        onUpdateExcludedProjects={this.onUpdateExcludedProjects}
+                    />
+                )}
             </BaseDomainDesigner>
         );
     }

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
@@ -95,7 +95,6 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
   visitedPanels={Immutable.List []}
 >
   <ComponentWithDomainPropertiesPanelCollapse
-    appPropertiesOnly={true}
     controlledCollapse={true}
     hideStudyProperties={true}
     initCollapsed={false}
@@ -214,6 +213,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -222,7 +222,6 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
     validate={true}
   />
   <DomainForm
-    appPropertiesOnly={true}
     controlledCollapse={true}
     domain={
       Immutable.Record {
@@ -361,7 +360,6 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
     <div />
   </DomainForm>
   <DomainForm
-    appPropertiesOnly={true}
     controlledCollapse={true}
     domain={
       Immutable.Record {
@@ -500,7 +498,6 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
     <div />
   </DomainForm>
   <DomainForm
-    appPropertiesOnly={true}
     controlledCollapse={true}
     domain={
       Immutable.Record {
@@ -638,6 +635,42 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
   >
     <div />
   </DomainForm>
+  <ComponentWithDomainPropertiesPanelCollapse
+    controlledCollapse={true}
+    dataType="AssayDesign"
+    entityDataType={
+      {
+        "deleteHelpLinkTopic": "manageAssayData#deleteRun",
+        "dependencyText": undefined,
+        "descriptionPlural": "assay runs",
+        "descriptionSingular": "assay run",
+        "instanceSchemaName": "assay",
+        "listingSchemaQuery": SchemaQuery {
+          "queryName": "AssayRuns",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "nounAsParentPlural": "Assay Runs",
+        "nounAsParentSingular": "Assay Run",
+        "nounPlural": "runs",
+        "nounSingular": "run",
+        "operationConfirmationActionName": "getAssayRunDeletionConfirmationData.api",
+        "operationConfirmationControllerName": "assay",
+        "projectConfigurableDataType": "AssayDesign",
+        "typeListingSchemaQuery": SchemaQuery {
+          "queryName": "AssayList",
+          "schemaName": "assay",
+          "viewName": undefined,
+        },
+        "typeNounAsParentSingular": "Assay Design",
+        "typeNounSingular": "Assay Design",
+        "uniqueFieldKey": "RowId",
+      }
+    }
+    initCollapsed={true}
+    onToggle={[Function]}
+    onUpdateExcludedProjects={[Function]}
+  />
 </BaseDomainDesigner>
 `;
 
@@ -978,7 +1011,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
   visitedPanels={Immutable.List []}
 >
   <ComponentWithDomainPropertiesPanelCollapse
-    appPropertiesOnly={true}
     controlledCollapse={true}
     hideStudyProperties={true}
     initCollapsed={false}
@@ -1338,6 +1370,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -1346,7 +1379,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
     validate={true}
   />
   <DomainForm
-    appPropertiesOnly={true}
     controlledCollapse={true}
     domain={
       Immutable.Record {
@@ -1727,7 +1759,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
     <div />
   </DomainForm>
   <DomainForm
-    appPropertiesOnly={true}
     controlledCollapse={true}
     domain={
       Immutable.Record {
@@ -2375,6 +2406,44 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
   >
     <div />
   </DomainForm>
+  <ComponentWithDomainPropertiesPanelCollapse
+    controlledCollapse={true}
+    dataType="AssayDesign"
+    dataTypeName="Test Assay Protocol"
+    dataTypeRowId={1}
+    entityDataType={
+      {
+        "deleteHelpLinkTopic": "manageAssayData#deleteRun",
+        "dependencyText": undefined,
+        "descriptionPlural": "assay runs",
+        "descriptionSingular": "assay run",
+        "instanceSchemaName": "assay",
+        "listingSchemaQuery": SchemaQuery {
+          "queryName": "AssayRuns",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "nounAsParentPlural": "Assay Runs",
+        "nounAsParentSingular": "Assay Run",
+        "nounPlural": "runs",
+        "nounSingular": "run",
+        "operationConfirmationActionName": "getAssayRunDeletionConfirmationData.api",
+        "operationConfirmationControllerName": "assay",
+        "projectConfigurableDataType": "AssayDesign",
+        "typeListingSchemaQuery": SchemaQuery {
+          "queryName": "AssayList",
+          "schemaName": "assay",
+          "viewName": undefined,
+        },
+        "typeNounAsParentSingular": "Assay Design",
+        "typeNounSingular": "Assay Design",
+        "uniqueFieldKey": "RowId",
+      }
+    }
+    initCollapsed={true}
+    onToggle={[Function]}
+    onUpdateExcludedProjects={[Function]}
+  />
 </BaseDomainDesigner>
 `;
 
@@ -2591,6 +2660,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -3228,6 +3298,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain for new assay 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -4210,6 +4281,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -5564,6 +5636,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
@@ -637,7 +637,6 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
   </DomainForm>
   <ComponentWithDomainPropertiesPanelCollapse
     controlledCollapse={true}
-    dataType="AssayDesign"
     entityDataType={
       {
         "deleteHelpLinkTopic": "manageAssayData#deleteRun",
@@ -2408,7 +2407,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
   </DomainForm>
   <ComponentWithDomainPropertiesPanelCollapse
     controlledCollapse={true}
-    dataType="AssayDesign"
     dataTypeName="Test Assay Protocol"
     dataTypeRowId={1}
     entityDataType={

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
@@ -123,6 +123,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
       "selectedPlateTemplate": undefined,
       "status": "Active",
       "qcEnabled": undefined,
+      "excludedContainerIds": undefined,
     }
   }
   onChange={[Function]}
@@ -252,6 +253,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -378,6 +380,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
           "selectedPlateTemplate": undefined,
           "status": "Active",
           "qcEnabled": undefined,
+          "excludedContainerIds": undefined,
         }
       }
       onChange={[Function]}
@@ -529,6 +532,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                       "selectedPlateTemplate": undefined,
                       "status": "Active",
                       "qcEnabled": undefined,
+                      "excludedContainerIds": undefined,
                     }
                   }
                   onChange={[Function]}
@@ -759,6 +763,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                       "selectedPlateTemplate": undefined,
                       "status": "Active",
                       "qcEnabled": undefined,
+                      "excludedContainerIds": undefined,
                     }
                   }
                   onChange={[Function]}
@@ -984,6 +989,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                       "selectedPlateTemplate": undefined,
                       "status": "Active",
                       "qcEnabled": undefined,
+                      "excludedContainerIds": undefined,
                     }
                   }
                   onChange={[Function]}
@@ -1210,6 +1216,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
       "selectedPlateTemplate": undefined,
       "status": "Active",
       "qcEnabled": undefined,
+      "excludedContainerIds": undefined,
     }
   }
   onChange={[Function]}
@@ -1339,6 +1346,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -1471,6 +1479,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
           "selectedPlateTemplate": undefined,
           "status": "Active",
           "qcEnabled": undefined,
+          "excludedContainerIds": undefined,
         }
       }
       onChange={[Function]}
@@ -1695,6 +1704,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                         "selectedPlateTemplate": undefined,
                         "status": "Active",
                         "qcEnabled": undefined,
+                        "excludedContainerIds": undefined,
                       }
                     }
                     onChange={[Function]}
@@ -1846,6 +1856,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -2076,6 +2087,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -2301,6 +2313,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -2558,6 +2571,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
       "selectedPlateTemplate": undefined,
       "status": "Active",
       "qcEnabled": undefined,
+      "excludedContainerIds": undefined,
     }
   }
   onChange={[Function]}
@@ -2687,6 +2701,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -2819,6 +2834,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
           "selectedPlateTemplate": undefined,
           "status": "Active",
           "qcEnabled": undefined,
+          "excludedContainerIds": undefined,
         }
       }
       onChange={[Function]}
@@ -3043,6 +3059,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                         "selectedPlateTemplate": undefined,
                         "status": "Active",
                         "qcEnabled": undefined,
+                        "excludedContainerIds": undefined,
                       }
                     }
                     onChange={[Function]}
@@ -3194,6 +3211,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -3424,6 +3442,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -3649,6 +3668,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -3824,6 +3844,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
       "selectedPlateTemplate": undefined,
       "status": "Active",
       "qcEnabled": undefined,
+      "excludedContainerIds": undefined,
     }
   }
   onChange={[Function]}
@@ -3871,6 +3892,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -3921,6 +3943,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
           "selectedPlateTemplate": undefined,
           "status": "Active",
           "qcEnabled": undefined,
+          "excludedContainerIds": undefined,
         }
       }
       onChange={[Function]}
@@ -4063,6 +4086,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                         "selectedPlateTemplate": undefined,
                         "status": "Active",
                         "qcEnabled": undefined,
+                        "excludedContainerIds": undefined,
                       }
                     }
                     onChange={[Function]}
@@ -4132,6 +4156,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -4280,6 +4305,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -4423,6 +4449,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -4682,6 +4709,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
       "selectedPlateTemplate": undefined,
       "status": "Active",
       "qcEnabled": undefined,
+      "excludedContainerIds": undefined,
     }
   }
   onChange={[Function]}
@@ -4811,6 +4839,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
         "selectedPlateTemplate": undefined,
         "status": "Active",
         "qcEnabled": undefined,
+        "excludedContainerIds": undefined,
       }
     }
     onChange={[Function]}
@@ -4943,6 +4972,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
           "selectedPlateTemplate": undefined,
           "status": "Active",
           "qcEnabled": undefined,
+          "excludedContainerIds": undefined,
         }
       }
       onChange={[Function]}
@@ -5130,6 +5160,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                         "selectedPlateTemplate": undefined,
                         "status": "Active",
                         "qcEnabled": undefined,
+                        "excludedContainerIds": undefined,
                       }
                     }
                     onChange={[Function]}
@@ -5281,6 +5312,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -5511,6 +5543,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}
@@ -5736,6 +5769,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                     "selectedPlateTemplate": undefined,
                                     "status": "Active",
                                     "qcEnabled": undefined,
+                                    "excludedContainerIds": undefined,
                                   }
                                 }
                                 onChange={[Function]}

--- a/packages/components/src/internal/components/domainproperties/assay/models.ts
+++ b/packages/components/src/internal/components/domainproperties/assay/models.ts
@@ -57,6 +57,7 @@ export class AssayProtocolModel extends Record({
     selectedPlateTemplate: undefined,
     status: Status.Active,
     qcEnabled: undefined,
+    excludedContainerIds: undefined,
 }) {
     declare allowBackgroundUpload: boolean;
     declare allowEditableResults: boolean;
@@ -89,6 +90,7 @@ export class AssayProtocolModel extends Record({
     declare selectedPlateTemplate: string;
     declare status: Status;
     declare qcEnabled: boolean;
+    declare excludedContainerIds: string[];
 
     static create(raw: any): AssayProtocolModel {
         let domains = raw.domains || List<DomainDesign>();

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -387,8 +387,8 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
         const newModel = {
             ...model,
             excludedContainerIds,
-        };
-        this.saveModel(newModel);
+        } as DataClassModel;
+        this.onPropertiesChange(newModel);
     };
 
     propertiesToggle = (collapsed: boolean, callback: () => void): void => {

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -514,7 +514,6 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
                         dataTypeName={model?.name}
                         entityDataType={DataClassDataType}
                         initCollapsed={currentPanelIndex !== PROJECTS_PANEL_INDEX}
-                        noun={nounSingular}
                         onToggle={this.projectsToggle}
                         onUpdateExcludedProjects={this.onUpdateExcludedProjects}
                     />

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent, ReactNode } from 'react';
 import { Draft, produce } from 'immer';
-import { List, Map, OrderedMap } from 'immutable';
+import { List, Map } from 'immutable';
 
 import { Domain } from '@labkey/api';
 
@@ -28,8 +28,9 @@ import { getDuplicateAlias, getParentAliasChangeResult, getParentAliasUpdateDupe
 
 import { DataClassPropertiesPanel } from './DataClassPropertiesPanel';
 import { DataClassModel, DataClassModelConfig } from './models';
-import { DATA_CLASS_IMPORT_PREFIX } from '../../entities/constants';
+import {DATA_CLASS_IMPORT_PREFIX, DataClassDataType} from '../../entities/constants';
 import { initParentOptionsSelects } from '../../entities/actions';
+import {DataTypeProjectsPanel} from "../DataTypeProjectsPanel";
 
 interface Props {
     allowParentAlias?: boolean;
@@ -73,6 +74,10 @@ const NEW_DATA_CLASS_OPTION: IParentOption = {
     value: '{{this_data_class}}',
     schema: SCHEMAS.DATA_CLASSES.SCHEMA,
 } as IParentOption;
+
+const PROPERTIES_PANEL_INDEX = 0;
+const DOMAIN_PANEL_INDEX = 1;
+const PROJECTS_PANEL_INDEX = 2;
 
 // Exported for testing
 export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDomainDesignerProps, State> {
@@ -376,6 +381,28 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
         };
         this.saveModel(newModel);
     };
+
+    onUpdateExcludedProjects = (excludedContainerIds: string[]): void => {
+        const { model } = this.state;
+        const newModel = {
+            ...model,
+            excludedContainerIds,
+        };
+        this.saveModel(newModel);
+    };
+
+    propertiesToggle = (collapsed: boolean, callback: () => void): void => {
+        this.props.onTogglePanel(PROPERTIES_PANEL_INDEX, collapsed, callback);
+    };
+
+    formToggle = (collapsed: boolean, callback: () => void): void => {
+        this.props.onTogglePanel(DOMAIN_PANEL_INDEX, collapsed, callback);
+    };
+
+    projectsToggle = (collapsed: boolean, callback: () => void): void => {
+        this.props.onTogglePanel(PROJECTS_PANEL_INDEX, collapsed, callback);
+    };
+
     render(): ReactNode {
         const {
             onCancel,
@@ -426,16 +453,14 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
                     helpTopic={helpTopic}
                     model={model}
                     onChange={this.onPropertiesChange}
-                    controlledCollapse={true}
-                    initCollapsed={currentPanelIndex !== 0}
+                    controlledCollapse
+                    initCollapsed={currentPanelIndex !== PROPERTIES_PANEL_INDEX}
                     panelStatus={
-                        model.isNew ? getDomainPanelStatus(0, currentPanelIndex, visitedPanels, firstState) : 'COMPLETE'
+                        model.isNew ? getDomainPanelStatus(PROPERTIES_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState) : 'COMPLETE'
                     }
-                    validate={validatePanel === 0}
+                    validate={validatePanel === PROPERTIES_PANEL_INDEX}
                     appPropertiesOnly={appPropertiesOnly}
-                    onToggle={(collapsed, callback) => {
-                        onTogglePanel(0, collapsed, callback);
-                    }}
+                    onToggle={this.propertiesToggle}
                     useTheme={useTheme}
                     namePreviewsLoading={namePreviewsLoading}
                     previewName={namePreviews?.[0]}
@@ -464,16 +489,16 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
                     domain={model.domain}
                     headerTitle="Fields"
                     helpTopic={null} // null so that we don't show the "learn more about this tool" link for this domains
-                    controlledCollapse={true}
-                    initCollapsed={currentPanelIndex !== 1}
-                    validate={validatePanel === 1}
+                    controlledCollapse
+                    initCollapsed={currentPanelIndex !== DOMAIN_PANEL_INDEX}
+                    validate={validatePanel === DOMAIN_PANEL_INDEX}
                     panelStatus={
-                        model.isNew ? getDomainPanelStatus(1, currentPanelIndex, visitedPanels, firstState) : 'COMPLETE'
+                        model.isNew
+                            ? getDomainPanelStatus(DOMAIN_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState)
+                            : 'COMPLETE'
                     }
                     onChange={this.onDomainChange}
-                    onToggle={(collapsed, callback) => {
-                        onTogglePanel(1, collapsed, callback);
-                    }}
+                    onToggle={this.formToggle}
                     appPropertiesOnly={appPropertiesOnly}
                     useTheme={useTheme}
                     successBsStyle={successBsStyle}
@@ -481,6 +506,19 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
                     domainFormDisplayOptions={domainFormDisplayOptions}
                     systemFields={model.options.systemFields}
                 />
+                {appPropertiesOnly && !model.isBuiltIn && (
+                    <DataTypeProjectsPanel
+                        controlledCollapse
+                        dataType="DataClass"
+                        dataTypeRowId={model?.rowId}
+                        dataTypeName={model?.name}
+                        entityDataType={DataClassDataType}
+                        initCollapsed={currentPanelIndex !== PROJECTS_PANEL_INDEX}
+                        noun={nounSingular}
+                        onToggle={this.projectsToggle}
+                        onUpdateExcludedProjects={this.onUpdateExcludedProjects}
+                    />
+                )}
                 <NameExpressionValidationModal
                     onHide={this.onNameExpressionWarningCancel}
                     onConfirm={this.onNameExpressionWarningConfirm}

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -57,9 +57,9 @@ interface Props {
     saveBtnText?: string;
     showGenIdBanner?: boolean;
     successBsStyle?: string;
+    testMode?: boolean;
     useTheme?: boolean;
     validateNameExpressions?: boolean;
-    testMode?: boolean;
 }
 
 interface State {

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -26,11 +26,12 @@ import { SCHEMAS } from '../../../schemas';
 
 import { getDuplicateAlias, getParentAliasChangeResult, getParentAliasUpdateDupesResults } from '../utils';
 
-import { DataClassPropertiesPanel } from './DataClassPropertiesPanel';
-import { DataClassModel, DataClassModelConfig } from './models';
-import {DATA_CLASS_IMPORT_PREFIX, DataClassDataType} from '../../entities/constants';
+import { DATA_CLASS_IMPORT_PREFIX, DataClassDataType } from '../../entities/constants';
 import { initParentOptionsSelects } from '../../entities/actions';
-import {DataTypeProjectsPanel} from "../DataTypeProjectsPanel";
+import { DataTypeProjectsPanel } from '../DataTypeProjectsPanel';
+
+import { DataClassModel, DataClassModelConfig } from './models';
+import { DataClassPropertiesPanel } from './DataClassPropertiesPanel';
 
 interface Props {
     allowParentAlias?: boolean;
@@ -46,6 +47,7 @@ interface Props {
     loadNameExpressionOptions?: (
         containerPath?: string
     ) => Promise<{ allowUserSpecifiedNames: boolean; prefix: string }>;
+    nameExpressionInfoUrl?: string;
     nameExpressionPlaceholder?: string;
     nounPlural?: string;
     nounSingular?: string;
@@ -55,10 +57,9 @@ interface Props {
     saveBtnText?: string;
     showGenIdBanner?: boolean;
     successBsStyle?: string;
-    testMode?: boolean;
     useTheme?: boolean;
     validateNameExpressions?: boolean;
-    nameExpressionInfoUrl?: string;
+    testMode?: boolean;
 }
 
 interface State {
@@ -456,7 +457,9 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
                     controlledCollapse
                     initCollapsed={currentPanelIndex !== PROPERTIES_PANEL_INDEX}
                     panelStatus={
-                        model.isNew ? getDomainPanelStatus(PROPERTIES_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState) : 'COMPLETE'
+                        model.isNew
+                            ? getDomainPanelStatus(PROPERTIES_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState)
+                            : 'COMPLETE'
                     }
                     validate={validatePanel === PROPERTIES_PANEL_INDEX}
                     appPropertiesOnly={appPropertiesOnly}

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -509,7 +509,6 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
                 {appPropertiesOnly && !model.isBuiltIn && (
                     <DataTypeProjectsPanel
                         controlledCollapse
-                        dataType="DataClass"
                         dataTypeRowId={model?.rowId}
                         dataTypeName={model?.name}
                         entityDataType={DataClassDataType}

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -198,7 +198,6 @@ exports[`DataClassDesigner custom properties 1`] = `
   />
   <ComponentWithDomainPropertiesPanelCollapse
     controlledCollapse={true}
-    dataType="DataClass"
     entityDataType={
       {
         "ancestorColumnName": "Ancestors/OtherData",

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -196,6 +196,53 @@ exports[`DataClassDesigner custom properties 1`] = `
     useTheme={true}
     validate={false}
   />
+  <ComponentWithDomainPropertiesPanelCollapse
+    controlledCollapse={true}
+    dataType="DataClass"
+    entityDataType={
+      {
+        "ancestorColumnName": "Ancestors/OtherData",
+        "deleteHelpLinkTopic": "dataClass#prevent",
+        "dependencyText": "derived data or sample dependencies",
+        "descriptionPlural": "parent types",
+        "descriptionSingular": "parent type",
+        "filterCardHeaderClass": "filter-card__header-primary",
+        "importFileAction": "importData",
+        "inputColumnName": "Inputs/Data/First",
+        "inputTypeValueField": "rowId",
+        "insertColumnNamePrefix": "DataInputs/",
+        "instanceSchemaName": "exp.data",
+        "listingSchemaQuery": SchemaQuery {
+          "queryName": "Data",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "moveActionName": "moveSources.api",
+        "moveControllerName": "experiment",
+        "nounAsParentPlural": "Data Types",
+        "nounAsParentSingular": "Parent",
+        "nounPlural": "data",
+        "nounSingular": "data",
+        "operationConfirmationActionName": "getDataOperationConfirmationData.api",
+        "operationConfirmationControllerName": "experiment",
+        "projectConfigurableDataType": "DataClass",
+        "sampleFinderCardType": "dataclassparent",
+        "typeIcon": "source_type",
+        "typeListingSchemaQuery": SchemaQuery {
+          "queryName": "DataClasses",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "typeNounAsParentSingular": "Data Type",
+        "typeNounSingular": "Data Type",
+        "uniqueFieldKey": "Name",
+      }
+    }
+    initCollapsed={true}
+    noun="Source"
+    onToggle={[Function]}
+    onUpdateExcludedProjects={[Function]}
+  />
   <NameExpressionValidationModal
     onConfirm={[Function]}
     onHide={[Function]}

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -239,7 +239,6 @@ exports[`DataClassDesigner custom properties 1`] = `
       }
     }
     initCollapsed={true}
-    noun="Source"
     onToggle={[Function]}
     onUpdateExcludedProjects={[Function]}
   />

--- a/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
@@ -27,6 +27,7 @@ import { DATACLASS_DOMAIN_SYSTEM_FIELDS, SOURCE_DOMAIN_SYSTEM_FIELDS } from './c
 interface DataClassOptionsConfig {
     category: string;
     description: string;
+    excludedContainerIds?: string[];
     importAliases?: Map<string, string>;
     name: string;
     nameExpression: string;
@@ -55,6 +56,7 @@ export class DataClassModel implements DataClassModelConfig {
     readonly systemFields: SystemField[];
     readonly parentAliases?: OrderedMap<string, IParentAlias>;
     readonly importAliases?: Map<string, string>;
+    readonly excludedContainerIds?: string[];
     readonly isBuiltIn?: boolean;
 
     constructor(values?: Partial<DataClassModelConfig>) {
@@ -129,6 +131,7 @@ export class DataClassModel implements DataClassModelConfig {
             rowId: this.rowId,
             name: this.name,
             description: this.description,
+            excludedContainerIds: this.excludedContainerIds,
             nameExpression: this.nameExpression,
             category: this.category,
             sampleSet: this.sampleSet,

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
@@ -7,7 +7,7 @@ import DomainForm from '../DomainForm';
 
 import { DomainDetails } from '../models';
 
-import {mountWithAppServerContext, waitForLifecycle} from '../../../testHelpers';
+import { mountWithAppServerContext, waitForLifecycle } from '../../../testHelpers';
 import { initUnitTestMocks } from '../../../../test/testHelperMocks';
 
 import { FileAttachmentForm } from '../../../../public/files/FileAttachmentForm';

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { List, Map } from 'immutable';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { PROPERTIES_PANEL_ERROR_MSG } from '../constants';
 import DomainForm from '../DomainForm';
 
 import { DomainDetails } from '../models';
 
-import { waitForLifecycle } from '../../../testHelpers';
+import {mountWithAppServerContext, waitForLifecycle} from '../../../testHelpers';
 import { initUnitTestMocks } from '../../../../test/testHelperMocks';
 
 import { FileAttachmentForm } from '../../../../public/files/FileAttachmentForm';
@@ -165,7 +165,7 @@ describe('SampleTypeDesigner', () => {
     });
 
     test('open fields panel', async () => {
-        const wrapped = mount(<SampleTypeDesigner {...BASE_PROPS} />);
+        const wrapped = mountWithAppServerContext(<SampleTypeDesigner {...BASE_PROPS} />);
         await waitForLifecycle(wrapped);
 
         const panelHeader = wrapped.find('div#domain-header');
@@ -183,7 +183,7 @@ describe('SampleTypeDesigner', () => {
 
     test('open fields panel, with barcodes', async () => {
         LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement', 'api', 'core', 'premium'] } };
-        const wrapped = mount(<SampleTypeDesigner {...BASE_PROPS} />);
+        const wrapped = mountWithAppServerContext(<SampleTypeDesigner {...BASE_PROPS} />);
         await waitForLifecycle(wrapped);
 
         const panelHeader = wrapped.find('div#domain-header');

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -36,12 +36,13 @@ import { Alert } from '../../base/Alert';
 
 import { getDuplicateAlias, getParentAliasChangeResult, getParentAliasUpdateDupesResults } from '../utils';
 
-import {SAMPLE_SET_IMPORT_PREFIX, SampleTypeDataType} from '../../entities/constants';
+import { SAMPLE_SET_IMPORT_PREFIX, SampleTypeDataType } from '../../entities/constants';
+
+import { DataTypeProjectsPanel } from '../DataTypeProjectsPanel';
 
 import { UniqueIdBanner } from './UniqueIdBanner';
 import { SampleTypePropertiesPanel } from './SampleTypePropertiesPanel';
 import { AliquotNamePatternProps, MetricUnitProps, SampleTypeModel } from './models';
-import { DataTypeProjectsPanel } from '../DataTypeProjectsPanel';
 
 const NEW_SAMPLE_SET_OPTION: IParentOption = {
     label: `(Current ${SAMPLE_SET_DISPLAY_TEXT})`,

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -761,8 +761,8 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                         controlledCollapse
                         dataType="SampleType"
                         dataTypeRowId={model?.rowId}
+                        dataTypeName={model?.name}
                         initCollapsed={currentPanelIndex !== PROJECTS_PANEL_INDEX}
-                        isNew={model.isNew()}
                         noun={NOUN}
                         onToggle={this.projectsToggle}
                         onUpdateExcludedProjects={this.onUpdateExcludedProjects}

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -36,12 +36,12 @@ import { Alert } from '../../base/Alert';
 
 import { getDuplicateAlias, getParentAliasChangeResult, getParentAliasUpdateDupesResults } from '../utils';
 
-import { SAMPLE_SET_IMPORT_PREFIX } from '../../entities/constants';
+import {SAMPLE_SET_IMPORT_PREFIX, SampleTypeDataType} from '../../entities/constants';
 
 import { UniqueIdBanner } from './UniqueIdBanner';
 import { SampleTypePropertiesPanel } from './SampleTypePropertiesPanel';
 import { AliquotNamePatternProps, MetricUnitProps, SampleTypeModel } from './models';
-import {DataTypeProjectsPanel} from "../DataTypeProjectsPanel";
+import { DataTypeProjectsPanel } from '../DataTypeProjectsPanel';
 
 const NEW_SAMPLE_SET_OPTION: IParentOption = {
     label: `(Current ${SAMPLE_SET_DISPLAY_TEXT})`,
@@ -287,9 +287,9 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         this.onFieldChange(newModel);
     };
 
-    onUpdateExcludedProjects = (excludedProjects: string[]): void => {
+    onUpdateExcludedProjects = (excludedContainerIds: string[]): void => {
         const { model } = this.state;
-        const newModel = model.set('excludedContainerIds', excludedProjects) as SampleTypeModel;
+        const newModel = model.set('excludedContainerIds', excludedContainerIds) as SampleTypeModel;
         this.onFieldChange(newModel);
     };
 
@@ -762,6 +762,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                         dataType="SampleType"
                         dataTypeRowId={model?.rowId}
                         dataTypeName={model?.name}
+                        entityDataType={SampleTypeDataType}
                         initCollapsed={currentPanelIndex !== PROJECTS_PANEL_INDEX}
                         noun={NOUN}
                         onToggle={this.projectsToggle}

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -56,7 +56,6 @@ const PROJECTS_PANEL_INDEX = 2;
 const SAMPLE_TYPE_NAME_EXPRESSION_TOPIC = 'sampleIDs#patterns';
 const SAMPLE_TYPE_NAME_EXPRESSION_PLACEHOLDER = 'Enter a naming pattern (e.g., S-${now:date}-${dailySampleCount})';
 const SAMPLE_TYPE_HELP_TOPIC = 'createSampleType';
-const NOUN = 'Sample Type';
 
 const AliquotOptionsHelp: FC<{ helpTopic: string }> = memo(({ helpTopic }) => {
     return (
@@ -141,7 +140,10 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         showParentLabelPrefix: true,
         useTheme: false,
         showLinkToStudy: false,
-        domainFormDisplayOptions: { ...DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS, domainKindDisplayName: NOUN.toLowerCase() },
+        domainFormDisplayOptions: {
+            ...DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
+            domainKindDisplayName: SampleTypeDataType.typeNounSingular.toLowerCase(),
+        },
         validateNameExpressions: true,
     };
 
@@ -626,7 +628,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
             ' field' +
             (numNewUniqueIdFields !== 1 ? 's' : '') +
             ' to this ' +
-            NOUN +
+            SampleTypeDataType.typeNounSingular +
             '. ' +
             'Values for ' +
             (numNewUniqueIdFields !== 1 ? 'these fields' : 'this field') +
@@ -764,7 +766,6 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                         dataTypeName={model?.name}
                         entityDataType={SampleTypeDataType}
                         initCollapsed={currentPanelIndex !== PROJECTS_PANEL_INDEX}
-                        noun={NOUN}
                         onToggle={this.projectsToggle}
                         onUpdateExcludedProjects={this.onUpdateExcludedProjects}
                     />
@@ -772,10 +773,17 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                 {error && <div className="domain-form-panel">{error && <Alert bsStyle="danger">{error}</Alert>}</div>}
                 {showUniqueIdConfirmation && (
                     <ConfirmModal
-                        title={'Updating ' + NOUN + ' with Unique ID field' + (numNewUniqueIdFields !== 1 ? 's' : '')}
+                        title={
+                            'Updating ' +
+                            SampleTypeDataType.typeNounSingular +
+                            ' with Unique ID field' +
+                            (numNewUniqueIdFields !== 1 ? 's' : '')
+                        }
                         onCancel={this.onUniqueIdCancel}
                         onConfirm={this.onUniqueIdConfirm}
-                        confirmButtonText={submitting ? 'Finishing ...' : 'Finish Updating ' + NOUN}
+                        confirmButtonText={
+                            submitting ? 'Finishing ...' : 'Finish Updating ' + SampleTypeDataType.typeNounSingular
+                        }
                         confirmVariant="success"
                         cancelButtonText="Cancel"
                         submitting={submitting}

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -761,7 +761,6 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                     // appPropertiesOnly check will prevent this panel from showing in LKS and in LKB media types
                     <DataTypeProjectsPanel
                         controlledCollapse
-                        dataType="SampleType"
                         dataTypeRowId={model?.rowId}
                         dataTypeName={model?.name}
                         entityDataType={SampleTypeDataType}

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -473,7 +473,6 @@ exports[`SampleTypeDesigner default properties 1`] = `
   />
   <ComponentWithDomainPropertiesPanelCollapse
     controlledCollapse={true}
-    dataType="SampleType"
     entityDataType={
       {
         "ancestorColumnName": "Ancestors/Samples",
@@ -1032,7 +1031,6 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
   />
   <ComponentWithDomainPropertiesPanelCollapse
     controlledCollapse={true}
-    dataType="SampleType"
     dataTypeName="Test Name"
     entityDataType={
       {

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -530,7 +530,6 @@ exports[`SampleTypeDesigner default properties 1`] = `
       }
     }
     initCollapsed={true}
-    noun="Sample Type"
     onToggle={[Function]}
     onUpdateExcludedProjects={[Function]}
   />
@@ -1091,7 +1090,6 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
       }
     }
     initCollapsed={true}
-    noun="Sample Type"
     onToggle={[Function]}
     onUpdateExcludedProjects={[Function]}
   />

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -474,6 +474,61 @@ exports[`SampleTypeDesigner default properties 1`] = `
   <ComponentWithDomainPropertiesPanelCollapse
     controlledCollapse={true}
     dataType="SampleType"
+    entityDataType={
+      {
+        "ancestorColumnName": "Ancestors/Samples",
+        "appUrlPrefixParts": [
+          "samples",
+        ],
+        "deleteHelpLinkTopic": "viewSampleSets#delete",
+        "dependencyText": [Function],
+        "descriptionPlural": "parent sample types",
+        "descriptionSingular": "parent sample type",
+        "editTypeAppUrlPrefix": "sampleType",
+        "exprColumnsWithSubSelect": [
+          "SourceProtocolLSID",
+          "StorageStatus",
+          "SampleTypeUnits",
+          "FreezeThawCount",
+          "CheckedOutBy",
+          "StorageRow",
+          "StorageCol",
+          "CheckedOut",
+        ],
+        "filterCardHeaderClass": "filter-card__header-success",
+        "importFileAction": "importSamples",
+        "inputColumnName": "Inputs/Materials/First",
+        "inputTypeValueField": "lsid",
+        "insertColumnNamePrefix": "MaterialInputs/",
+        "instanceKey": "samples",
+        "instanceSchemaName": "samples",
+        "labelColorCol": "labelcolor",
+        "listingSchemaQuery": SchemaQuery {
+          "queryName": "Materials",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "moveActionName": "moveSamples.api",
+        "moveControllerName": "experiment",
+        "nounAsParentPlural": "Parents",
+        "nounAsParentSingular": "Parent",
+        "nounPlural": "samples",
+        "nounSingular": "sample",
+        "operationConfirmationActionName": "getMaterialOperationConfirmationData.api",
+        "operationConfirmationControllerName": "experiment",
+        "projectConfigurableDataType": "SampleType",
+        "sampleFinderCardType": "sampleparent",
+        "typeIcon": "sample_set",
+        "typeListingSchemaQuery": SchemaQuery {
+          "queryName": "SampleSets",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "typeNounAsParentSingular": "Parent Type",
+        "typeNounSingular": "Sample Type",
+        "uniqueFieldKey": "Name",
+      }
+    }
     initCollapsed={true}
     noun="Sample Type"
     onToggle={[Function]}
@@ -980,6 +1035,61 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
     controlledCollapse={true}
     dataType="SampleType"
     dataTypeName="Test Name"
+    entityDataType={
+      {
+        "ancestorColumnName": "Ancestors/Samples",
+        "appUrlPrefixParts": [
+          "samples",
+        ],
+        "deleteHelpLinkTopic": "viewSampleSets#delete",
+        "dependencyText": [Function],
+        "descriptionPlural": "parent sample types",
+        "descriptionSingular": "parent sample type",
+        "editTypeAppUrlPrefix": "sampleType",
+        "exprColumnsWithSubSelect": [
+          "SourceProtocolLSID",
+          "StorageStatus",
+          "SampleTypeUnits",
+          "FreezeThawCount",
+          "CheckedOutBy",
+          "StorageRow",
+          "StorageCol",
+          "CheckedOut",
+        ],
+        "filterCardHeaderClass": "filter-card__header-success",
+        "importFileAction": "importSamples",
+        "inputColumnName": "Inputs/Materials/First",
+        "inputTypeValueField": "lsid",
+        "insertColumnNamePrefix": "MaterialInputs/",
+        "instanceKey": "samples",
+        "instanceSchemaName": "samples",
+        "labelColorCol": "labelcolor",
+        "listingSchemaQuery": SchemaQuery {
+          "queryName": "Materials",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "moveActionName": "moveSamples.api",
+        "moveControllerName": "experiment",
+        "nounAsParentPlural": "Parents",
+        "nounAsParentSingular": "Parent",
+        "nounPlural": "samples",
+        "nounSingular": "sample",
+        "operationConfirmationActionName": "getMaterialOperationConfirmationData.api",
+        "operationConfirmationControllerName": "experiment",
+        "projectConfigurableDataType": "SampleType",
+        "sampleFinderCardType": "sampleparent",
+        "typeIcon": "sample_set",
+        "typeListingSchemaQuery": SchemaQuery {
+          "queryName": "SampleSets",
+          "schemaName": "exp",
+          "viewName": undefined,
+        },
+        "typeNounAsParentSingular": "Parent Type",
+        "typeNounSingular": "Sample Type",
+        "uniqueFieldKey": "Name",
+      }
+    }
     initCollapsed={true}
     noun="Sample Type"
     onToggle={[Function]}

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -475,7 +475,6 @@ exports[`SampleTypeDesigner default properties 1`] = `
     controlledCollapse={true}
     dataType="SampleType"
     initCollapsed={true}
-    isNew={true}
     noun="Sample Type"
     onToggle={[Function]}
     onUpdateExcludedProjects={[Function]}
@@ -980,8 +979,8 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
   <ComponentWithDomainPropertiesPanelCollapse
     controlledCollapse={true}
     dataType="SampleType"
+    dataTypeName="Test Name"
     initCollapsed={true}
-    isNew={true}
     noun="Sample Type"
     onToggle={[Function]}
     onUpdateExcludedProjects={[Function]}

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -94,6 +94,7 @@ exports[`SampleTypeDesigner custom properties 1`] = `
         },
         "autoLinkTargetContainerId": undefined,
         "autoLinkCategory": undefined,
+        "excludedContainerIds": undefined,
         "exception": undefined,
       }
     }
@@ -333,6 +334,7 @@ exports[`SampleTypeDesigner default properties 1`] = `
         },
         "autoLinkTargetContainerId": undefined,
         "autoLinkCategory": undefined,
+        "excludedContainerIds": undefined,
         "exception": undefined,
       }
     }
@@ -468,6 +470,15 @@ exports[`SampleTypeDesigner default properties 1`] = `
     testMode={true}
     useTheme={false}
     validate={false}
+  />
+  <ComponentWithDomainPropertiesPanelCollapse
+    controlledCollapse={true}
+    dataType="SampleType"
+    initCollapsed={true}
+    isNew={true}
+    noun="Sample Type"
+    onToggle={[Function]}
+    onUpdateExcludedProjects={[Function]}
   />
   <NameExpressionValidationModal
     onConfirm={[Function]}
@@ -750,6 +761,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
         },
         "autoLinkTargetContainerId": undefined,
         "autoLinkCategory": undefined,
+        "excludedContainerIds": undefined,
         "exception": undefined,
       }
     }
@@ -964,6 +976,15 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
     testMode={true}
     useTheme={false}
     validate={false}
+  />
+  <ComponentWithDomainPropertiesPanelCollapse
+    controlledCollapse={true}
+    dataType="SampleType"
+    initCollapsed={true}
+    isNew={true}
+    noun="Sample Type"
+    onToggle={[Function]}
+    onUpdateExcludedProjects={[Function]}
   />
   <NameExpressionValidationModal
     onConfirm={[Function]}

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -1553,6 +1553,7 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
       },
       "autoLinkTargetContainerId": undefined,
       "autoLinkCategory": undefined,
+      "excludedContainerIds": undefined,
       "exception": undefined,
     }
   }
@@ -1633,6 +1634,7 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
         },
         "autoLinkTargetContainerId": undefined,
         "autoLinkCategory": undefined,
+        "excludedContainerIds": undefined,
         "exception": undefined,
       }
     }
@@ -1724,6 +1726,7 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
           },
           "autoLinkTargetContainerId": undefined,
           "autoLinkCategory": undefined,
+          "excludedContainerIds": undefined,
           "exception": undefined,
         }
       }
@@ -1913,6 +1916,7 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                         },
                         "autoLinkTargetContainerId": undefined,
                         "autoLinkCategory": undefined,
+                        "excludedContainerIds": undefined,
                         "exception": undefined,
                       }
                     }
@@ -2368,6 +2372,7 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                         },
                         "autoLinkTargetContainerId": undefined,
                         "autoLinkCategory": undefined,
+                        "excludedContainerIds": undefined,
                         "exception": undefined,
                       }
                     }
@@ -2644,6 +2649,7 @@ exports[`<SampleTypePropertiesPanel/> with aliquot preview name 1`] = `
                                 },
                                 "autoLinkTargetContainerId": undefined,
                                 "autoLinkCategory": undefined,
+                                "excludedContainerIds": undefined,
                                 "exception": undefined,
                               }
                             }

--- a/packages/components/src/internal/components/domainproperties/samples/models.ts
+++ b/packages/components/src/internal/components/domainproperties/samples/models.ts
@@ -19,6 +19,7 @@ export class SampleTypeModel extends Record({
     domain: undefined,
     autoLinkTargetContainerId: undefined,
     autoLinkCategory: undefined,
+    excludedContainerIds: undefined,
     exception: undefined,
 }) {
     declare rowId: number;
@@ -35,6 +36,7 @@ export class SampleTypeModel extends Record({
     declare domain?: DomainDesign;
     declare autoLinkTargetContainerId: string;
     declare autoLinkCategory: string;
+    declare excludedContainerIds?: string[];
     declare exception: string;
 
     static create(raw?: DomainDetails, name?: string): SampleTypeModel {

--- a/packages/components/src/internal/components/entities/DataTypeSelector.tsx
+++ b/packages/components/src/internal/components/entities/DataTypeSelector.tsx
@@ -7,15 +7,13 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
-import { getDataTypeDataCount } from '../project/actions';
-
 import { ColorIcon } from '../base/ColorIcon';
 import { Tip } from '../base/Tip';
 
 import { DataTypeEntity, EntityDataType, ProjectConfigurableDataType } from './models';
 
 interface Props {
-    allDataCounts?: { [key: string]: number };
+    allDataCounts?: Record<string, number>;
     allDataTypes?: DataTypeEntity[]; // either use allDataTypes to pass in dataTypes, or specify entityDataType to query dataTypes
     api?: ComponentsAPIWrapper;
     columns?: number; // partition list to N columns
@@ -34,7 +32,7 @@ interface Props {
 export const getUncheckedEntityWarning = (
     uncheckedEntities: any[], // number[] | string[]
     uncheckedEntitiesDB: any[], // number[] | string[]
-    dataCounts: { [key: string]: number },
+    dataCounts: Record<string, number>,
     entityDataType: EntityDataType,
     rowId: number | string
 ): React.ReactNode => {
@@ -78,7 +76,7 @@ export const DataTypeSelector: FC<Props> = memo(props => {
     const [dataType, setDataType] = useState<ProjectConfigurableDataType>(undefined);
     const [error, setError] = useState<string>(undefined);
     const [loading, setLoading] = useState<boolean>(false);
-    const [dataCounts, setDataCounts] = useState<{ [key: string]: number }>(undefined);
+    const [dataCounts, setDataCounts] = useState<Record<string, number>>(undefined);
     const [uncheckedEntities, setUncheckedEntities] = useState<any[] /*number[] | string[]*/>(undefined);
 
     useEffect(() => {
@@ -105,14 +103,17 @@ export const DataTypeSelector: FC<Props> = memo(props => {
         } finally {
             setLoading(false);
         }
-    }, [entityDataType]);
+    }, [api, entityDataType]);
 
     const ensureCount = useCallback(async () => {
         if (dataCounts) return;
 
-        const results = await getDataTypeDataCount(entityDataType.projectConfigurableDataType, dataTypes);
+        const results = await api.query.getProjectDataTypeDataCount(
+            entityDataType.projectConfigurableDataType,
+            dataTypes
+        );
         setDataCounts(results);
-    }, [dataCounts, dataTypes, entityDataType, allDataTypes]);
+    }, [api, dataCounts, dataTypes, entityDataType]);
 
     const onChange = useCallback(
         (entityId: number | string, toggle: boolean, check?: boolean) => {

--- a/packages/components/src/internal/components/entities/DataTypeSelector.tsx
+++ b/packages/components/src/internal/components/entities/DataTypeSelector.tsx
@@ -28,7 +28,7 @@ interface Props {
     toggleSelectAll?: boolean;
 
     uncheckedEntitiesDB: any[]; // number[] | string[]
-    updateUncheckedTypes: (dataType: string, unchecked: any[] /*number[] | string[]*/) => void;
+    updateUncheckedTypes: (dataType: string, unchecked: any[] /* number[] | string[]*/) => void;
 }
 
 export const getUncheckedEntityWarning = (
@@ -80,7 +80,7 @@ export const DataTypeSelector: FC<Props> = memo(props => {
     const [error, setError] = useState<string>(undefined);
     const [loading, setLoading] = useState<boolean>(false);
     const [dataCounts, setDataCounts] = useState<Record<string, number>>(undefined);
-    const [uncheckedEntities, setUncheckedEntities] = useState<any[] /*number[] | string[]*/>(undefined);
+    const [uncheckedEntities, setUncheckedEntities] = useState<any[] /* number[] | string[]*/>(undefined);
 
     useEffect(() => {
         if (allDataCounts) setDataCounts(allDataCounts);

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -441,7 +441,7 @@ export interface IEntityTypeDetails extends IEntityDetails {
 }
 
 export type SampleFinderCardType = 'sampleproperty' | 'sampleparent' | 'dataclassparent' | 'assaydata';
-export type ProjectConfigurableDataType = 'SampleType' | 'DataClass' | 'AssayDesign' | 'StorageLocation';
+export type ProjectConfigurableDataType = 'SampleType' | 'DataClass' | 'AssayDesign' | 'StorageLocation' | 'Project';
 
 /**
  *  Avoid inline comment or above line comments for properties due to es-lint's limitation on moving comments:
@@ -597,7 +597,7 @@ export interface DataTypeEntity {
     label: string;
     labelColor?: string;
     lsid?: string;
-    rowId: number;
+    rowId?: number;
     sublabel?: string;
     type: ProjectConfigurableDataType;
 }

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
@@ -62,10 +62,11 @@ describe('SampleStatusInput', () => {
         const component = mountWithServerContext(<SampleStatusInput {...DEFAULT_PROPS} formsy={false} />, {
             user: TEST_USER_STORAGE_EDITOR,
         });
-        await waitForLifecycle(component, 5);
+        await waitForLifecycle(component, 50);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);
+        component.unmount();
     });
 
     test('initial value is Consumed', async () => {
@@ -73,67 +74,72 @@ describe('SampleStatusInput', () => {
             <SampleStatusInput {...DEFAULT_PROPS} formsy={false} value={INIT_CONSUMED} />,
             { user: TEST_USER_STORAGE_EDITOR }
         );
-        await waitForLifecycle(component, 5);
+        await waitForLifecycle(component, 50);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);
+        component.unmount();
     });
 
     test('change to consumed status, editor', async () => {
         const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} allowDisable />;
         const wrapper = mountWithServerContext(component, { user: TEST_USER_EDITOR });
 
-        await waitForLifecycle(wrapper, 5); // retrieve statuses
+        await waitForLifecycle(wrapper, 50); // retrieve statuses
         act(() => {
             wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined, undefined);
         });
-        await waitForLifecycle(wrapper, 5); // update after select
+        await waitForLifecycle(wrapper, 50); // update after select
         const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);
+        wrapper.unmount();
     });
 
     test('change to consumed status, storage editor, allow disable (bulk edit)', async () => {
         const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} allowDisable />;
         const wrapper = mountWithServerContext(component, { user: TEST_USER_STORAGE_EDITOR });
 
-        await waitForLifecycle(wrapper, 5);
+        await waitForLifecycle(wrapper, 50);
         act(() => {
             wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined, undefined);
         });
-        await waitForLifecycle(wrapper, 5);
+        await waitForLifecycle(wrapper, 50);
         const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(1);
 
         expect(wrapper.find('.sample-bulk-update-discard-panel')).toHaveLength(1);
+        wrapper.unmount();
     });
 
     test('change to consumed status, storage editor, no allowDisable', async () => {
         const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />;
         const wrapper = mountWithServerContext(component, { user: TEST_USER_STORAGE_EDITOR });
 
-        await waitForLifecycle(wrapper, 5);
+        await waitForLifecycle(wrapper, 50);
         act(() => {
             wrapper.find(QuerySelect).prop('onQSChange')('name', 200, [], undefined, undefined);
         });
-        await waitForLifecycle(wrapper, 5);
+        await waitForLifecycle(wrapper, 50);
         const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(1);
 
         expect(wrapper.find('.sample-bulk-update-discard-panel')).toHaveLength(0);
+        wrapper.unmount();
     });
 
     test('change to not consumed, storage editor', async () => {
         const component = <SampleStatusInput {...DEFAULT_PROPS} formsy={false} />;
         const wrapper = mountWithServerContext(component, { user: TEST_USER_STORAGE_EDITOR });
 
-        await waitForLifecycle(wrapper, 5);
+        await waitForLifecycle(wrapper, 50);
         act(() => {
             wrapper.find(QuerySelect).prop('onQSChange')('name', 100, [], undefined, undefined);
         });
-        await waitForLifecycle(wrapper, 5);
+        await waitForLifecycle(wrapper, 50);
         const discardPanel = wrapper.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);
 
         expect(wrapper.find('.sample-bulk-update-discard-panel')).toHaveLength(0);
+        wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.spec.tsx
@@ -62,7 +62,7 @@ describe('SampleStatusInput', () => {
         const component = mountWithServerContext(<SampleStatusInput {...DEFAULT_PROPS} formsy={false} />, {
             user: TEST_USER_STORAGE_EDITOR,
         });
-        await waitForLifecycle(component);
+        await waitForLifecycle(component, 5);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);
@@ -73,7 +73,7 @@ describe('SampleStatusInput', () => {
             <SampleStatusInput {...DEFAULT_PROPS} formsy={false} value={INIT_CONSUMED} />,
             { user: TEST_USER_STORAGE_EDITOR }
         );
-        await waitForLifecycle(component);
+        await waitForLifecycle(component, 5);
 
         const discardPanel = component.find(DiscardConsumedSamplesPanel);
         expect(discardPanel).toHaveLength(0);

--- a/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
@@ -19,7 +19,7 @@ import { AdminAppContext, AppContext } from '../../AppContext';
 import { getTestAPIWrapper } from '../../APIWrapper';
 
 import { CreateProjectContainer, CreateProjectContainerProps, CreateProjectPage } from './CreateProjectPage';
-import {ProjectDataTypeSelections} from "./ProjectDataTypeSelections";
+import { ProjectDataTypeSelections } from './ProjectDataTypeSelections';
 
 describe('CreateProjectPage', () => {
     function getDefaultProps(overrides?: Partial<FolderAPIWrapper>): CreateProjectContainerProps {

--- a/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
@@ -64,8 +64,8 @@ describe('CreateProjectPage', () => {
         );
 
         // Assert
-        expect(wrapper.find('.panel-heading').text()).toBe('Name of Project');
-        expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(0); // TODO change this to 1 after experimental feature is removed
+        expect(wrapper.find('.panel-heading').first().text()).toBe('Name of Project');
+        expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(1);
         const form = wrapper.find('.create-project-form');
         expect(form.exists()).toBe(true);
         form.simulate('submit');

--- a/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.spec.tsx
@@ -18,6 +18,7 @@ import { TEST_LIMS_STARTER_MODULE_CONTEXT } from '../../productFixtures';
 import { CreateProjectContainer, CreateProjectContainerProps, CreateProjectPage } from './CreateProjectPage';
 import {AdminAppContext, AppContext} from "../../AppContext";
 import {getTestAPIWrapper} from "../../APIWrapper";
+import {ProjectDataTypeSelections} from "./ProjectDataTypeSelections";
 
 describe('CreateProjectPage', () => {
     function getDefaultProps(overrides?: Partial<FolderAPIWrapper>): CreateProjectContainerProps {
@@ -59,6 +60,8 @@ describe('CreateProjectPage', () => {
         );
 
         // Assert
+        expect(wrapper.find('.panel-heading').text()).toBe('Name of Project');
+        expect(wrapper.find(ProjectDataTypeSelections)).toHaveLength(0); // TODO change this to 1 after experimental feature is removed
         const form = wrapper.find('.create-project-form');
         expect(form.exists()).toBe(true);
         form.simulate('submit');

--- a/packages/components/src/internal/components/project/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.tsx
@@ -22,9 +22,10 @@ import { useAdminAppContext } from '../administration/useAdminAppContext';
 
 import { ProjectConfigurableDataType } from '../entities/models';
 
+import { PageDetailHeader } from '../forms/PageDetailHeader';
+
 import { ProjectProperties } from './ProjectProperties';
 import { ProjectDataTypeSelections } from './ProjectDataTypeSelections';
-import { PageDetailHeader } from '../forms/PageDetailHeader';
 
 const TITLE = 'Create New Project';
 
@@ -94,7 +95,6 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                     <div className="panel-heading">Name of Project</div>
                     <div className="panel-body">
                         <div className="form-horizontal">
-
                             <ProjectProperties autoFocus />
 
                             {/* Dummy submit button so browsers trigger onSubmit with enter key */}

--- a/packages/components/src/internal/components/project/CreateProjectPage.tsx
+++ b/packages/components/src/internal/components/project/CreateProjectPage.tsx
@@ -1,4 +1,4 @@
-import React, {FC, memo, useCallback, useEffect, useState} from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 import { WithRouterProps } from 'react-router';
 import { ActionURL } from '@labkey/api';
 
@@ -27,8 +27,10 @@ import { useAdminAppContext } from '../administration/useAdminAppContext';
 
 import { ProjectProperties } from './ProjectProperties';
 import { ProjectDataTypeSelections } from './ProjectDataTypeSelections';
-import {ProjectConfigurableDataType} from "../entities/models";
+import { ProjectConfigurableDataType } from '../entities/models';
+import { PageDetailHeader } from '../forms/PageDetailHeader';
 
+const TITLE = 'Create New Project';
 
 export interface CreateProjectContainerProps {
     api: FolderAPIWrapper;
@@ -38,10 +40,7 @@ export interface CreateProjectContainerProps {
 
 export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(props => {
     const { api, onCancel, onCreated } = props;
-    const {
-        projectDataTypes,
-        ProjectFreezerSelectionComponent,
-    } = useAdminAppContext();
+    const { projectDataTypes, ProjectFreezerSelectionComponent } = useAdminAppContext();
 
     const [error, setError] = useState<string>();
     const [isSaving, setIsSaving] = useState<boolean>(false);
@@ -96,9 +95,9 @@ export const CreateProjectContainer: FC<CreateProjectContainerProps> = memo(prop
                 {!!error && <Alert>{error}</Alert>}
 
                 <div className="panel panel-default">
+                    <div className="panel-heading">Name of Project</div>
                     <div className="panel-body">
                         <div className="form-horizontal">
-                            <div className="form-subtitle">Name of Project</div>
 
                             <ProjectProperties autoFocus />
 
@@ -183,7 +182,8 @@ export const CreateProjectPage: FC<WithRouterProps> = memo(({ router }) => {
     );
 
     return (
-        <Page notAuthorized={!user.isAdmin} hasHeader={false} title="Create Project">
+        <Page notAuthorized={!user.isAdmin} hasHeader title={TITLE}>
+            <PageDetailHeader title={TITLE} />
             <CreateProjectContainer api={api.folder} onCancel={router.goBack} onCreated={onCreated} />
         </Page>
     );

--- a/packages/components/src/internal/components/project/ProjectDataTypeSelections.spec.tsx
+++ b/packages/components/src/internal/components/project/ProjectDataTypeSelections.spec.tsx
@@ -18,6 +18,7 @@ describe('ProjectDataTypeSelections', () => {
             <ProjectDataTypeSelections entityDataTypes={[SampleTypeDataType]} projectId="123" />
         );
         expect(wrapper.find(Button)).toHaveLength(1);
+        expect(wrapper.find(Button).text()).toBe('Save');
         expect(wrapper.find(Col)).toHaveLength(1);
     });
 
@@ -26,6 +27,7 @@ describe('ProjectDataTypeSelections', () => {
             <ProjectDataTypeSelections entityDataTypes={[SampleTypeDataType, AssayRunDataType]} projectId="123" />
         );
         expect(wrapper.find(Button)).toHaveLength(1);
+        expect(wrapper.find(Button).text()).toBe('Save');
         expect(wrapper.find(Col)).toHaveLength(2);
     });
 });

--- a/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
+++ b/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
@@ -96,7 +96,7 @@ export const ProjectDataTypeSelections: FC<Props> = memo(props => {
                                 disabled={isSaving || !dirty}
                                 onClick={onSave}
                             >
-                                {isSaving ? 'Saving' : 'Save'}
+                                {isSaving ? 'Saving...' : 'Save'}
                             </Button>
                         </div>
                     )}

--- a/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
+++ b/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
@@ -67,9 +67,9 @@ export const ProjectDataTypeSelections: FC<Props> = memo(props => {
 
     return (
         <div className="panel panel-default">
+            <div className="panel-heading">Data in Project</div>
             <div className="panel-body">
                 <div className="form-horizontal">
-                    <div className="form-subtitle">Data in Project</div>
                     {error && <Alert>{error}</Alert>}
                     <div className="bottom-spacing">Select the types of data that will be used in this project.</div>
                     <Row>

--- a/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
+++ b/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
@@ -96,7 +96,7 @@ export const ProjectDataTypeSelections: FC<Props> = memo(props => {
                                 disabled={isSaving || !dirty}
                                 onClick={onSave}
                             >
-                                Save
+                                {isSaving ? 'Saving' : 'Save'}
                             </Button>
                         </div>
                     )}

--- a/packages/components/src/internal/components/project/ProjectSettings.spec.tsx
+++ b/packages/components/src/internal/components/project/ProjectSettings.spec.tsx
@@ -8,13 +8,13 @@ import { TEST_USER_APP_ADMIN, TEST_USER_EDITOR } from '../../userFixtures';
 
 import { ServerContext } from '../base/ServerContext';
 
-import { ProjectProperties } from '../project/ProjectProperties';
-
 import { getTestAPIWrapper } from '../../APIWrapper';
 import { getFolderTestAPIWrapper } from '../container/FolderAPIWrapper';
 
+import { AdminAppContext, AppContext } from '../../AppContext';
+
+import { ProjectProperties } from './ProjectProperties';
 import { ProjectSettings, ProjectSettingsProps } from './ProjectSettings';
-import {AdminAppContext, AppContext} from "../../AppContext";
 
 describe('ProjectSettings', () => {
     function getDefaultProps(): ProjectSettingsProps {
@@ -57,7 +57,11 @@ describe('ProjectSettings', () => {
         expect(wrapper.find('.delete-project-button')).toHaveLength(0);
         wrapper.unmount();
 
-        wrapper = mountWithAppServerContext(<ProjectSettings {...getDefaultProps()} />, getDefaultAppContext(), getServerContext());
+        wrapper = mountWithAppServerContext(
+            <ProjectSettings {...getDefaultProps()} />,
+            getDefaultAppContext(),
+            getServerContext()
+        );
 
         expect(wrapper.find('.project-settings')).toHaveLength(1);
         expect(wrapper.find('.panel-heading').text()).toBe('Name of Project');

--- a/packages/components/src/internal/components/project/ProjectSettings.spec.tsx
+++ b/packages/components/src/internal/components/project/ProjectSettings.spec.tsx
@@ -44,8 +44,8 @@ describe('ProjectSettings', () => {
             user: TEST_USER_APP_ADMIN,
         });
 
-        expect(wrapper.find('.project-settings').exists()).toBe(false);
-        expect(wrapper.find('.delete-project-button').exists()).toBe(false);
+        expect(wrapper.find('.project-settings')).toHaveLength(0);
+        expect(wrapper.find('.delete-project-button')).toHaveLength(0);
         wrapper.unmount();
 
         wrapper = mountWithAppServerContext(<ProjectSettings {...getDefaultProps()} />, getDefaultAppContext(), {
@@ -53,14 +53,16 @@ describe('ProjectSettings', () => {
             user: TEST_USER_EDITOR,
         });
 
-        expect(wrapper.find('.project-settings').exists()).toBe(false);
-        expect(wrapper.find('.delete-project-button').exists()).toBe(false);
+        expect(wrapper.find('.project-settings')).toHaveLength(0);
+        expect(wrapper.find('.delete-project-button')).toHaveLength(0);
         wrapper.unmount();
 
         wrapper = mountWithAppServerContext(<ProjectSettings {...getDefaultProps()} />, getDefaultAppContext(), getServerContext());
 
-        expect(wrapper.find('.project-settings').exists()).toBe(true);
-        expect(wrapper.find('.delete-project-button').exists()).toBe(true);
+        expect(wrapper.find('.project-settings')).toHaveLength(1);
+        expect(wrapper.find('.panel-heading').text()).toBe('Name of Project');
+        expect(wrapper.find('.delete-project-button').hostNodes()).toHaveLength(1);
+        expect(wrapper.find('.delete-project-button').hostNodes().text()).toBe(' Delete Project');
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/project/ProjectSettings.tsx
+++ b/packages/components/src/internal/components/project/ProjectSettings.tsx
@@ -94,7 +94,7 @@ export const ProjectSettings: FC<ProjectSettingsProps> = memo(({ onChange, onSuc
 
     return (
         <div className="project-settings panel panel-default">
-            <div className="panel-heading">Project Settings</div>
+            <div className="panel-heading">Name of Project</div>
             <div className="panel-body">
                 {!!error && <Alert>{error}</Alert>}
 
@@ -111,7 +111,7 @@ export const ProjectSettings: FC<ProjectSettingsProps> = memo(({ onChange, onSuc
                             type="button"
                             onClick={openModalHandler}
                         >
-                            <i className="fa fa-trash" /> Delete
+                            <i className="fa fa-trash" /> Delete Project
                         </Button>
 
                         <button className="btn btn-success" disabled={isSaving || !dirty} type="submit">

--- a/packages/components/src/internal/components/project/ProjectSettings.tsx
+++ b/packages/components/src/internal/components/project/ProjectSettings.tsx
@@ -115,7 +115,7 @@ export const ProjectSettings: FC<ProjectSettingsProps> = memo(({ onChange, onSuc
                         </Button>
 
                         <button className="btn btn-success" disabled={isSaving || !dirty} type="submit">
-                            {isSaving ? 'Saving' : 'Save'}
+                            {isSaving ? 'Saving...' : 'Save'}
                         </button>
                     </div>
                 </form>

--- a/packages/components/src/internal/components/project/ProjectSettings.tsx
+++ b/packages/components/src/internal/components/project/ProjectSettings.tsx
@@ -2,13 +2,15 @@ import React, { FC, memo, useCallback, useState } from 'react';
 
 import { Button } from 'react-bootstrap';
 
-import { useAppContext} from '../../AppContext';
+import { useAppContext } from '../../AppContext';
 import { useServerContext, useServerContextDispatch } from '../base/ServerContext';
-import { ProjectProperties } from '../project/ProjectProperties';
+
 import { ProjectSettingsOptions } from '../container/FolderAPIWrapper';
 import { resolveErrorMessage } from '../../util/messaging';
 import { Alert } from '../base/Alert';
 import { Container } from '../base/models/Container';
+
+import { ProjectProperties } from './ProjectProperties';
 
 import { DeleteProjectModal } from './DeleteProjectModal';
 

--- a/packages/components/src/internal/components/project/actions.spec.ts
+++ b/packages/components/src/internal/components/project/actions.spec.ts
@@ -1,4 +1,8 @@
-import { getProjectDataTypeDataCountSql } from './actions';
+import { AssayRunDataType, DataClassDataType, SampleTypeDataType } from '../entities/constants';
+
+import { SchemaQuery } from '../../../public/SchemaQuery';
+
+import { getDataTypeProjectDataCountSql, getProjectDataTypeDataCountSql } from './actions';
 
 describe('getProjectDataTypeDataCountSql', () => {
     test('null', () => {
@@ -20,6 +24,37 @@ describe('getProjectDataTypeDataCountSql', () => {
     test('AssayDesign', () => {
         expect(getProjectDataTypeDataCountSql('AssayDesign')).toBe(
             'SELECT protocol as Type, COUNT(*) as DataCount FROM exp.AssayRuns GROUP BY protocol'
+        );
+    });
+});
+
+describe('getDataTypeProjectDataCountSql', () => {
+    test('SampleType', () => {
+        expect(getDataTypeProjectDataCountSql(SampleTypeDataType, 1, 'blood')).toBe(
+            'SELECT Folder AS Project, COUNT(*) as DataCount FROM "blood"  GROUP BY Folder'
+        );
+    });
+
+    test('DataClass', () => {
+        expect(getDataTypeProjectDataCountSql(DataClassDataType, 1, 'lab')).toBe(
+            'SELECT Folder AS Project, COUNT(*) as DataCount FROM "lab"  GROUP BY Folder'
+        );
+    });
+
+    test('AssayDesign', () => {
+        expect(getDataTypeProjectDataCountSql(AssayRunDataType, 1, 'GPAT')).toBe(
+            'SELECT Folder AS Project, COUNT(*) as DataCount FROM "AssayRuns" WHERE Protocol.RowId = 1 GROUP BY Folder'
+        );
+    });
+
+    test('StorageLocation', () => {
+        const FakeStorageDataType = {
+            ...AssayRunDataType,
+            projectConfigurableDataType: 'StorageLocation',
+            listingSchemaQuery: new SchemaQuery('inventory', 'testQuery'),
+        };
+        expect(getDataTypeProjectDataCountSql(FakeStorageDataType, 'Freezer', 1)).toBe(
+            'SELECT Folder AS Project, COUNT(*) as DataCount FROM "testQuery"  GROUP BY Folder'
         );
     });
 });

--- a/packages/components/src/internal/components/project/actions.spec.ts
+++ b/packages/components/src/internal/components/project/actions.spec.ts
@@ -29,6 +29,10 @@ describe('getProjectDataTypeDataCountSql', () => {
 });
 
 describe('getDataTypeProjectDataCountSql', () => {
+    test('create case, no queryName', () => {
+        expect(getDataTypeProjectDataCountSql(SampleTypeDataType, undefined, undefined)).toBeNull();
+    });
+
     test('SampleType', () => {
         expect(getDataTypeProjectDataCountSql(SampleTypeDataType, 1, 'blood')).toBe(
             'SELECT Folder AS Project, COUNT(*) as DataCount FROM "blood"  GROUP BY Folder'

--- a/packages/components/src/internal/components/project/actions.ts
+++ b/packages/components/src/internal/components/project/actions.ts
@@ -73,6 +73,8 @@ export function getDataTypeProjectDataCountSql(
     const isStorage = entityDataType.projectConfigurableDataType === 'StorageLocation';
     const queryName = isAssay || isStorage ? entityDataType.listingSchemaQuery.queryName : dataTypeName;
     const whereClause = isAssay ? 'WHERE Protocol.RowId = ' + dataTypeRowId : '';
+    if (!queryName) return null;
+
     return (
         'SELECT Folder AS Project, COUNT(*) as DataCount FROM "' + queryName + '" ' + whereClause + ' GROUP BY Folder'
     );

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -41,7 +41,11 @@ export interface QueryAPIWrapper {
         dataType: ProjectConfigurableDataType,
         allDataTypes?: DataTypeEntity[]
     ) => Promise<Record<string, number>>;
-    getDataTypeProjectDataCount: (schemaQuery: SchemaQuery) => Promise<Record<string, number>>;
+    getDataTypeProjectDataCount: (
+        entityDataType: EntityDataType,
+        dataTypeRowId: number,
+        dataTypeName: string
+    ) => Promise<Record<string, number>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
     selectDistinctRows: (selectDistinctOptions: Query.SelectDistinctOptions) => Promise<Query.SelectDistinctResponse>;

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -21,6 +21,11 @@ import { getQueryDetails, GetQueryDetailsOptions, selectDistinctRows } from './a
 import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows';
 
 export interface QueryAPIWrapper {
+    getDataTypeProjectDataCount: (
+        entityDataType: EntityDataType,
+        dataTypeRowId: number,
+        dataTypeName: string
+    ) => Promise<Record<string, number>>;
     getEntityTypeOptions: (
         entityDataType: EntityDataType,
         containerPath?: string
@@ -41,11 +46,6 @@ export interface QueryAPIWrapper {
         dataType: ProjectConfigurableDataType,
         allDataTypes?: DataTypeEntity[],
         isNewFolder?: boolean
-    ) => Promise<Record<string, number>>;
-    getDataTypeProjectDataCount: (
-        entityDataType: EntityDataType,
-        dataTypeRowId: number,
-        dataTypeName: string
     ) => Promise<Record<string, number>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -2,8 +2,14 @@ import { List, Map } from 'immutable';
 import { Query } from '@labkey/api';
 
 import { QueryInfo } from '../../public/QueryInfo';
-import { DataTypeEntity, EntityDataType, IEntityTypeOption } from '../components/entities/models';
+import {
+    DataTypeEntity,
+    EntityDataType,
+    IEntityTypeOption,
+    ProjectConfigurableDataType,
+} from '../components/entities/models';
 import { getEntityTypeOptions, getProjectConfigurableEntityTypeOptions } from '../components/entities/actions';
+import { getProjectDataTypeDataCount, getDataTypeProjectDataCount } from '../components/project/actions';
 
 import { getGridViews, incrementClientSideMetricCount } from '../actions';
 
@@ -31,6 +37,11 @@ export interface QueryAPIWrapper {
         containerPath?: string,
         containerFilter?: Query.ContainerFilter
     ) => Promise<DataTypeEntity[]>;
+    getProjectDataTypeDataCount: (
+        dataType: ProjectConfigurableDataType,
+        allDataTypes?: DataTypeEntity[]
+    ) => Promise<Record<string, number>>;
+    getDataTypeProjectDataCount: (schemaQuery: SchemaQuery) => Promise<Record<string, number>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
     selectDistinctRows: (selectDistinctOptions: Query.SelectDistinctOptions) => Promise<Query.SelectDistinctResponse>;
@@ -45,6 +56,8 @@ export class QueryServerAPIWrapper implements QueryAPIWrapper {
     selectDistinctRows = selectDistinctRows;
     getGridViews = getGridViews;
     getProjectConfigurableEntityTypeOptions = getProjectConfigurableEntityTypeOptions;
+    getProjectDataTypeDataCount = getProjectDataTypeDataCount;
+    getDataTypeProjectDataCount = getDataTypeProjectDataCount;
 }
 
 /**
@@ -62,6 +75,8 @@ export function getQueryTestAPIWrapper(
         selectDistinctRows: mockFn(),
         getGridViews: mockFn(),
         getProjectConfigurableEntityTypeOptions: mockFn(),
+        getProjectDataTypeDataCount: mockFn(),
+        getDataTypeProjectDataCount: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -39,7 +39,8 @@ export interface QueryAPIWrapper {
     ) => Promise<DataTypeEntity[]>;
     getProjectDataTypeDataCount: (
         dataType: ProjectConfigurableDataType,
-        allDataTypes?: DataTypeEntity[]
+        allDataTypes?: DataTypeEntity[],
+        isNewFolder?: boolean
     ) => Promise<Record<string, number>>;
     getDataTypeProjectDataCount: (
         entityDataType: EntityDataType,


### PR DESCRIPTION
#### Rationale
Recent PRs have allowed the app project settings page to exclude certain data types (sample types, data classes, assay designs, and storage) from the UI for that project. This PR introduces the reverse, allowing for a data type field editor / designer to show a panel that allow for project exclusions to be made. The two methods both insert/update the exclusions in the same DB table and add similar audit entries.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1202
- https://github.com/LabKey/labkey-ui-premium/pull/100
- https://github.com/LabKey/platform/pull/4470
- https://github.com/LabKey/biologics/pull/2156
- https://github.com/LabKey/sampleManagement/pull/1865
- https://github.com/LabKey/inventory/pull/871

#### Changes
- Add DataTypeProjectsPanel to show panel in field editor for selecting excluded projects for a given data type domain
- implement for Sample Type designer, Data Class designer (sources and non-built in registry), Assay Designer
- Misc updates to admin panel titles for consistency
