### PR TITLE
Render R Reports

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.359.4",
+  "version": "2.360.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,8 +3,13 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 2.360.0
 *Released*: 17 August 2023
-- Add optional support for R Reports in Chart component
-  - Only enabled if experimental flag is set
+- Add isRReportEnabled helper
+- Add RReport component
+- Move SVG rendering to SVGChart component
+- Make Chart render RReports and SVGCharts
+- Refactor Chart to re-render when filter array changes
+- Add APIWrapper for Chart
+  - not exposed via context
 
 ### version 2.359.4
 *Released*: 18 August 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.360.0
-*Released*: 17 August 2023
+*Released*: 21 August 2023
 - Add isRReportEnabled helper
 - Add RReport component
 - Move SVG rendering to SVGChart component

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.360.0
+*Released*: 17 August 2023
+- Add optional support for R Reports in Chart component
+  - Only enabled if experimental flag is set
+
 ### version 2.359.4
 *Released*: 18 August 2023
 - Migrated components are `DeleteConfirmationModal`, `EntityDeleteConfirmModal` and `EntityDeleteConfirmModalDisplay`.

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -604,7 +604,7 @@ export async function getSelection(
     return { resolved: false, selected: [] };
 }
 
-export function fetchCharts(schemaQuery: SchemaQuery, containerPath?: string): Promise<List<DataViewInfo>> {
+export function fetchCharts(schemaQuery: SchemaQuery, containerPath?: string): Promise<DataViewInfo[]> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL(
@@ -620,11 +620,7 @@ export function fetchCharts(schemaQuery: SchemaQuery, containerPath?: string): P
             ),
             success: Utils.getCallbackWrapper((response: any) => {
                 if (response && response.success) {
-                    const result = response.reports.reduce(
-                        (list, rawDataViewInfo) => list.push(new DataViewInfo(rawDataViewInfo)),
-                        List<DataViewInfo>()
-                    );
-                    resolve(result);
+                    resolve(response.reports.map(report => new DataViewInfo(report)));
                 } else {
                     reject({
                         error:

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -111,6 +111,9 @@ export const NOTIFICATION_TIMEOUT = 500;
 export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 
 export const EXPERIMENTAL_APP_PLATE_SUPPORT = 'experimental-app-plate-support';
+
+export const EXPERIMENTAL_APP_R_SUPPORT = 'experimental-app-r-support';
+
 export const EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = 'queryProductAllFolderLookups';
 export const EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED = 'queryProductProjectDataListingScoped';
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -50,6 +50,7 @@ import {
     SOURCES_KEY,
     USER_KEY,
     WORKFLOW_KEY,
+    EXPERIMENTAL_APP_R_SUPPORT,
 } from './constants';
 
 declare var LABKEY: LabKey;
@@ -319,6 +320,13 @@ export function isPlatesEnabled(moduleContext?: ModuleContext): boolean {
     return (
         biologicsIsPrimaryApp(moduleContext) &&
         resolveModuleContext(moduleContext)?.biologics?.[EXPERIMENTAL_APP_PLATE_SUPPORT] === true
+    );
+}
+
+export function isRReportsEnabled(moduleContext?: ModuleContext): boolean {
+    return (
+        biologicsIsPrimaryApp(moduleContext) &&
+        resolveModuleContext(moduleContext)?.biologics?.[EXPERIMENTAL_APP_R_SUPPORT] === true
     );
 }
 

--- a/packages/components/src/internal/components/chart/BarChartViewer.tsx
+++ b/packages/components/src/internal/components/chart/BarChartViewer.tsx
@@ -29,7 +29,7 @@ import { Section } from '../base/Section';
 import { Tip } from '../base/Tip';
 import { RequiresPermission } from '../base/Permissions';
 
-import { ChartConfig, ChartData, ChartSelector } from './types';
+import { BarChartConfig, BarChartData, BarChartSelector } from './models';
 import { BaseBarChart } from './BaseBarChart';
 import { processChartData } from './utils';
 import { useServerContext } from '../base/ServerContext';
@@ -51,7 +51,7 @@ async function fetchItemCount(schemaQuery: SchemaQuery, filterArray: Filter.IFil
 }
 
 interface Props {
-    chartConfigs: ChartConfig[];
+    chartConfigs: BarChartConfig[];
     containerFilter?: Query.ContainerFilter;
     dataTypeExclusions?: { [key: string]: number[] };
     navigate: (url: string | AppURL) => any;
@@ -120,15 +120,15 @@ export class BarChartViewer extends PureComponent<Props, State> {
         }
     };
 
-    getSelectedChartGroup = (): ChartConfig => {
+    getSelectedChartGroup = (): BarChartConfig => {
         return this.props.chartConfigs[this.state.currentGroup];
     };
 
-    getSelectedChartGroupCharts = (): ChartSelector[] => {
+    getSelectedChartGroupCharts = (): BarChartSelector[] => {
         return this.getSelectedChartGroup().charts;
     };
 
-    onBarClick = (evt: any, row: ChartData): void => {
+    onBarClick = (evt: any, row: BarChartData): void => {
         const { getAppURL, filterDataRegionName = 'query' } = this.getSelectedChartGroup();
 
         if (getAppURL) {

--- a/packages/components/src/internal/components/chart/BaseBarChart.tsx
+++ b/packages/components/src/internal/components/chart/BaseBarChart.tsx
@@ -4,13 +4,13 @@ import { LABKEY_VIS } from '../../constants';
 
 import { debounce, generateId } from '../../util/utils';
 
-import { ChartData } from './types';
+import { BarChartData } from './models';
 import { getBarChartPlotConfig } from './utils';
 
 interface Props {
     barFillColors?: Record<string, string>;
     chartHeight: number;
-    data: ChartData[];
+    data: BarChartData[];
     defaultBorderColor?: string;
     defaultFillColor?: string;
     grouped?: boolean;

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -101,6 +101,10 @@ export const SVGChart: FC<Props> = memo(({ api, chart, filters }) => {
         const render = (): void => {
             if (queryConfig !== undefined && chartConfig !== undefined) {
                 ref.current.innerHTML = '';
+                // Note: our usage of renderChartSVG to render the chart means that every time we call render we make
+                // a new API request to the server to fetch the data, even if all we've done is change screen size. This
+                // updated in the future to use the underlying VIS library to separate fetching of data from rendering
+                // the chart. We should only be fetching data when the reportId or filterArray change.
                 LABKEY_VIS.GenericChartHelper.renderChartSVG(divId, queryConfig, chartConfig);
             }
         };

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -13,14 +13,99 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import { Ajax, Filter, Query, Utils } from '@labkey/api';
 import { List, Record } from 'immutable';
-import { Filter, Query } from '@labkey/api';
+import React, { FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { isLoading, LoadingState } from '../../../public/LoadingState';
+import { DataViewInfoTypes, LABKEY_VIS } from '../../constants';
 
 import { DataViewInfo } from '../../DataViewInfo';
-import { LABKEY_VIS } from '../../constants';
+import { buildURL } from '../../url/AppURL';
 import { debounce, generateId } from '../../util/utils';
 import { LoadingSpinner } from '../base/LoadingSpinner';
+
+class ChartConfigModel extends Record({
+    geomOptions: undefined,
+    height: undefined,
+    labels: undefined,
+    measures: undefined,
+    pointType: undefined,
+    renderType: undefined,
+    scales: undefined,
+    width: undefined,
+}) {
+    declare geomOptions: any;
+    declare height: number;
+    declare labels: any;
+    declare measures: any;
+    declare pointType: string;
+    declare renderType: string;
+    declare scales: any;
+    declare width: number;
+}
+
+class QueryConfigModel extends Record({
+    columns: undefined,
+    containerPath: undefined,
+    // dataRegionName: undefined,
+    filterArray: undefined,
+    maxRows: undefined,
+    method: undefined,
+    parameters: undefined,
+    // queryLabel: undefined,
+    queryName: undefined,
+    requiredVersion: undefined,
+    schemaName: undefined,
+    // sort: undefined,
+    viewName: undefined,
+}) {
+    declare columns: List<string>;
+    declare containerPath: string;
+    // declare dataRegionName: string;
+    declare filterArray: List<any>;
+    declare maxRows: number;
+    declare method: string;
+    declare parameters: any;
+    // declare queryLabel: string;
+    declare queryName: string;
+    declare requiredVersion: string;
+    declare schemaName: string;
+    // declare sort: string;
+    declare viewName: string;
+}
+
+class VisualizationConfigModel extends Record({
+    queryConfig: undefined,
+    chartConfig: undefined,
+}) {
+    declare queryConfig: QueryConfigModel;
+    declare chartConfig: ChartConfigModel;
+
+    static create(raw: any): VisualizationConfigModel {
+        return new VisualizationConfigModel(
+            Object.assign({}, raw, {
+                chartConfig: new ChartConfigModel(raw.chartConfig),
+                queryConfig: new QueryConfigModel(raw.queryConfig),
+            })
+        );
+    }
+}
+
+function getVisualizationConfig(reportId: string): Promise<VisualizationConfigModel> {
+    return new Promise((resolve, reject) => {
+        Query.Visualization.get({
+            reportId,
+            name: undefined,
+            schemaName: undefined,
+            queryName: undefined,
+            success: response => {
+                resolve(VisualizationConfigModel.create(response.visualizationConfig));
+            },
+            failure: reject,
+        });
+    });
+}
 
 interface Props {
     chart: DataViewInfo;
@@ -32,7 +117,7 @@ interface State {
     divId: string;
 }
 
-export class Chart extends React.Component<Props, State> {
+class SVGChart extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
@@ -122,84 +207,103 @@ export class Chart extends React.Component<Props, State> {
     }
 }
 
-function getVisualizationConfig(reportId: string): Promise<VisualizationConfigModel> {
+function fetchRReport(reportId: string, filters?: Filter.IFilter[]): Promise<string> {
     return new Promise((resolve, reject) => {
-        Query.Visualization.get({
-            reportId,
-            name: undefined,
-            schemaName: undefined,
-            queryName: undefined,
-            success: response => {
-                resolve(VisualizationConfigModel.create(response.visualizationConfig));
-            },
-            failure: reject,
+        const params = { reportId, 'webpart.name': 'report' };
+        if (filters) {
+            filters.forEach(filter => {
+                params[filter.getURLParameterName()] = filter.getURLParameterValue();
+            });
+        }
+        const url = buildURL('project', 'getWebPart.view', params);
+        Ajax.request({
+            url,
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response.html);
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                reject(response);
+            }),
         });
     });
 }
 
-class VisualizationConfigModel extends Record({
-    queryConfig: undefined,
-    chartConfig: undefined,
-}) {
-    declare queryConfig: QueryConfigModel;
-    declare chartConfig: ChartConfigModel;
-
-    static create(raw: any): VisualizationConfigModel {
-        return new VisualizationConfigModel(
-            Object.assign({}, raw, {
-                chartConfig: new ChartConfigModel(raw.chartConfig),
-                queryConfig: new QueryConfigModel(raw.queryConfig),
-            })
+const RReport: FC<Props> = memo(({ chart, filters }) => {
+    const { error, reportId } = chart;
+    const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
+    const [reportHtml, setReportHtml] = useState<string>(undefined);
+    const [loadError, setLoadError] = useState<string>(undefined);
+    const filterKey = useMemo(() => {
+        // Note the incoming filters object comes from QueryModel.filters, which is not cached/memoized thus is a new
+        // array every render cycle. To get around this we create a "filterKey" that is a string representation of the
+        // incoming filter array, and we only trigger a reload if the key changes.
+        return (
+            filters
+                ?.map(f => f.getURLParameterName() + '=' + f.getURLParameterValue)
+                .sort()
+                .join('_') ?? ''
         );
+    }, [filters]);
+    const loadReport = useCallback(async () => {
+        setLoadingState(LoadingState.LOADING);
+        setLoadError(undefined);
+
+        try {
+            const html = await fetchRReport(reportId, filters);
+            setReportHtml(html);
+        } catch (e) {
+            setLoadError(e.exception);
+        } finally {
+            setLoadingState(LoadingState.LOADED);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [reportId, filterKey]);
+    const imageUrls = useMemo(() => {
+        if (reportHtml !== undefined) {
+            // The HTML returned by our server includes a bunch of stuff we don't want. So instead of inserting it
+            // directly we'll just grab the URLs for all the images named "resultImage", which are the outputs from an
+            // R Report.
+            const el = document.createElement('div');
+            el.innerHTML = reportHtml;
+            const resultImages = el.querySelectorAll('img[name="resultImage"]');
+            return Array.from(resultImages).map((img: HTMLImageElement) => img.src);
+        }
+
+        return undefined;
+    }, [reportHtml]);
+
+    useEffect(() => {
+        if (error) {
+            // We won't bother loading anything if the chart object has an error
+            setLoadingState(LoadingState.LOADED);
+        } else {
+            loadReport();
+        }
+    }, [error, loadReport]);
+
+    return (
+        <div className="r-report">
+            {isLoading(loadingState) && <LoadingSpinner />}
+            {error !== undefined && <span className="text-danger">{error}</span>}
+            {loadError !== undefined && <span className="text-danger">{loadError}</span>}
+            {imageUrls !== undefined && (
+                <div className="r-report__images">
+                    {imageUrls?.map(url => (
+                        <img alt="R Report Image Output" key={url} src={url} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+});
+RReport.displayName = 'RReport';
+
+export const Chart: FC<Props> = memo(({ chart, filters }) => {
+    if (chart.type === DataViewInfoTypes.RReport) {
+        return <RReport chart={chart} filters={filters} />;
     }
-}
 
-class ChartConfigModel extends Record({
-    geomOptions: undefined,
-    height: undefined,
-    labels: undefined,
-    measures: undefined,
-    pointType: undefined,
-    renderType: undefined,
-    scales: undefined,
-    width: undefined,
-}) {
-    declare geomOptions: any;
-    declare height: number;
-    declare labels: any;
-    declare measures: any;
-    declare pointType: string;
-    declare renderType: string;
-    declare scales: any;
-    declare width: number;
-}
+    return <SVGChart chart={chart} filters={filters} />;
+});
 
-class QueryConfigModel extends Record({
-    columns: undefined,
-    containerPath: undefined,
-    // dataRegionName: undefined,
-    filterArray: undefined,
-    maxRows: undefined,
-    method: undefined,
-    parameters: undefined,
-    // queryLabel: undefined,
-    queryName: undefined,
-    requiredVersion: undefined,
-    schemaName: undefined,
-    // sort: undefined,
-    viewName: undefined,
-}) {
-    declare columns: List<string>;
-    declare containerPath: string;
-    // declare dataRegionName: string;
-    declare filterArray: List<any>;
-    declare maxRows: number;
-    declare method: string;
-    declare parameters: any;
-    // declare queryLabel: string;
-    declare queryName: string;
-    declare requiredVersion: string;
-    declare schemaName: string;
-    // declare sort: string;
-    declare viewName: string;
-}
+Chart.displayName = 'Chart';

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -41,6 +41,7 @@ function computeFilterKey(filters: Filter.IFilter[]): string {
 interface Props {
     api?: ChartAPIWrapper;
     chart: DataViewInfo;
+    container?: string;
     filters?: Filter.IFilter[];
 }
 
@@ -126,7 +127,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, filters }) => {
 });
 SVGChart.displayName = 'SVGChart';
 
-const RReport: FC<Props> = memo(({ api, chart, filters }) => {
+const RReport: FC<Props> = memo(({ api, chart, container, filters }) => {
     const { error, reportId } = chart;
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [reportHtml, setReportHtml] = useState<string>(undefined);
@@ -137,7 +138,7 @@ const RReport: FC<Props> = memo(({ api, chart, filters }) => {
         setLoadError(undefined);
 
         try {
-            const html = await api.fetchRReport(reportId, filters);
+            const html = await api.fetchRReport(reportId, container, filters);
             setReportHtml(html);
         } catch (e) {
             setLoadError(e.exception);
@@ -187,12 +188,12 @@ const RReport: FC<Props> = memo(({ api, chart, filters }) => {
 });
 RReport.displayName = 'RReport';
 
-export const Chart: FC<Props> = memo(({ api = DEFAULT_API_WRAPPER, chart, filters }) => {
+export const Chart: FC<Props> = memo(({ api = DEFAULT_API_WRAPPER, chart, container, filters }) => {
     if (chart.type === DataViewInfoTypes.RReport) {
-        return <RReport api={api} chart={chart} filters={filters} />;
+        return <RReport api={api} chart={chart} container={container} filters={filters} />;
     }
 
-    return <SVGChart api={api} chart={chart} filters={filters} />;
+    return <SVGChart api={api} chart={chart} container={container} filters={filters} />;
 });
 
 Chart.displayName = 'Chart';

--- a/packages/components/src/internal/components/chart/api.ts
+++ b/packages/components/src/internal/components/chart/api.ts
@@ -1,6 +1,6 @@
 import { Ajax, Filter, Query, Utils } from '@labkey/api';
+import { getContainerFilter } from '../../query/api';
 import { buildURL } from '../../url/AppURL';
-import { ProductSectionModel } from '../productnavigation/models';
 import { VisualizationConfigModel } from './models';
 
 export function fetchVisualizationConfig(reportId: string): Promise<VisualizationConfigModel> {
@@ -18,15 +18,15 @@ export function fetchVisualizationConfig(reportId: string): Promise<Visualizatio
     });
 }
 
-export function fetchRReport(reportId: string, filters?: Filter.IFilter[]): Promise<string> {
+export function fetchRReport(reportId: string, container?: string, filters?: Filter.IFilter[]): Promise<string> {
     return new Promise((resolve, reject) => {
-        const params = { reportId, 'webpart.name': 'report' };
+        const params = { reportId, 'webpart.name': 'report', containerFilter: getContainerFilter(container) };
         if (filters) {
             filters.forEach(filter => {
                 params[filter.getURLParameterName()] = filter.getURLParameterValue();
             });
         }
-        const url = buildURL('project', 'getWebPart.view', params);
+        const url = buildURL('project', 'getWebPart.view', params, { container });
         Ajax.request({
             url,
             success: Utils.getCallbackWrapper(response => {
@@ -40,11 +40,11 @@ export function fetchRReport(reportId: string, filters?: Filter.IFilter[]): Prom
 }
 
 export interface ChartAPIWrapper {
-    fetchRReport: (reportId, filters?: Filter.IFilter[]) => Promise<string>;
+    fetchRReport: (reportId: string, container?: string, filters?: Filter.IFilter[]) => Promise<string>;
     fetchVisualizationConfig: (reportId: string) => Promise<VisualizationConfigModel>;
 }
 
 export const DEFAULT_API_WRAPPER = {
     fetchRReport,
     fetchVisualizationConfig,
-}
+};

--- a/packages/components/src/internal/components/chart/api.ts
+++ b/packages/components/src/internal/components/chart/api.ts
@@ -1,0 +1,50 @@
+import { Ajax, Filter, Query, Utils } from '@labkey/api';
+import { buildURL } from '../../url/AppURL';
+import { ProductSectionModel } from '../productnavigation/models';
+import { VisualizationConfigModel } from './models';
+
+export function fetchVisualizationConfig(reportId: string): Promise<VisualizationConfigModel> {
+    return new Promise((resolve, reject) => {
+        Query.Visualization.get({
+            reportId,
+            name: undefined,
+            schemaName: undefined,
+            queryName: undefined,
+            success: response => {
+                resolve(response.visualizationConfig);
+            },
+            failure: reject,
+        });
+    });
+}
+
+export function fetchRReport(reportId: string, filters?: Filter.IFilter[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const params = { reportId, 'webpart.name': 'report' };
+        if (filters) {
+            filters.forEach(filter => {
+                params[filter.getURLParameterName()] = filter.getURLParameterValue();
+            });
+        }
+        const url = buildURL('project', 'getWebPart.view', params);
+        Ajax.request({
+            url,
+            success: Utils.getCallbackWrapper(response => {
+                resolve(response.html);
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                reject(response);
+            }),
+        });
+    });
+}
+
+export interface ChartAPIWrapper {
+    fetchRReport: (reportId, filters?: Filter.IFilter[]) => Promise<string>;
+    fetchVisualizationConfig: (reportId: string) => Promise<VisualizationConfigModel>;
+}
+
+export const DEFAULT_API_WRAPPER = {
+    fetchRReport,
+    fetchVisualizationConfig,
+}

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -5,9 +5,9 @@ import { ASSAYS_KEY, SAMPLES_KEY } from '../../app/constants';
 import { AppURL } from '../../url/AppURL';
 import { SCHEMAS } from '../../schemas';
 
-import { ChartConfig, ChartSelector } from './types';
+import { BarChartConfig, BarChartSelector } from './models';
 
-const CHART_SELECTORS: Record<string, ChartSelector> = {
+const CHART_SELECTORS: Record<string, BarChartSelector> = {
     All: { name: 'TotalCount', label: 'All' },
     Month: { name: 'Last30DaysCount', label: 'In the Last Month', filter: -29 },
     Today: { name: 'TodayCount', label: 'Today', filter: 0 },
@@ -23,7 +23,7 @@ const getExclusionFilter = (dataType: string): ((projectExclusions: { [key: stri
     };
 };
 
-export const CHART_GROUPS: Record<string, ChartConfig> = {
+export const CHART_GROUPS: Record<string, BarChartConfig> = {
     Assays: {
         charts: [
             CHART_SELECTORS.All,

--- a/packages/components/src/internal/components/chart/models.ts
+++ b/packages/components/src/internal/components/chart/models.ts
@@ -35,3 +35,35 @@ export interface BarChartConfig {
     showSampleButtons?: boolean;
     sort?: string;
 }
+
+export interface ChartConfig {
+    geomOptions: any;
+    height: number;
+    labels: any;
+    measures: any;
+    pointType: string;
+    renderType: string;
+    scales: any;
+    width: number;
+}
+
+export interface ChartQueryConfig {
+    columns: string[];
+    containerPath: string;
+    // dataRegionName: string;
+    filterArray: Filter.IFilter[];
+    maxRows: number;
+    method: string;
+    parameters: any;
+    // queryLabel: string;
+    queryName: string;
+    requiredVersion: string;
+    schemaName: string;
+    // sort: string;
+    viewName: string;
+}
+
+export interface VisualizationConfigModel {
+    chartConfig: ChartConfig;
+    queryConfig: ChartQueryConfig;
+}

--- a/packages/components/src/internal/components/chart/models.ts
+++ b/packages/components/src/internal/components/chart/models.ts
@@ -4,25 +4,25 @@ import { Filter } from '@labkey/api';
 import { AppURL } from '../../url/AppURL';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 
-export interface ChartData {
+export interface BarChartData {
     count: number;
     id?: string | number;
     x: string;
     xSub?: string;
 }
 
-export interface ChartSelector {
+export interface BarChartSelector {
     filter?: number;
     label: string;
     name: string;
 }
 
-export interface ChartConfig {
-    charts: ChartSelector[];
+export interface BarChartConfig {
+    charts: BarChartSelector[];
     colorPath?: string[];
     emptyStateMsg?: ReactNode;
     filterDataRegionName?: string;
-    getAppURL?: (data: ChartData, evt?: any) => AppURL;
+    getAppURL?: (data: BarChartData, evt?: any) => AppURL;
     getProjectExclusionFilter?: (projectExclusions: { [key: string]: number[] }) => Filter.IFilter;
     groupPath?: string[];
     itemCountFilters?: Filter.IFilter[];

--- a/packages/components/src/internal/components/chart/utils.ts
+++ b/packages/components/src/internal/components/chart/utils.ts
@@ -6,12 +6,12 @@ import { caseInsensitive } from '../../util/utils';
 
 import { Row } from '../../query/selectRows';
 
-import { ChartData } from './types';
+import { BarChartData } from './models';
 import { HorizontalBarData } from './HorizontalBarSection';
 
 interface ChartDataProps {
     barFillColors: Record<string, string>;
-    data: ChartData[];
+    data: BarChartData[];
 }
 
 interface ProcessChartOptions {

--- a/packages/components/src/internal/constants.ts
+++ b/packages/components/src/internal/constants.ts
@@ -207,6 +207,7 @@ export const VISUALIZATION_REPORTS = Set([
     DataViewInfoTypes.BarChart,
     DataViewInfoTypes.BoxAndWhiskerPlot,
     DataViewInfoTypes.PieChart,
+    DataViewInfoTypes.RReport,
     DataViewInfoTypes.XYScatterPlot,
     DataViewInfoTypes.XYSeriesLinePlot,
 ]);

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -112,3 +112,7 @@
         overflow: hidden;
     }
 }
+
+.r-report__images img {
+    max-width: 100%;
+}


### PR DESCRIPTION
#### Rationale
This PR allows grids to render R reports when an experimental flag is present.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1257
- https://github.com/LabKey/labkey-ui-premium/pull/157
- https://github.com/LabKey/biologics/pull/2291
- https://github.com/LabKey/inventory/pull/974
- https://github.com/LabKey/sampleManagement/pull/2014

#### Changes
- Add isRReportEnabled helper
- Add RReport component
- Move SVG rendering to SVGChart component
- Make Chart render RReports and SVGCharts
- Refactor Chart to re-render when filter array changes
- Add APIWrapper for Chart
    - not exposed via context
