### PR TITLE
Add to Storage From Grid - sample position editable grid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.0",
+  "version": "2.356.0-fb-storageEditableGridModal.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.2-fb-storageEditableGridModal.0",
+  "version": "2.357.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.1-fb-storageEditableGridModal.1",
+  "version": "2.356.1-fb-storageEditableGridModal.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.1-fb-storageEditableGridModal.0",
+  "version": "2.356.1-fb-storageEditableGridModal.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.2",
+  "version": "2.356.2-fb-storageEditableGridModal.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.356.1",
+  "version": "2.356.1-fb-storageEditableGridModal.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.357.0
+*Released*: 1 August 2023
 - EditableGrid prop to hideTopControls
 - EditableGrid null checks for tabBtnProps and cancelBtnProps
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- EditableGrid prop to hideTopControls
+
 ### version 2.356.0
 *Released*: 27 July 2023
 - Upon using a multi-value filter that is not BETWEEN, make value input a textarea

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - EditableGrid prop to hideTopControls
+- EditableGrid null checks for tabBtnProps and cancelBtnProps
 
 ### version 2.356.1
 *Released*: 28 July 2023

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -279,6 +279,7 @@ export interface SharedEditableGridProps {
     extraExportColumns?: Array<Partial<QueryColumn>>;
     forUpdate?: boolean;
     hideCountCol?: boolean;
+    hideTopControls?: boolean;
     insertColumns?: QueryColumn[];
     isSubmitting?: boolean;
     // list of key values for rows that are locked. locked rows are readonly but might have a different display from readonly rows
@@ -382,6 +383,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         striped: false,
         maxRows: MAX_EDITABLE_GRID_ROWS,
         hideCountCol: false,
+        hideTopControls: false,
         rowNumColumn: COUNT_COL,
     };
 
@@ -1438,7 +1440,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         this.props.cancelBtnProps?.onClick?.();
     };
 
-    renderTabButtons = (): ReactNode => {
+    renderButtons = (): ReactNode => {
         const { primaryBtnProps, cancelBtnProps, tabBtnProps } = this.props;
         if (!tabBtnProps?.show) return null;
 
@@ -1499,12 +1501,13 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             showAsTab,
             tabBtnProps,
             maxRows,
+            hideTopControls,
         } = this.props;
         const { showBulkAdd, showBulkUpdate, showMask, activeEditTab, selected } = this.state;
 
         const gridContent = (
             <>
-                {this.renderTopControls()}
+                {!hideTopControls && this.renderTopControls()}
                 <div
                     className={classNames(EDITABLE_GRID_CONTAINER_CLS, { 'loading-mask': showMask })}
                     onKeyDown={this.onKeyDown}
@@ -1535,7 +1538,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
             return (
                 <>
-                    {tabBtnProps.placement === 'top' && this.renderTabButtons()}
+                    {tabBtnProps.placement === 'top' && this.renderButtons()}
                     <Tab.Container activeKey={activeEditTab} id="editable-grid-tabs" onSelect={this.onTabChange}>
                         <div>
                             <Nav bsStyle="tabs">
@@ -1559,15 +1562,17 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                             </Tab.Content>
                         </div>
                     </Tab.Container>
-                    {tabBtnProps.placement === 'bottom' && this.renderTabButtons()}
+                    {tabBtnProps.placement === 'bottom' && this.renderButtons()}
                 </>
             );
         }
 
         return (
             <div>
+                {tabBtnProps?.placement === 'top' && this.renderButtons()}
                 {gridContent}
                 {error && <Alert className="margin-top">{error}</Alert>}
+                {tabBtnProps?.placement === 'bottom' && this.renderButtons()}
                 {showBulkAdd && this.renderBulkAdd()}
                 {showBulkUpdate && this.renderBulkUpdate()}
             </div>

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1445,7 +1445,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         if (!tabBtnProps?.show) return null;
 
         return (
-            <div className={tabBtnProps.cls}>
+            <div className={tabBtnProps?.cls}>
                 <Button
                     bsStyle="primary"
                     bsClass={primaryBtnProps.cls}
@@ -1454,9 +1454,11 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 >
                     {primaryBtnProps.caption ?? 'Save'}
                 </Button>
-                <Button bsStyle="default" bsClass={cancelBtnProps.cls} onClick={this.onCancelClick}>
-                    {cancelBtnProps.caption ?? 'Cancel'}
-                </Button>
+                {cancelBtnProps && (
+                    <Button bsStyle="default" bsClass={cancelBtnProps.cls} onClick={this.onCancelClick}>
+                        {cancelBtnProps.caption ?? 'Cancel'}
+                    </Button>
+                )}
             </div>
         );
     };
@@ -1538,7 +1540,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
             return (
                 <>
-                    {tabBtnProps.placement === 'top' && this.renderButtons()}
+                    {tabBtnProps?.placement === 'top' && this.renderButtons()}
                     <Tab.Container activeKey={activeEditTab} id="editable-grid-tabs" onSelect={this.onTabChange}>
                         <div>
                             <Nav bsStyle="tabs">
@@ -1562,7 +1564,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                             </Tab.Content>
                         </div>
                     </Tab.Container>
-                    {tabBtnProps.placement === 'bottom' && this.renderButtons()}
+                    {tabBtnProps?.placement === 'bottom' && this.renderButtons()}
                 </>
             );
         }

--- a/packages/components/src/internal/components/editable/actions.spec.ts
+++ b/packages/components/src/internal/components/editable/actions.spec.ts
@@ -694,4 +694,14 @@ describe('splitPrefixedNumber', () => {
         expect(splitPrefixedNumber('123')).toEqual([undefined, '123']);
         expect(splitPrefixedNumber('123.45')).toEqual([undefined, '123.45']);
     });
+
+    test('param as number', () => {
+        expect(splitPrefixedNumber(123)).toEqual([undefined, '123']);
+    });
+
+    test('param empty', () => {
+        expect(splitPrefixedNumber(undefined)).toEqual([undefined, undefined]);
+        expect(splitPrefixedNumber(null)).toEqual([undefined, undefined]);
+        expect(splitPrefixedNumber('')).toEqual([undefined, undefined]);
+    });
 });

--- a/packages/components/src/internal/components/editable/actions.spec.ts
+++ b/packages/components/src/internal/components/editable/actions.spec.ts
@@ -1,10 +1,12 @@
 import { fromJS, List, Map, Set } from 'immutable';
+
 import { ExtendedMap } from '../../../public/ExtendedMap';
 import { QueryColumn, QueryLookup } from '../../../public/QueryColumn';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import sampleSet2QueryInfo from '../../../test/data/sampleSet2-getQueryDetails.json';
+
 import {
     addColumns,
     changeColumn,

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -753,8 +753,8 @@ type PrefixAndNumber = [string | undefined, string | undefined];
  * intentionally does not parse the numbers.
  */
 export function splitPrefixedNumber(text: string): PrefixAndNumber {
-    if (text === undefined) return [undefined, undefined];
-    const matches = text.match(POSTFIX_REGEX);
+    if (text === undefined || text === null || text === '') return [undefined, undefined];
+    const matches = text?.toString().match(POSTFIX_REGEX);
 
     if (matches === null) {
         return [text, undefined];


### PR DESCRIPTION
#### Rationale
This is the next story in the "Improve Freezer View during Add to Storage" epic. This set of PRs adds a 2nd step to the Add to Storage modal which shows the editable grid for the selected storage location(s) to allow setting the location properties (amount, units, F/T count).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1249
- https://github.com/LabKey/labkey-ui-premium/pull/146
- https://github.com/LabKey/inventory/pull/945
- https://github.com/LabKey/sampleManagement/pull/1991
- https://github.com/LabKey/biologics/pull/2266
- https://github.com/LabKey/testAutomation/pull/1589

#### Changes
- EditableGrid prop to hideTopControls
- EditableGrid null checks for tabBtnProps and cancelBtnProps
