### PR TITLE
Issue 48291: Sample Manager: bulk update form gives (Amount) must be a number error

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.1",
+  "version": "2.356.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.0",
+  "version": "2.356.1-fb-issue48291.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X July 2023
+* Issue 48291: Sample Manager: bulk update form gives (Amount) must be a number error
+
 ### version 2.356.0
 *Released*: 27 July 2023
 - Upon using a multi-value filter that is not BETWEEN, make value input a textarea

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -134,7 +134,9 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                     if (displayValueFields.includes(key)) {
                         const valuesDiffer =
                             field.has('displayValue') && field.get('value') !== field.get('displayValue');
-                        const comparisonValue = field.get('displayValue') ?? field.get('value');
+                        let comparisonValue = field.get('displayValue') ?? field.get('value');
+                        if (comparisonValue)
+                            comparisonValue += ''; // force to string
                         if (!conflictKeys.has(key)) {
                             if (!bulkUpdates.has(key)) {
                                 bulkUpdates = bulkUpdates.set(key, comparisonValue);
@@ -145,9 +147,9 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                         }
                         if (valuesDiffer) {
                             field = field.set('value', comparisonValue);
-                            updatedRow = updatedRow.set(key, field);
                         }
                     }
+                    updatedRow = updatedRow.set(key, field);
                 });
                 if (!updatedRow.isEmpty()) updates = updates.set(id, updatedRow);
             }

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -30,10 +30,10 @@ interface Props {
     ) => any;
     pluralNoun?: string;
     queryFilters?: Record<string, List<Filter.IFilter>>;
+    queryInfo: QueryInfo;
     readOnlyColumns?: string[];
     requiredColumns?: string[];
     selectedIds: Set<string>;
-    queryInfo: QueryInfo;
     singularNoun?: string;
     // sortString is used so we render editable grids with the proper sorts when using onSubmitForEdit
     sortString?: string;
@@ -87,7 +87,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
         // Get all shownInUpdateView and required columns or undefined
         const columns =
             getUpdateColumnsOnly || requiredColumns
-                ? (queryInfo.getPkCols().concat(queryInfo.getUpdateColumns(readOnlyColumns ?? [])))
+                ? queryInfo.getPkCols().concat(queryInfo.getUpdateColumns(readOnlyColumns ?? []))
                 : undefined;
         let columnString = columns?.map(c => c.fieldKey).join(',');
         if (requiredColumns) columnString = `${columnString ? columnString + ',' : ''}${requiredColumns.join(',')}`;
@@ -135,8 +135,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
                         const valuesDiffer =
                             field.has('displayValue') && field.get('value') !== field.get('displayValue');
                         let comparisonValue = field.get('displayValue') ?? field.get('value');
-                        if (comparisonValue)
-                            comparisonValue += ''; // force to string
+                        if (comparisonValue) comparisonValue += ''; // force to string
                         if (!conflictKeys.has(key)) {
                             if (!bulkUpdates.has(key)) {
                                 bulkUpdates = bulkUpdates.set(key, comparisonValue);


### PR DESCRIPTION
#### Rationale
A previous change on bulk update form to use display value for amount and unit introduced a issue with non display fields no longer showing the current value on bulk form open. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1144
- 
- https://github.com/LabKey/labkey-ui-components/pull/1248
- https://github.com/LabKey/sampleManagement/pull/1990
- https://github.com/LabKey/biologics/pull/2265

#### Changes
- set field value for all fields, not just display fields
