### PR TITLE
EditableGrid: performance improvements

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.351.1",
+  "version": "2.351.1-fb-edit-grid-perf.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.351.1-fb-edit-grid-perf.0",
+  "version": "2.352.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.352.0
+Released*: 20 July 2023
+- Convert `EditorModel.selectionCells` to a `string[]`.
+- Precompute new property `EditorModel.isSparseSelection`.
+- Add `dragDelay` to reduce redundant render cycles when clicking on cells.
+- Split out `BorderMask` properties on the `Cell` interface.
+- Add and export interface for `EditableGridChange`.
+
 ### version 2.351.1
 Released*: 20 July 2023
 * Merge release23.7-SNAPSHOT to develop:

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1804,3 +1804,4 @@ export type { GetParentTypeDataForLineage } from './internal/components/entities
 export type { DeleteConfirmationModalProps } from './internal/components/entities/DeleteConfirmationModal';
 export type { EntityDeleteConfirmHandler } from './internal/components/entities/EntityDeleteConfirmModalDisplay';
 export type { URLMapper } from './internal/url/URLResolver';
+export type { EditableGridChange } from './internal/components/editable/EditableGrid';

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 import React, { PureComponent, ReactNode } from 'react';
-import { List, Map } from 'immutable';
+import { Map } from 'immutable';
 
 import { Operation } from '../../../public/QueryColumn';
 
 import { AssayUploadTabs } from '../../constants';
 import { InferDomainResponse } from '../../../public/InferDomainResponse';
-import { EditorModel, EditorModelProps } from '../editable/models';
+import { EditorModel } from '../editable/models';
 
 import { DATA_IMPORT_TOPIC, HelpLink } from '../../util/helpLinks';
+import { EditableGridChange } from '../editable/EditableGrid';
 import { EditableGridPanel } from '../editable/EditableGridPanel';
 
 import { FileSizeLimitProps } from '../../../public/files/models';
@@ -55,11 +56,7 @@ interface Props {
     maxRows?: number;
     onFileChange: (attachments: Map<string, File>) => any;
     onFileRemoval: (attachmentName: string) => any;
-    onGridChange: (
-        editorModelChanges: Partial<EditorModelProps>,
-        dataKeys?: List<any>,
-        data?: Map<any, Map<string, any>>
-    ) => void;
+    onGridChange: EditableGridChange;
     onTextChange: (value: any) => any;
     operation: Operation;
     queryModel: QueryModel;

--- a/packages/components/src/internal/components/editable/Cell.spec.tsx
+++ b/packages/components/src/internal/components/editable/Cell.spec.tsx
@@ -24,47 +24,43 @@ import { QueryColumn, QueryLookup } from '../../../public/QueryColumn';
 
 import { ValueDescriptor } from './models';
 
-import { BorderMask, Cell } from './Cell';
+import { Cell, CellProps } from './Cell';
 import { LookupCell } from './LookupCell';
 import { DateInputCell } from './DateInputCell';
-
-let actions;
-
-beforeAll(() => {
-    actions = {
-        focusCell: jest.fn(),
-        modifyCell: jest.fn(),
-        selectCell: jest.fn(),
-    };
-
-    LABKEY.container = {
-        formats: {
-            dateFormat: 'yyyy-MM-dd',
-            dateTimeFormat: 'yyyy-MM-dd HH:mm',
-            numberFormat: null,
-        },
-    };
-});
 
 const queryColumn = new QueryColumn({ lookup: undefined, name: 'myColumn' });
 const lookupCol = new QueryColumn({ name: 'test', lookup: { isPublic: false } as QueryLookup });
 const publicLookupCol = new QueryColumn({ name: 'test', lookup: { isPublic: true } as QueryLookup });
 const validValuesCol = new QueryColumn({ name: 'test', validValues: ['a', 'b'] });
 const dateCol = new QueryColumn({ name: 'test', jsonType: 'date', caption: 'Test' });
-const DEFAULT_PROPS = { forUpdate: false, borderMask: [false, false, false, false] as BorderMask, row: undefined };
 
 describe('Cell', () => {
+    function defaultProps(): CellProps {
+        return {
+            cellActions: {
+                clearSelection: jest.fn(),
+                fillDown: jest.fn(),
+                focusCell: jest.fn(),
+                inDrag: jest.fn(),
+                modifyCell: jest.fn(),
+                selectCell: jest.fn(),
+            },
+            col: queryColumn,
+            colIdx: 1,
+            forUpdate: false,
+            rowIdx: 2,
+        };
+    }
+
     test('default props', () => {
-        const cell = mount(<Cell {...DEFAULT_PROPS} cellActions={actions} col={queryColumn} colIdx={1} rowIdx={2} />);
+        const cell = mount(<Cell {...defaultProps()} />);
         expect(cell.find('div')).toHaveLength(1);
         expect(cell.find('input')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
     test('with focus', () => {
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={queryColumn} colIdx={1} rowIdx={2} focused selected />
-        );
+        const cell = mount(<Cell {...defaultProps()} focused selected />);
         expect(cell.find('div')).toHaveLength(0);
         expect(cell.find('input')).toHaveLength(1);
         expect(cell.find(LookupCell)).toHaveLength(0);
@@ -72,14 +68,7 @@ describe('Cell', () => {
 
     test('with placeholder', () => {
         const cell = mount(
-            <Cell
-                {...DEFAULT_PROPS}
-                cellActions={actions}
-                col={queryColumn}
-                colIdx={2}
-                placeholder="placeholder text"
-                rowIdx={3}
-            />
+            <Cell {...defaultProps()} col={queryColumn} colIdx={2} placeholder="placeholder text" rowIdx={3} />
         );
         const div = cell.find('div');
         expect(div).toHaveLength(1);
@@ -91,8 +80,7 @@ describe('Cell', () => {
     test('with placeholder while focused', () => {
         const cell = mount(
             <Cell
-                {...DEFAULT_PROPS}
-                cellActions={actions}
+                {...defaultProps()}
                 col={queryColumn}
                 colIdx={2}
                 placeholder="placeholder text"
@@ -109,9 +97,7 @@ describe('Cell', () => {
     });
 
     test('readOnly property', () => {
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={queryColumn} colIdx={3} readOnly rowIdx={3} />
-        );
+        const cell = mount(<Cell {...defaultProps()} colIdx={3} readOnly rowIdx={3} />);
         expect(cell.find('div')).toHaveLength(1);
         expect(cell.find('input')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
@@ -119,9 +105,7 @@ describe('Cell', () => {
 
     test('column is readOnly', () => {
         const roColumn = new QueryColumn({ readOnly: true, name: 'roColumn' });
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={roColumn} colIdx={4} readOnly={false} rowIdx={3} />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={roColumn} colIdx={4} readOnly={false} rowIdx={3} />);
         expect(cell.find('div')).toHaveLength(1);
         expect(cell.find('input')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
@@ -129,15 +113,7 @@ describe('Cell', () => {
 
     test('with placeholder and readOnly', () => {
         const cell = mount(
-            <Cell
-                {...DEFAULT_PROPS}
-                cellActions={actions}
-                col={queryColumn}
-                colIdx={3}
-                placeholder="readOnly placeholder"
-                readOnly
-                rowIdx={3}
-            />
+            <Cell {...defaultProps()} colIdx={3} placeholder="readOnly placeholder" readOnly rowIdx={3} />
         );
 
         const div = cell.find('div');
@@ -148,7 +124,7 @@ describe('Cell', () => {
     });
 
     test('col is lookup, not public', () => {
-        const cell = mount(<Cell {...DEFAULT_PROPS} cellActions={actions} col={lookupCol} colIdx={1} rowIdx={2} />);
+        const cell = mount(<Cell {...defaultProps()} col={lookupCol} colIdx={1} rowIdx={2} />);
         expect(cell.find('div')).toHaveLength(1);
         expect(cell.find('.cell-menu')).toHaveLength(0);
         expect(cell.find('input')).toHaveLength(0);
@@ -166,31 +142,17 @@ describe('Cell', () => {
     };
 
     test('col is lookup, public', () => {
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={publicLookupCol} colIdx={1} rowIdx={2} />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={publicLookupCol} />);
         expectLookup(cell);
     });
 
     test('col is lookup, public and focused', () => {
-        const cell = mount(
-            <Cell
-                {...DEFAULT_PROPS}
-                cellActions={actions}
-                col={publicLookupCol}
-                colIdx={1}
-                rowIdx={2}
-                focused
-                selected
-            />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={publicLookupCol} focused selected />);
         expectLookup(cell, true);
     });
 
     test('col has validValues', () => {
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={validValuesCol} colIdx={1} rowIdx={2} />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={validValuesCol} />);
         expectLookup(cell);
     });
 
@@ -201,24 +163,12 @@ describe('Cell', () => {
             lookup: { isPublic: false } as QueryLookup,
             validValues: ['a', 'b'],
         });
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={readOnlyLookup} colIdx={1} rowIdx={2} readOnly />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={readOnlyLookup} readOnly />);
         expectLookup(cell, false, true);
     });
 
     test('col has validValues and focused', () => {
-        const cell = mount(
-            <Cell
-                {...DEFAULT_PROPS}
-                cellActions={actions}
-                col={validValuesCol}
-                colIdx={1}
-                rowIdx={2}
-                focused
-                selected
-            />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={validValuesCol} focused selected />);
         expect(cell.find('div')).toHaveLength(9);
         expect(cell.find('.cell-menu')).toHaveLength(0);
         expect(cell.find('.cell-menu-value')).toHaveLength(0);
@@ -229,16 +179,7 @@ describe('Cell', () => {
     });
 
     test('cell renderDragHandle', () => {
-        const cell = mount(
-            <Cell
-                {...DEFAULT_PROPS}
-                cellActions={actions}
-                col={validValuesCol}
-                colIdx={1}
-                rowIdx={2}
-                renderDragHandle
-            />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={validValuesCol} renderDragHandle />);
         expect(cell.find('div')).toHaveLength(2);
         expect(cell.find('.cell-menu')).toHaveLength(1);
         expect(cell.find('.cell-menu-value')).toHaveLength(1);
@@ -260,7 +201,7 @@ describe('Cell', () => {
     };
 
     test('col is date', () => {
-        const cell = mount(<Cell {...DEFAULT_PROPS} cellActions={actions} col={dateCol} colIdx={1} rowIdx={2} />);
+        const cell = mount(<Cell {...defaultProps()} col={dateCol} />);
         expectDate(cell);
         cell.unmount();
     });
@@ -272,17 +213,13 @@ describe('Cell', () => {
                 raw: '2022-08-05 00:00:00.000',
             },
         ]);
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={dateCol} colIdx={1} rowIdx={2} values={values} />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={dateCol} values={values} />);
         expectDate(cell, false, '2022-08-05 00:00');
         cell.unmount();
     });
 
     test('col is date, focused', () => {
-        const cell = mount(
-            <Cell {...DEFAULT_PROPS} cellActions={actions} col={dateCol} colIdx={1} rowIdx={2} focused selected />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={dateCol} focused selected />);
         expectDate(cell, true);
         cell.unmount();
     });
@@ -294,18 +231,7 @@ describe('Cell', () => {
                 raw: '2022-08-05 00:00:00.000',
             },
         ]);
-        const cell = mount(
-            <Cell
-                {...DEFAULT_PROPS}
-                cellActions={actions}
-                col={dateCol}
-                colIdx={1}
-                rowIdx={2}
-                values={values}
-                focused
-                selected
-            />
-        );
+        const cell = mount(<Cell {...defaultProps()} col={dateCol} values={values} focused selected />);
         expectDate(cell, true, '2022-08-05 00:00', '2022-08-05 00:00:00.000');
         cell.unmount();
     });

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -40,8 +40,11 @@ import { DateInputCell } from './DateInputCell';
 // CSS Order: top, right, bottom, left
 export type BorderMask = [boolean, boolean, boolean, boolean];
 
-interface Props {
-    borderMask: BorderMask;
+export interface CellProps {
+    borderMaskBottom?: boolean;
+    borderMaskLeft?: boolean;
+    borderMaskRight?: boolean;
+    borderMaskTop?: boolean;
     cellActions: CellActions;
     col: QueryColumn;
     colIdx: number;
@@ -59,7 +62,7 @@ interface Props {
     placeholder?: string;
     readOnly?: boolean;
     renderDragHandle?: boolean;
-    row: any;
+    row?: any;
     rowIdx: number;
     selected?: boolean;
     selection?: boolean;
@@ -70,12 +73,16 @@ interface State {
     filteredLookupKeys?: List<any>;
 }
 
-export class Cell extends React.PureComponent<Props, State> {
+export class Cell extends React.PureComponent<CellProps, State> {
     private changeTO: number;
     private clickTO: number;
     private displayEl: React.RefObject<any>;
 
     static defaultProps = {
+        borderMaskBottom: false,
+        borderMaskLeft: false,
+        borderMaskRight: false,
+        borderMaskTop: false,
         focused: false,
         renderDragHandle: false,
         message: undefined,
@@ -84,7 +91,7 @@ export class Cell extends React.PureComponent<Props, State> {
         values: List<ValueDescriptor>(),
     };
 
-    constructor(props: Props) {
+    constructor(props: CellProps) {
         super(props);
 
         this.state = {
@@ -94,7 +101,7 @@ export class Cell extends React.PureComponent<Props, State> {
         this.displayEl = React.createRef();
     }
 
-    componentDidUpdate(prevProps: Readonly<Props>): void {
+    componentDidUpdate(prevProps: Readonly<CellProps>): void {
         if (!this.props.focused && this.props.selected) {
             this.displayEl.current.focus();
 
@@ -296,7 +303,10 @@ export class Cell extends React.PureComponent<Props, State> {
 
     render() {
         const {
-            borderMask,
+            borderMaskBottom,
+            borderMaskLeft,
+            borderMaskRight,
+            borderMaskTop,
             cellActions,
             col,
             colIdx,
@@ -329,10 +339,10 @@ export class Cell extends React.PureComponent<Props, State> {
             const displayProps = {
                 autoFocus: selected,
                 className: classNames('cellular-display', {
-                    'cell-border-top': borderMask[0],
-                    'cell-border-right': borderMask[1],
-                    'cell-border-bottom': borderMask[2],
-                    'cell-border-left': borderMask[3],
+                    'cell-border-top': borderMaskTop,
+                    'cell-border-right': borderMaskRight,
+                    'cell-border-bottom': borderMaskBottom,
+                    'cell-border-left': borderMaskLeft,
                     'cell-selected': selected,
                     'cell-selection': selection,
                     'cell-warning': message !== undefined,

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -175,6 +175,7 @@ function inputCellFactory(
     cellActions: CellActions,
     containerFilter: Query.ContainerFilter,
     forUpdate: boolean,
+    isSparse: boolean,
     initialSelection: string[]
 ): GridColumnCellRenderer {
     return (value, row, c, rn, cn) => {
@@ -201,7 +202,6 @@ function inputCellFactory(
         }
 
         const { selectionCells } = editorModel;
-        const isSparse = isSparseSelection(selectionCells);
         const renderDragHandle = !isSparse && editorModel.lastSelection(colIdx, rn);
         let inSelection = editorModel.inSelection(colIdx, rn);
         let borderMask: BorderMask = [false, false, false, false];
@@ -786,6 +786,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         if (!hideCountCol) gridColumns = gridColumns.push(rowNumColumn ? rowNumColumn : COUNT_COL);
 
         const loweredColumnMetadata = this.getLoweredColumnMetadata();
+        const isSparse = isSparseSelection(editorModel.selectionCells);
 
         this.getColumns().forEach(qCol => {
             const metadata = loweredColumnMetadata[qCol.fieldKey.toLowerCase()];
@@ -803,6 +804,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                         this.cellActions,
                         containerFilter,
                         forUpdate,
+                        isSparse,
                         this.state.initialSelection
                     ),
                     index: qCol.fieldKey,

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -364,17 +364,20 @@ export interface SharedEditableGridPanelProps extends SharedEditableGridProps {
     title?: string;
 }
 
+export type EditableGridChange = (
+    editorModelChanges: Partial<EditorModelProps>,
+    dataKeys?: List<any>,
+    data?: Map<any, Map<string, any>>,
+    index?: number
+) => void;
+
 export interface EditableGridProps extends SharedEditableGridProps {
     data?: Map<any, Map<string, any>>;
     dataKeys?: List<any>;
     editorModel: EditorModel;
     error: string;
     exportHandler?: (option: ExportOption) => void;
-    onChange: (
-        editorModelChanges: Partial<EditorModelProps>,
-        dataKeys?: List<any>,
-        data?: Map<any, Map<string, any>>
-    ) => void;
+    onChange: EditableGridChange;
     queryInfo: QueryInfo;
 }
 

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1509,7 +1509,6 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     render(): ReactNode {
-        console.log('EditableGrid -- render');
         const {
             allowAdd,
             editorModel,

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import React, { ChangeEvent, MouseEvent, PureComponent, ReactNode, SyntheticEvent } from 'react';
 import { Query } from '@labkey/api';
 import classNames from 'classnames';
 import { List, Map, OrderedMap, Set } from 'immutable';
-import React, { ChangeEvent, MouseEvent, PureComponent, ReactNode, SyntheticEvent } from 'react';
 import { Button, Nav, NavItem, OverlayTrigger, Popover, Tab, TabContainer } from 'react-bootstrap';
 
 import { Operation, QueryColumn } from '../../../public/QueryColumn';
@@ -235,20 +235,25 @@ function inputCellFactory(
             inSelection = initialSelection.includes(genCellKey(colIdx, rn));
         }
 
+        const focused = editorModel.isFocused(colIdx, rn);
+
         return (
             <Cell
-                borderMask={borderMask}
+                borderMaskTop={borderMask[0]}
+                borderMaskRight={borderMask[1]}
+                borderMaskBottom={borderMask[2]}
+                borderMaskLeft={borderMask[3]}
                 cellActions={cellActions}
                 col={c.raw}
                 colIdx={colIdx}
-                row={row}
+                row={focused ? row : undefined}
                 containerFilter={containerFilter}
                 key={inputCellKey(c.raw, row)}
                 placeholder={columnMetadata?.placeholder}
                 readOnly={isReadonlyCol || isReadonlyRow || isReadonlyCell}
                 locked={isLockedRow}
                 rowIdx={rn}
-                focused={editorModel.isFocused(colIdx, rn)}
+                focused={focused}
                 forUpdate={forUpdate}
                 message={editorModel.getMessage(colIdx, rn)}
                 selected={editorModel.isSelected(colIdx, rn)}
@@ -1233,6 +1238,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         if (metricFeatureArea) {
             incrementClientSideMetricCount(metricFeatureArea, 'bulkAdd');
         }
+
         // Result of this promise passed to toggleBulkAdd, which doesn't expect anything to be passed
         return Promise.resolve();
     };
@@ -1255,6 +1261,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         if (metricFeatureArea) {
             incrementClientSideMetricCount(metricFeatureArea, 'bulkUpdate');
         }
+
         // The result of this promise is used by toggleBulkUpdate, which doesn't expect anything to be passed
         return Promise.resolve(editorModelChanges);
     };
@@ -1502,6 +1509,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     render(): ReactNode {
+        console.log('EditableGrid -- render');
         const {
             allowAdd,
             editorModel,

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -14,7 +14,7 @@ import { ExportOption } from '../../../public/QueryModel/ExportMenu';
 
 import { EditorModel, EditorModelProps } from './models';
 
-import { EditableGrid, SharedEditableGridPanelProps } from './EditableGrid';
+import { EditableGrid, EditableGridChange, SharedEditableGridPanelProps } from './EditableGrid';
 
 import { exportEditedData, getEditorExportData } from './utils';
 
@@ -97,9 +97,8 @@ export const EditableGridPanel: FC<Props> = memo(props => {
     const hasTabs = models.length > 1;
     let wasDirty = false;
 
-    const _onChange = useCallback(
-        (editorModelChanges: Partial<EditorModelProps>, dataKeys?: List<any>, data?: Map<any, Map<string, any>>) =>
-            onChange(editorModelChanges, dataKeys, data, activeTab),
+    const _onChange = useCallback<EditableGridChange>(
+        (editorModelChanges, dataKeys, data) => onChange(editorModelChanges, dataKeys, data, activeTab),
         [activeTab, onChange]
     );
 

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -30,7 +30,7 @@ import {
     ValueDescriptor,
 } from './models';
 
-import { decimalDifference, genCellKey, parseCellKey, sortCellKeys } from './utils';
+import { decimalDifference, genCellKey, parseCellKey } from './utils';
 
 const EMPTY_ROW = Map<string, any>();
 let ID_COUNTER = 0;
@@ -362,7 +362,7 @@ export async function addRowsToEditorModel(
     return {
         cellValues,
         cellMessages,
-        selectionCells: sortCellKeys(selectionCells),
+        selectionCells,
         rowCount: Math.max(rowMin + Number(numToAdd), rowCount),
     };
 }
@@ -1424,7 +1424,7 @@ function insertPastedData(
     });
 
     return {
-        editorModel: { cellMessages, cellValues, rowCount, selectionCells: sortCellKeys(selectionCells) },
+        editorModel: { cellMessages, cellValues, rowCount, selectionCells },
         data: updatedData,
         dataKeys: updatedDataKeys,
     };

--- a/packages/components/src/internal/components/editable/models.spec.ts
+++ b/packages/components/src/internal/components/editable/models.spec.ts
@@ -768,92 +768,73 @@ describe('EditorModel', () => {
         });
 
         test('hasMultipleSelection', () => {
-            expect(new EditorModel({ selectionCells: ImmutableSet([]) }).isMultiSelect).toBeFalsy();
-            expect(new EditorModel({ selectionCells: ImmutableSet(['0-0']) }).isMultiSelect).toBeFalsy();
-            expect(new EditorModel({ selectionCells: ImmutableSet(['0-0', '1-1']) }).isMultiSelect).toBeTruthy();
+            expect(new EditorModel({ selectionCells: [] }).isMultiSelect).toBeFalsy();
+            expect(new EditorModel({ selectionCells: ['0-0'] }).isMultiSelect).toBeFalsy();
+            expect(new EditorModel({ selectionCells: ['0-0', '1-1'] }).isMultiSelect).toBeTruthy();
         });
 
         test('isMultiColumnSelection', () => {
-            expect(new EditorModel({ selectionCells: ImmutableSet([]) }).isMultiColumnSelection).toBeFalsy();
-            expect(new EditorModel({ selectionCells: ImmutableSet(['0-0']) }).isMultiColumnSelection).toBeFalsy();
-            expect(
-                new EditorModel({ selectionCells: ImmutableSet(['0-0', '0-1']) }).isMultiColumnSelection
-            ).toBeFalsy();
-            expect(
-                new EditorModel({ selectionCells: ImmutableSet(['0-0', '1-1']) }).isMultiColumnSelection
-            ).toBeTruthy();
-        });
-
-        test('sortedSelectionKeys', () => {
-            expect(
-                new EditorModel({ selectionCells: ImmutableSet(['0-0', '0-1', '1-0', '1-1']), rowCount: 100 })
-                    .sortedSelectionKeys
-            ).toStrictEqual(['0-0', '1-0', '0-1', '1-1']);
-            expect(
-                new EditorModel({ selectionCells: ImmutableSet(['1-0', '1-1', '0-1', '0-0']), rowCount: 100 })
-                    .sortedSelectionKeys
-            ).toStrictEqual(['0-0', '1-0', '0-1', '1-1']);
-            expect(
-                new EditorModel({ selectionCells: ImmutableSet(['1-10', '1-1', '1-5', '1-15']), rowCount: 100 })
-                    .sortedSelectionKeys
-            ).toStrictEqual(['1-1', '1-5', '1-10', '1-15']);
+            expect(new EditorModel({ selectionCells: [] }).isMultiColumnSelection).toBeFalsy();
+            expect(new EditorModel({ selectionCells: ['0-0'] }).isMultiColumnSelection).toBeFalsy();
+            expect(new EditorModel({ selectionCells: ['0-0', '0-1'] }).isMultiColumnSelection).toBeFalsy();
+            expect(new EditorModel({ selectionCells: ['0-0', '1-1'] }).isMultiColumnSelection).toBeTruthy();
         });
 
         test('lastSelection', () => {
             // multiple columns should always return false
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['0-0', '0-1', '1-0', '1-1']),
+                    selectionCells: ['0-0', '0-1', '1-0', '1-1'],
                     rowCount: 100,
                 }).lastSelection(0, 0)
             ).toBeFalsy();
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['0-0', '0-1', '1-0', '1-1']),
+                    selectionCells: ['0-0', '0-1', '1-0', '1-1'],
                     rowCount: 100,
                 }).lastSelection(1, 1)
             ).toBeTruthy();
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['1-0', '1-1', '0-1', '0-0']),
+                    selectionCells: ['1-0', '1-1', '0-0', '0-1'],
                     rowCount: 100,
                 }).lastSelection(0, 0)
             ).toBeFalsy();
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['1-0', '1-1', '0-1', '0-0']),
+                    selectionCells: ['1-0', '0-0', '0-1', '1-1'],
                     rowCount: 100,
                 }).lastSelection(1, 1)
             ).toBeTruthy();
             // single column should have a true
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['1-0', '1-1', '1-2', '1-3']),
+                    selectionCells: ['1-0', '1-1', '1-2', '1-3'],
                     rowCount: 100,
                 }).lastSelection(1, 0)
             ).toBeFalsy();
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['1-0', '1-1', '1-2', '1-3']),
+                    selectionCells: ['1-0', '1-1', '1-2', '1-3'],
                     rowCount: 100,
                 }).lastSelection(1, 1)
             ).toBeFalsy();
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['1-0', '1-1', '1-2', '1-3']),
+                    selectionCells: ['1-0', '1-1', '1-2', '1-3'],
                     rowCount: 100,
                 }).lastSelection(1, 2)
             ).toBeFalsy();
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(['1-0', '1-1', '1-2', '1-3']),
+                    selectionCells: ['1-0', '1-1', '1-2', '1-3'],
                     rowCount: 100,
                 }).lastSelection(1, 3)
             ).toBeTruthy();
             // single cell should always be true
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(),
+                    selectionCells: [],
                     selectedColIdx: 0,
                     selectedRowIdx: 0,
                     rowCount: 100,
@@ -861,7 +842,7 @@ describe('EditorModel', () => {
             ).toBeTruthy();
             expect(
                 new EditorModel({
-                    selectionCells: ImmutableSet(),
+                    selectionCells: [],
                     selectedColIdx: 100,
                     selectedRowIdx: 100,
                     rowCount: 100,
@@ -881,7 +862,7 @@ describe('EditorModel', () => {
         });
 
         test('inSelection', () => {
-            const model = new EditorModel({ selectionCells: ImmutableSet(['0-0', '1-1']) });
+            const model = new EditorModel({ selectionCells: ['0-0', '1-1'] });
             expect(model.inSelection(-1, -1)).toBeFalsy();
             expect(model.inSelection(0, -1)).toBeFalsy();
             expect(model.inSelection(-1, 0)).toBeFalsy();

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -130,10 +130,14 @@ export class EditorModel
     declare focusValue: List<ValueDescriptor>;
     declare id: string;
     declare isPasting: boolean;
+    // NK: This is precomputed property that is updated whenever the selection is updated.
+    // See applyEditableGridChangesToModels().
     declare isSparseSelection: boolean;
     declare rowCount: number;
     declare selectedColIdx: number;
     declare selectedRowIdx: number;
+    // NK: This is pre-sorted array that is updated whenever the selection is updated.
+    // See applyEditableGridChangesToModels().
     declare selectionCells: string[];
 
     findNextCell(

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -113,6 +113,7 @@ export class EditorModel
         focusValue: undefined,
         id: undefined,
         isPasting: false,
+        isSparseSelection: false,
         rowCount: 0,
         selectedColIdx: -1,
         selectedRowIdx: -1,
@@ -129,6 +130,7 @@ export class EditorModel
     declare focusValue: List<ValueDescriptor>;
     declare id: string;
     declare isPasting: boolean;
+    declare isSparseSelection: boolean;
     declare rowCount: number;
     declare selectedColIdx: number;
     declare selectedRowIdx: number;
@@ -477,10 +479,6 @@ export class EditorModel
         if (colIdx < 0 || rowIdx < 0) return false;
         const cellKey = genCellKey(colIdx, rowIdx);
         return this.selectionCells.find(ck => cellKey === ck) !== undefined;
-    }
-
-    get sortedSelectionKeys(): string[] {
-        return this.selectionCells;
     }
 
     hasRawValue(descriptor: ValueDescriptor): boolean {

--- a/packages/components/src/internal/components/editable/utils.spec.ts
+++ b/packages/components/src/internal/components/editable/utils.spec.ts
@@ -536,7 +536,7 @@ describe('getUpdatedDataFromGrid', () => {
     });
 
     test('getSortedCellKeys', () => {
-        expect(sortCellKeys(['0-0', '1-1', '0-1', '1-0'])).toStrictEqual(['0-0', '1-0', '0-1', '1-1']);
+        expect(sortCellKeys(['0-0', '1-1', '1-1', '0-1', '1-0'])).toStrictEqual(['0-0', '1-0', '0-1', '1-1']);
         expect(sortCellKeys(['1-1', '1-15', '0-10', '1-5'])).toStrictEqual(['1-1', '1-5', '0-10', '1-15']);
     });
 });

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -26,7 +26,15 @@ export const applyEditableGridChangesToModels = (
     tabIndex = 0
 ): EditableGridModels => {
     const updatedEditorModels = [...editorModels];
-    const editorModel = editorModels[tabIndex].merge(editorModelChanges) as EditorModel;
+    let editorModel = editorModels[tabIndex].merge(editorModelChanges) as EditorModel;
+
+    // NK: The "selectionCells" property is of type string[]. When merge() is used it utilizes
+    // Immutable.fromJS() which turns the Array into a List. We want to maintain the property
+    // as an Array so here we set it explicitly.
+    if (editorModelChanges.selectionCells !== undefined) {
+        editorModel = editorModel.set('selectionCells', editorModelChanges.selectionCells) as EditorModel;
+    }
+
     updatedEditorModels.splice(tabIndex, 1, editorModel);
 
     const updatedDataModels = [...dataModels];

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -344,7 +344,7 @@ export function parseCellKey(cellKey: string): CellCoordinates {
  * Sorts cell keys left to right, top to bottom.
  */
 export function sortCellKeys(cellKeys: string[]): string[] {
-    return cellKeys.sort((a, b) => {
+    return Array.from(new Set(cellKeys)).sort((a, b) => {
         const aCoords = parseCellKey(a);
         const bCoords = parseCellKey(b);
         if (aCoords.rowIdx === bCoords.rowIdx) return aCoords.colIdx - bCoords.colIdx;


### PR DESCRIPTION
#### Rationale
A test failure in LKB is being caused by sluggish response within the EditableGrid. This sluggish response is specifically occurring in relation to selecting a large number of cells (1000s). This work makes the following changes to improve performance:

1. Convert `EditorModel.selectionCells` property to a `string[]` from an `ImmutableSet<string>`. This array is pre-sorted so render time calculations are not needed. Significantly improves render performance.
1. Precompute `isSparseSelection` whenever an `EditorModel` is updated so render time calculation is not needed.
1. Add a `dragDelay` to allow for clicking on a single cell to not invoke two full render cycles when the user is not attempting to drag.
1. Only supply the `row` prop when the `Cell` is focused to prevent redundant `Cell` rendering.
1. Separate out the `borderMask` prop on `Cell` to be individual props `borderMaskTop`, `borderMaskRight`, `borderMaskBottom` and `borderMaskLeft`. This alleviates instantiation of a `new Array()` for each render in turn causing each `Cell` to re-render on each render cycle. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1240
- https://github.com/LabKey/labkey-ui-premium/pull/141
- https://github.com/LabKey/biologics/pull/2245
- https://github.com/LabKey/sampleManagement/pull/1977
- https://github.com/LabKey/inventory/pull/932
- https://github.com/LabKey/platform/pull/4609

#### Changes
- Convert `EditorModel.selectionCells` to a `string[]`.
- Precompute new property `EditorModel.isSparseSelection`.
- Add `dragDelay` to reduce redundant render cycles when clicking on cells.
- Split out `BorderMask` properties on the `Cell` interface.
- Add and export interface for `EditableGridChange`.
