### PR TITLE
Project setting updates for Data in Project and Project Storage needs a manual refresh to take effect

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.347.1",
+  "version": "2.347.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.345.3",
+  "version": "2.345.4-fb-issue48127.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X June 2023
+- Project setting updates for Data in Project and Project Storage needs a manual refresh to take effect
+
 ### version 2.345.3
 *Released*: 21 June 2023
 * Moving entities between projects - Assay Data

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.X
-*Released*: X June 2023
+### version 2.347.2
+*Released*: 27 June 2023
 - Project setting updates for Data in Project and Project Storage needs a manual refresh to take effect
 
 ### version 2.347.1

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -54,8 +54,10 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
         setIsDirty(true);
     }, [setIsDirty]);
 
-    const onSettingsSuccess = useCallback(() => {
+    const onSettingsSuccess = useCallback((reload?: boolean) => {
         setIsDirty(false);
+        if (reload)
+            window.location.reload();
     }, [setIsDirty]);
 
     const onBarTenderSuccess = useCallback(() => {

--- a/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
+++ b/packages/components/src/internal/components/project/ProjectDataTypeSelections.tsx
@@ -13,7 +13,7 @@ interface Props {
     api?: FolderAPIWrapper;
     disabledTypesMap?: { [key: string]: number[] };
     entityDataTypes?: EntityDataType[];
-    onSuccess?: () => void;
+    onSuccess?: (reload?: boolean) => void;
     projectId?: string;
     updateDataTypeExclusions: (dataType: ProjectConfigurableDataType, exclusions: number[]) => void;
 }
@@ -57,7 +57,7 @@ export const ProjectDataTypeSelections: FC<Props> = memo(props => {
             await api.updateProjectDataExclusions(options);
 
             setDirty(false);
-            onSuccess();
+            onSuccess(true);
         } catch (e) {
             setError(resolveErrorMessage(e) ?? 'Failed to update project settings');
         } finally {


### PR DESCRIPTION
#### Rationale
project data exclusions are part of moduleContext. When project's exclusion setting is updated, a page reload should be performed to update the page's context. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/116
- https://github.com/LabKey/sampleManagement/pull/1911
- https://github.com/LabKey/biologics/pull/2191

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
