### PR TITLE
Field editor fix for community usage to check for SM module during getFolderExcludedDataTypes() call

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.343.0-fb-fieldEditorExcludedDataTypesCheck.0",
+  "version": "2.343.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.343.0",
+  "version": "2.343.0-fb-fieldEditorExcludedDataTypesCheck.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD June 2023
+### version 2.343.1
+*Released*: 2 June 2023
 - Field editor fix for community usage to check for SM module during getFolderExcludedDataTypes() call
 
 ### version 2.343.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD June 2023
+- Field editor fix for community usage to check for SM module during getFolderExcludedDataTypes() call
+
 ### version 2.343.0
 *Released*: 2 June 2023
 - Introduce enums for `SearchCategory` and new `SearchField`

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -20,7 +20,7 @@ import { ViewInfo } from '../../ViewInfo';
 
 import { Container } from '../base/models/Container';
 
-import { getProjectDataExclusion } from '../../app/utils';
+import { getProjectDataExclusion, hasModule } from '../../app/utils';
 
 import { resolveErrorMessage } from '../../util/messaging';
 
@@ -937,6 +937,10 @@ export const initParentOptionsSelects = (
 };
 
 export const getFolderExcludedDataTypes = (dataType: string, excludedContainer?: string): Promise<number[]> => {
+    if (!hasModule(SAMPLE_MANAGER_APP_PROPERTIES.moduleName)) {
+        return Promise.resolve(undefined);
+    }
+
     let isCurrentContainer = true;
     if (excludedContainer) {
         const currentContainer = getServerContext().container;


### PR DESCRIPTION
#### Rationale
Recent PRs have added API calls to the field editor for getting excluded schema/query information for the lookup fields context. This API call was an action in the sampleManagement controller. This updated field editor version was then recently put into the platform/core module and started causing issues on TeamCity since those API calls were now being made when the SM controller/module wasn't present. This PR adds a `hasModule` check and returns if not present from within `getFolderExcludedDataTypes`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1207
- https://github.com/LabKey/platform/pull/4484
- https://github.com/LabKey/biologics/pull/2166
- https://github.com/LabKey/inventory/pull/879
- https://github.com/LabKey/sampleManagement/pull/1878

#### Changes
- check for SM module during getFolderExcludedDataTypes() call
