### PR TITLE
Issue 48333: Skip sample status check when creating samples from sources

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.355.1",
+  "version": "2.355.2-sourceSampleOverlap.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.1-sourceSampleOverlap.1",
+  "version": "2.356.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48333: When creating samples from sources, don't check sample status of parents (that aren't samples)
+
 ### version 2.355.1
 *Released*: 27 July 2023
 - Updates to allow sources to have parent sources

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.356.1
+*Released*: 28 July 2023
 - Issue 48333: When creating samples from sources, don't check sample status of parents (that aren't samples)
 
 ### version 2.356.0

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -30,10 +30,10 @@ export interface SampleCreationTypeModel {
 
 export const CHILD_SAMPLE_CREATION: SampleCreationTypeModel = {
     type: SampleCreationType.Independents,
-    description: 'Create multiple output samples per parent.',
+    description: 'Create multiple output samples per source.',
     minParentsPerSample: 1,
     iconSrc: 'derivatives',
-    quantityLabel: 'New Samples per Parent',
+    quantityLabel: 'New Samples per Source',
 };
 
 export const DERIVATIVE_CREATION: SampleCreationTypeModel = {


### PR DESCRIPTION
#### Rationale
[Issue 48333](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48333) When creating samples from sources, there's no need to check the sample status of the parents (since they aren't samples), and when we do that check, beyond just being unnecessary, it can produce very confusing results if the rowIds of the sources being used as parents are the same as rowIds of samples that happen to be locked (or in different projects).

This PR is just an incidental update to the nouns used in the creating modal.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/145
- https://github.com/LabKey/biologics/pull/2262
- https://github.com/LabKey/sampleManagement/pull/1988

#### Changes
- Use "source" instead of "parent" as the noun in the modal for creating samples from sources.
