### PR TITLE
Issue 47501: App specialty assay creation should not remove locked fields from Batch domain

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.350.0",
+  "version": "2.350.0-fb-specialtyAssay47501.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.350.0-fb-specialtyAssay47501.0",
+  "version": "2.350.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD July 2023
-- Issue 47501: ELISA assay created from LKB app doesn't have required ParticipantVisitResolver field
+- Issue 47501: App specialty assay creation should not remove locked fields from Batch domain
   - add isDeletable() to DomainField
 
 ### version 2.350.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD July 2023
+- Issue 47501: ELISA assay created from LKB app doesn't have required ParticipantVisitResolver field
+  - add isDeletable() to DomainField
+
 ### version 2.350.0
 *Released*: 4 July 2023
 - Add `onKeyDown` event handling for `TAB` and `ESCAPE` for dropdown cells.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD July 2023
+### version 2.350.1
+*Released*: 6 July 2023
 - Issue 47501: App specialty assay creation should not remove locked fields from Batch domain
   - add isDeletable() to DomainField
 

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -759,7 +759,9 @@ describe('DomainField', () => {
         expect(DomainField.create({ name: 'foo', lockExistingField: true }).isDeletable()).toBeFalsy();
         expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_PARTIALLY_LOCKED }).isDeletable()).toBeFalsy();
         expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_FULLY_LOCKED }).isDeletable()).toBeFalsy();
-        expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_PRIMARY_KEY_LOCKED }).isDeletable()).toBeFalsy();
+        expect(
+            DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_PRIMARY_KEY_LOCKED }).isDeletable()
+        ).toBeFalsy();
         expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_NOT_LOCKED }).isDeletable()).toBeTruthy();
     });
 

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -78,6 +78,7 @@ import {
     STRING_RANGE_URI,
     TEXT_CHOICE_CONCEPT_URI,
     DERIVATION_DATA_SCOPES,
+    DOMAIN_FIELD_PRIMARY_KEY_LOCKED,
 } from './constants';
 
 beforeAll(() => {
@@ -752,6 +753,14 @@ describe('DomainField', () => {
         expect(DomainField.create({ name: 'foo', PHI: PHILEVEL_LIMITED_PHI }).isPHI()).toBeTruthy();
         expect(DomainField.create({ name: 'foo', PHI: PHILEVEL_FULL_PHI }).isPHI()).toBeTruthy();
         expect(DomainField.create({ name: 'foo', PHI: PHILEVEL_RESTRICTED_PHI }).isPHI()).toBeTruthy();
+    });
+
+    test('isDeletable', () => {
+        expect(DomainField.create({ name: 'foo', lockExistingField: true }).isDeletable()).toBeFalsy();
+        expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_PARTIALLY_LOCKED }).isDeletable()).toBeFalsy();
+        expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_FULLY_LOCKED }).isDeletable()).toBeFalsy();
+        expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_PRIMARY_KEY_LOCKED }).isDeletable()).toBeFalsy();
+        expect(DomainField.create({ name: 'foo', lockType: DOMAIN_FIELD_NOT_LOCKED }).isDeletable()).toBeTruthy();
     });
 
     test('updateDefaultValues', () => {

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -80,6 +80,7 @@ import {
     USERS_TYPE,
 } from './PropDescType';
 import {
+    isFieldDeletable,
     removeFalseyObjKeys,
     removeNonAppProperties,
     removeUnusedOntologyProperties,
@@ -1132,6 +1133,10 @@ export class DomainField
 
     isPHI(): boolean {
         return this.PHI !== PHILEVEL_NOT_PHI;
+    }
+
+    isDeletable(): boolean {
+        return isFieldDeletable(this);
     }
 
     static hasRangeValidation(field: DomainField): boolean {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47501

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1226
- https://github.com/LabKey/labkey-ui-premium/pull/128
- https://github.com/LabKey/biologics/pull/2221
- https://github.com/LabKey/sampleManagement/pull/1938

#### Changes
- add isDeletable() to DomainField
