### PR TITLE
Plates: initial support for in-app plates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.350.5-fb-app-plates.2",
+  "version": "2.351.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.350.5-fb-app-plates.1",
+  "version": "2.350.5-fb-app-plates.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.21.0-fb-app-plates.0",
+    "@labkey/api": "1.21.0-fb-app-plates.1",
     "@testing-library/jest-dom": "~5.16.5",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.21.0",
+    "@labkey/api": "1.21.0-fb-app-plates.0",
     "@testing-library/jest-dom": "~5.16.5",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -95,6 +95,7 @@
     "@types/react-dom": "~16.9.17",
     "@types/react-router": "~3.0.28",
     "@types/react-test-renderer": "~16.9.5",
+    "blob-polyfill": "7.0.20220408",
     "bootstrap-sass": "~3.4.3",
     "cross-env": "~7.0.3",
     "enzyme": "~3.11.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.350.5-fb-app-plates.0",
+  "version": "2.350.5-fb-app-plates.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.350.5",
+  "version": "2.350.5-fb-app-plates.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.21.0-fb-app-plates.1",
+    "@labkey/api": "1.22.0",
     "@testing-library/jest-dom": "~5.16.5",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.351.0
+*Released*: 14 July 2023
+- Expose `inputId` prop from `react-select` on `SelectInput`
+- Delete `parseDataTextToRunRows` as it is no longer utilized
+- Rename `IAssayUploadOptions` to `AssayUploadOptions`
+- Add devDependency on `blob-polyfill` to support `Blob` and `File interactions within tests. Only exposed in RTL tests.
+
 ### version 2.350.5
 *Released*: 13 July 2023
 * Issue 48050 and 48209: Update parsing of duplicate key error messages for Postgres

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -253,7 +253,7 @@ import {
     replaceParameters,
     resetParameters,
 } from './internal/util/URL';
-import { ActionMapper, LookupMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
+import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
 import { DATA_IMPORT_TOPIC, getHelpLink, HELP_LINK_REFERRER, HelpLink } from './internal/util/helpLinks';
 import { ExperimentRunResolver, ListResolver } from './internal/url/AppURLResolver';
 import { NOT_ANY_FILTER_TYPE } from './internal/url/NotAnyFilterType';
@@ -1061,7 +1061,6 @@ export {
     // url and location related items
     AppURL,
     ActionMapper,
-    LookupMapper,
     URL_MAPPERS,
     URLResolver,
     URLService,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -253,7 +253,7 @@ import {
     replaceParameters,
     resetParameters,
 } from './internal/util/URL';
-import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
+import { ActionMapper, LookupMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
 import { DATA_IMPORT_TOPIC, getHelpLink, HELP_LINK_REFERRER, HelpLink } from './internal/util/helpLinks';
 import { ExperimentRunResolver, ListResolver } from './internal/url/AppURLResolver';
 import { NOT_ANY_FILTER_TYPE } from './internal/url/NotAnyFilterType';
@@ -1061,6 +1061,7 @@ export {
     // url and location related items
     AppURL,
     ActionMapper,
+    LookupMapper,
     URL_MAPPERS,
     URLResolver,
     URLService,
@@ -1802,3 +1803,4 @@ export type { ComponentsAPIWrapper } from './internal/APIWrapper';
 export type { GetParentTypeDataForLineage } from './internal/components/entities/actions';
 export type { DeleteConfirmationModalProps } from './internal/components/entities/DeleteConfirmationModal';
 export type { EntityDeleteConfirmHandler } from './internal/components/entities/EntityDeleteConfirmModalDisplay';
+export type { URLMapper } from './internal/url/URLResolver';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -692,6 +692,7 @@ import {
     isELNEnabled,
     isFreezerManagementEnabled,
     isMediaEnabled,
+    isPlatesEnabled,
     isPremiumProductEnabled,
     isProductProjectsEnabled,
     isProjectContainer,
@@ -793,6 +794,7 @@ import {
     USER_KEY,
     WORKFLOW_HOME_HREF,
     WORKFLOW_KEY,
+    PLATES_KEY,
 } from './internal/app/constants';
 import { Key, useEnterEscape } from './public/useEnterEscape';
 import { DateInput } from './internal/components/DateInput';
@@ -856,6 +858,7 @@ const App = {
     isWorkflowEnabled,
     isELNEnabled,
     isFreezerManagementEnabled,
+    isPlatesEnabled,
     isSampleManagerEnabled,
     isBiologicsEnabled,
     isPremiumProductEnabled,
@@ -979,6 +982,7 @@ const App = {
     PRIVATE_PICKLIST_CATEGORY,
     PUBLIC_PICKLIST_CATEGORY,
     DATA_IMPORT_TOPIC,
+    PLATES_KEY,
 };
 
 const Hooks = {

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -101,6 +101,7 @@ export const NOTIFICATION_TIMEOUT = 500;
 
 export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 
+export const EXPERIMENTAL_APP_PLATE_SUPPORT = 'experimental-app-plate-support';
 export const EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = 'queryProductAllFolderLookups';
 export const EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED = 'queryProductProjectDataListingScoped';
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -63,9 +63,18 @@ export enum EntityCreationMode {
 
 export const FIND_SAMPLES_BY_ID_HREF = AppURL.create(SEARCH_KEY, FIND_SAMPLES_BY_ID_KEY);
 export const FIND_SAMPLES_BY_FILTER_HREF = AppURL.create(SEARCH_KEY, FIND_SAMPLES_BY_FILTER_KEY);
-export const FILE_IMPORT_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new').addParam('mode', EntityCreationMode.FILE_IMPORT);
-export const GRID_INSERT_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new').addParam('mode', EntityCreationMode.GRID_INSERT);
-export const FILE_UPDATE_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new').addParam('mode', EntityCreationMode.FILE_UPDATE);
+export const FILE_IMPORT_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new').addParam(
+    'mode',
+    EntityCreationMode.FILE_IMPORT
+);
+export const GRID_INSERT_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new').addParam(
+    'mode',
+    EntityCreationMode.GRID_INSERT
+);
+export const FILE_UPDATE_SAMPLES_HREF = AppURL.create(SAMPLES_KEY, 'new').addParam(
+    'mode',
+    EntityCreationMode.FILE_UPDATE
+);
 export const NEW_SOURCE_TYPE_HREF = AppURL.create(SOURCE_TYPE_KEY, 'new');
 export const NEW_SAMPLE_TYPE_HREF = AppURL.create(SAMPLE_TYPE_KEY, 'new');
 export const NEW_STANDARD_ASSAY_DESIGN_HREF = AppURL.create(ASSAY_DESIGN_KEY, GENERAL_ASSAY_PROVIDER_NAME);

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -41,6 +41,7 @@ export const FREEZERS_KEY = 'freezers';
 export const BOXES_KEY = 'boxes';
 export const HOME_KEY = 'home';
 export const USER_KEY = 'user';
+export const PLATES_KEY = 'plates';
 export const PICKLIST_KEY = 'picklist';
 export const FIND_SAMPLES_BY_ID_KEY = 'samplesById';
 export const FIND_SAMPLES_BY_FILTER_KEY = 'samplesByFilter';

--- a/packages/components/src/internal/app/utils.spec.tsx
+++ b/packages/components/src/internal/app/utils.spec.tsx
@@ -24,7 +24,7 @@ import { MenuSectionConfig } from '../components/navigation/model';
 
 import {
     addAssaysSectionConfig,
-    addSamplesSectionConfig,
+    getSamplesSectionConfig,
     addSourcesSectionConfig,
     biologicsIsPrimaryApp,
     getCurrentAppProperties,
@@ -1037,12 +1037,9 @@ describe('addSourcesSectionConfig', () => {
     });
 });
 
-describe('addSamplesSectionConfig', () => {
+describe('getSamplesSectionConfig', () => {
     test('reader', () => {
-        let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addSamplesSectionConfig(TEST_USER_READER, configs);
-        expect(configs.size).toBe(1);
-        const sectionConfig = configs.get(0).get(SAMPLES_KEY);
+        const sectionConfig = getSamplesSectionConfig(TEST_USER_READER);
         expect(sectionConfig.emptyText).toBe('No sample types have been defined');
         expect(sectionConfig.emptyAppURL).toBe(undefined);
         expect(sectionConfig.showActiveJobIcon).toBeTruthy();
@@ -1052,10 +1049,7 @@ describe('addSamplesSectionConfig', () => {
     });
 
     test('admin', () => {
-        let configs = List<Map<string, MenuSectionConfig>>();
-        configs = addSamplesSectionConfig(TEST_USER_FOLDER_ADMIN, configs);
-        expect(configs.size).toBe(1);
-        const sectionConfig = configs.get(0).get(SAMPLES_KEY);
+        const sectionConfig = getSamplesSectionConfig(TEST_USER_FOLDER_ADMIN);
         expect(sectionConfig.emptyAppURL?.toHref()).toBe('#/sampleType/new');
         expect(sectionConfig.emptyURLText).toBe('Create a sample type');
     });

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -506,14 +506,13 @@ const REQUESTS_SECTION_CONFIG = new MenuSectionConfig({
     iconURL: imageURL('_images', 'default.svg'),
 });
 
-function getBioWorkflowNotebookMediaConfigs(user: User): Map<string, MenuSectionConfig> {
-    let configs = Map({
+function getBioWorkflowNotebookMediaConfigs(): Map<string, MenuSectionConfig> {
+    return Map({
         [WORKFLOW_KEY]: getWorkflowSectionConfig(),
+        [MEDIA_KEY]: getMediaSectionConfig(),
+        [PICKLIST_KEY]: getPicklistsSectionConfig(),
+        [NOTEBOOKS_KEY]: getNotebooksSectionConfig(),
     });
-    configs = configs.set(MEDIA_KEY, getMediaSectionConfig());
-    configs = configs.set(PICKLIST_KEY, getPicklistsSectionConfig());
-    configs = configs.set(NOTEBOOKS_KEY, getNotebooksSectionConfig());
-    return configs;
 }
 
 // exported for testing
@@ -535,11 +534,11 @@ export function getMenuSectionConfigs(
         sectionConfigs = sectionConfigs.push(Map({ [REGISTRY_KEY]: getRegistrySectionConfig() }));
     }
     if (isBioOrSM) {
-        const configs = Map<string, MenuSectionConfig>({ [SAMPLES_KEY]: getSamplesSectionConfig(user) }).asMutable();
+        let configs = Map<string, MenuSectionConfig>({ [SAMPLES_KEY]: getSamplesSectionConfig(user) });
         if (isPlatesEnabled(moduleContext)) {
-            configs.set(PLATES_KEY, getPlatesSectionConfig());
+            configs = configs.set(PLATES_KEY, getPlatesSectionConfig());
         }
-        sectionConfigs = sectionConfigs.push(configs.asImmutable());
+        sectionConfigs = sectionConfigs.push(configs);
 
         if (isAssayEnabled(moduleContext)) {
             sectionConfigs = addAssaysSectionConfig(user, sectionConfigs, isSMPrimary);
@@ -571,13 +570,13 @@ export function getMenuSectionConfigs(
             if (storageConfig) {
                 requestsCol = requestsCol.set(FREEZERS_KEY, storageConfig);
             }
-            sectionConfigs = sectionConfigs.push(requestsCol, getBioWorkflowNotebookMediaConfigs(user));
+            sectionConfigs = sectionConfigs.push(requestsCol, getBioWorkflowNotebookMediaConfigs());
         } else {
             if (storageConfig) {
                 sectionConfigs = sectionConfigs.push(Map({ [FREEZERS_KEY]: storageConfig }));
             }
 
-            sectionConfigs = sectionConfigs.push(getBioWorkflowNotebookMediaConfigs(user));
+            sectionConfigs = sectionConfigs.push(getBioWorkflowNotebookMediaConfigs());
         }
     } else {
         if (storageConfig) {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -22,6 +22,7 @@ import { AppProperties } from './models';
 import {
     ASSAYS_KEY,
     BIOLOGICS_APP_PROPERTIES,
+    EXPERIMENTAL_APP_PLATE_SUPPORT,
     EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS,
     EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED,
     EXPERIMENTAL_REQUESTS_MENU,
@@ -315,8 +316,10 @@ export function isAssayDesignExportEnabled(moduleContext?: ModuleContext): boole
 }
 
 export function isPlatesEnabled(moduleContext?: ModuleContext): boolean {
-    // TODO: Update to check against feature flag / url
-    return biologicsIsPrimaryApp(moduleContext);
+    return (
+        biologicsIsPrimaryApp(moduleContext) &&
+        resolveModuleContext(moduleContext)?.biologics?.[EXPERIMENTAL_APP_PLATE_SUPPORT] === true
+    );
 }
 
 export function isELNEnabled(moduleContext?: ModuleContext): boolean {

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -157,7 +157,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         const { location, selectStep } = this.props;
 
         if (location?.query?.dataTab) {

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -300,6 +300,18 @@ class AssayImportPanelsBody extends Component<Props, State> {
                             column.caption = 'Plate';
                             column.shortCaption = 'Short Plate';
                             column.description = 'Select a plate.';
+                            column.lookup.filterGroups = [
+                                {
+                                    filters: [
+                                        {
+                                            column: 'template',
+                                            operator: 'equal',
+                                            value: 'false',
+                                        },
+                                    ],
+                                    operation: this.isReimport() ? Operation.update : Operation.insert,
+                                },
+                            ];
                         }
                         plateColumns.set(fieldKey, runColumns.get(fieldKey));
                         runColumns.remove(fieldKey);
@@ -716,7 +728,6 @@ class AssayImportPanelsBody extends Component<Props, State> {
             allowBulkRemove,
             allowBulkInsert,
             allowBulkUpdate,
-            assayProtocol,
             maxRows,
             onSave,
             showUploadTabs,
@@ -774,7 +785,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 <Alert bsStyle="warning">{sampleStatusWarning}</Alert>
                 <BatchPropertiesPanel model={model} operation={operation} onChange={this.handleBatchChange} />
                 <RunPropertiesPanel model={model} operation={operation} onChange={this.handleRunChange} />
-                {isPlatesEnabled() && assayProtocol.plateMetadata && (
+                {this.plateSupportEnabled && (
                     <PlatePropertiesPanel model={model} operation={operation} onChange={this.handleRunChange} />
                 )}
                 <RunDataPanel

--- a/packages/components/src/internal/components/assay/AssayReimportHeader.tsx
+++ b/packages/components/src/internal/components/assay/AssayReimportHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, memo } from 'react';
 import { Panel } from 'react-bootstrap';
 
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
@@ -11,27 +11,25 @@ interface Props {
     replacedRunProperties: Record<string, any>;
 }
 
-export class AssayReimportHeader extends React.Component<Props> {
-    render() {
-        const { assay, hasBatchProperties, replacedRunProperties } = this.props;
-        const rowId = caseInsensitive(replacedRunProperties, 'RowId').value;
-        const name = caseInsensitive(replacedRunProperties, 'Name').value;
-        const assayRunUrl = AppURL.create('assays', assay.type, assay.name, 'runs', rowId);
-        return (
-            <Panel>
-                <Panel.Heading>Re-Import Run</Panel.Heading>
-                <Panel.Body>
-                    <p>
-                        <strong>
-                            Replacing Run: <a href={assayRunUrl.toHref()}>{name}</a>
-                        </strong>
-                    </p>
-                    <p>
-                        Edit the {hasBatchProperties ? 'batch and ' : ''} run properties below or provide updated data
-                        for this assay run. Changes will be reflected in the audit history for this run.
-                    </p>
-                </Panel.Body>
-            </Panel>
-        );
-    }
-}
+export const AssayReimportHeader: FC<Props> = memo(({ assay, hasBatchProperties, replacedRunProperties }) => {
+    const rowId = caseInsensitive(replacedRunProperties, 'RowId').value;
+    const name = caseInsensitive(replacedRunProperties, 'Name').value;
+    const assayRunUrl = AppURL.create('assays', assay.type, assay.name, 'runs', rowId);
+
+    return (
+        <Panel>
+            <Panel.Heading>Re-Import Run</Panel.Heading>
+            <Panel.Body>
+                <p>
+                    <strong>
+                        Replacing Run: <a href={assayRunUrl.toHref()}>{name}</a>
+                    </strong>
+                </p>
+                <p>
+                    Edit the {hasBatchProperties ? 'batch and ' : ''} run properties below or provide updated data for
+                    this assay run. Changes will be reflected in the audit history for this run.
+                </p>
+            </Panel.Body>
+        </Panel>
+    );
+});

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -11,6 +11,7 @@ import { AppURL } from '../../url/AppURL';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { EditorModel } from '../editable/models';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { PLATE_METADATA_COLUMN } from './constants';
 
 // exported for jest testing
 export function parseDataTextToRunRows(rawData: string): any[] {
@@ -43,7 +44,7 @@ export function parseDataTextToRunRows(rawData: string): any[] {
     return rows.length > 0 ? rows : null;
 }
 
-export interface IAssayUploadOptions extends AssayDOM.IImportRunOptions {
+export interface AssayUploadOptions extends AssayDOM.ImportRunOptions {
     dataRows?: any; // Array<any>
     maxFileSize?: number;
     maxRowCount?: number;
@@ -64,16 +65,18 @@ export class AssayWizardModel
         attachedFiles: Map<string, File>(),
         batchColumns: OrderedMap<string, QueryColumn>(),
         batchProperties: Map<string, any>(),
-        usePreviousRunFile: false,
+        comment: undefined,
+        dataText: undefined,
+        plateColumns: OrderedMap<string, QueryColumn>(),
+        plateProperties: Map<string, any>(),
         runColumns: OrderedMap<string, QueryColumn>(),
         runId: undefined,
         runProperties: Map<string, any>(),
         runName: undefined,
-        comment: undefined,
-        dataText: undefined,
         queryInfo: undefined,
-        toDelete: undefined,
         selectedSamples: undefined,
+        toDelete: undefined,
+        usePreviousRunFile: false,
 
         jobDescription: undefined,
         jobNotificationProvider: undefined,
@@ -96,6 +99,8 @@ export class AssayWizardModel
     declare batchColumns: OrderedMap<string, QueryColumn>;
     declare batchProperties: Map<string, any>;
     declare usePreviousRunFile: boolean;
+    declare plateColumns: OrderedMap<string, QueryColumn>;
+    declare plateProperties?: Map<string, any>;
     declare runColumns: OrderedMap<string, QueryColumn>;
     declare runId?: string;
     declare runProperties?: Map<string, any>;
@@ -154,7 +159,7 @@ export class AssayWizardModel
         return false;
     }
 
-    prepareFormData(currentStep: number, editorModel: EditorModel, queryModel: QueryModel): IAssayUploadOptions {
+    prepareFormData(currentStep: number, editorModel: EditorModel, queryModel: QueryModel): AssayUploadOptions {
         const {
             batchId,
             batchProperties,
@@ -169,7 +174,7 @@ export class AssayWizardModel
             workflowTask,
         } = this;
 
-        const assayData: any = {
+        const assayData: AssayUploadOptions = {
             assayId: assayDef.id,
             batchId,
             batchProperties: batchProperties.toObject(),
@@ -247,5 +252,15 @@ export class AssayWizardModel
         const queryModelData = this.getInitialQueryModelData();
         const editorModelData = await loadEditorModelData(queryModelData);
         return { editorModel: editorModelData, queryModel: queryModelData };
+    }
+
+    async processPlateData(data: AssayUploadOptions): Promise<AssayUploadOptions> {
+        if (data.properties?.[PLATE_METADATA_COLUMN] instanceof File) {
+            const text = await data.properties[PLATE_METADATA_COLUMN].text();
+            data.plateMetadata = JSON.parse(text);
+            delete data.properties[PLATE_METADATA_COLUMN];
+        }
+
+        return data;
     }
 }

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -13,37 +13,6 @@ import { EditorModel } from '../editable/models';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { PLATE_METADATA_COLUMN } from './constants';
 
-// exported for jest testing
-export function parseDataTextToRunRows(rawData: string): any[] {
-    if (!rawData || !rawData.length) {
-        return null;
-    }
-
-    const rows = [];
-    let columns = [];
-
-    rawData
-        .split('\n')
-        .filter(row => row.trim().length > 0)
-        .forEach(row => {
-            const parts = row.split('\t');
-            if (parts.length === 0) return;
-
-            if (columns.length === 0) columns = parts;
-            else {
-                const row = {};
-                parts.forEach((part, index) => {
-                    if (part.trim() !== '') {
-                        row[columns[index]] = part;
-                    }
-                });
-                rows.push(row);
-            }
-        });
-
-    return rows.length > 0 ? rows : null;
-}
-
 export interface AssayUploadOptions extends AssayDOM.ImportRunOptions {
     dataRows?: any; // Array<any>
     maxFileSize?: number;

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -11,6 +11,7 @@ import { AppURL } from '../../url/AppURL';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { EditorModel } from '../editable/models';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
+
 import { PLATE_METADATA_COLUMN } from './constants';
 
 export interface AssayUploadOptions extends AssayDOM.ImportRunOptions {

--- a/packages/components/src/internal/components/assay/PlatePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/PlatePropertiesPanel.tsx
@@ -1,0 +1,55 @@
+import React, { FC, memo, useMemo } from 'react';
+import { List } from 'immutable';
+import { Filter } from '@labkey/api';
+import Formsy from 'formsy-react';
+
+import { ExtendedMap } from '../../../public/ExtendedMap';
+import { QueryColumn } from '../../../public/QueryColumn';
+
+import { QueryFormInputs } from '../forms/QueryFormInputs';
+
+import { getContainerFilterForLookups } from '../../query/api';
+
+import { AssayPropertiesPanelProps } from './models';
+
+export const PlatePropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, onChange, operation }) => {
+    // FIXME: Update the AssayWizardModel to use ExtendedMap for plateColumns so we don't need to do this conversion.
+    const { queryColumns, queryFilters } = useMemo(() => {
+        const columns = new ExtendedMap<string, QueryColumn>(model.plateColumns.toJS());
+        const filters: Record<string, List<Filter.IFilter>> = {};
+
+        // NK: This is a bit of hack -- we need to filter for only plate instances, as opposed to plate templates,
+        // so this is done via LSID. We should consider exposing the "template" column to this assay.PlateTemplate
+        // query or querying against plate.Plate directly. Could that mean we can get rid of assay.PlateTemplate?
+        if (columns.has('platetemplate')) {
+            const col = columns.get('platetemplate');
+            filters[col.fieldKey] = List([Filter.create('lsid', 'PlateInstance', Filter.Types.CONTAINS)]);
+        }
+
+        return { queryColumns: columns, queryFilters: filters };
+    }, [model.plateColumns]);
+
+    if (queryColumns.size === 0) {
+        return null;
+    }
+
+    return (
+        <div className="panel panel-default">
+            <div className="panel-heading">Plate Details</div>
+            <div className="panel-body">
+                <Formsy className="form-horizontal" onChange={onChange}>
+                    <QueryFormInputs
+                        containerFilter={getContainerFilterForLookups()}
+                        fieldValues={model.plateProperties.toObject()}
+                        queryFilters={queryFilters}
+                        operation={operation}
+                        queryColumns={queryColumns}
+                        renderFileInputs
+                    />
+                </Formsy>
+            </div>
+        </div>
+    );
+});
+
+PlatePropertiesPanel.displayName = 'PlatePropertiesPanel';

--- a/packages/components/src/internal/components/assay/PlatePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/PlatePropertiesPanel.tsx
@@ -1,6 +1,4 @@
 import React, { FC, memo, useMemo } from 'react';
-import { List } from 'immutable';
-import { Filter } from '@labkey/api';
 import Formsy from 'formsy-react';
 
 import { ExtendedMap } from '../../../public/ExtendedMap';
@@ -14,20 +12,10 @@ import { AssayPropertiesPanelProps } from './models';
 
 export const PlatePropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, onChange, operation }) => {
     // FIXME: Update the AssayWizardModel to use ExtendedMap for plateColumns so we don't need to do this conversion.
-    const { queryColumns, queryFilters } = useMemo(() => {
-        const columns = new ExtendedMap<string, QueryColumn>(model.plateColumns.toJS());
-        const filters: Record<string, List<Filter.IFilter>> = {};
-
-        // NK: This is a bit of hack -- we need to filter for only plate instances, as opposed to plate templates,
-        // so this is done via LSID. We should consider exposing the "template" column to this assay.PlateTemplate
-        // query or querying against plate.Plate directly. Could that mean we can get rid of assay.PlateTemplate?
-        if (columns.has('platetemplate')) {
-            const col = columns.get('platetemplate');
-            filters[col.fieldKey] = List([Filter.create('lsid', 'PlateInstance', Filter.Types.CONTAINS)]);
-        }
-
-        return { queryColumns: columns, queryFilters: filters };
-    }, [model.plateColumns]);
+    const queryColumns = useMemo(
+        () => new ExtendedMap<string, QueryColumn>(model.plateColumns.toJS()),
+        [model.plateColumns]
+    );
 
     if (queryColumns.size === 0) {
         return null;
@@ -41,7 +29,6 @@ export const PlatePropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model
                     <QueryFormInputs
                         containerFilter={getContainerFilterForLookups()}
                         fieldValues={model.plateProperties.toObject()}
-                        queryFilters={queryFilters}
                         operation={operation}
                         queryColumns={queryColumns}
                         renderFileInputs

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -69,7 +69,6 @@ export function fetchAllAssays(type?: string, containerPath?: string): Promise<L
 type ImportAssayRunOptions = Omit<AssayDOM.ImportRunOptions, 'success' | 'failure' | 'scope'>;
 
 export function importAssayRun(config: ImportAssayRunOptions): Promise<AssayUploadResultModel> {
-    console.log('config', config);
     return new Promise((resolve, reject) => {
         AssayDOM.importRun({
             ...config,

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -21,7 +21,7 @@ import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 import { buildURL } from '../../url/AppURL';
 import { caseInsensitive } from '../../util/utils';
 
-import { IAssayUploadOptions } from './AssayWizardModel';
+import { AssayUploadOptions } from './AssayWizardModel';
 import { AssayUploadResultModel } from './models';
 
 /**
@@ -66,22 +66,25 @@ export function fetchAllAssays(type?: string, containerPath?: string): Promise<L
     return assayDefinitionCache[key];
 }
 
-export function importAssayRun(config: Partial<AssayDOM.IImportRunOptions>): Promise<AssayUploadResultModel> {
+type ImportAssayRunOptions = Omit<AssayDOM.ImportRunOptions, 'success' | 'failure' | 'scope'>;
+
+export function importAssayRun(config: ImportAssayRunOptions): Promise<AssayUploadResultModel> {
+    console.log('config', config);
     return new Promise((resolve, reject) => {
-        AssayDOM.importRun(
-            Object.assign({}, config, {
-                success: (rawModel: any) => {
-                    resolve(new AssayUploadResultModel(rawModel));
-                },
-                failure: error => {
-                    reject(error);
-                },
-            })
-        );
+        AssayDOM.importRun({
+            ...config,
+            success: rawModel => {
+                resolve(new AssayUploadResultModel(rawModel));
+            },
+            failure: error => {
+                console.error('Failed to import assay run', error);
+                reject(error);
+            },
+        });
     });
 }
 
-export function uploadAssayRunFiles(data: IAssayUploadOptions): Promise<IAssayUploadOptions> {
+export function uploadAssayRunFiles(data: AssayUploadOptions): Promise<AssayUploadOptions> {
     return new Promise((resolve, reject) => {
         const batchFiles = collectFiles(data.batchProperties);
         const runFiles = collectFiles(data.properties);

--- a/packages/components/src/internal/components/assay/constants.ts
+++ b/packages/components/src/internal/components/assay/constants.ts
@@ -1,6 +1,10 @@
 import { SCHEMAS } from '../../schemas';
 
 export const GENERAL_ASSAY_PROVIDER_NAME = 'General';
+
+export const PLATE_METADATA_COLUMN = 'PlateMetadata';
+export const PLATE_TEMPLATE_COLUMN = 'PlateTemplate';
+
 // TODO make this an array
 export const RUN_PROPERTIES_REQUIRED_COLUMNS = SCHEMAS.CBMB.concat(
     'Name',
@@ -16,3 +20,4 @@ export const RUN_PROPERTIES_REQUIRED_COLUMNS = SCHEMAS.CBMB.concat(
     'WorkflowTask/Run',
     'Protocol/RowId'
 ).toList();
+

--- a/packages/components/src/internal/components/assay/constants.ts
+++ b/packages/components/src/internal/components/assay/constants.ts
@@ -20,4 +20,3 @@ export const RUN_PROPERTIES_REQUIRED_COLUMNS = SCHEMAS.CBMB.concat(
     'WorkflowTask/Run',
     'Protocol/RowId'
 ).toList();
-

--- a/packages/components/src/internal/components/assay/utils.ts
+++ b/packages/components/src/internal/components/assay/utils.ts
@@ -1,10 +1,10 @@
-import React from 'react';
 import { Ajax, Utils } from '@labkey/api';
 
 import { buildURL } from '../../url/AppURL';
 import { InferDomainResponse } from '../../../public/InferDomainResponse';
 import { processRequest } from '../../query/api';
 
+// TODO: Move this out of assay/utils
 export function inferDomainFromFile(
     file: File,
     numLinesToInclude: number,
@@ -38,8 +38,8 @@ export function inferDomainFromFile(
 
 /**
  * This is used for retrieving preview data for a file already on the server side
- * @param file  This can be a rowId for the file, or a path to the file
- * @param file  The file name to be used to check the extension
+ * @param file This can be a rowId for the file, or a path to the file
+ * @param fileName The file name to be used to check the extension
  * @param numLinesToInclude: the number of lines of data to include (excludes the header)
  */
 export function getServerFilePreview(
@@ -50,7 +50,6 @@ export function getServerFilePreview(
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL('property', 'getFilePreview.api'),
-            method: 'GET',
             params: {
                 file,
                 numLinesToInclude: numLinesToInclude ? numLinesToInclude + 1 : undefined, // add one to account for the header

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -23,9 +23,8 @@ export const applyEditableGridChangesToModels = (
     queryInfo?: QueryInfo,
     dataKeys?: List<any>,
     data?: Map<string, Map<string, any>>,
-    index?: number
+    tabIndex = 0
 ): EditableGridModels => {
-    const tabIndex = index ?? 0;
     const updatedEditorModels = [...editorModels];
     const editorModel = editorModels[tabIndex].merge(editorModelChanges) as EditorModel;
     updatedEditorModels.splice(tabIndex, 1, editorModel);
@@ -140,7 +139,7 @@ export const getUpdatedDataFromEditableGrid = (
     editorModels: EditorModel[],
     idField: string,
     selectionData?: Map<string, any>,
-    tabIndex?: number
+    tabIndex = 0
 ): Record<string, any> => {
     const model = dataModels[tabIndex];
     const editorModel = editorModels[tabIndex];
@@ -159,7 +158,7 @@ export const getUpdatedDataFromEditableGrid = (
     return {
         originalRows: model.rows,
         schemaQuery: model.queryInfo.schemaQuery,
-        tabIndex: tabIndex ?? 0,
+        tabIndex,
         updatedRows: getUpdatedDataFromGrid(initData, editorData, idField, model.queryInfo),
     };
 };

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -179,6 +179,7 @@ export interface SelectInputProps extends WithFormsyProps {
     id?: any;
     initiallyDisabled?: boolean;
     inputClass?: string;
+    inputId?: string;
     isLoading?: boolean;
     isValidNewOption?: (inputValue: string) => boolean;
     // FIXME: this is named incorrectly. I would expect that if this is true it would join the values, nope, it joins
@@ -515,6 +516,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
             disabled,
             filterOption,
             formatCreateLabel,
+            inputId,
             isLoading,
             isValidNewOption,
             labelKey,
@@ -575,6 +577,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
             getOptionLabel: labelKey && labelKey !== 'label' ? this.getOptionLabel : undefined,
             getOptionValue: valueKey && valueKey !== 'value' ? this.getOptionValue : undefined,
             id: this.getId(),
+            inputId,
             isClearable: clearable,
             isDisabled: disabled || this.state.isDisabled,
             isLoading,

--- a/packages/components/src/internal/components/navigation/ProductMenu.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.tsx
@@ -56,6 +56,7 @@ import {
     SOURCES_KEY,
     FREEZERS_KEY,
     BOXES_KEY,
+    PLATES_KEY,
 } from '../../app/constants';
 
 import { FolderMenu, FolderMenuItem } from './FolderMenu';
@@ -363,6 +364,7 @@ const HEADER_MENU_SUBTITLE_MAP = {
     [ELN_KEY]: 'Notebooks',
     [FREEZERS_KEY]: 'Storage',
     [MEDIA_KEY]: 'Media',
+    [PLATES_KEY]: 'Plates',
     [PICKLIST_KEY]: 'Picklists',
     [REGISTRY_KEY]: 'Registry',
     [SAMPLE_TYPE_KEY.toLowerCase()]: 'Sample Types',

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -27,10 +27,8 @@ const ASSAY_SCHEMA = 'assay';
 export const ASSAY_TABLES = {
     ASSAY_LIST: new SchemaQuery(ASSAY_SCHEMA, 'AssayList'),
     ASSAY_DETAILS_SQ: new SchemaQuery(ASSAY_SCHEMA, 'AssayList', ViewInfo.DETAIL_NAME),
-    PLATES: new SchemaQuery('lists', 'plates'),
     RESULTS_QUERYNAME: 'Data',
     SCHEMA: ASSAY_SCHEMA,
-    WELLS: new SchemaQuery('lists', 'wells'),
 };
 
 // EXP
@@ -145,6 +143,14 @@ export const AUDIT_TABLES = {
     SCHEMA: AUDIT_SCHEMA,
 };
 
+const PLATE_SCHEMA = 'plate';
+const PLATE_TABLES = {
+    PLATE: new SchemaQuery(PLATE_SCHEMA, 'Plate'),
+    SCHEMA: PLATE_SCHEMA,
+    WELL: new SchemaQuery(PLATE_SCHEMA, 'Well'),
+    WELL_GROUP: new SchemaQuery(PLATE_SCHEMA, 'WellGroup'),
+};
+
 export const SCHEMAS = {
     ASSAY_TABLES,
     AUDIT_TABLES,
@@ -157,5 +163,6 @@ export const SCHEMAS = {
     INVENTORY,
     LIST_METADATA_TABLES,
     PICKLIST_TABLES,
+    PLATE_TABLES,
     SAMPLE_MANAGEMENT,
 };

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -27,8 +27,10 @@ const ASSAY_SCHEMA = 'assay';
 export const ASSAY_TABLES = {
     ASSAY_LIST: new SchemaQuery(ASSAY_SCHEMA, 'AssayList'),
     ASSAY_DETAILS_SQ: new SchemaQuery(ASSAY_SCHEMA, 'AssayList', ViewInfo.DETAIL_NAME),
-    SCHEMA: ASSAY_SCHEMA,
+    PLATES: new SchemaQuery('lists', 'plates'),
     RESULTS_QUERYNAME: 'Data',
+    SCHEMA: ASSAY_SCHEMA,
+    WELLS: new SchemaQuery('lists', 'wells'),
 };
 
 // EXP

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -190,17 +190,16 @@ export class LookupMapper implements URLMapper {
 
             // Issue 46747: When the lookup goes to a different container, don't rewrite the URL
             const containerPath = getServerContext().container.path;
-            if (lookupContainerPath && lookupContainerPath !== containerPath)
+            if (lookupContainerPath && lookupContainerPath !== containerPath) {
                 return undefined;
+            }
 
-            const parts = [
-                this.defaultPrefix,
-                lookup.get('schemaName'),
-                lookup.get('queryName'),
-                row.get('value').toString(),
-            ];
+            const value = row.get('value')?.toString();
+            if (!value) {
+                return undefined;
+            }
 
-            return AppURL.create(...parts);
+            return AppURL.create(this.defaultPrefix, schema, query, value);
         }
     }
 }
@@ -553,7 +552,7 @@ export class URLResolver {
             return _url;
         }
 
-        if (_url !== false && getServerContext().devMode) {
+        if (mapper.url !== undefined && _url !== false && getServerContext().devMode) {
             console.warn('Unable to map URL:', mapper.url);
         }
 
@@ -618,7 +617,7 @@ export class URLResolver {
                 const rows = resolved.get('rows').map(row => {
                     return row.map((cell, fieldKey) => {
                         // single-value cells
-                        if (Map.isMap(cell) && cell.has('url')) {
+                        if (Map.isMap(cell)) {
                             return cell.set(
                                 'url',
                                 this.mapURL({
@@ -635,7 +634,7 @@ export class URLResolver {
                         if (List.isList(cell) && cell.size > 0) {
                             return cell
                                 .map(innerCell => {
-                                    if (Map.isMap(innerCell) && innerCell.has('url')) {
+                                    if (Map.isMap(innerCell)) {
                                         return innerCell.set(
                                             'url',
                                             this.mapURL({

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -194,12 +194,14 @@ export class LookupMapper implements URLMapper {
                 return undefined;
             }
 
-            const value = row.get('value')?.toString();
-            if (!value) {
-                return undefined;
-            }
+            const parts = [
+                this.defaultPrefix,
+                lookup.get('schemaName'),
+                lookup.get('queryName'),
+                row.get('value').toString(),
+            ];
 
-            return AppURL.create(this.defaultPrefix, schema, query, value);
+            return AppURL.create(...parts);
         }
     }
 }
@@ -617,7 +619,7 @@ export class URLResolver {
                 const rows = resolved.get('rows').map(row => {
                     return row.map((cell, fieldKey) => {
                         // single-value cells
-                        if (Map.isMap(cell)) {
+                        if (Map.isMap(cell) && cell.has('url')) {
                             return cell.set(
                                 'url',
                                 this.mapURL({
@@ -634,7 +636,7 @@ export class URLResolver {
                         if (List.isList(cell) && cell.size > 0) {
                             return cell
                                 .map(innerCell => {
-                                    if (Map.isMap(innerCell)) {
+                                    if (Map.isMap(innerCell) && innerCell.has('url')) {
                                         return innerCell.set(
                                             'url',
                                             this.mapURL({

--- a/packages/components/src/test/jest.setup.react.ts
+++ b/packages/components/src/test/jest.setup.react.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom'; // add custom jest matchers from jest-dom
+require('blob-polyfill');

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1518,10 +1518,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.21.0":
-  version "1.21.0"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.21.0.tgz#e64741a197e56c4e11889c9943da0a7ade06f6cf"
-  integrity sha512-ydxt19BW7bF+DYYJNfQmmgw177xPUuS946wc6PgKFkTXJUW3CA+33AirXUB5D+waJZwdXmwLubMf41gK1qP17g==
+"@labkey/api@1.21.0-fb-app-plates.0":
+  version "1.21.0-fb-app-plates.0"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.21.0-fb-app-plates.0.tgz#c3a4c111d0437d9497e723438aa2d421277f282c"
+  integrity sha512-PfdawCNnBkwija9IYkBDF+J7NfaPkTljVUGkm7QaGa1A8qQQj6xzcuJQehJs9nL8QbO3eFsOPyULZirfYI8bJw==
 
 "@labkey/build@6.12.0":
   version "6.12.0"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -2786,6 +2786,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+blob-polyfill@7.0.20220408:
+  version "7.0.20220408"
+  resolved "https://registry.yarnpkg.com/blob-polyfill/-/blob-polyfill-7.0.20220408.tgz#38bf5e046c41a21bb13654d9d19f303233b8218c"
+  integrity sha512-oD8Ydw+5lNoqq+en24iuPt1QixdPpe/nUF8azTHnviCZYu9zUC+TwdzIp5orpblJosNlgNbVmmAb//c6d6ImUQ==
+
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1518,10 +1518,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.21.0-fb-app-plates.1":
-  version "1.21.0-fb-app-plates.1"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.21.0-fb-app-plates.1.tgz#e941f1c65479ff404d25366bb9f41b7c0d55acc5"
-  integrity sha512-St4qtl7bu9ReMcPYnHq/ctIEGOipiITpwA5bNnRpbzbZuA5nejdM3qdVCrJINROiaroDcOyTV05OfpLAVGwW5A==
+"@labkey/api@1.22.0":
+  version "1.22.0"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.22.0.tgz#ebabc9aea9da7aeaf945b4872d4dfe48be785542"
+  integrity sha512-SGEV/0Z87eDhgYOKBBrysk8zI01DuuzLH3HI8tYOZi9Sab+RSDSiNwc6jAKxDjFPX+ZW5qojdDPIdcu6/N/1ow==
 
 "@labkey/build@6.12.0":
   version "6.12.0"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1518,10 +1518,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@labkey/api@1.21.0-fb-app-plates.0":
-  version "1.21.0-fb-app-plates.0"
-  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.21.0-fb-app-plates.0.tgz#c3a4c111d0437d9497e723438aa2d421277f282c"
-  integrity sha512-PfdawCNnBkwija9IYkBDF+J7NfaPkTljVUGkm7QaGa1A8qQQj6xzcuJQehJs9nL8QbO3eFsOPyULZirfYI8bJw==
+"@labkey/api@1.21.0-fb-app-plates.1":
+  version "1.21.0-fb-app-plates.1"
+  resolved "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.21.0-fb-app-plates.1.tgz#e941f1c65479ff404d25366bb9f41b7c0d55acc5"
+  integrity sha512-St4qtl7bu9ReMcPYnHq/ctIEGOipiITpwA5bNnRpbzbZuA5nejdM3qdVCrJINROiaroDcOyTV05OfpLAVGwW5A==
 
 "@labkey/build@6.12.0":
   version "6.12.0"


### PR DESCRIPTION
#### Rationale
This adds support for in-app plating. Primarily, this distinguishes plate-specific processing for plate-enabled standard assays during assay run import.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/155
* https://github.com/LabKey/labkey-ui-components/pull/1234
* https://github.com/LabKey/labkey-ui-premium/pull/137
* https://github.com/LabKey/platform/pull/4583
* https://github.com/LabKey/commonAssays/pull/624
* https://github.com/LabKey/biologics/pull/2237
* https://github.com/LabKey/sampleManagement/pull/1966
* https://github.com/LabKey/inventory/pull/923

#### Changes
**Plates**
- Introduce `isPlatesEnabled` for client-side control of plate features.
- Support "Plates" section in navigation menu via `getPlatesSectionConfig`
- Add `PLATE_SCHEMA` and `PLATE_TABLES` to `SCHEMAS` constant
- Create `PlatePropertiesPanel` which displays plate-specific properties for assay run import
- Separate out plate-specific columns from assay run domain data (i.e. "PlateTemplate" column)
- Spawn a temporary `QueryColumn` to support import of plate metadata

**Miscellaneous**
- Expose `inputId` prop from `react-select` on `SelectInput`
- Delete `parseDataTextToRunRows` as it is no longer utilized
- Rename `IAssayUploadOptions` to `AssayUploadOptions`

**Tests**
- Add devDependency on `blob-polyfill` to support `Blob` and `File interactions within tests. Only exposed in RTL tests. Can expose in Enzyme tests later if needed.