### PR TITLE
Further utilize APIWrapper pattern

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.344.0-fb-query-api.0",
+  "version": "2.345.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.344.0",
+  "version": "2.344.0-fb-query-api.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.345.0
+*Released*: 8 June 2023
+- Revise `QueryAPIWrapper` to support a number of additional API endpoints including query view APIs.
+- Refactor a number of components to utilize the `APIWrapper` pattern and update associated tests.
+- Remove `getDataClassDetails` from top-level export as it has been added to the `DomainPropertiesAPIWrapper`.
+
 ### version 2.344.0
 *Released*: 6 June 2023
 - Introduce React Testing Library

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -568,11 +568,7 @@ import { SampleTypeDesigner } from './internal/components/domainproperties/sampl
 import { ListDesignerPanels } from './internal/components/domainproperties/list/ListDesignerPanels';
 import { DataClassDesigner } from './internal/components/domainproperties/dataclasses/DataClassDesigner';
 import { DataClassModel } from './internal/components/domainproperties/dataclasses/models';
-import {
-    deleteDataClass,
-    fetchDataClass,
-    getDataClassDetails,
-} from './internal/components/domainproperties/dataclasses/actions';
+import { deleteDataClass, fetchDataClass } from './internal/components/domainproperties/dataclasses/actions';
 import { DesignerDetailPanel } from './internal/components/domainproperties/DesignerDetailPanel';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { RangeValidationOptionsModal } from './internal/components/domainproperties/validation/RangeValidationOptions';
@@ -1171,7 +1167,6 @@ export {
     ALIQUOT_FILTER_MODE,
     DataClassModel,
     deleteDataClass,
-    getDataClassDetails,
     fetchDataClass,
     isSampleOperationPermitted,
     isSamplesSchema,

--- a/packages/components/src/internal/components/domainproperties/APIWrapper.ts
+++ b/packages/components/src/internal/components/domainproperties/APIWrapper.ts
@@ -8,6 +8,7 @@ import {
     hasExistingDomainData,
     fetchDomainDetails,
 } from './actions';
+import { getDataClassDetails } from './dataclasses/actions';
 import { DomainDesign, DomainDetails, NameExpressionsValidationResults } from './models';
 
 export interface DomainPropertiesAPIWrapper {
@@ -17,6 +18,7 @@ export interface DomainPropertiesAPIWrapper {
         queryName: string,
         domainKind?: string
     ) => Promise<DomainDetails>;
+    getDataClassDetails: (query?: SchemaQuery, domainId?: number, containerPath?: string) => Promise<DomainDetails>;
     getDomainNamePreviews: (schemaQuery?: SchemaQuery, domainId?: number, containerPath?: string) => Promise<string[]>;
     getGenId: (rowId: number, kindName: 'SampleSet' | 'DataClass', containerPath?: string) => Promise<number>;
     hasExistingDomainData: (
@@ -41,6 +43,7 @@ export interface DomainPropertiesAPIWrapper {
 
 export class DomainPropertiesAPIWrapper implements DomainPropertiesAPIWrapper {
     fetchDomainDetails = fetchDomainDetails;
+    getDataClassDetails = getDataClassDetails;
     getDomainNamePreviews = getDomainNamePreviews;
     getGenId = getGenId;
     hasExistingDomainData = hasExistingDomainData;
@@ -57,6 +60,7 @@ export function getDomainPropertiesTestAPIWrapper(
 ): DomainPropertiesAPIWrapper {
     return {
         fetchDomainDetails: mockFn(),
+        getDataClassDetails: mockFn(),
         getDomainNamePreviews: mockFn(),
         getGenId: mockFn(),
         hasExistingDomainData: mockFn(),

--- a/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
@@ -65,6 +65,7 @@ function _fetchDataClass(queryName?: string, domainId?: number, containerPath?: 
     });
 }
 
+// TODO: This should share implementation with api.samples.getSampleTypeDetails / api.domain.fetchDomainDetails
 export function getDataClassDetails(
     query?: SchemaQuery,
     domainId?: number,

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.spec.tsx
@@ -8,8 +8,6 @@ import DomainForm from '../DomainForm';
 
 import { PROPERTIES_PANEL_ERROR_MSG } from '../constants';
 
-import { initUnitTestMocks } from '../../../../test/testHelperMocks';
-
 import { Alert } from '../../base/Alert';
 
 import { waitForLifecycle } from '../../../test/enzymeTestHelpers';
@@ -17,20 +15,18 @@ import { waitForLifecycle } from '../../../test/enzymeTestHelpers';
 import { IssuesListDefPropertiesPanel } from './IssuesListDefPropertiesPanel';
 import { IssuesDesignerPanelsImpl, IssuesListDefDesignerPanels } from './IssuesListDefDesignerPanels';
 import { IssuesListDefModel } from './models';
-
-const emptyNewModel = IssuesListDefModel.create(null, { issueDefName: 'Issues List For Jest' });
-
-const BASE_PROPS = {
-    onComplete: jest.fn(),
-    onCancel: jest.fn(),
-    testMode: true,
-};
-
-beforeAll(() => {
-    initUnitTestMocks();
-});
+import { getIssuesTestAPIWrapper } from './actions';
 
 describe('IssuesListDefDesignerPanel', () => {
+    const emptyNewModel = IssuesListDefModel.create(null, { issueDefName: 'Issues List For Jest' });
+
+    const BASE_PROPS = {
+        api: getIssuesTestAPIWrapper(jest.fn),
+        onComplete: jest.fn(),
+        onCancel: jest.fn(),
+        testMode: true,
+    };
+
     test('new Issue List Definition', async () => {
         const issuesDesignerPanels = shallow(
             <IssuesDesignerPanelsImpl

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
@@ -142,6 +142,7 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
 
     render() {
         const {
+            api,
             onCancel,
             useTheme,
             successBsStyle,
@@ -170,6 +171,7 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
                 successBsStyle={successBsStyle}
             >
                 <IssuesListDefPropertiesPanel
+                    api={api}
                     model={model}
                     onChange={this.onPropertiesChange}
                     controlledCollapse={true}

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
@@ -11,24 +11,30 @@ import { resolveErrorMessage } from '../../../util/messaging';
 
 import { IssuesListDefPropertiesPanel } from './IssuesListDefPropertiesPanel';
 import { IssuesListDefModel } from './models';
-import { saveIssueListDefOptions } from './actions';
+import { getDefaultIssuesAPIWrapper, IssuesAPIWrapper } from './actions';
 
 interface Props {
+    api?: IssuesAPIWrapper;
     initModel?: IssuesListDefModel;
-    onChange?: (model: IssuesListDefModel) => void;
     onCancel: () => void;
+    onChange?: (model: IssuesListDefModel) => void;
     onComplete: (model: IssuesListDefModel) => void;
-    useTheme?: boolean;
-    successBsStyle?: string;
     saveBtnText?: string;
+    successBsStyle?: string;
     testMode?: boolean;
+    useTheme?: boolean;
 }
 
 interface State {
     model: IssuesListDefModel;
 }
+
 // exported for testing
 export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & InjectedBaseDomainDesignerProps, State> {
+    static defaultProps = {
+        api: getDefaultIssuesAPIWrapper(),
+    };
+
     constructor(props: Props & InjectedBaseDomainDesignerProps) {
         super(props);
         this.state = produce(
@@ -75,10 +81,10 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
     };
 
     saveOptions = () => {
-        const { setSubmitting } = this.props;
+        const { api, setSubmitting } = this.props;
         const { model } = this.state;
 
-        saveIssueListDefOptions(model.getOptions())
+        api.saveIssueListDefOptions(model.getOptions())
             .then(() => this.onSaveComplete())
             .catch(response => {
                 setSubmitting(false, () => {

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.spec.tsx
@@ -10,21 +10,25 @@ import getDomainDetailsJSON from '../../../../test/data/issuesListDef-getDomainD
 
 import { Alert } from '../../base/Alert';
 
+import { waitForLifecycle } from '../../../test/enzymeTestHelpers';
+
+import { getIssuesTestAPIWrapper } from './actions';
 import { IssuesListDefModel } from './models';
 import { IssuesListDefPropertiesPanel, IssuesListDefPropertiesPanelImpl } from './IssuesListDefPropertiesPanel';
 
 const emptyNewModel = IssuesListDefModel.create(null, { issueDefName: 'Issues List For Jest' });
 
-const BASE_PROPS = {
-    panelStatus: 'NONE' as DomainPanelStatus,
-    validate: false,
-    useTheme: false,
-    controlledCollapse: false,
-    initCollapsed: false,
-    collapsed: false,
-};
-
 describe('IssuesListDefPropertiesPanel', () => {
+    const BASE_PROPS = {
+        api: getIssuesTestAPIWrapper(jest.fn),
+        panelStatus: 'NONE' as DomainPanelStatus,
+        validate: false,
+        useTheme: false,
+        controlledCollapse: false,
+        initCollapsed: false,
+        collapsed: false,
+    };
+
     test('new Issue Def', () => {
         const issuesPropertiesPanel = (
             <IssuesListDefPropertiesPanel {...BASE_PROPS} model={emptyNewModel} onChange={jest.fn()} />
@@ -34,18 +38,19 @@ describe('IssuesListDefPropertiesPanel', () => {
         expect(tree).toMatchSnapshot();
     });
 
-    test('set state for isValid', () => {
+    test('set state for isValid', async () => {
         const wrapped = mount(
             <IssuesListDefPropertiesPanelImpl
                 {...BASE_PROPS}
                 model={IssuesListDefModel.create(getDomainDetailsJSON)}
-                controlledCollapse={true}
+                controlledCollapse
                 togglePanel={jest.fn()}
                 panelStatus="TODO"
                 onChange={jest.fn()}
             />
         );
 
+        await waitForLifecycle(wrapped);
         expect(wrapped.find(CollapsiblePanelHeader)).toHaveLength(1);
         expect(wrapped.find(Alert)).toHaveLength(0);
 

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanel.tsx
@@ -24,10 +24,12 @@ import {
     RestrictedOptions,
 } from './IssuesListDefPropertiesPanelFormElements';
 import { IssuesListDefModel } from './models';
+import { getDefaultIssuesAPIWrapper, IssuesAPIWrapper } from './actions';
 
 const PROPERTIES_HEADER_ID = 'issues-properties-hdr';
 
 interface OwnProps {
+    api?: IssuesAPIWrapper;
     model: IssuesListDefModel;
     onChange: (model: IssuesListDefModel) => void;
     successBsStyle?: string;
@@ -43,6 +45,10 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
     Props & InjectedDomainPropertiesPanelCollapseProps,
     State
 > {
+    static defaultProps = {
+        api: getDefaultIssuesAPIWrapper(),
+    };
+
     constructor(props: Props & InjectedDomainPropertiesPanelCollapseProps) {
         super(props);
 
@@ -112,7 +118,7 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
     };
 
     render() {
-        const { model } = this.props;
+        const { api, model } = this.props;
         const { isValid } = this.state;
         return (
             <BasePropertiesPanel
@@ -140,6 +146,7 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
                         {isRestrictedIssueListSupported() && (
                             <div className="domain-field-padding-bottom">
                                 <RestrictedOptions
+                                    api={api}
                                     model={model}
                                     onCheckChange={this.onRestrictedListCheckChange}
                                     onSelect={this.onSelectChange}
@@ -147,7 +154,7 @@ export class IssuesListDefPropertiesPanelImpl extends React.PureComponent<
                             </div>
                         )}
                     </Col>
-                    <AssignmentOptions model={model} onSelect={this.onSelectChange} />
+                    <AssignmentOptions api={api} model={model} onSelect={this.onSelectChange} />
                 </Form>
             </BasePropertiesPanel>
         );

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefPropertiesPanelFormElements.tsx
@@ -23,7 +23,7 @@ import {
     ISSUES_LIST_RESTRICTED_TRACKER_TIP,
     ISSUES_LIST_USER_ASSIGN_TIP,
 } from './constants';
-import { getProjectGroups, getRelatedFolders, getUsersForGroup } from './actions';
+import { IssuesAPIWrapper } from './actions';
 
 interface IssuesListDefBasicPropertiesInputsProps {
     model: IssuesListDefModel;
@@ -32,6 +32,7 @@ interface IssuesListDefBasicPropertiesInputsProps {
 }
 
 interface AssignmentOptionsProps {
+    api: IssuesAPIWrapper;
     model: IssuesListDefModel;
     onSelect: (name: string, value: any) => any;
 }
@@ -53,6 +54,7 @@ interface AssignmentOptionsInputProps {
 }
 
 interface RestrictedOptionsProps {
+    api: IssuesAPIWrapper;
     model: IssuesListDefModel;
     onCheckChange?: (any) => void;
     onSelect: (name: string, value: any) => any;
@@ -84,9 +86,11 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
     };
 
     componentDidMount = async (): Promise<void> => {
+        const { api, model } = this.props;
+
         try {
-            const coreGroups = await getProjectGroups();
-            const relatedFolders = await getRelatedFolders(this.props.model.issueDefName);
+            const coreGroups = await api.getProjectGroups();
+            const relatedFolders = await api.getRelatedFolders(model.issueDefName);
             this.setState({ coreGroups, relatedFolders });
         } catch (e) {
             console.error('AssignmentOptions: failed to load initialize project groups and related folders.', e);
@@ -97,7 +101,7 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
 
     loadUsersForGroup = async (groupId: number): Promise<void> => {
         try {
-            const coreUsers = await getUsersForGroup(groupId);
+            const coreUsers = await this.props.api.getUsersForGroup(groupId);
             this.setState({ coreUsers });
         } catch (e) {
             console.error(`AssignmentOptions: failed to load users for group ${groupId}`, e);
@@ -126,13 +130,13 @@ export class AssignmentOptions extends PureComponent<AssignmentOptionsProps, Ass
 
 export class RestrictedOptions extends PureComponent<RestrictedOptionsProps> {
     render() {
-        const { model, onCheckChange, onSelect } = this.props;
+        const { api, model, onCheckChange, onSelect } = this.props;
 
         return (
             <div>
                 <SectionHeading title="Restricted List Options" />
-                <RestrictedIssueInput model={model} onCheckChange={onCheckChange} onSelect={onSelect} />
-                <RestrictedIssueGroupInput model={model} onSelect={onSelect} />
+                <RestrictedIssueInput api={api} model={model} onCheckChange={onCheckChange} onSelect={onSelect} />
+                <RestrictedIssueGroupInput api={api} model={model} onSelect={onSelect} />
             </div>
         );
     }
@@ -366,7 +370,7 @@ export class RestrictedIssueGroupInput extends PureComponent<RestrictedOptionsPr
 
     componentDidMount = async (): Promise<void> => {
         try {
-            const coreGroups = await getProjectGroups();
+            const coreGroups = await this.props.api.getProjectGroups();
             this.setState({ coreGroups });
         } catch (e) {
             console.error('RestrictedOptions: failed to load initialize project groups', e);

--- a/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefDesignerPanels.spec.tsx.snap
@@ -42,6 +42,14 @@ exports[`IssuesListDefDesignerPanel new Issue List Definition 1`] = `
   visitedPanels={Immutable.List []}
 >
   <ComponentWithDomainPropertiesPanelCollapse
+    api={
+      {
+        "getProjectGroups": [MockFunction],
+        "getRelatedFolders": [MockFunction],
+        "getUsersForGroup": [MockFunction],
+        "saveIssueListDefOptions": [MockFunction],
+      }
+    }
     controlledCollapse={true}
     initCollapsed={false}
     model={

--- a/packages/components/src/internal/components/domainproperties/issues/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/actions.ts
@@ -26,71 +26,102 @@ export function fetchIssuesListDefDesign(issueDefName?: string): Promise<IssuesL
     });
 }
 
-export function getUsersForGroup(groupId: number): Promise<List<Principal>> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: ActionURL.buildURL('issues', 'getUsersForGroup.api'),
-            params: { groupId },
-            success: Utils.getCallbackWrapper(coreUsersData => {
-                let users = List<Principal>();
-                coreUsersData.forEach(user => {
-                    const usr = Principal.create(user);
-                    users = users.push(usr);
-                });
-
-                resolve(users);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to fetch users for group'),
-        });
-    });
+export interface IssuesAPIWrapper {
+    getProjectGroups: () => Promise<List<Principal>>;
+    getRelatedFolders: (issueDefName?: string) => Promise<List<IssuesRelatedFolder>>;
+    getUsersForGroup: (groupId: number) => Promise<List<Principal>>;
+    saveIssueListDefOptions: (options: IssuesListDefOptionsConfig) => Promise<DuplicateFilesResponse>;
 }
 
-export function getProjectGroups(): Promise<List<Principal>> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: ActionURL.buildURL('issues', 'getProjectGroups.api'),
-            success: Utils.getCallbackWrapper(coreGroupsData => {
-                let groups = List<Principal>();
-                coreGroupsData.forEach(principal => {
-                    const grp = Principal.create(principal);
-                    groups = groups.push(grp);
-                });
+export class IssuesServerAPIWrapper implements IssuesAPIWrapper {
+    getProjectGroups(): Promise<List<Principal>> {
+        return new Promise((resolve, reject) => {
+            Ajax.request({
+                url: ActionURL.buildURL('issues', 'getProjectGroups.api'),
+                success: Utils.getCallbackWrapper(coreGroupsData => {
+                    let groups = List<Principal>();
+                    coreGroupsData.forEach(principal => {
+                        const grp = Principal.create(principal);
+                        groups = groups.push(grp);
+                    });
 
-                resolve(groups);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to fetch project groups'),
+                    resolve(groups);
+                }),
+                failure: handleRequestFailure(reject, 'Failed to fetch project groups'),
+            });
         });
-    });
+    }
+
+    getRelatedFolders(issueDefName?: string): Promise<List<IssuesRelatedFolder>> {
+        return new Promise((resolve, reject) => {
+            Ajax.request({
+                url: ActionURL.buildURL('issues', 'getRelatedFolder.api'),
+                params: { issueDefName },
+                success: Utils.getCallbackWrapper(res => {
+                    let folders = List<IssuesRelatedFolder>();
+                    res.containers.forEach(container => {
+                        const folder = IssuesRelatedFolder.create(container);
+                        folders = folders.push(folder);
+                    });
+                    resolve(folders);
+                }),
+                failure: handleRequestFailure(reject, 'Failed to fetch related folders'),
+            });
+        });
+    }
+
+    getUsersForGroup(groupId: number): Promise<List<Principal>> {
+        return new Promise((resolve, reject) => {
+            Ajax.request({
+                url: ActionURL.buildURL('issues', 'getUsersForGroup.api'),
+                params: { groupId },
+                success: Utils.getCallbackWrapper(coreUsersData => {
+                    let users = List<Principal>();
+                    coreUsersData.forEach(user => {
+                        const usr = Principal.create(user);
+                        users = users.push(usr);
+                    });
+
+                    resolve(users);
+                }),
+                failure: handleRequestFailure(reject, 'Failed to fetch users for group'),
+            });
+        });
+    }
+
+    saveIssueListDefOptions(options: IssuesListDefOptionsConfig): Promise<DuplicateFilesResponse> {
+        return new Promise((resolve, reject) => {
+            Ajax.request({
+                url: buildURL('issues', 'admin.api'),
+                method: 'POST',
+                params: options,
+                success: Utils.getCallbackWrapper(res => {
+                    resolve(res);
+                }),
+                failure: handleRequestFailure(reject, 'Failed to save issue list definition options'),
+            });
+        });
+    }
 }
 
-export function saveIssueListDefOptions(options: IssuesListDefOptionsConfig): Promise<DuplicateFilesResponse> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: buildURL('issues', 'admin.api'),
-            method: 'POST',
-            params: options,
-            success: Utils.getCallbackWrapper(res => {
-                resolve(res);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to save issue list definition options'),
-        });
-    });
+let DEFAULT_WRAPPER: IssuesAPIWrapper;
+
+export function getDefaultIssuesAPIWrapper(): IssuesAPIWrapper {
+    if (!DEFAULT_WRAPPER) {
+        DEFAULT_WRAPPER = new IssuesServerAPIWrapper();
+    }
+
+    return DEFAULT_WRAPPER;
 }
 
-export function getRelatedFolders(issueDefName?: string): Promise<List<IssuesRelatedFolder>> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: ActionURL.buildURL('issues', 'getRelatedFolder.api'),
-            params: { issueDefName },
-            success: Utils.getCallbackWrapper(res => {
-                let folders = List<IssuesRelatedFolder>();
-                res.containers.forEach(container => {
-                    const folder = IssuesRelatedFolder.create(container);
-                    folders = folders.push(folder);
-                });
-                resolve(folders);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to fetch related folders'),
-        });
-    });
+export function getIssuesTestAPIWrapper(
+    mockFn = (): any => () => {},
+    overrides: Partial<IssuesAPIWrapper> = {}
+): IssuesAPIWrapper {
+    return {
+        getProjectGroups: mockFn(),
+        getRelatedFolders: mockFn(),
+        getUsersForGroup: mockFn(),
+        saveIssueListDefOptions: mockFn(),
+    };
 }

--- a/packages/components/src/internal/components/domainproperties/issues/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/actions.ts
@@ -8,6 +8,7 @@ import { Principal } from '../../permissions/models';
 import { buildURL } from '../../../url/AppURL';
 
 import { IssuesListDefModel, IssuesListDefOptionsConfig, IssuesRelatedFolder } from './models';
+import { handleRequestFailure } from '../../../util/utils';
 
 export function fetchIssuesListDefDesign(issueDefName?: string): Promise<IssuesListDefModel> {
     return new Promise((resolve, reject) => {
@@ -29,9 +30,7 @@ export function getUsersForGroup(groupId: number): Promise<List<Principal>> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('issues', 'getUsersForGroup.api'),
-            method: 'GET',
             params: { groupId },
-            scope: this,
             success: Utils.getCallbackWrapper(coreUsersData => {
                 let users = List<Principal>();
                 coreUsersData.forEach(user => {
@@ -41,9 +40,7 @@ export function getUsersForGroup(groupId: number): Promise<List<Principal>> {
 
                 resolve(users);
             }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
+            failure: handleRequestFailure(reject, 'Failed to fetch users for group'),
         });
     });
 }
@@ -52,8 +49,6 @@ export function getProjectGroups(): Promise<List<Principal>> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('issues', 'getProjectGroups.api'),
-            method: 'GET',
-            scope: this,
             success: Utils.getCallbackWrapper(coreGroupsData => {
                 let groups = List<Principal>();
                 coreGroupsData.forEach(principal => {
@@ -63,9 +58,7 @@ export function getProjectGroups(): Promise<List<Principal>> {
 
                 resolve(groups);
             }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
+            failure: handleRequestFailure(reject, 'Failed to fetch project groups'),
         });
     });
 }
@@ -79,10 +72,7 @@ export function saveIssueListDefOptions(options: IssuesListDefOptionsConfig): Pr
             success: Utils.getCallbackWrapper(res => {
                 resolve(res);
             }),
-            failure: Utils.getCallbackWrapper(response => {
-                console.error(response);
-                reject(response);
-            }),
+            failure: handleRequestFailure(reject, 'Failed to save issue list definition options'),
         });
     });
 }
@@ -91,9 +81,7 @@ export function getRelatedFolders(issueDefName?: string): Promise<List<IssuesRel
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('issues', 'getRelatedFolder.api'),
-            method: 'GET',
             params: { issueDefName },
-            scope: this,
             success: Utils.getCallbackWrapper(res => {
                 let folders = List<IssuesRelatedFolder>();
                 res.containers.forEach(container => {
@@ -102,9 +90,7 @@ export function getRelatedFolders(issueDefName?: string): Promise<List<IssuesRel
                 });
                 resolve(folders);
             }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
+            failure: handleRequestFailure(reject, 'Failed to fetch related folders'),
         });
     });
 }

--- a/packages/components/src/internal/components/domainproperties/issues/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/issues/actions.ts
@@ -7,8 +7,9 @@ import { DuplicateFilesResponse } from '../../assay/actions';
 import { Principal } from '../../permissions/models';
 import { buildURL } from '../../../url/AppURL';
 
-import { IssuesListDefModel, IssuesListDefOptionsConfig, IssuesRelatedFolder } from './models';
 import { handleRequestFailure } from '../../../util/utils';
+
+import { IssuesListDefModel, IssuesListDefOptionsConfig, IssuesRelatedFolder } from './models';
 
 export function fetchIssuesListDefDesign(issueDefName?: string): Promise<IssuesListDefModel> {
     return new Promise((resolve, reject) => {

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -29,10 +29,11 @@ import { SCHEMAS } from '../../schemas';
 import { SampleCreationType } from '../samples/models';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { EditorModel } from '../editable/models';
-import { insertRows, InsertRowsResponse } from '../../query/api';
+import { InsertRowsResponse } from '../../query/api';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { ViewInfo } from '../../ViewInfo';
 import { FieldFilter } from '../search/models';
+import { ComponentsAPIWrapper } from '../../APIWrapper';
 
 export interface EntityInputProps {
     role: string;
@@ -357,6 +358,7 @@ export class EntityIdCreationModel extends Record({
     }
 
     postEntityGrid(
+        api: ComponentsAPIWrapper,
         dataModel: QueryModel,
         editorModel: EditorModel,
         extraColumnsToInclude?: QueryColumn[]
@@ -373,7 +375,7 @@ export class EntityIdCreationModel extends Record({
                 return rows_;
             }, List<Map<string, any>>());
 
-        return insertRows({
+        return api.query.insertRows({
             auditBehavior: AuditBehaviorTypes.DETAILED,
             fillEmptyFields: true,
             rows,

--- a/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
+++ b/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Col, Panel, FormControl, Row, Button } from 'react-bootstrap';
 
 import { Alert } from '../base/Alert';
@@ -15,7 +15,7 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { BarTenderConfiguration, BarTenderResponse } from './models';
 import { withLabelPrintingContext, LabelPrintingProviderProps } from './LabelPrintingContextProvider';
-import { BAR_TENDER_TOPIC, BARTENDER_CONFIGURATION_TITLE, LABEL_NOT_FOUND_ERROR } from './constants';
+import { BAR_TENDER_TOPIC, BARTENDER_CONFIGURATION_TITLE } from './constants';
 import { LabelsConfigurationPanel } from './LabelsConfigurationPanel';
 
 interface OwnProps extends InjectedRouteLeaveProps {
@@ -104,10 +104,10 @@ const btTestConnectionTemplate = (label: string): string => {
             </Command>
         </XMLScript>`;
 };
-const apiWrapper = getDefaultAPIWrapper();
+
 // exported for jest testing
 export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
-    const { api = apiWrapper, title = BARTENDER_CONFIGURATION_TITLE, onChange, onSuccess } = props;
+    const { api, title = BARTENDER_CONFIGURATION_TITLE, onChange, onSuccess } = props;
     const [btServiceURL, setBtServiceURL] = useState<string>();
     const [defaultLabel, setDefaultLabel] = useState<number>();
     const [dirty, setDirty] = useState<boolean>(false);
@@ -159,7 +159,7 @@ export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
                 setSubmitting(false);
                 setFailureMessage(FAILED_TO_SAVE_MESSAGE);
             });
-    }, [api?.labelprinting, btServiceURL, onSuccess]);
+    }, [api, btServiceURL, onSuccess]);
 
     const onConnectionFailure = (message: string): void => {
         setTesting(false);
@@ -186,7 +186,7 @@ export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
             .catch(() => {
                 onConnectionFailure(FAILED_NOTIFICATION_MESSAGE);
             });
-    }, [api?.labelprinting, btServiceURL]);
+    }, [api, btServiceURL]);
 
     const isBlank = !btServiceURL || btServiceURL.trim() === '';
 
@@ -241,5 +241,9 @@ export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
         </Row>
     );
 });
+
+BarTenderSettingsFormImpl.defaultProps = {
+    api: getDefaultAPIWrapper(),
+};
 
 export const BarTenderSettingsForm = withLabelPrintingContext(BarTenderSettingsFormImpl);

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
@@ -26,9 +26,10 @@ import { useServerContext } from '../base/ServerContext';
 
 import { LabelHelpTip } from '../base/LabelHelpTip';
 
+import { isAppHomeFolder } from '../../app/utils';
+
 import { LabelTemplate } from './models';
 import { LABEL_TEMPLATE_SQ } from './constants';
-import { isAppHomeFolder } from '../../app/utils';
 
 const TITLE = 'Manage Label Templates';
 const NEW_LABEL_INDEX = -1;
@@ -426,7 +427,9 @@ export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props
                                 onSelect={onSetSelected}
                                 defaultLabel={newDefaultLabel}
                             />
-                            {showAdd && <AddEntityButton onClick={onAddLabel} entity="New Label Template" disabled={addNew} />}
+                            {showAdd && (
+                                <AddEntityButton onClick={onAddLabel} entity="New Label Template" disabled={addNew} />
+                            )}
                         </div>
                         <div className="col-lg-8 col-md-6">
                             <LabelTemplateDetails

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
@@ -16,7 +16,7 @@ import { AddEntityButton } from '../buttons/AddEntityButton';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { ConfirmModal } from '../base/ConfirmModal';
 import { DomainFieldLabel } from '../domainproperties/DomainFieldLabel';
-import { deleteRows, insertRows, InsertRowsResponse, updateRows } from '../../query/api';
+import { InsertRowsResponse } from '../../query/api';
 import { resolveErrorMessage } from '../../util/messaging';
 import { DisableableButton } from '../buttons/DisableableButton';
 
@@ -156,11 +156,12 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
     const onToggleDeleteConfirm = useCallback(() => setShowDeleteConfirm(!showDeleteConfirm), [showDeleteConfirm]);
     const onConfirmDelete = useCallback(() => {
         if (updatedTemplate.rowId) {
-            deleteRows({
-                schemaQuery: LABEL_TEMPLATE_SQ,
-                rows: [updatedTemplate],
-                containerPath: updatedTemplate.container,
-            })
+            api.query
+                .deleteRows({
+                    schemaQuery: LABEL_TEMPLATE_SQ,
+                    rows: [updatedTemplate],
+                    containerPath: updatedTemplate.container,
+                })
                 .then(() => {
                     onToggleDeleteConfirm();
                     onActionCompleted(undefined, true);
@@ -172,7 +173,7 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
         } else {
             onToggleDeleteConfirm();
         }
-    }, [updatedTemplate, onActionCompleted, onToggleDeleteConfirm]);
+    }, [api, updatedTemplate, onActionCompleted, onToggleDeleteConfirm]);
 
     const onFormChange = useCallback(
         (evt): void => {
@@ -194,13 +195,13 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
         let rowId = templateToSave?.rowId;
         try {
             if (rowId) {
-                await updateRows({
+                await api.query.updateRows({
                     schemaQuery: LABEL_TEMPLATE_SQ,
                     rows: [templateToSave],
                     containerPath: templateToSave.container,
                 });
             } else {
-                const response = await insertRows({
+                const response = await api.query.insertRows({
                     schemaQuery: LABEL_TEMPLATE_SQ,
                     rows: List([templateToSave]),
                 });
@@ -209,7 +210,7 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
             }
 
             if ((isDefault && defaultLabel !== rowId) || (defaultLabel === rowId && !isDefault)) {
-                const newBtConfig = await api?.labelprinting.saveDefaultLabelConfiguration({
+                const newBtConfig = await api.labelprinting.saveDefaultLabelConfiguration({
                     defaultLabel: isDefault ? rowId : undefined,
                 });
 
@@ -227,7 +228,7 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
         } finally {
             setSaving(false);
         }
-    }, [api?.labelprinting, defaultLabel, isDefault, onActionCompleted, onDefaultChanged, updatedTemplate]);
+    }, [api, defaultLabel, isDefault, onActionCompleted, onDefaultChanged, updatedTemplate]);
 
     return (
         <>
@@ -358,7 +359,7 @@ export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props
         (newLabelTemplate?: number) => {
             setError(undefined);
 
-            api?.labelprinting
+            api.labelprinting
                 .ensureLabelTemplatesList(user)
                 .then(labelTemplates => {
                     setTemplates(labelTemplates ?? []);
@@ -370,7 +371,7 @@ export const LabelsConfigurationPanel: FC<LabelTemplatesPanelProps> = memo(props
                     setError('Error: Unable to load label templates.');
                 });
         },
-        [api?.labelprinting, user]
+        [api, user]
     );
 
     // Load template list

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { Button } from 'react-bootstrap';
 
-import { mountWithServerContext, waitForLifecycle } from '../../test/enzymeTestHelpers';
+import { mountWithAppServerContext, waitForLifecycle } from '../../test/enzymeTestHelpers';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { AddEntityButton } from '../buttons/AddEntityButton';
 import { Alert } from '../base/Alert';
@@ -26,7 +26,7 @@ describe('ManageSampleStatusesPanel', () => {
     const DEFAULT_PROPS = {
         api: getTestAPIWrapper(jest.fn, {
             samples: getSamplesTestAPIWrapper(jest.fn, {
-                getSampleStatuses: () => Promise.resolve([new SampleState({ isLocal: true, rowId: 1 })]),
+                getSampleStatuses: jest.fn().mockResolvedValue([new SampleState({ isLocal: true, rowId: 1 })]),
             }),
         }),
         getIsDirty: jest.fn(),
@@ -48,7 +48,7 @@ describe('ManageSampleStatusesPanel', () => {
     }
 
     test('loading', async () => {
-        const wrapper = mountWithServerContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithAppServerContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />, undefined, {
             container: TEST_PROJECT_CONTAINER,
             project: TEST_PROJECT,
         });
@@ -59,15 +59,16 @@ describe('ManageSampleStatusesPanel', () => {
     });
 
     test('no states', async () => {
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <ManageSampleStatusesPanel
                 {...DEFAULT_PROPS}
                 api={getTestAPIWrapper(jest.fn, {
                     samples: getSamplesTestAPIWrapper(jest.fn, {
-                        getSampleStatuses: () => Promise.resolve([]),
+                        getSampleStatuses: jest.fn().mockResolvedValue([]),
                     }),
                 })}
             />,
+            undefined,
             {
                 container: TEST_PROJECT_CONTAINER,
                 project: TEST_PROJECT,
@@ -81,7 +82,7 @@ describe('ManageSampleStatusesPanel', () => {
     });
 
     test('with states and selection', async () => {
-        const wrapper = mountWithServerContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithAppServerContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />, undefined, {
             container: TEST_PROJECT_CONTAINER,
             project: TEST_PROJECT,
         });
@@ -103,7 +104,7 @@ describe('ManageSampleStatusesPanel', () => {
     });
 
     test('error retrieving states', async () => {
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <ManageSampleStatusesPanel
                 {...DEFAULT_PROPS}
                 api={getTestAPIWrapper(jest.fn, {
@@ -112,6 +113,7 @@ describe('ManageSampleStatusesPanel', () => {
                     }),
                 })}
             />,
+            undefined,
             {
                 container: TEST_PROJECT_CONTAINER,
                 project: TEST_PROJECT,
@@ -123,7 +125,7 @@ describe('ManageSampleStatusesPanel', () => {
     });
 
     test('add new', async () => {
-        const wrapper = mountWithServerContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithAppServerContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} />, undefined, {
             container: TEST_PROJECT_CONTAINER,
             project: TEST_PROJECT,
         });
@@ -224,16 +226,20 @@ describe('SampleStatusDetail', () => {
     }
 
     test('show select message', async () => {
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} state={undefined} />, {
-            project: TEST_PROJECT,
-        });
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusDetail {...DEFAULT_PROPS} state={undefined} />,
+            undefined,
+            {
+                project: TEST_PROJECT,
+            }
+        );
         await waitForLifecycle(wrapper);
         validate(wrapper, false);
         wrapper.unmount();
     });
 
     test('do not show select message', async () => {
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} state={null} />, {
+        const wrapper = mountWithAppServerContext(<SampleStatusDetail {...DEFAULT_PROPS} state={null} />, undefined, {
             project: TEST_PROJECT,
         });
         await waitForLifecycle(wrapper);
@@ -242,7 +248,7 @@ describe('SampleStatusDetail', () => {
     });
 
     test('input values from state', async () => {
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithAppServerContext(<SampleStatusDetail {...DEFAULT_PROPS} />, undefined, {
             project: TEST_PROJECT,
         });
         await waitForLifecycle(wrapper);
@@ -269,9 +275,13 @@ describe('SampleStatusDetail', () => {
             isLocal: true,
             containerPath: '/Test',
         });
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} state={inUseState} />, {
-            project: TEST_PROJECT,
-        });
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusDetail {...DEFAULT_PROPS} state={inUseState} />,
+            undefined,
+            {
+                project: TEST_PROJECT,
+            }
+        );
         await waitForLifecycle(wrapper);
         validate(wrapper, true, true, 2);
         expect(wrapper.find('input[name="label"]').prop('disabled')).toBe(false);
@@ -293,9 +303,13 @@ describe('SampleStatusDetail', () => {
             isLocal: false,
             containerPath: '/Test',
         });
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} state={inUseState} />, {
-            project: TEST_PROJECT,
-        });
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusDetail {...DEFAULT_PROPS} state={inUseState} />,
+            undefined,
+            {
+                project: TEST_PROJECT,
+            }
+        );
         await waitForLifecycle(wrapper);
         validate(wrapper, true, false, 2);
         expect(wrapper.find('input[name="label"]').prop('disabled')).toBe(true);
@@ -306,7 +320,7 @@ describe('SampleStatusDetail', () => {
     });
 
     test('save button disabled', async () => {
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithAppServerContext(<SampleStatusDetail {...DEFAULT_PROPS} />, undefined, {
             project: TEST_PROJECT,
         });
         await waitForLifecycle(wrapper);
@@ -322,7 +336,7 @@ describe('SampleStatusDetail', () => {
     });
 
     test('add new', async () => {
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} addNew />, {
+        const wrapper = mountWithAppServerContext(<SampleStatusDetail {...DEFAULT_PROPS} addNew />, undefined, {
             project: TEST_PROJECT,
         });
         await waitForLifecycle(wrapper);
@@ -334,7 +348,7 @@ describe('SampleStatusDetail', () => {
     });
 
     test('show confirm delete', async () => {
-        const wrapper = mountWithServerContext(<SampleStatusDetail {...DEFAULT_PROPS} />, {
+        const wrapper = mountWithAppServerContext(<SampleStatusDetail {...DEFAULT_PROPS} />, undefined, {
             project: TEST_PROJECT,
         });
         await waitForLifecycle(wrapper);

--- a/packages/components/src/internal/components/samples/SampleAmountEditModal.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleAmountEditModal.spec.tsx
@@ -5,7 +5,7 @@ import { Button } from 'react-bootstrap';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 
 import { Alert } from '../base/Alert';
-import { mountWithServerContext } from '../../test/enzymeTestHelpers';
+import { mountWithAppServerContext } from '../../test/enzymeTestHelpers';
 import { TEST_USER_EDITOR } from '../../userFixtures';
 
 import { SampleAmountEditModal } from './SampleAmountEditModal';
@@ -25,7 +25,7 @@ describe('SampleAmountEditModal', () => {
         canSave: boolean,
         isNegative?: boolean,
         hasLabelUnits = true
-    ) {
+    ): void {
         expect(wrapper.find('.checkin-amount-label').text()).toContain(
             'Amount' + (units && hasLabelUnits ? ' (' + units + ')' : '')
         );
@@ -40,14 +40,14 @@ describe('SampleAmountEditModal', () => {
         validateSubmitButton(wrapper, noun, canSave);
     }
 
-    function validateSubmitButton(wrapper: ReactWrapper, noun: string, canSave: boolean) {
+    function validateSubmitButton(wrapper: ReactWrapper, noun: string, canSave: boolean): void {
         const success = wrapper.find(Button).at(1);
         expect(success.text()).toBe('Update ' + noun);
         expect(success.prop('disabled')).toBe(!canSave);
     }
 
     test('minimal props', () => {
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={emptyRow}
@@ -55,6 +55,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 
@@ -72,7 +73,7 @@ describe('SampleAmountEditModal', () => {
             FreezeThawCount: { value: 1 },
         } as any;
 
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={row}
@@ -80,6 +81,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 
@@ -96,7 +98,7 @@ describe('SampleAmountEditModal', () => {
             FreezeThawCount: { value: 1 },
         } as any;
 
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={row}
@@ -104,6 +106,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 
@@ -120,7 +123,7 @@ describe('SampleAmountEditModal', () => {
             FreezeThawCount: { value: 1 },
         } as any;
 
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={row}
@@ -128,6 +131,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 
@@ -144,7 +148,7 @@ describe('SampleAmountEditModal', () => {
             FreezeThawCount: { value: 1 },
         } as any;
 
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={row}
@@ -152,6 +156,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 
@@ -168,7 +173,7 @@ describe('SampleAmountEditModal', () => {
             FreezeThawCount: { value: 1 },
         } as any;
 
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={row}
@@ -176,6 +181,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 
@@ -196,7 +202,7 @@ describe('SampleAmountEditModal', () => {
             FreezeThawCount: { value: 1 },
         } as any;
 
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={row}
@@ -204,6 +210,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 
@@ -228,7 +235,7 @@ describe('SampleAmountEditModal', () => {
             FreezeThawCount: { value: 1 },
         } as any;
 
-        const wrapper = mountWithServerContext(
+        const wrapper = mountWithAppServerContext(
             <SampleAmountEditModal
                 schemaQuery={testSchemaQuery}
                 row={row}
@@ -236,6 +243,7 @@ describe('SampleAmountEditModal', () => {
                 updateListener={jest.fn()}
                 onClose={jest.fn()}
             />,
+            undefined,
             { user: TEST_USER_EDITOR }
         );
 

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -72,6 +72,7 @@ export function getSampleSet(config: IEntityTypeDetails): Promise<any> {
     });
 }
 
+// TODO: This should share implementation with api.domain.fetchDomainDetails / api.domain.getDataClassDetails
 export function getSampleTypeDetails(
     query?: SchemaQuery,
     domainId?: number,
@@ -615,13 +616,13 @@ export function updateSampleStorageData(
     containerPath?: string,
     userComment?: string
 ): Promise<any> {
-    if (sampleStorageData.length == 0) {
+    if (sampleStorageData.length === 0) {
         return Promise.resolve();
     }
 
     return new Promise<any>((resolve, reject) => {
         return Ajax.request({
-            url: buildURL('inventory', 'UpdateSampleStorageData.api', undefined, { container: containerPath }),
+            url: buildURL('inventory', 'updateSampleStorageData.api', undefined, { container: containerPath }),
             jsonData: {
                 sampleRows: sampleStorageData,
                 [STORED_AMOUNT_FIELDS.AUDIT_COMMENT]: userComment,

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -17,10 +17,24 @@ import { SchemaQuery } from '../../public/SchemaQuery';
 
 import { ViewInfo } from '../ViewInfo';
 
-import { getQueryDetails, GetQueryDetailsOptions, selectDistinctRows } from './api';
+import {
+    deleteRows,
+    DeleteRowsOptions,
+    DeleteRowsResponse,
+    getQueryDetails,
+    GetQueryDetailsOptions,
+    insertRows,
+    InsertRowsOptions,
+    InsertRowsResponse,
+    selectDistinctRows,
+    updateRows,
+    UpdateRowsOptions,
+    UpdateRowsResponse,
+} from './api';
 import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows';
 
 export interface QueryAPIWrapper {
+    deleteRows: (options: DeleteRowsOptions) => Promise<DeleteRowsResponse>;
     getDataTypeProjectDataCount: (
         entityDataType: EntityDataType,
         dataTypeRowId: number,
@@ -49,20 +63,25 @@ export interface QueryAPIWrapper {
     ) => Promise<Record<string, number>>;
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
+    insertRows: (options: InsertRowsOptions) => Promise<InsertRowsResponse>;
     selectDistinctRows: (selectDistinctOptions: Query.SelectDistinctOptions) => Promise<Query.SelectDistinctResponse>;
     selectRows: (options: SelectRowsOptions) => Promise<SelectRowsResponse>;
+    updateRows: (options: UpdateRowsOptions) => Promise<UpdateRowsResponse>;
 }
 
 export class QueryServerAPIWrapper implements QueryAPIWrapper {
+    deleteRows = deleteRows;
+    getDataTypeProjectDataCount = getDataTypeProjectDataCount;
     getEntityTypeOptions = getEntityTypeOptions;
-    getQueryDetails = getQueryDetails;
-    incrementClientSideMetricCount = incrementClientSideMetricCount;
-    selectRows = selectRows;
-    selectDistinctRows = selectDistinctRows;
     getGridViews = getGridViews;
     getProjectConfigurableEntityTypeOptions = getProjectConfigurableEntityTypeOptions;
     getProjectDataTypeDataCount = getProjectDataTypeDataCount;
-    getDataTypeProjectDataCount = getDataTypeProjectDataCount;
+    getQueryDetails = getQueryDetails;
+    incrementClientSideMetricCount = incrementClientSideMetricCount;
+    insertRows = insertRows;
+    selectRows = selectRows;
+    selectDistinctRows = selectDistinctRows;
+    updateRows = updateRows;
 }
 
 /**
@@ -73,15 +92,18 @@ export function getQueryTestAPIWrapper(
     overrides: Partial<QueryAPIWrapper> = {}
 ): QueryAPIWrapper {
     return {
+        deleteRows: mockFn(),
+        getDataTypeProjectDataCount: mockFn(),
         getEntityTypeOptions: mockFn(),
-        getQueryDetails: mockFn(),
-        incrementClientSideMetricCount: mockFn(),
-        selectRows: mockFn(),
-        selectDistinctRows: mockFn(),
         getGridViews: mockFn(),
         getProjectConfigurableEntityTypeOptions: mockFn(),
         getProjectDataTypeDataCount: mockFn(),
-        getDataTypeProjectDataCount: mockFn(),
+        getQueryDetails: mockFn(),
+        incrementClientSideMetricCount: mockFn(),
+        insertRows: mockFn(),
+        selectRows: mockFn(),
+        selectDistinctRows: mockFn(),
+        updateRows: mockFn(),
         ...overrides,
     };
 }

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -11,7 +11,14 @@ import {
 import { getEntityTypeOptions, getProjectConfigurableEntityTypeOptions } from '../components/entities/actions';
 import { getProjectDataTypeDataCount, getDataTypeProjectDataCount } from '../components/project/actions';
 
-import { getGridViews, incrementClientSideMetricCount } from '../actions';
+import {
+    deleteView,
+    getGridViews,
+    incrementClientSideMetricCount,
+    renameGridView,
+    saveGridView,
+    saveSessionView,
+} from '../actions';
 
 import { SchemaQuery } from '../../public/SchemaQuery';
 
@@ -35,6 +42,7 @@ import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows'
 
 export interface QueryAPIWrapper {
     deleteRows: (options: DeleteRowsOptions) => Promise<DeleteRowsResponse>;
+    deleteView: (schemaQuery: SchemaQuery, containerPath: string, viewName?: string, revert?: boolean) => Promise<void>;
     getDataTypeProjectDataCount: (
         entityDataType: EntityDataType,
         dataTypeRowId: number,
@@ -64,6 +72,30 @@ export interface QueryAPIWrapper {
     getQueryDetails: (options: GetQueryDetailsOptions) => Promise<QueryInfo>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
     insertRows: (options: InsertRowsOptions) => Promise<InsertRowsResponse>;
+    renameGridView: (
+        schemaQuery: SchemaQuery,
+        containerPath: string,
+        viewName: string,
+        newName: string
+    ) => Promise<void>;
+    saveGridView: (
+        schemaQuery: SchemaQuery,
+        containerPath: string,
+        viewInfo: ViewInfo,
+        replace: boolean,
+        session: boolean,
+        inherit: boolean,
+        shared: boolean
+    ) => Promise<void>;
+    saveSessionView: (
+        schemaQuery: SchemaQuery,
+        containerPath: string,
+        viewName: string,
+        newName: string,
+        inherit?: boolean,
+        shared?: boolean,
+        replace?: boolean
+    ) => Promise<void>;
     selectDistinctRows: (selectDistinctOptions: Query.SelectDistinctOptions) => Promise<Query.SelectDistinctResponse>;
     selectRows: (options: SelectRowsOptions) => Promise<SelectRowsResponse>;
     updateRows: (options: UpdateRowsOptions) => Promise<UpdateRowsResponse>;
@@ -71,6 +103,7 @@ export interface QueryAPIWrapper {
 
 export class QueryServerAPIWrapper implements QueryAPIWrapper {
     deleteRows = deleteRows;
+    deleteView = deleteView;
     getDataTypeProjectDataCount = getDataTypeProjectDataCount;
     getEntityTypeOptions = getEntityTypeOptions;
     getGridViews = getGridViews;
@@ -79,6 +112,9 @@ export class QueryServerAPIWrapper implements QueryAPIWrapper {
     getQueryDetails = getQueryDetails;
     incrementClientSideMetricCount = incrementClientSideMetricCount;
     insertRows = insertRows;
+    renameGridView = renameGridView;
+    saveGridView = saveGridView;
+    saveSessionView = saveSessionView;
     selectRows = selectRows;
     selectDistinctRows = selectDistinctRows;
     updateRows = updateRows;
@@ -93,6 +129,7 @@ export function getQueryTestAPIWrapper(
 ): QueryAPIWrapper {
     return {
         deleteRows: mockFn(),
+        deleteView: mockFn(),
         getDataTypeProjectDataCount: mockFn(),
         getEntityTypeOptions: mockFn(),
         getGridViews: mockFn(),
@@ -101,6 +138,9 @@ export function getQueryTestAPIWrapper(
         getQueryDetails: mockFn(),
         incrementClientSideMetricCount: mockFn(),
         insertRows: mockFn(),
+        renameGridView: mockFn(),
+        saveGridView: mockFn(),
+        saveSessionView: mockFn(),
         selectRows: mockFn(),
         selectDistinctRows: mockFn(),
         updateRows: mockFn(),

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fromJS, List, Map, OrderedMap, Record as ImmutableRecord, Set as ImmutableSet } from 'immutable';
+import { fromJS, List, Map, Record as ImmutableRecord, Set as ImmutableSet } from 'immutable';
 import { normalize, schema } from 'normalizr';
 import { Filter, Query, QueryDOM } from '@labkey/api';
+
 import { ExtendedMap } from '../../public/ExtendedMap';
 
 import { getQueryMetadata } from '../global';
@@ -120,7 +121,7 @@ export function applyQueryMetadata(rawQueryInfo: any, schemaName?: string, query
     if (rawQueryInfo && _schemaName && _queryName) {
         const schemaQuery = new SchemaQuery(_schemaName, _queryName);
 
-        let columns = new ExtendedMap<string, QueryColumn>();
+        const columns = new ExtendedMap<string, QueryColumn>();
         rawQueryInfo.columns.forEach(rawColumn => {
             columns.set(rawColumn.fieldKey.toLowerCase(), applyColumnMetadata(schemaQuery, rawColumn));
         });
@@ -738,7 +739,10 @@ export function insertRows(options: InsertRowsOptions): Promise<InsertRowsRespon
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             rows: _rows.toArray(),
-            skipReselectRows: (options.skipReselectRows === null || options.skipReselectRows === undefined) ? true : options.skipReselectRows,
+            skipReselectRows:
+                options.skipReselectRows === null || options.skipReselectRows === undefined
+                    ? true
+                    : options.skipReselectRows,
             apiVersion: 13.2,
             success: (response, request) => {
                 if (processRequest(response, request, reject)) return;
@@ -803,11 +807,11 @@ function ensureNullForUndefined(row: Map<string, any>): Map<string, any> {
     return row.reduce((map, v, k) => map.set(k, v === undefined ? null : v), Map<string, any>());
 }
 
-interface UpdateRowsOptions extends Omit<Query.QueryRequestOptions, 'schemaName' | 'queryName'> {
+export interface UpdateRowsOptions extends Omit<Query.QueryRequestOptions, 'schemaName' | 'queryName'> {
     schemaQuery: SchemaQuery;
 }
 
-interface UpdateRowsResponse {
+export interface UpdateRowsResponse {
     rows: any[];
     schemaQuery: SchemaQuery;
     transactionAuditId?: number;
@@ -821,7 +825,10 @@ export function updateRows(options: UpdateRowsOptions): Promise<UpdateRowsRespon
             ...updateRowOptions,
             queryName: schemaQuery.queryName,
             schemaName: schemaQuery.schemaName,
-            skipReselectRows: (options.skipReselectRows === null || options.skipReselectRows === undefined) ? true : options.skipReselectRows,
+            skipReselectRows:
+                options.skipReselectRows === null || options.skipReselectRows === undefined
+                    ? true
+                    : options.skipReselectRows,
             success: (response, request) => {
                 if (processRequest(response, request, reject)) return;
 
@@ -852,11 +859,17 @@ export function updateRows(options: UpdateRowsOptions): Promise<UpdateRowsRespon
     });
 }
 
-interface DeleteRowsOptions extends Omit<Query.QueryRequestOptions, 'schemaName' | 'queryName'> {
+export interface DeleteRowsOptions extends Omit<Query.QueryRequestOptions, 'schemaName' | 'queryName'> {
     schemaQuery: SchemaQuery;
 }
 
-export function deleteRows(options: DeleteRowsOptions): Promise<any> {
+export interface DeleteRowsResponse {
+    rows: any[];
+    schemaQuery: SchemaQuery;
+    transactionAuditId?: number;
+}
+
+export function deleteRows(options: DeleteRowsOptions): Promise<DeleteRowsResponse> {
     return new Promise((resolve, reject) => {
         const { schemaQuery, ...deleteRowsOptions } = options;
         Query.deleteRows({

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -10,14 +10,16 @@ import { extractChanges } from '../../internal/components/forms/detail/utils';
 
 import { QueryColumn } from '../QueryColumn';
 import { FileInput } from '../../internal/components/forms/input/FileInput';
-import { updateRows } from '../../internal/query/api';
 import { resolveErrorMessage } from '../../internal/util/messaging';
 import { Alert } from '../../internal/components/base/Alert';
+
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../internal/APIWrapper';
 
 import { RequiresModelAndActions } from './withQueryModels';
 import { DetailPanel, DetailPanelWithModel } from './DetailPanel';
 
 export interface EditableDetailPanelProps extends RequiresModelAndActions {
+    api?: ComponentsAPIWrapper;
     appEditable?: boolean;
     asSubPanel?: boolean;
     canUpdate: boolean;
@@ -46,6 +48,7 @@ interface State {
 
 export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps, State> {
     static defaultProps = {
+        api: getDefaultAPIWrapper(),
         useEditIcon: true,
         cancelText: 'Cancel',
         submitText: 'Save',
@@ -85,7 +88,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleSubmit = async (values: Record<string, any>): Promise<void> => {
-        const { containerPath, model, onEditToggle, onUpdate } = this.props;
+        const { api, containerPath, model, onEditToggle, onUpdate } = this.props;
         const { queryInfo } = model;
         const row = model.getRow();
         const updatedValues = extractChanges(queryInfo, fromJS(model.getRow()), values);
@@ -112,7 +115,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
         });
 
         try {
-            await updateRows({
+            await api.query.updateRows({
                 auditBehavior: AuditBehaviorTypes.DETAILED,
                 containerPath,
                 rows: [updatedValues],

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -25,8 +25,6 @@ import { ViewInfo } from '../../internal/ViewInfo';
 
 import { QueryColumn } from '../QueryColumn';
 
-import { QueryInfo } from '../QueryInfo';
-
 import { QuerySort } from '../QuerySort';
 
 import { GridColumn } from '../../internal/components/base/models/GridColumn';
@@ -287,7 +285,7 @@ export const GridTitle: FC<GridTitleProps> = memo(props => {
         isUpdated,
     } = props;
     const { viewName } = model;
-    const [errorMsg, setErrorMsg] = useState<string>(undefined);
+    const [errorMsg, setErrorMsg] = useState<string>();
 
     // TODO: unable to get jest to pass with useServerContext() due to GridPanel being Component instead of FC
     // const { user } = useServerContext();

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -838,8 +838,11 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                         this.setState({ errorMsg });
                     });
             } else {
-                const isCustomView = !!newName && (newName !== ViewInfo.DEFAULT_NAME);
-                const finalViewInfo = updatedViewInfo.mutate({ name: newName, isDefault: isCustomView ? false : updatedViewInfo.isDefault, });
+                const isCustomView = !!newName && newName !== ViewInfo.DEFAULT_NAME;
+                const finalViewInfo = updatedViewInfo.mutate({
+                    name: newName,
+                    isDefault: isCustomView ? false : updatedViewInfo.isDefault,
+                });
 
                 saveGridView(model.schemaQuery, model.containerPath, finalViewInfo, replace, false, inherit, shared)
                     .then(response => {

--- a/packages/components/src/public/QueryModel/ManageViewsModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/ManageViewsModal.spec.tsx
@@ -13,7 +13,7 @@ import { getQueryTestAPIWrapper } from '../../internal/query/APIWrapper';
 
 import { ManageViewsModal, ViewLabel } from './ManageViewsModal';
 
-export const getQueryAPI = (views: ViewInfo[]) => {
+const getQueryAPI = (views: ViewInfo[]) => {
     return getTestAPIWrapper(jest.fn, {
         query: getQueryTestAPIWrapper(jest.fn, {
             getGridViews: jest.fn().mockResolvedValue(views),


### PR DESCRIPTION
#### Rationale
This extends our usage of the APIWrapper pattern for additional components. This makes unit testing components much easier and reduces the flakiness of test runs in CI.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1209
- https://github.com/LabKey/labkey-ui-premium/pull/108
- https://github.com/LabKey/biologics/pull/2172
- https://github.com/LabKey/sampleManagement/pull/1883
- https://github.com/LabKey/inventory/pull/884
- https://github.com/LabKey/platform/pull/4493

#### Changes
- Revise `QueryAPIWrapper` to support a number of additional API endpoints including query view APIs.
- Refactor a number of components to utilize the `APIWrapper` pattern and update associated tests.
- Remove `getDataClassDetails` from top-level export as it has been added to the `DomainPropertiesAPIWrapper`.
