### PR TITLE
ELN: Plate References

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.354.1",
+  "version": "2.355.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.355.0
+Released*: 26 July 2023
+- Introduce `SearchCategory.Plate`.
+- Update various search interfaces to use `SearchCategory`
+
 ### version 2.354.1
 Released*: 25 July 2023
 * Merge release23.7-SNAPSHOT to develop:

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -463,7 +463,7 @@ export function addAssaysSectionConfig(
 
 export function getPlatesSectionConfig(): MenuSectionConfig {
     return new MenuSectionConfig({
-        iconURL: imageURL('_images', 'samples.svg'),
+        iconURL: imageURL('_images', 'plates.svg'),
     });
 }
 
@@ -590,11 +590,12 @@ export function getMenuSectionConfigs(
 export const useMenuSectionConfigs = (
     user: User,
     appProperties: AppProperties,
-    moduleContext: any
+    moduleContext?: ModuleContext
 ): List<Map<string, MenuSectionConfig>> => {
-    return useMemo(() => {
-        return getMenuSectionConfigs(user, appProperties.productId, moduleContext);
-    }, [user, moduleContext, appProperties.productId]);
+    return useMemo(
+        () => getMenuSectionConfigs(user, appProperties.productId, moduleContext),
+        [user, moduleContext, appProperties.productId]
+    );
 };
 
 // Returns the friendly name of the product, primarily for use in help text.

--- a/packages/components/src/internal/components/search/SearchPanel.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.tsx
@@ -10,7 +10,7 @@ import { resolveErrorMessage } from '../../util/messaging';
 
 import { PaginationButtons } from '../buttons/PaginationButtons';
 
-import { biologicsIsPrimaryApp } from '../../app/utils';
+import { biologicsIsPrimaryApp, isPlatesEnabled } from '../../app/utils';
 
 import { useServerContext } from '../base/ServerContext';
 
@@ -136,31 +136,37 @@ export const SearchPanelImpl: FC<SearchPanelImplProps> = memo(props => {
     );
 });
 
-const SEARCH_CATEGORIES = [
-    SearchCategory.Assay,
-    SearchCategory.AssayBatch,
-    SearchCategory.AssayRun,
-    SearchCategory.Data,
-    SearchCategory.DataClass,
-    SearchCategory.File,
-    SearchCategory.FileWorkflowJob,
-    SearchCategory.Material,
-    SearchCategory.MaterialSource,
-    SearchCategory.Notebook,
-    SearchCategory.NotebookTemplate,
-    SearchCategory.WorkflowJob,
-];
-const MEDIA_SEARCH_CATEGORIES = [SearchCategory.Media, SearchCategory.MediaData];
-
 export const SearchPanel: FC<SearchPanelProps> = memo(props => {
     const { offset = 0, pageSize = SEARCH_PAGE_DEFAULT_SIZE, searchTerm, search, searchMetadata } = props;
     const [model, setModel] = useState<SearchResultsModel>(() => SearchResultsModel.create({ isLoading: true }));
     const { moduleContext } = useServerContext();
     const isBiologics = biologicsIsPrimaryApp(moduleContext);
-    const category = useMemo(
-        () => (isBiologics ? [...SEARCH_CATEGORIES, ...MEDIA_SEARCH_CATEGORIES] : SEARCH_CATEGORIES),
-        [isBiologics]
-    );
+    const platesEnabled = isPlatesEnabled(moduleContext);
+    const category = useMemo(() => {
+        const categories = [
+            SearchCategory.Assay,
+            SearchCategory.AssayBatch,
+            SearchCategory.AssayRun,
+            SearchCategory.Data,
+            SearchCategory.DataClass,
+            SearchCategory.File,
+            SearchCategory.FileWorkflowJob,
+            SearchCategory.Material,
+            SearchCategory.MaterialSource,
+            SearchCategory.Notebook,
+            SearchCategory.NotebookTemplate,
+            SearchCategory.WorkflowJob,
+        ];
+
+        if (isBiologics) {
+            categories.push(SearchCategory.Media, SearchCategory.MediaData);
+        }
+        if (platesEnabled) {
+            categories.push(SearchCategory.Plate);
+        }
+
+        return categories;
+    }, [isBiologics, platesEnabled]);
     const getCardDataFn = useCallback(
         (data, cat) => getSearchResultCardData(data, cat, searchMetadata),
         [searchMetadata]

--- a/packages/components/src/internal/components/search/actions.spec.ts
+++ b/packages/components/src/internal/components/search/actions.spec.ts
@@ -22,7 +22,7 @@ describe('search actions', () => {
                 },
             };
 
-            const resultCardData = getSearchResultCardData(data, 'dataClass', 'my title');
+            const resultCardData = getSearchResultCardData(data, SearchCategory.DataClass, 'my title');
             expect(resultCardData).toStrictEqual({
                 title: 'my title',
                 iconDir: undefined,
@@ -39,7 +39,7 @@ describe('search actions', () => {
                 },
             };
 
-            const resultCardData = getSearchResultCardData(data, 'material', undefined);
+            const resultCardData = getSearchResultCardData(data, SearchCategory.Material, undefined);
             expect(resultCardData).toStrictEqual({
                 title: undefined,
                 iconDir: undefined,
@@ -54,7 +54,7 @@ describe('search actions', () => {
                 type: 'dataClass',
             };
 
-            const resultCardData = getSearchResultCardData(data, 'dataClass', 'my title');
+            const resultCardData = getSearchResultCardData(data, SearchCategory.DataClass, 'my title');
             expect(resultCardData).toStrictEqual({
                 title: 'my title',
                 iconDir: undefined,
@@ -69,7 +69,7 @@ describe('search actions', () => {
                 },
             };
 
-            const sourceCardData = getSearchResultCardData(sourceData, 'dataClass', 'bruno');
+            const sourceCardData = getSearchResultCardData(sourceData, SearchCategory.DataClass, 'bruno');
             expect(sourceCardData).toStrictEqual({
                 title: 'bruno',
                 iconDir: undefined,
@@ -84,7 +84,7 @@ describe('search actions', () => {
                 type: 'sampleSet',
             };
 
-            const resultCardData = getSearchResultCardData(data, 'materialSource', undefined);
+            const resultCardData = getSearchResultCardData(data, SearchCategory.MaterialSource, undefined);
             expect(resultCardData).toStrictEqual({
                 title: undefined,
                 iconDir: undefined,
@@ -101,7 +101,7 @@ describe('search actions', () => {
                 },
             };
 
-            const resultCardData = getSearchResultCardData(data, 'material', undefined);
+            const resultCardData = getSearchResultCardData(data, SearchCategory.Material, undefined);
             expect(resultCardData).toStrictEqual({
                 title: undefined,
                 iconDir: undefined,
@@ -118,7 +118,7 @@ describe('search actions', () => {
                 },
             };
 
-            const resultCardData = getSearchResultCardData(data, 'material', undefined);
+            const resultCardData = getSearchResultCardData(data, SearchCategory.Material, undefined);
             expect(resultCardData).toStrictEqual({
                 title: undefined,
                 iconDir: undefined,
@@ -130,7 +130,7 @@ describe('search actions', () => {
         test('sample icon', () => {
             const data = {};
 
-            const resultCardData = getSearchResultCardData(data, 'material', undefined);
+            const resultCardData = getSearchResultCardData(data, SearchCategory.Material, undefined);
             expect(resultCardData).toStrictEqual({
                 title: undefined,
                 iconDir: undefined,
@@ -195,9 +195,9 @@ describe('search actions', () => {
         test('data undefined', () => {
             expect(resolveTypeName(undefined, undefined)).toBeUndefined();
             expect(resolveTypeName(undefined, null)).toBeUndefined();
-            expect(resolveTypeName(undefined, 'test')).toBeUndefined();
-            expect(resolveTypeName(undefined, 'notebook')).toBe('Notebook');
-            expect(resolveTypeName(undefined, 'notebookTemplate')).toBe('Notebook Template');
+            expect(resolveTypeName(undefined, 'invalid' as SearchCategory)).toBeUndefined();
+            expect(resolveTypeName(undefined, SearchCategory.Notebook)).toBe('Notebook');
+            expect(resolveTypeName(undefined, SearchCategory.NotebookTemplate)).toBe('Notebook Template');
         });
 
         test('data defined', () => {
@@ -206,19 +206,21 @@ describe('search actions', () => {
             expect(resolveTypeName({ dataClass: { name: 'testDataClass' } }, undefined)).toBe('testDataClass');
             expect(resolveTypeName({ sampleSet: { name: undefined } }, undefined)).toBeUndefined();
             expect(resolveTypeName({ sampleSet: { name: 'testSampleSet' } }, undefined)).toBe('testSampleSet');
-            expect(resolveTypeName({ sampleSet: { name: 'testSampleSet' } }, 'notebook')).toBe('testSampleSet');
-            expect(resolveTypeName({ sampleSet: { name: undefined } }, 'notebook')).toBe('Notebook');
+            expect(resolveTypeName({ sampleSet: { name: 'testSampleSet' } }, SearchCategory.Notebook)).toBe(
+                'testSampleSet'
+            );
+            expect(resolveTypeName({ sampleSet: { name: undefined } }, SearchCategory.Notebook)).toBe('Notebook');
         });
     });
 
     describe('resolveIconSrc', () => {
         test('data undefined', () => {
             expect(resolveIconSrc(undefined, undefined)).toBeUndefined();
-            expect(resolveIconSrc(undefined, 'test')).toBeUndefined();
-            expect(resolveIconSrc(undefined, 'material')).toBe('samples');
-            expect(resolveIconSrc(undefined, 'workflowJob')).toBe('workflow');
-            expect(resolveIconSrc(undefined, 'notebook')).toBe('notebook_blue');
-            expect(resolveIconSrc(undefined, 'notebookTemplate')).toBe('notebook_blue');
+            expect(resolveIconSrc(undefined, 'invalid' as SearchCategory)).toBeUndefined();
+            expect(resolveIconSrc(undefined, SearchCategory.Material)).toBe('samples');
+            expect(resolveIconSrc(undefined, SearchCategory.WorkflowJob)).toBe('workflow');
+            expect(resolveIconSrc(undefined, SearchCategory.Notebook)).toBe('notebook_blue');
+            expect(resolveIconSrc(undefined, SearchCategory.NotebookTemplate)).toBe('notebook_blue');
         });
 
         test('data defined', () => {
@@ -240,9 +242,9 @@ describe('search actions', () => {
     describe('resolveIconDir', () => {
         test('category', () => {
             expect(resolveIconDir(undefined)).toBeUndefined();
-            expect(resolveIconDir('test')).toBeUndefined();
-            expect(resolveIconDir('notebook')).toBe('labbook/images');
-            expect(resolveIconDir('notebookTemplate')).toBe('labbook/images');
+            expect(resolveIconDir('invalid' as SearchCategory)).toBeUndefined();
+            expect(resolveIconDir(SearchCategory.Notebook)).toBe('labbook/images');
+            expect(resolveIconDir(SearchCategory.NotebookTemplate)).toBe('labbook/images');
         });
     });
 

--- a/packages/components/src/internal/components/search/actions.ts
+++ b/packages/components/src/internal/components/search/actions.ts
@@ -1,4 +1,3 @@
-import { Map } from 'immutable';
 import { Ajax, Utils } from '@labkey/api';
 
 import { RELEVANT_SEARCH_RESULT_TYPES } from '../../constants';
@@ -171,7 +170,7 @@ function parseSearchHitToData(hit: SearchHit): SearchIdData {
 }
 
 // exported for jest testing
-export function resolveTypeName(data: any, category: string): string {
+export function resolveTypeName(data: any, category: SearchCategory): string {
     let typeName;
     if (data) {
         if (data.dataClass?.name) {
@@ -181,9 +180,9 @@ export function resolveTypeName(data: any, category: string): string {
         }
     }
     if (!typeName && category) {
-        if (category === 'notebook') {
+        if (category === SearchCategory.Notebook) {
             typeName = 'Notebook';
-        } else if (category === 'notebookTemplate') {
+        } else if (category === SearchCategory.NotebookTemplate) {
             typeName = 'Notebook Template';
         }
     }
@@ -191,7 +190,7 @@ export function resolveTypeName(data: any, category: string): string {
 }
 
 // exported for jest testing
-export function resolveIconSrc(data: any, category: string): string {
+export function resolveIconSrc(data: any, category: SearchCategory): string {
     let iconSrc: string;
     if (data) {
         if (data.dataClass?.name) {
@@ -213,40 +212,50 @@ export function resolveIconSrc(data: any, category: string): string {
         }
     }
     if (!iconSrc && category) {
-        if (category === 'material') {
-            iconSrc = 'samples';
-        }
-        if (category === 'workflowJob') {
-            iconSrc = 'workflow';
-        }
-        if (category === 'notebook' || category === 'notebookTemplate') {
-            iconSrc = 'notebook_blue';
+        switch (category) {
+            case SearchCategory.Material:
+                iconSrc = 'samples';
+                break;
+            case SearchCategory.Notebook:
+            case SearchCategory.NotebookTemplate:
+                iconSrc = 'notebook_blue';
+                break;
+            case SearchCategory.Plate:
+                iconSrc = 'plates';
+                break;
+            case SearchCategory.WorkflowJob:
+                iconSrc = 'workflow';
+                break;
+            default:
         }
     }
     return iconSrc;
 }
 
 // exported for jest testing
-export function resolveIconDir(category: string): string {
+export function resolveIconDir(category: SearchCategory): string {
     let iconDir;
-    if (category) {
-        if (category === 'notebook' || category === 'notebookTemplate') {
-            iconDir = 'labbook/images';
-        }
+    if (category === SearchCategory.Notebook || category === SearchCategory.NotebookTemplate) {
+        iconDir = 'labbook/images';
     }
     return iconDir;
 }
 
-export function getSearchResultCardData(data: any, category: string, title: string): SearchResultCardData {
+export function getSearchResultCardData(data: any, category: SearchCategory, title: string): SearchResultCardData {
     return {
-        title,
         iconDir: resolveIconDir(category),
         iconSrc: resolveIconSrc(data, category),
+        title,
         typeName: resolveTypeName(data, category),
     };
 }
 
-function getCardData(category: string, data: any, title: string, getCardDataFn?: GetCardDataFn): SearchResultCardData {
+function getCardData(
+    category: SearchCategory,
+    data: any,
+    title: string,
+    getCardDataFn?: GetCardDataFn
+): SearchResultCardData {
     const cardData = getSearchResultCardData(data, category, title);
     if (getCardDataFn) {
         return { ...cardData, ...getCardDataFn(data, category) };

--- a/packages/components/src/internal/components/search/constants.ts
+++ b/packages/components/src/internal/components/search/constants.ts
@@ -13,6 +13,7 @@ export enum SearchCategory {
     MediaData = 'mediaData',
     Notebook = 'notebook',
     NotebookTemplate = 'notebookTemplate',
+    Plate = 'plate',
     WorkflowJob = 'workflowJob',
 }
 

--- a/packages/components/src/internal/components/search/models.ts
+++ b/packages/components/src/internal/components/search/models.ts
@@ -17,6 +17,7 @@ import { fromJS, List, Map, Record } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { JsonType } from '../domainproperties/PropDescType';
+import { SearchCategory } from './constants';
 
 export class SearchResultsModel extends Record({
     entities: undefined,
@@ -76,4 +77,4 @@ export interface FilterSelection {
     secondFilterValue?: any;
 }
 
-export type GetCardDataFn = (data: Map<any, any>, category?: string) => SearchResultCardData;
+export type GetCardDataFn = (data: Map<any, any>, category?: SearchCategory) => SearchResultCardData;

--- a/packages/components/src/internal/components/search/models.ts
+++ b/packages/components/src/internal/components/search/models.ts
@@ -17,6 +17,7 @@ import { fromJS, List, Map, Record } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { JsonType } from '../domainproperties/PropDescType';
+
 import { SearchCategory } from './constants';
 
 export class SearchResultsModel extends Record({

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -28,6 +28,7 @@ import {
     getUpdateFilterExpressionFilter,
     isValidFilterField,
 } from './utils';
+import { SearchCategory } from './constants';
 import { FieldFilter } from './models';
 
 beforeAll(() => {
@@ -1030,134 +1031,182 @@ describe('getUpdatedFilterSelection', () => {
     });
 });
 
-describe("getSearchResultCardData", () => {
+describe('getSearchResultCardData', () => {
     const QUERY_METADATA = fromJS({
-      schema: {
-          samples: {
-              query: {
-                  testmedia: {
-                      iconURL: 'test-media'
-                  }
-              }
-          }
-      }
+        schema: {
+            samples: {
+                query: {
+                    testmedia: {
+                        iconURL: 'test-media',
+                    },
+                },
+            },
+        },
     });
-    test("no data, not workflow", () => {
-        expect(getSearchResultCardData(undefined, 'other')).toStrictEqual({});
-    });
-
-    test("no data, workflow category", () => {
-        expect(getSearchResultCardData(undefined, 'workflowJob')).toStrictEqual({category: 'Job'});
+    test('no data, not workflow', () => {
+        expect(getSearchResultCardData(undefined, 'other' as SearchCategory)).toStrictEqual({});
     });
 
-    test("data.dataClass", () => {
-        expect(getSearchResultCardData({
-            name: 'Test',
-            dataClass: {
-                name: 'Test Class',
-                category: 'sources'
-            }
-        }, undefined)).toStrictEqual({
+    test('no data, workflow category', () => {
+        expect(getSearchResultCardData(undefined, SearchCategory.WorkflowJob)).toStrictEqual({ category: 'Job' });
+    });
+
+    test('data.dataClass', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'Test',
+                    dataClass: {
+                        name: 'Test Class',
+                        category: 'sources',
+                    },
+                },
+                undefined
+            )
+        ).toStrictEqual({
             iconSrc: 'sources',
             category: 'Sources',
-            title: 'Test'
+            title: 'Test',
         });
     });
 
-    test("data.type is sampleSet, no metadata", () => {
-        expect(getSearchResultCardData({
-            name: 'Test',
-            type: 'sampleSet'
-        }, undefined)).toStrictEqual({
+    test('data.type is sampleSet, no metadata', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'Test',
+                    type: 'sampleSet',
+                },
+                undefined
+            )
+        ).toStrictEqual({
             iconSrc: 'sample_set',
             category: 'Sample Type',
             altText: 'sample_type-icon',
-            title: 'Test'
+            title: 'Test',
         });
     });
 
-    test("data.type is sampleSet, with metadata, no match", () => {
-        expect(getSearchResultCardData({
-            name: 'Test',
-            type: 'sampleSet'
-        }, undefined, QUERY_METADATA)).toStrictEqual({
+    test('data.type is sampleSet, with metadata, no match', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'Test',
+                    type: 'sampleSet',
+                },
+                undefined,
+                QUERY_METADATA
+            )
+        ).toStrictEqual({
             iconSrc: 'sample_set',
             category: 'Sample Type',
             altText: 'sample_type-icon',
-            title: 'Test'
+            title: 'Test',
         });
     });
 
-    test("data.type is sampleSet, with matching metadata", () => {
-        expect(getSearchResultCardData({
-            name: 'testMedia',
-            type: 'sampleSet'
-        }, undefined, QUERY_METADATA)).toStrictEqual({
+    test('data.type is sampleSet, with matching metadata', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'testMedia',
+                    type: 'sampleSet',
+                },
+                undefined,
+                QUERY_METADATA
+            )
+        ).toStrictEqual({
             iconSrc: 'test-media',
             category: 'Sample Type',
             altText: 'sample_type-icon',
-            title: 'testMedia'
+            title: 'testMedia',
         });
     });
 
-    test("data.sampleSet, with matching metadata", () => {
-        expect(getSearchResultCardData({
-            name: 'someMedia',
-            sampleSet: {
-                name: 'testMedia'
-            }
-        }, undefined, QUERY_METADATA)).toStrictEqual({
+    test('data.sampleSet, with matching metadata', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'someMedia',
+                    sampleSet: {
+                        name: 'testMedia',
+                    },
+                },
+                undefined,
+                QUERY_METADATA
+            )
+        ).toStrictEqual({
             iconSrc: 'test-media',
             category: 'Sample Type',
             altText: 'sample_type-icon',
-            title: 'someMedia'
+            title: 'someMedia',
         });
     });
 
-    test("data.sampleSet, without matching metadata", () => {
-        expect(getSearchResultCardData({
-            name: 'someMedia',
-            sampleSet: {
-                name: 'otherMedia'
-            }
-        }, undefined, QUERY_METADATA)).toStrictEqual({
+    test('data.sampleSet, without matching metadata', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'someMedia',
+                    sampleSet: {
+                        name: 'otherMedia',
+                    },
+                },
+                undefined,
+                QUERY_METADATA
+            )
+        ).toStrictEqual({
             iconSrc: 'samples',
             category: 'Sample Type',
             altText: 'sample_type-icon',
-            title: 'someMedia'
+            title: 'someMedia',
         });
     });
 
-    test("data.type is generic dataClass", () => {
-        expect(getSearchResultCardData({
-            name: 'Test Source',
-            type: 'dataClass'
-        }, undefined)).toStrictEqual({
+    test('data.type is generic dataClass', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'Test Source',
+                    type: 'dataClass',
+                },
+                undefined
+            )
+        ).toStrictEqual({
             iconSrc: 'source_type',
             category: 'Source Type',
             altText: 'source_type-icon',
-            title: 'Test Source'
+            title: 'Test Source',
         });
     });
 
-    test("data.type is source dataClass", () => {
-        expect(getSearchResultCardData({
-            name: 'Test Source',
-            type: 'dataClass:sources'
-        }, undefined)).toStrictEqual({
+    test('data.type is source dataClass', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'Test Source',
+                    type: 'dataClass:sources',
+                },
+                undefined
+            )
+        ).toStrictEqual({
             iconSrc: 'source_type',
             category: 'Source Type',
             altText: 'source_type-icon',
-            title: 'Test Source'
+            title: 'Test Source',
         });
     });
 
-
-    test("data.type is registry dataClass", () => {
-        expect(getSearchResultCardData({
-            name: 'TestRegistrySource',
-            type: 'dataClass:registry'
-        }, undefined)).toStrictEqual({
+    test('data.type is registry dataClass', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'TestRegistrySource',
+                    type: 'dataClass:registry',
+                },
+                undefined
+            )
+        ).toStrictEqual({
             iconSrc: 'testregistrysource',
             category: 'Registry Source Type',
             altText: 'source_type-icon',
@@ -1165,42 +1214,56 @@ describe("getSearchResultCardData", () => {
     });
 
     test('data.type is assay', () => {
-       expect(getSearchResultCardData({
-           name: 'Test Assay',
-           type: 'assay'
-       }, undefined)).toStrictEqual({
-           category: 'Assay',
-       });
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'Test Assay',
+                    type: 'assay',
+                },
+                undefined
+            )
+        ).toStrictEqual({
+            category: 'Assay',
+        });
     });
 
-    test("data.name with material category", () => {
-        expect(getSearchResultCardData({
-            name: "S-1",
-        }, 'material')).toStrictEqual({
+    test('data.name with material category', () => {
+        expect(
+            getSearchResultCardData(
+                {
+                    name: 'S-1',
+                },
+                SearchCategory.Material
+            )
+        ).toStrictEqual({
             category: 'Sample',
             title: 'S-1',
         });
     });
 });
 
-describe("decodeErrorMessage", () => {
-    test("emtpy string", () => {
-        expect(decodeErrorMessage("")).toBe("");
+describe('decodeErrorMessage', () => {
+    test('emtpy string', () => {
+        expect(decodeErrorMessage('')).toBe('');
     });
-    test("undefined", () => {
+    test('undefined', () => {
         expect(decodeErrorMessage(undefined)).toBeUndefined();
     });
-    test("null", () => {
+    test('null', () => {
         expect(decodeErrorMessage(null)).toBeNull();
     });
 
-    test("nothing encoded", () => {
-        expect(decodeErrorMessage("Nothing to see here. Move along.")).toBe("Nothing to see here. Move along.");
-        expect(decodeErrorMessage("errors are fun.")).toBe("errors are fun.")
+    test('nothing encoded', () => {
+        expect(decodeErrorMessage('Nothing to see here. Move along.')).toBe('Nothing to see here. Move along.');
+        expect(decodeErrorMessage('errors are fun.')).toBe('errors are fun.');
     });
 
-    test("encoded", () => {
-        expect(decodeErrorMessage("Can&#039;t do &quot;this&quot; or &lt;that&gt;.")).toBe("Can't do \"this\" or <that>.")
-        expect(decodeErrorMessage("Can&#039;t do &quot;this&quot; or &lt;that&gt;")).toBe("Can't do \"this\" or <that>.")
+    test('encoded', () => {
+        expect(decodeErrorMessage('Can&#039;t do &quot;this&quot; or &lt;that&gt;.')).toBe(
+            'Can\'t do "this" or <that>.'
+        );
+        expect(decodeErrorMessage('Can&#039;t do &quot;this&quot; or &lt;that&gt;')).toBe(
+            'Can\'t do "this" or <that>.'
+        );
     });
 });

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -18,7 +18,7 @@ import { isOntologyEnabled } from '../../app/utils';
 
 import { REGISTRY_KEY } from '../../app/constants';
 
-import { SearchScope } from './constants';
+import { SearchCategory, SearchScope } from './constants';
 import { FieldFilter, FieldFilterOption, FilterSelection, SearchResultCardData } from './models';
 
 export const SAMPLE_FILTER_METRIC_AREA = 'sampleFinder';
@@ -514,7 +514,7 @@ export function getSearchScopeFromContainerFilter(cf: Query.ContainerFilter): Se
     }
 }
 
-export function getSearchResultCardData(data, category, queryMetadata?: any): SearchResultCardData {
+export function getSearchResultCardData(data: any, category?: SearchCategory, queryMetadata?: any): SearchResultCardData {
     if (data) {
         const dataName = data.name;
         if (data.dataClass?.name) {
@@ -571,21 +571,24 @@ export function getSearchResultCardData(data, category, queryMetadata?: any): Se
                 category: 'Sample Type',
                 title: dataName,
             };
-        } else if (category === 'material') {
+        } else if (category === SearchCategory.Material) {
             return {
                 category: 'Sample',
                 title: dataName,
             };
         }
-    } else {
-        if (category === 'workflowJob') {
-            return { category: 'Job' };
-        } else if (category === 'assay') {
-            return { category: 'Assay' };
-        }
     }
 
-    return {};
+    switch (category) {
+        case SearchCategory.Assay:
+            return { category: 'Assay' };
+        case SearchCategory.Plate:
+            return { iconSrc: 'plates' };
+        case SearchCategory.WorkflowJob:
+            return { category: 'Job' };
+        default:
+            return {};
+    }
 }
 
 export const decodeErrorMessage = (msg: string): string => {

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -514,7 +514,11 @@ export function getSearchScopeFromContainerFilter(cf: Query.ContainerFilter): Se
     }
 }
 
-export function getSearchResultCardData(data: any, category?: SearchCategory, queryMetadata?: any): SearchResultCardData {
+export function getSearchResultCardData(
+    data: any,
+    category?: SearchCategory,
+    queryMetadata?: any
+): SearchResultCardData {
     if (data) {
         const dataName = data.name;
         if (data.dataClass?.name) {

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -706,6 +706,11 @@ export class URLResolver {
                         return row.set('url', this.mapURL({ url, row, column }));
                     } else if (url.indexOf('notebook') >= 0) {
                         return row.set('url', this.mapURL({ url, row, column }));
+                    } else if (url.indexOf('plate-designer') > -1) {
+                        const plateRowId = row.getIn(['data', 'rowId']);
+                        if (plateRowId) {
+                            return row.set('url', this.mapURL({ url, row, column, query: plateRowId }));
+                        }
                     }
                 }
                 return row;


### PR DESCRIPTION
#### Rationale
This adds support for referencing Plates from an ELN. Additionally, with these changes users will also now be able to see Plates in search results within the application.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1244
- https://github.com/LabKey/labkey-ui-premium/pull/143
- https://github.com/LabKey/platform/pull/4618
- https://github.com/LabKey/labbook/pull/518
- https://github.com/LabKey/biologics/pull/2253
- https://github.com/LabKey/sampleManagement/pull/1981
- https://github.com/LabKey/inventory/pull/936

#### Changes
- Introduce `SearchCategory.Plate`.
- Update various search interfaces to use `SearchCategory`.
- Update to use new `plates.svg` icon(s). Resolve icon in menus and search results.
