### PR TITLE
Adjust scope used for ontology searches

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.346.0-fb-ontologyScope.0",
+  "version": "2.346.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.346.0",
+  "version": "2.346.0-fb-ontologyScope.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.346.1
+*Released*: 26 June 2023
+* Add scope to ontology search queries
+  * add scope that includes Shared folder (where ontologies reside)
+  * switch from deprecated searchUsingIndex
+
 ### version 2.346.0
 *Released*: 26 June 2023
 - EditableGrid Improvements

--- a/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyTreeSearchContainer.tsx
@@ -2,8 +2,8 @@ import React, { ChangeEvent, FC, memo, MouseEvent, useCallback, useEffect, useMe
 
 import { Alert } from '../base/Alert';
 
-import { searchUsingIndex } from '../search/actions';
-import { SearchCategory } from '../search/constants';
+import { search } from '../search/actions';
+import { SearchCategory, SearchScope } from '../search/constants';
 
 import { ConceptModel, OntologyModel, PathModel } from './models';
 import { fetchAlternatePaths, getOntologyDetails } from './actions';
@@ -64,10 +64,11 @@ export const OntologyTreeSearchContainer: FC<OntologyTreeSearchContainerProps> =
 
         if (searchTerm) {
             const timeOutId = setTimeout(() => {
-                searchUsingIndex({
+                search({
                     q: getOntologySearchTerm(ontology, searchTerm),
                     category: SearchCategory.Concept,
                     limit: SEARCH_LIMIT,
+                    scope: SearchScope.FolderAndSubfoldersAndShared,
                 })
                     .then(response => {
                         setSearchHits(


### PR DESCRIPTION
#### Rationale
Test failures (https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitPostgres/2507808?buildTab=tests&status=failed&name=OntologyFieldAnnotationTest)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1217
- https://github.com/LabKey/platform/pull/4536
- https://github.com/LabKey/biologics/pull/2193
- https://github.com/LabKey/sampleManagement/pull/1915

#### Changes
- add scope that includes Shared folder (where ontologies reside)
- switch from deprecated searchUsingIndex
