### PR TITLE
Fix parsing of duplicate key error message

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.357.0",
+  "version": "2.357.1-idPermissionTests.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Update parsing of duplicate key errors to account for single-field keys
+
 ### version 2.357.0
 *Released*: 1 August 2023
 - EditableGrid prop to hideTopControls

--- a/packages/components/src/internal/util/messaging.spec.tsx
+++ b/packages/components/src/internal/util/messaging.spec.tsx
@@ -155,7 +155,7 @@ describe('resolveErrorMessage', () => {
         );
     });
 
-    test('Duplicate key - Postgres', () => {
+    test('Duplicate single-field key - Postgres', () => {
         const error = {
             exception:
                 'ERROR: duplicate key value violates unique constraint "c7094d54716_st_sample_move_name"\n Detail: Key (name)=(PtoC2-0) already exists.',

--- a/packages/components/src/internal/util/messaging.spec.tsx
+++ b/packages/components/src/internal/util/messaging.spec.tsx
@@ -155,6 +155,28 @@ describe('resolveErrorMessage', () => {
         );
     });
 
+    test('Duplicate key - Postgres', () => {
+        const error = {
+            exception:
+                'ERROR: duplicate key value violates unique constraint "c7094d54716_st_sample_move_name"\n Detail: Key (name)=(PtoC2-0) already exists.',
+            extraContext: {},
+            success: false,
+            errors: [
+                {
+                    exception:
+                        'ERROR: duplicate key value violates unique constraint "c7094d54716_st_sample_move_name"\n  Detail: Key (name)=(PtoC2-0) already exists.',
+                    errors: {
+                        _form: 'ERROR: duplicate key value violates unique constraint "c7094d54716_st_sample_move_name"\n  Detail: Key (name)=(PtoC2-0) already exists.',
+                    },
+                },
+            ],
+            errorCount: 1,
+        };
+        expect(resolveErrorMessage(error, 'samples', undefined)).toBe(
+            "There was a problem creating your samples. Duplicate name 'PtoC2-0' found."
+        );
+    });
+
     test('Existing row now found', () => {
         const error = {
             exception: 'The existing row was not found.',

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -71,8 +71,12 @@ export function resolveErrorMessage(error: any, noun = 'data', nounPlural?: stri
                     index = keyMatch[2].indexOf(', ', index + 1);
                 }
                 if (index < keyMatch[2].length) {
-                    // one for comma and one for space
-                    name = keyMatch[2].substring(index + 2);
+                    if (numParts > 1) {
+                        // one for comma and one for space
+                        name = keyMatch[2].substring(index + 2);
+                    } else {
+                        name = keyMatch[2];
+                    }
                 }
             }
             if (name) {


### PR DESCRIPTION
#### Rationale
While writing test elsewhere, I noticed that we weren't handling single-field duplicate key error message parsing well. This fixes that.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/150
- https://github.com/LabKey/labbook/pull/521
- https://github.com/LabKey/sampleManagement/pull/1997
- https://github.com/LabKey/biologics/pull/2278

#### Changes
- Update logic in `resolveErrorMessage`
