### PR TITLE
Remove initUnitTests() and fix up related tests

### DIFF
--- a/packages/components/src/internal/components/PreviewGrid.spec.tsx
+++ b/packages/components/src/internal/components/PreviewGrid.spec.tsx
@@ -9,6 +9,12 @@ import { SchemaQuery } from '../../public/SchemaQuery';
 import { PreviewGrid } from './PreviewGrid';
 
 beforeAll(() => {
+    LABKEY.container = {
+        id: 'testContainerEntityId',
+        title: 'Test Container',
+        path: '/testContainer',
+    };
+
     initUnitTestMocks();
     registerDefaultURLMappers();
 });

--- a/packages/components/src/internal/components/administration/UserManagement.spec.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.spec.tsx
@@ -3,7 +3,7 @@ import { List, Map } from 'immutable';
 import { ReactWrapper } from 'enzyme';
 import { PermissionRoles } from '@labkey/api';
 
-import { initQueryGridState } from '../../global';
+import { initBrowserHistoryState } from '../../util/global';
 import { mountWithAppServerContext } from '../../test/enzymeTestHelpers';
 import { BasePermissionsCheckPage } from '../permissions/BasePermissionsCheckPage';
 import { UsersGridPanel } from '../user/UsersGridPanel';
@@ -22,7 +22,7 @@ import { AdminAppContext } from '../../AppContext';
 import { getNewUserRoles, UserManagementPageImpl } from './UserManagement';
 
 beforeAll(() => {
-    initQueryGridState();
+    initBrowserHistoryState();
 });
 
 describe('UserManagement', () => {

--- a/packages/components/src/internal/components/assay/actions.spec.ts
+++ b/packages/components/src/internal/components/assay/actions.spec.ts
@@ -13,15 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { initQueryGridState } from '../../global';
-
 import { TEST_USER_EDITOR, TEST_USER_READER } from '../../userFixtures';
 
 import { allowReimportAssayRun, getRunPropertiesFileName } from './actions';
-
-beforeAll(() => {
-    initQueryGridState();
-});
 
 describe('allowReimportAssayRun', () => {
     test('require insert permissions', () => {

--- a/packages/components/src/internal/components/domainproperties/models.spec.ts
+++ b/packages/components/src/internal/components/domainproperties/models.spec.ts
@@ -82,6 +82,12 @@ import {
 } from './constants';
 
 beforeAll(() => {
+    LABKEY.container = {
+        id: 'testContainerEntityId',
+        title: 'Test Container',
+        path: '/testContainer',
+    };
+
     initUnitTestMocks([initOnotologyMocks]);
 });
 

--- a/packages/components/src/internal/components/lineage/grid/LineageGrid.spec.tsx
+++ b/packages/components/src/internal/components/lineage/grid/LineageGrid.spec.tsx
@@ -8,6 +8,12 @@ import { initLineageMocks } from '../../../../test/mock';
 import { LineageGrid } from './LineageGrid';
 
 beforeAll(() => {
+    LABKEY.container = {
+        id: 'testContainerEntityId',
+        title: 'Test Container',
+        path: '/testContainer',
+    };
+
     initUnitTestMocks([initLineageMocks]);
     registerDefaultURLMappers();
 });

--- a/packages/components/src/internal/components/lineage/grid/LineageGrid.spec.tsx
+++ b/packages/components/src/internal/components/lineage/grid/LineageGrid.spec.tsx
@@ -4,6 +4,7 @@ import renderer from 'react-test-renderer';
 import { registerDefaultURLMappers, sleep } from '../../../test/testHelpers';
 import { initUnitTestMocks } from '../../../../test/testHelperMocks';
 import { initLineageMocks } from '../../../../test/mock';
+import { initBrowserHistoryState } from '../../../util/global';
 
 import { LineageGrid } from './LineageGrid';
 
@@ -14,6 +15,7 @@ beforeAll(() => {
         path: '/testContainer',
     };
 
+    initBrowserHistoryState();
     initUnitTestMocks([initLineageMocks]);
     registerDefaultURLMappers();
 });

--- a/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { getRolesByUniqueName, processGetRolesResponse, UserLimitSettings } from '../permissions/actions';
-import { initQueryGridState } from '../../global';
+import { initBrowserHistoryState } from '../../util/global';
 import policyJSON from '../../../test/data/security-getPolicy.json';
 import rolesJSON from '../../../test/data/security-getRoles.json';
 import { TEST_USER_APP_ADMIN, TEST_USER_FOLDER_ADMIN, TEST_USER_PROJECT_ADMIN } from '../../userFixtures';
@@ -36,7 +36,7 @@ const ROLES = processGetRolesResponse(rolesJSON.roles);
 const ROLES_BY_NAME = getRolesByUniqueName(ROLES);
 
 beforeAll(() => {
-    initQueryGridState();
+    initBrowserHistoryState();
 });
 
 describe('<UsersGridPanel/>', () => {

--- a/packages/components/src/internal/test/testHelpers.tsx
+++ b/packages/components/src/internal/test/testHelpers.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useMemo } from 'react';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import { Map } from 'immutable';
-import { LabKey, Query } from '@labkey/api';
+import { Query } from '@labkey/api';
 
 import { AppContext, AppContextProvider } from '../AppContext';
 import { getTestAPIWrapper } from '../APIWrapper';
@@ -15,7 +14,6 @@ import { LabelPrintingContextProps, LabelPrintingProvider } from '../components/
 import { GlobalStateContextProvider } from '../GlobalStateContext';
 import { URL_MAPPERS, URLService } from '../url/URLResolver';
 
-import { initQueryGridState } from '../global';
 import { QueryInfo } from '../../public/QueryInfo';
 import { applyQueryMetadata, handleSelectRowsResponse } from '../query/api';
 import { bindColumnRenderers, RowsResponse } from '../../public/QueryModel/QueryModelLoader';
@@ -46,36 +44,9 @@ export const AppContextTestProvider: FC<AppContextTestProviderProps> = props => 
     );
 };
 
-declare let LABKEY: LabKey;
-
-export function initMockServerContext(context: Partial<LabKey>): void {
-    Object.assign(LABKEY, context);
-}
-
-/**
- * Initializes the server context and QueryGrid state which is needed in order to run most tests.
- */
-export const initUnitTests = (metadata?: Map<string, any>, columnRenderers?: Record<string, any>): void => {
-    initMockServerContext({
-        container: {
-            id: 'testContainerEntityId',
-            title: 'Test Container',
-            path: '/testContainer',
-            formats: {
-                dateFormat: 'yyyy-MM-dd',
-                dateTimeFormat: 'yyyy-MM-dd HH:mm',
-                numberFormat: null,
-            },
-            activeModules: ['Core', 'Query'], // add in the Ontology module if you want to test the Field Editor integrations
-        },
-        contextPath: '/labkey',
-    });
-    initQueryGridState(metadata, columnRenderers);
-};
-
 /**
  * Instantiates a QueryInfo from a captured query details response payload. Cannot be used until you've called
- * initQueryGridState, initUnitTests, or initUnitTestMocks.
+ * initQueryGridState or initUnitTestMocks.
  * @param getQueryDetailsResponse: getQueryDetails response object (e.g. imported from
  * test/data/mixtures-getQueryDetails.json)
  */

--- a/packages/components/src/internal/url/AppURLResolver.spec.ts
+++ b/packages/components/src/internal/url/AppURLResolver.spec.ts
@@ -15,7 +15,7 @@
  */
 import { fromJS, Map } from 'immutable';
 
-import { initMockServerContext, registerDefaultURLMappers } from '../test/testHelpers';
+import { registerDefaultURLMappers } from '../test/testHelpers';
 
 import { initUnitTestMocks } from '../../test/testHelperMocks';
 
@@ -25,6 +25,12 @@ import { AppURL } from './AppURL';
 import { encodeListResolverPath } from './utils';
 
 beforeAll(() => {
+    LABKEY.container = {
+        id: 'testContainerEntityId',
+        title: 'Test Container',
+        path: '/testContainer',
+    };
+
     initUnitTestMocks();
     registerDefaultURLMappers();
 });
@@ -366,21 +372,6 @@ describe('URL Resolvers', () => {
     });
 
     test('Should remap URLs within SelectRowsResult if url containers are super-folders', () => {
-        initMockServerContext({
-            container: {
-                id: 'subTestContainerEntityId',
-                title: 'Sub Test Container',
-                path: '/testContainer/subContainer1/subContainer2',
-                formats: {
-                    dateFormat: 'yyyy-MM-dd',
-                    dateTimeFormat: 'yyyy-MM-dd HH:mm',
-                    numberFormat: null,
-                },
-                activeModules: ['Core', 'Query'], // add in the Ontology module if you want to test the Field Editor integrations
-            },
-            contextPath: '/labkey',
-        });
-
         const resolver = new URLResolver();
 
         // http://facebook.github.io/jest/docs/en/expect.html#expectassertionsnumber

--- a/packages/components/src/internal/url/URLResolver.spec.ts
+++ b/packages/components/src/internal/url/URLResolver.spec.ts
@@ -12,6 +12,12 @@ import { LookupMapper, URLResolver } from './URLResolver';
 import { AppURL } from './AppURL';
 
 beforeAll(() => {
+    LABKEY.container = {
+        id: 'testContainerEntityId',
+        title: 'Test Container',
+        path: '/testContainer',
+    };
+
     initUnitTestMocks();
     registerDefaultURLMappers();
 });

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { initUnitTests } from '../test/testHelpers';
-
 import { QueryColumn } from '../../public/QueryColumn';
 import { DATE_TYPE, DATETIME_TYPE } from '../components/domainproperties/PropDescType';
 
@@ -33,10 +31,6 @@ import {
     isRelativeDateFilterValue,
     parseDate,
 } from './Date';
-
-beforeAll(() => {
-    initUnitTests();
-});
 
 describe('Date Utilities', () => {
     describe('generateNameWithTimestamp', () => {

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactNode } from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { Filter } from '@labkey/api';
 
-import { initUnitTests, makeQueryInfo, makeTestData } from '../../internal/test/testHelpers';
+import { makeQueryInfo, makeTestData } from '../../internal/test/testHelpers';
 import { mountWithServerContext } from '../../internal/test/enzymeTestHelpers';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 import mixturesQuery from '../../test/data/mixtures-getQueryPaging.json';
@@ -40,7 +40,6 @@ class TestButtons extends PureComponent<RequiresModelAndActions> {
 }
 
 beforeAll(() => {
-    initUnitTests();
     QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
     DATA = makeTestData(mixturesQuery);
     LABKEY.user = TEST_USER_READER;

--- a/packages/components/src/public/QueryModel/QueryModel.spec.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.spec.ts
@@ -1,6 +1,6 @@
 import { Filter } from '@labkey/api';
 
-import { initUnitTests, makeQueryInfo } from '../../internal/test/testHelpers';
+import { makeQueryInfo } from '../../internal/test/testHelpers';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 import { ExtendedMap } from '../ExtendedMap';
 
@@ -30,7 +30,6 @@ const ROWS = {
 const ORDERED_ROWS = ['0', '1'];
 
 beforeAll(() => {
-    initUnitTests();
     // Have to instantiate QUERY_INFO here because it relies on initQueryGridState being called first.
     QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
 });

--- a/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
+++ b/packages/components/src/public/QueryModel/ViewMenu.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
-import { initUnitTests, makeQueryInfo } from '../../internal/test/testHelpers';
+import { makeQueryInfo } from '../../internal/test/testHelpers';
 
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 
@@ -20,7 +20,6 @@ let QUERY_INFO_PRIVATE_VIEWS: QueryInfo;
 let QUERY_INFO_HIDDEN_VIEWS: QueryInfo;
 
 beforeAll(() => {
-    initUnitTests();
     // Have to instantiate QueryInfos here because applyQueryMetadata relies on initQueryGridState being called first.
     QUERY_INFO_NO_VIEWS = makeQueryInfo({
         ...mixturesQueryInfo,

--- a/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { createMemoryHistory, InjectedRouter, Route, Router } from 'react-router';
 import { Filter } from '@labkey/api';
 
-import { initUnitTests, makeQueryInfo, makeTestData, sleep } from '../../internal/test/testHelpers';
+import { makeQueryInfo, makeTestData, sleep } from '../../internal/test/testHelpers';
 import { MockQueryModelLoader } from '../../test/MockQueryModelLoader';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
 import mixturesQuery from '../../test/data/mixtures-getQueryPaging.json';
@@ -38,7 +38,6 @@ let AMINO_ACIDS_QUERY_INFO: QueryInfo;
 let AMINO_ACIDS_DATA: RowsResponse;
 
 beforeAll(() => {
-    initUnitTests();
     MIXTURES_QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
     AMINO_ACIDS_QUERY_INFO = makeQueryInfo(aminoAcidsQueryInfo);
     AMINO_ACIDS_DATA = makeTestData(aminoAcidsQuery);

--- a/packages/components/src/test/testHelperMocks.ts
+++ b/packages/components/src/test/testHelperMocks.ts
@@ -1,16 +1,13 @@
-import { Map } from 'immutable';
 import mock, { proxy } from 'xhr-mock';
 
 import { initDomainPropertiesMocks, initQueryGridMocks, initUserPropsMocks } from './mock';
-import { initQueryGridState } from '../internal/global';
 
 /**
  * Use this method in beforeAll() for your jest tests and you'll have full access
  * to all of the same mock API responses we use in storybook.
  */
-export function initUnitTestMocks(extraMocks?: Array<() => void>, metadata?: Map<string, any>): void {
+export function initUnitTestMocks(extraMocks?: Array<() => void>): void {
     window['__react-beautiful-dnd-disable-dev-warnings'] = true;
-    initQueryGridState(metadata);
     mock.setup();
     initQueryGridMocks();
     initDomainPropertiesMocks();

--- a/packages/components/src/test/testHelperMocks.ts
+++ b/packages/components/src/test/testHelperMocks.ts
@@ -1,9 +1,8 @@
 import { Map } from 'immutable';
 import mock, { proxy } from 'xhr-mock';
 
-import { initUnitTests } from '../internal/test/testHelpers';
-
 import { initDomainPropertiesMocks, initQueryGridMocks, initUserPropsMocks } from './mock';
+import { initQueryGridState } from '../internal/global';
 
 /**
  * Use this method in beforeAll() for your jest tests and you'll have full access
@@ -11,7 +10,7 @@ import { initDomainPropertiesMocks, initQueryGridMocks, initUserPropsMocks } fro
  */
 export function initUnitTestMocks(extraMocks?: Array<() => void>, metadata?: Map<string, any>): void {
     window['__react-beautiful-dnd-disable-dev-warnings'] = true;
-    initUnitTests(metadata);
+    initQueryGridState(metadata);
     mock.setup();
     initQueryGridMocks();
     initDomainPropertiesMocks();


### PR DESCRIPTION
#### Rationale
initUnitTests() was a legacy helper that is no longer needed. A few tests needed to be converted to set LABKEY.container directly or call initQueryGridState() directly.

#### Changes
- Remove unnecessary calls to initQueryGridState (replace a few with calls to initBrowserHistoryState() instead)
- Remove unnecessary calls to initUnitTests()
- Remove initUnitTests (set LABKEY.container directly in tests that need it)
- change initUnitTestMocks() to call initQueryGridState() instead
