### PR TITLE
Create storage on sample import or update via file in apps

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.346.1",
+  "version": "2.346.1-fb-createStorageOnSampleImport.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.345.3",
+  "version": "2.345.3-fb-createStorageOnSampleImport.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.347.0",
+  "version": "2.347.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.347.1
+*Released*: 27 June 2023
 * Create Storage on Sample Import
   * add StorageUnit column to SAMPLE_STORAGE_COLUMNS const
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Create Storage on Sample Import
+  * add StorageUnit column to SAMPLE_STORAGE_COLUMNS const
+
 ### version 2.345.3
 *Released*: 21 June 2023
 * Moving entities between projects - Assay Data

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -177,6 +177,7 @@ export const SAMPLE_STORAGE_COLUMNS = [
     'StorageLocation',
     'StorageRow',
     'StorageCol',
+    'StorageUnit',
     'RawAmount',
     'RawUnits',
     'FreezeThawCount',


### PR DESCRIPTION
#### Rationale
This set of PRs allows for the apps to create new storage items (freezers, locations, and boxes) during a sample import/update via file, if the appropriate StorageLocation and StorageUnit columns are provided in the file and the user has the proper permissions. This is something the user has to opt into during the file import (error messages will be shown re: invalid storage locations otherwise). This allows for more streamlined workflows for the users to put new or existing samples into storage without first having to go to the freezer designer and define each locations/box.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1215
- https://github.com/LabKey/labkey-ui-premium/pull/117
- https://github.com/LabKey/platform/pull/4532
- https://github.com/LabKey/inventory/pull/900
- https://github.com/LabKey/sampleManagement/pull/1912
- https://github.com/LabKey/biologics/pull/2192

#### Changes
- add StorageUnit column to SAMPLE_STORAGE_COLUMNS const
