### PR TITLE
ResponsiveMenuButtonGroup: Collapse buttons as space is available

### DIFF
--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -4,6 +4,10 @@
 *Released* : 26 July 2023
 * Add JSX files to loaders test.
 
+### 6.13.0
+*Released*: 12 July 2023
+* Add support for @labkey/premium/search package
+
 ### version 6.12.0
 *Released* : 6 June 2023
 * declare `@testing-library` as externals.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.357.0",
+  "version": "2.358.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.358.0
-*Released*: 7 August 2023
+*Released*: 8 August 2023
 - GridPanel ButtonBar
   - Slightly change DOM layout to make size calculations easier
   - Do not render buttons until we've first loaded data

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,16 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.358.0
+*Released*: 7 August 2023
+- GridPanel ButtonBar
+  - Slightly change DOM layout to make size calculations easier
+  - Do not render buttons until we've first loaded data
+- Update ResponsiveMenuButtonGroup to calculate available space and render as many buttons as possible
+  - Buttons that cannot fit will be rendered under a more menu
+- QueryInfo: appEditableTable is no longer private
+  - We need to be able to set this property for tests
+
 ### version 2.357.0
 *Released*: 1 August 2023
 - EditableGrid prop to hideTopControls

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.spec.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.spec.tsx
@@ -22,18 +22,12 @@ describe('ResponsiveMenuButtonGroup', () => {
         ],
     };
 
-    function validate(wrapper: ReactWrapper, rendered = true): void {
-        expect(wrapper.find(DropdownButton)).toHaveLength(rendered ? 1 : 0);
-        expect(wrapper.find(MenuItem)).toHaveLength(rendered ? 3 : 0); // with divider
-        if (rendered) expect(wrapper.find(PicklistButton).first().prop('asSubMenu')).toBe(true);
-    }
-
     test('admin', () => {
         const wrapper = mountWithServerContext(
             <ResponsiveMenuButtonGroup {...DEFAULT_PROPS} user={TEST_USER_FOLDER_ADMIN} />,
             { user: TEST_USER_FOLDER_ADMIN }
         );
-        validate(wrapper);
+        expect(wrapper.find(DropdownButton)).toHaveLength(2);
         wrapper.unmount();
     });
 
@@ -42,7 +36,7 @@ describe('ResponsiveMenuButtonGroup', () => {
             <ResponsiveMenuButtonGroup {...DEFAULT_PROPS} user={TEST_USER_READER} />,
             { user: TEST_USER_READER }
         );
-        validate(wrapper, false);
+        expect(wrapper.find(DropdownButton)).toHaveLength(0);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, FC, memo, useMemo, useState, useEffect } from 'react';
+import React, { ReactElement, FC, memo, useState, useEffect, useCallback, useRef, Fragment } from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { hasPermissions, User } from '../base/models/User';
@@ -9,45 +9,105 @@ interface ResponsiveMenuItem {
 }
 
 interface Props {
-    asSubMenu?: boolean;
     items: ResponsiveMenuItem[];
-    subMenuWidth?: number;
     user: User;
 }
 
-export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
-    const { items, user, subMenuWidth = 1600, asSubMenu = true } = props;
-    const [width, setWidth] = useState<number>(window.innerWidth);
-    useEffect(() => {
-        function handleResize() {
-            setWidth(window.innerWidth);
-        }
-        window.addEventListener('resize', handleResize);
-        return () => window.removeEventListener('resize', handleResize);
-    });
+// The known size of the More dropdown. Ideally we'd calculate this, but we need to know it before we inject it, so
+// this was calculated by inspecting the DOM in FireFox.
+const MORE_SIZE = 70;
 
-    // bootstrap v3 doesn't support hidden-xl/visible-xl, so use the width=1600 check as a proxy
-    const _asSubMenu = useMemo(() => asSubMenu && width < subMenuWidth, [asSubMenu, width, subMenuWidth]);
+export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
+    const { items, user } = props;
+    const [renderedItems, setRenderedItems] = useState<ReactElement[]>(items.map(item => item.button));
+    const [collapsedItems, setCollapsedItems] = useState<ReactElement[]>([]);
+    const [itemWidths, setItemWidths] = useState<number[]>([]);
+    const ref = useRef<HTMLElement>(undefined);
+    const computeButtonLayout = useCallback((): void => {
+        if (itemWidths.length === 0 || ref.current === undefined) {
+            // If we haven't determined itemWidths then we cannot properly determine how to render the buttons
+            return;
+        }
+        const parent = ref.current.parentNode; // Should be responsive-btn-group, contains all the grid buttons
+        const grandParent = parent.parentNode as HTMLElement; // Should be button-bar__section, contains buttons + filter/search
+        const staticButtons = Array.from(parent.childNodes).reduce((reduction, node: HTMLElement) => {
+            if (!node.getAttribute('class').includes('responsive-menu-button-group')) {
+                reduction += node.getBoundingClientRect().width;
+            }
+            return reduction;
+        }, 0);
+        const filterAndSearch = grandParent.querySelector('.button-bar__filter-search').getBoundingClientRect().width;
+        // 24 = 12px margin on filterAndSearch wrapper, 12px margin on search box.
+        const siblingSize = staticButtons + filterAndSearch + 24;
+        const sizeLeft = grandParent.getBoundingClientRect().width - siblingSize;
+        const allButtonsSize = itemWidths.reduce((sum, size) => sum + size, 0);
+
+        if (allButtonsSize > sizeLeft) {
+            const collapsed = [];
+            const rendered = [];
+            // calculate visible buttons
+            let currentSize = MORE_SIZE;
+            items.forEach((item, idx) => {
+                const itemWidth = itemWidths[idx];
+
+                if (currentSize + itemWidth > sizeLeft) {
+                    collapsed.push(item.button);
+                } else {
+                    rendered.push(item.button);
+                    currentSize = currentSize + itemWidth;
+                }
+            });
+            setCollapsedItems(collapsed);
+            setRenderedItems(rendered);
+        } else {
+            // All buttons visible
+            setRenderedItems(items.map(item => item.button));
+            setCollapsedItems([]);
+        }
+    }, [itemWidths, items]);
+
+    useEffect(() => {
+        // Need to call computeButtonLayout here to compute the layout after first render
+        computeButtonLayout();
+        window.addEventListener('resize', computeButtonLayout);
+        return () => window.removeEventListener('resize', computeButtonLayout);
+    }, [computeButtonLayout]);
+
+    // After the first render we need to calculate the width of each item passed to this component
+    useEffect(() => {
+        const itemEls = ref.current.childNodes;
+        // childNodes is a nodeList which does not have the map method
+        const widths = Array.from(itemEls).map((element: HTMLElement) => element.getBoundingClientRect().width);
+        setItemWidths(widths);
+    }, []);
 
     const buttons = items.filter(item => hasPermissions(user, [item.perm], false)).map(item => item.button);
 
     if (buttons.length === 0) return null;
 
     return (
-        <>
-            {!_asSubMenu && buttons}
-            {_asSubMenu && (
+        <span className="responsive-menu-button-group" ref={ref}>
+            {renderedItems.length > 0 &&
+                renderedItems.map((button, idx) => (
+                    // Issue 47167
+                    // We wrap buttons in Fragment because otherwise we'll get an error warning about unique keys if
+                    // each button passed in wasn't given a key.
+                    <Fragment key={idx}>{button}</Fragment>
+                ))}
+            {collapsedItems.length > 0 && (
                 <DropdownButton id="responsive-menu-button-group" title="More" className="responsive-menu">
-                    {buttons.map((item, index) => {
+                    {collapsedItems.map((item, index) => {
                         return (
-                            <React.Fragment key={index}>
+                            <Fragment key={index}>
                                 {React.cloneElement(item, { asSubMenu: true })}
                                 {index < buttons.length - 1 && <MenuItem divider />}
-                            </React.Fragment>
+                            </Fragment>
                         );
                     })}
                 </DropdownButton>
             )}
-        </>
+        </span>
     );
 });
+
+ResponsiveMenuButtonGroup.displayName = 'ResponsiveMenuButtonGroup';

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, FC, memo, useState, useEffect, useCallback, useRef, Fragment } from 'react';
+import React, { ReactElement, FC, memo, useState, useEffect, useCallback, useRef, Fragment, useMemo } from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { hasPermissions, User } from '../base/models/User';
@@ -19,7 +19,8 @@ const MORE_SIZE = 70;
 
 export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
     const { items, user } = props;
-    const [renderedItems, setRenderedItems] = useState<ReactElement[]>(items.map(item => item.button));
+    const filteredItems = useMemo(() => items.filter(item => hasPermissions(user, [item.perm], false)), [items, user]);
+    const [renderedItems, setRenderedItems] = useState<ReactElement[]>(filteredItems.map(item => item.button));
     const [collapsedItems, setCollapsedItems] = useState<ReactElement[]>([]);
     const [itemWidths, setItemWidths] = useState<number[]>([]);
     const elRef = useRef<HTMLElement>(undefined);
@@ -80,7 +81,7 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
             // [Derive, Assay, Picklists, Jobs, More] on a larger screen
             // [Derive, Assay, Jobs, More] on a smaller screen
             let canRenderMore = true;
-            items.forEach((item, idx) => {
+            filteredItems.forEach((item, idx) => {
                 const itemWidth = itemWidths[idx];
 
                 // The button is likely being hidden due to permissions or something similar.
@@ -101,10 +102,10 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
             setRenderedItems(rendered);
         } else {
             // All buttons visible
-            setRenderedItems(items.map(item => item.button));
+            setRenderedItems(filteredItems.map(item => item.button));
             setCollapsedItems([]);
         }
-    }, [itemWidths, items]);
+    }, [itemWidths, filteredItems]);
 
     useEffect(() => {
         // Need to call computeButtonLayout here to compute the layout after first render
@@ -123,7 +124,7 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
         setItemWidths(widths);
     }, []);
 
-    const buttons = items.filter(item => hasPermissions(user, [item.perm], false)).map(item => item.button);
+    const buttons = filteredItems.map(item => item.button);
 
     if (buttons.length === 0) return null;
 

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -115,6 +115,8 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
 
     // After the first render we need to calculate the width of each item passed to this component
     useEffect(() => {
+        // Don't attempt to compute widths when we're in tests, or we'll fall over
+        if (navigator.userAgent.includes('jsdom')) return;
         const itemEls = elRef.current.childNodes;
         // childNodes is a nodeList which does not have the map method
         const widths = Array.from(itemEls).map((element: HTMLElement) => element.getBoundingClientRect().width);

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -184,6 +184,5 @@ export interface SampleGridButtonProps {
     onTabbedViewAliquotSelectorUpdate?: (filter: Filter.IFilter, filterColumnToRemove?: string) => void;
     sampleFinderBaseProps?: Record<string, any>;
     showBulkUpdate?: () => void;
-    subMenuWidth?: number;
     toggleEditWithGridUpdate?: () => void;
 }

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -67,7 +67,7 @@ const QUERY_INFO_DEFAULTS = {
 
 // Commented out attributes are not used in app, but are returned by the server
 export class QueryInfo {
-    private declare appEditableTable: boolean; // use isAppEditable()
+    declare appEditableTable: boolean; // use isAppEditable()
     declare altUpdateKeys: Set<string>;
     declare disabledSystemFields: Set<string>;
     // declare canEdit: boolean;

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -160,7 +160,7 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
             supportedExportTypes,
         } = this.props;
 
-        const { hasRows, queryInfo, queryInfoError, rowsError, selectionsError } = model;
+        const { hasData, hasRows, queryInfo, queryInfoError, rowsError, selectionsError } = model;
         const hasError = queryInfoError !== undefined || rowsError !== undefined || selectionsError !== undefined;
         const paginate = showPagination && hasRows && !hasError;
         const canExport = showExport && !hasError;
@@ -168,6 +168,9 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
         const canSelectView = showViewMenu && queryInfo !== undefined;
         const buttonsComponentProps = this.props.buttonsComponentProps ?? ({} as T);
         const hasLeftButtonsComp = ButtonsComponent !== undefined;
+        // We do not want to render the buttons component until after we've loaded the query model at least once,
+        // otherwise the ResponsiveMenuButtonGroup will not be able to collapse buttons correctly.
+        const showButtonsComponent = hasLeftButtonsComp && hasData;
         const hiddenWithLeftButtonsCls = classNames({ 'hidden-md hidden-sm hidden-xs': hasLeftButtonsComp });
 
         const paginationComp = (
@@ -187,7 +190,7 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
                 <div className="grid-panel__button-bar">
                     <div className="grid-panel__button-bar-left">
                         <div className="button-bar__section">
-                            {hasLeftButtonsComp && (
+                            {showButtonsComponent && (
                                 <ButtonsComponent {...buttonsComponentProps} model={model} actions={actions} />
                             )}
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -190,12 +190,11 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
                             {hasLeftButtonsComp && (
                                 <ButtonsComponent {...buttonsComponentProps} model={model} actions={actions} />
                             )}
-                            <span className={hiddenWithLeftButtonsCls}>
+
+                            <div className={'button-bar__filter-search ' + hiddenWithLeftButtonsCls}>
                                 {showFiltersButton && <FiltersButton onFilter={onFilter} />}
-                            </span>
-                            <span className={hiddenWithLeftButtonsCls}>
                                 {showSearchInput && <SearchBox actionValues={actionValues} onSearch={onSearch} />}
-                            </span>
+                            </div>
                         </div>
                     </div>
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -170,7 +170,7 @@ class ButtonBar<T> extends PureComponent<GridBarProps<T>> {
         const hasLeftButtonsComp = ButtonsComponent !== undefined;
         // We do not want to render the buttons component until after we've loaded the query model at least once,
         // otherwise the ResponsiveMenuButtonGroup will not be able to collapse buttons correctly.
-        const showButtonsComponent = hasLeftButtonsComp && hasData;
+        const showButtonsComponent = hasLeftButtonsComp && (hasData || rowsError);
         const hiddenWithLeftButtonsCls = classNames({ 'hidden-md hidden-sm hidden-xs': hasLeftButtonsComp });
 
         const paginationComp = (

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -22,8 +22,6 @@ import { exportTabsXlsx } from '../../internal/actions';
 
 import { useNotificationsContext } from '../../internal/components/notifications/NotificationsContext';
 
-import { LoadingState } from '../LoadingState';
-
 import { GridPanel, GridPanelProps } from './GridPanel';
 import { InjectedQueryModels } from './withQueryModels';
 import { QueryModel } from './QueryModel';

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -10,8 +10,13 @@
     display: flex;
 }
 
+.button-bar__filter-search > *:not(:first-child),
 .button-bar__section > *:not(:first-child) {
     margin-left: 12px;
+}
+
+.button-bar__filter-search {
+    display: flex;
 }
 
 .grid-panel__info {


### PR DESCRIPTION
#### Rationale
Presently we collapse grid buttons based on current window size in an all or nothing manner. This means that often users see most of our grid buttons under a single "More" menu. This PR changes the rendering behavior of ResponsiveMenuButtonGroup to better take into account the available space to render buttons, rendering as many as possible, with the rest of the buttons being collapsed under "more".

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1250
- https://github.com/LabKey/labkey-ui-premium/pull/147
- https://github.com/LabKey/sampleManagement/pull/1992
- https://github.com/LabKey/inventory/pull/946
- https://github.com/LabKey/biologics/pull/2268

#### Changes
- Slightly change DOM layout of GridPanel <ButtonBar /> to make size calculations easier
- Update ResponsiveMenuButtonGroup to calculate available space and render as many buttons as possible
- QueryInfo: appEditableTable is no longer private
  - We need to be able to set this property for tests