### PR TITLE
Issue 48367: Remove no-data styling from Sample Finder tabs

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.358.1-noDataStyling.0",
+  "version": "2.358.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.358.0",
+  "version": "2.358.1-noDataStyling.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.358.1
+*Released*: 8 August 2023
 - Issue 48367: Remove no-data styling from Sample Finder tabs
 
 ### version 2.358.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48367: Remove no-data styling from Sample Finder tabs
+
 ### version 2.358.0
 *Released*: 8 August 2023
 - GridPanel ButtonBar

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -41,7 +41,6 @@ const GridTab: FC<GridTabProps> = memo(({ isActive, model, onSelect, pullRight, 
     const className = classNames({
         active: isActive,
         'pull-right': pullRight,
-        'no-data': showRowCount && !rowCount,
     });
     const onClick = useCallback(() => onSelect(id), [id, onSelect]);
 

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -479,12 +479,6 @@ $table-cell-selection-bg-color: #EDF3FF;
   margin-left: 10px;
 }
 
-.tabbed-grid-panel .nav-tabs {
-    & > li.no-data {
-        opacity: 0.5;
-    }
-}
-
 .view-menu .dropdown-menu {
     max-width: 600px;
     width: max-content;


### PR DESCRIPTION
#### Rationale
Issue [48367](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48367)

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/2000
- https://github.com/LabKey/biologics/pull/2279

#### Changes
- Remove styling from sample finder sample type tabs
