### PR TITLE
Issue 48014: fix the BarTender test connection health check

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.349.5",
+  "version": "2.349.5-fb-btTestConnection.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.349.5-fb-btTestConnection.0",
+  "version": "2.349.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.349.TBD
+*Released*: TBD
+* Fix Issue #48014: BarTender Test connection error
+
 ### version 2.349.5
 *Released*: 10 July 2023
 * Remove BaseSearchPage and SearchForm

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.349.TBD
-*Released*: TBD
+### version 2.349.6
+*Released*: 21 July 2023
 * Fix Issue #48014: BarTender Test connection health check
 
 ### version 2.349.5

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.349.TBD
 *Released*: TBD
-* Fix Issue #48014: BarTender Test connection error
+* Fix Issue #48014: BarTender Test connection health check
 
 ### version 2.349.5
 *Released*: 10 July 2023

--- a/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
+++ b/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
@@ -92,15 +92,11 @@ const SettingsInput: FC<SettingsInputProps> = memo(({ children, description, lab
     );
 });
 
-const btTestConnectionTemplate = (label: string): string => {
-    // Should be able to run connection test w/o a default label set.
-    const formatNode = `<Format>${label}</Format>`;
-
+const btTestConnectionTemplate = (): string => {
+    // This will fail script validation, but will have status "RanToCompletion" which means that the server was successfully
+    // connected to. Issue #48014
     return `<XMLScript Version="2.0">
             <Command Name="Job1">
-                <FormatSetup>
-                    ${formatNode}
-                </FormatSetup>
             </Command>
         </XMLScript>`;
 };
@@ -171,7 +167,7 @@ export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
         setTesting(true);
 
         api.labelprinting
-            .printBarTenderLabels(btTestConnectionTemplate(''), btServiceURL)
+            .printBarTenderLabels(btTestConnectionTemplate(), btServiceURL)
             .then((btResponse: BarTenderResponse) => {
                 if (btResponse.ranToCompletion()) {
                     setTesting(false);


### PR DESCRIPTION
#### Rationale
Issue 48014 -- Test script for the BarTender service health check returns a false negative due to a script validation error 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1242
- https://github.com/LabKey/sampleManagement/pull/1979
- https://github.com/LabKey/biologics/pull/2249
- https://github.com/LabKey/inventory/pull/934

#### Changes
- Adjust test script to get valid status when run
