### PR TITLE
Issue 48067: Add metrics for action buttons on editable grid

### DIFF
--- a/packages/components/docs/public.md
+++ b/packages/components/docs/public.md
@@ -43,7 +43,7 @@ fetch and render data from LabKey server.
 
 ## Related Documentation
 
-* [Demo Module](https://github.com/LabKey/tutorialModules/tree/develop/demo/src/client/QueryModelPage) - LabKey demo module with React page and
+* [Examples Module](https://github.com/LabKey/tutorialModules/tree/develop/reactExamples/src/client/QueryModelPage) - LabKey module with React page and
 component usage examples
 in a GridPanel component
 * [Immer for Immutability](./immer.md) - information and examples on using the Immer library for JavaScript object immutability

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.345.0",
+  "version": "2.345.1-bulkActionMetrics.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.345.1-bulkActionMetrics.0",
+  "version": "2.345.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48067: Add metrics for action buttons on editable grid
+
 ### version 2.345.0
 *Released*: 8 June 2023
 - Revise `QueryAPIWrapper` to support a number of additional API endpoints including query view APIs.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.345.1
+*Released*: 19 June 2023
 - Issue 48067: Add metrics for action buttons on editable grid
 
 ### version 2.345.0

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -259,6 +259,7 @@ export class RunDataPanel extends PureComponent<Props, State> {
                                             emptyGridMsg="Start by adding the quantity of assay data rows you want to create."
                                             isSubmitting={wizardModel.isSubmitting}
                                             maxRows={this.props.maxRows}
+                                            metricFeatureArea="assayResultsEditableGrid"
                                             model={queryModel}
                                             onChange={this.props.onGridChange}
                                             striped

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -33,6 +33,7 @@ import {
     copyEvent,
     dragFillEvent,
     endDrag,
+    incrementClientSideMetricCount,
     inDrag,
     pasteEvent,
     updateGridFromBulkForm,
@@ -236,6 +237,7 @@ export interface SharedEditableGridProps {
     // list of key values for rows that are locked. locked rows are readonly but might have a different display from readonly rows
     lockedRows?: List<any>;
     maxRows?: number;
+    metricFeatureArea?: string;
     // list of key values that cannot be deleted.
     notDeletable?: List<any>;
     primaryBtnProps?: EditableGridBtnProps;
@@ -624,7 +626,11 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     removeSelected = (): void => {
+        const { metricFeatureArea } = this.props;
         this.removeRows(this.state.selected);
+        if (metricFeatureArea) {
+            incrementClientSideMetricCount(metricFeatureArea, 'removeRows');
+        }
     };
 
     getLoweredColumnMetadata = (): Map<string, EditableColumnMetadata> =>
@@ -1029,7 +1035,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     bulkAdd = async (bulkData: OrderedMap<string, any>): Promise<void> => {
-        const { addControlProps, bulkAddProps, editorModel, data, dataKeys, onChange, processBulkData, queryInfo } =
+        const { addControlProps, bulkAddProps, editorModel, data, dataKeys, metricFeatureArea, onChange, processBulkData, queryInfo} =
             this.props;
         const { nounPlural } = addControlProps;
         // numItems is a string because we rely on Formsy to grab the value for us (See QueryInfoForm for details). We
@@ -1082,12 +1088,15 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             onChange(changes.editorModel, changes.dataKeys, changes.data);
         }
 
+        if (metricFeatureArea) {
+            incrementClientSideMetricCount(metricFeatureArea, 'bulkAdd');
+        }
         // Result of this promise passed to toggleBulkAdd, which doesn't expect anything to be passed
         return Promise.resolve();
     };
 
     bulkUpdate = async (updatedData: OrderedMap<string, any>): Promise<Partial<EditorModelProps>> => {
-        const { editorModel, queryInfo, onChange, bulkUpdateProps } = this.props;
+        const { editorModel, queryInfo, onChange, bulkUpdateProps, metricFeatureArea } = this.props;
         if (!updatedData) return Promise.resolve(undefined);
 
         const selectedIndices = this.getSelectedRowIndices();
@@ -1100,6 +1109,10 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             bulkUpdateProps?.isIncludedColumn
         );
         onChange(editorModelChanges);
+
+        if (metricFeatureArea) {
+            incrementClientSideMetricCount(metricFeatureArea, 'bulkUpdate');
+        }
         // The result of this promise is used by toggleBulkUpdate, which doesn't expect anything to be passed
         return Promise.resolve(editorModelChanges);
     };


### PR DESCRIPTION
#### Rationale
We want to understand if the bulk operation buttons on the editable grids are being used and how often.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/113
- https://github.com/LabKey/biologics/pull/2188
- https://github.com/LabKey/sampleManagement/pull/1897

#### Changes
- Add an optional `metricFeatureArea` property to the `EditableGridPanel`
