### PR TITLE
Remove updateDomainPanelClassList

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.360.0",
+  "version": "2.360.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version ????
+*Released*: ?? August 2023
+- Remove updateDomainPanelClassList
+  - Instead we manually toggle the necessary classname in the component
+
 ### version 2.360.0
 *Released*: 21 August 2023
 - Add isRReportEnabled helper

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version ????
 *Released*: ?? August 2023
 - Remove updateDomainPanelClassList
-  - Instead we manually toggle the necessary classname in the component
+  - Manually toggle the necessary classname in the component instead of manually manipulationg the DOM
+- Update tests to no longer attempt to make network requests
 
 ### version 2.360.0
 *Released*: 21 August 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version ????
-*Released*: ?? August 2023
+### version 2.360.1
+*Released*: 21 August 2023
 - Remove updateDomainPanelClassList
   - Manually toggle the necessary classname in the component instead of manually manipulationg the DOM
 - Update tests to no longer attempt to make network requests

--- a/packages/components/src/internal/components/domainproperties/BasePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/BasePropertiesPanel.tsx
@@ -4,7 +4,7 @@ import { Panel } from 'react-bootstrap';
 import { Alert } from '../base/Alert';
 
 import { DomainPanelStatus } from './models';
-import { getDomainAlertClasses, getDomainPanelClass, updateDomainPanelClassList } from './actions';
+import { getDomainAlertClasses, getDomainPanelClass } from './actions';
 import { CollapsiblePanelHeader } from './CollapsiblePanelHeader';
 import { PROPERTIES_PANEL_ERROR_MSG } from './constants';
 import { InjectedDomainPropertiesPanelCollapseProps } from './DomainPropertiesPanelCollapse';
@@ -38,13 +38,8 @@ export class BasePropertiesPanel extends React.PureComponent<Props> {
         useTheme: false,
     };
 
-    componentDidMount(): void {
-        updateDomainPanelClassList(this.props.useTheme, undefined, this.props.headerId);
-    }
-
     componentDidUpdate(prevProps: Props): void {
         const { validate, updateValidStatus } = this.props;
-        updateDomainPanelClassList(prevProps.useTheme, undefined, this.props.headerId);
 
         if (validate && prevProps.validate !== validate) {
             updateValidStatus();

--- a/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
+++ b/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
-import { Panel } from 'react-bootstrap';
 
 import { LabelHelpTip } from '../base/LabelHelpTip';
 
@@ -85,6 +84,7 @@ export class CollapsiblePanelHeader extends React.PureComponent<Props> {
             'domain-form-collapse-btn': !collapsed,
         });
         const panelHeaderClass = classNames('domain-panel-header', {
+            'panel-heading': !useTheme,
             'domain-heading-collapsible': collapsible || controlledCollapse,
             'domain-panel-header-expanded': !collapsed,
             'domain-panel-header-collapsed': collapsed,
@@ -93,7 +93,7 @@ export class CollapsiblePanelHeader extends React.PureComponent<Props> {
         });
 
         return (
-            <Panel.Heading id={id} onClick={togglePanel} className={panelHeaderClass}>
+            <div id={id} onClick={togglePanel} className={panelHeaderClass}>
                 {/* Header help icon*/}
                 {iconHelpMsg && (
                     <LabelHelpTip iconComponent={this.getHeaderIconComponent()} placement="top" title={title}>
@@ -123,7 +123,7 @@ export class CollapsiblePanelHeader extends React.PureComponent<Props> {
                 {controlledCollapse && headerDetails && (
                     <span className="domain-panel-header-fields-defined">{headerDetails}</span>
                 )}
-            </Panel.Heading>
+            </div>
         );
     }
 }

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -71,7 +71,6 @@ import {
     processJsonImport,
     removeFields,
     setDomainFields,
-    updateDomainPanelClassList,
     updateOntologyFieldProperties,
 } from './actions';
 import { getIndexFromId, getNameFromId } from './utils';
@@ -258,15 +257,8 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             onChange(this.validateDomain(domain), false);
         }
 
-        // TODO since this is called in componentDidUpdate, can it be removed here?
-        updateDomainPanelClassList(useTheme, domain);
-
         this.setState(() => ({ isLoading: false }));
     };
-
-    componentDidUpdate(prevProps: Readonly<IDomainFormInput>): void {
-        updateDomainPanelClassList(prevProps.useTheme, this.props.domain);
-    }
 
     UNSAFE_componentWillReceiveProps(nextProps: Readonly<IDomainFormInput>): void {
         const { controlledCollapse, initCollapsed, validate, onChange } = this.props;

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/CollapsiblePanelHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/CollapsiblePanelHeader.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<CollapsiblePanelHeader/> custom properties 1`] = `
 <div
-  className="domain-panel-header domain-heading-collapsible domain-panel-header-collapsed panel-heading"
+  className="domain-panel-header domain-heading-collapsible domain-panel-header-collapsed"
   id="test-id"
   onClick={[MockFunction]}
 >
@@ -35,7 +35,7 @@ exports[`<CollapsiblePanelHeader/> custom properties 1`] = `
 
 exports[`<CollapsiblePanelHeader/> default properties 1`] = `
 <div
-  className="domain-panel-header domain-heading-collapsible domain-panel-header-collapsed panel-heading"
+  className="domain-panel-header domain-heading-collapsible domain-panel-header-collapsed"
   id="test-id"
   onClick={[MockFunction]}
 >
@@ -56,7 +56,7 @@ exports[`<CollapsiblePanelHeader/> default properties 1`] = `
 
 exports[`<CollapsiblePanelHeader/> invalid, iconHelpMsg, and expanded 1`] = `
 <div
-  className="domain-panel-header domain-heading-collapsible domain-panel-header-expanded labkey-page-nav panel-heading"
+  className="domain-panel-header domain-heading-collapsible domain-panel-header-expanded labkey-page-nav"
   id="test-id"
   onClick={[MockFunction]}
 >
@@ -90,7 +90,7 @@ exports[`<CollapsiblePanelHeader/> invalid, iconHelpMsg, and expanded 1`] = `
 
 exports[`<CollapsiblePanelHeader/> not collapsible 1`] = `
 <div
-  className="domain-panel-header domain-panel-header-expanded labkey-page-nav panel-heading"
+  className="domain-panel-header domain-panel-header-expanded labkey-page-nav"
   id="test-id"
   onClick={[MockFunction]}
 >
@@ -104,7 +104,7 @@ exports[`<CollapsiblePanelHeader/> not collapsible 1`] = `
 
 exports[`<CollapsiblePanelHeader/> not controlledCollapse 1`] = `
 <div
-  className="domain-panel-header domain-panel-header-collapsed panel-heading"
+  className="domain-panel-header domain-panel-header-collapsed"
   id="test-id"
   onClick={[MockFunction]}
 >
@@ -125,7 +125,7 @@ exports[`<CollapsiblePanelHeader/> not controlledCollapse 1`] = `
 
 exports[`<CollapsiblePanelHeader/> not useTheme 1`] = `
 <div
-  className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+  className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
   id="test-id"
   onClick={[MockFunction]}
 >
@@ -139,7 +139,7 @@ exports[`<CollapsiblePanelHeader/> not useTheme 1`] = `
 
 exports[`<CollapsiblePanelHeader/> panelStatus TODO and help tip 1`] = `
 <div
-  className="domain-panel-header domain-heading-collapsible domain-panel-header-collapsed panel-heading"
+  className="domain-panel-header domain-heading-collapsible domain-panel-header-collapsed"
   id="test-id"
   onClick={[MockFunction]}
 >

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -989,16 +989,6 @@ export function getDomainAlertClasses(collapsed: boolean, controlledCollapse: bo
     });
 }
 
-// This is kind of a hacky way to remove a class from core css so we can set the color of the panel hdr to match the theme
-export function updateDomainPanelClassList(useTheme: boolean, domain: DomainDesign, id?: string) {
-    if (useTheme) {
-        const el = document.getElementById(getDomainPanelHeaderId(domain, id));
-        if (el) {
-            el.classList.remove('panel-heading');
-        }
-    }
-}
-
 export function getDomainPanelHeaderId(domain: DomainDesign, id?: string): string {
     if (domain && domain.name) {
         return createFormInputName(domain.name.replace(/\s/g, '-') + '-hdr');

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { List, Map } from 'immutable';
 import { Panel } from 'react-bootstrap';
-import { getTestAPIWrapper } from '../../../APIWrapper';
 import { getDomainPropertiesTestAPIWrapper } from '../APIWrapper';
 
 import { DomainDesign } from '../models';
@@ -317,6 +316,8 @@ describe('AssayDesignerPanels', () => {
         );
     });
 
+    // FIXME: This test case triggers issues with React Beautiful DND, I think there is a way to put that library in
+    //  test mode. We maybe accidentally disabled that in the test stabilization PR.
     test('Show app headers', async () => {
         const _appHeaderId = 'mock-app-header';
         const _appHeaderText = 'This is a mock app header';
@@ -341,7 +342,7 @@ describe('AssayDesignerPanels', () => {
 
         // Open Sample Fields panel body
         wrapper
-            .find(Panel.Heading)
+            .find('.panel-heading')
             .filterWhere(n => n.text().indexOf('Sample Fields') === 0)
             .simulate('click');
         expect(wrapper.find('#' + _appHeaderId)).toHaveLength(1);

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
@@ -1522,25 +1522,17 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                 togglePanel={[Function]}
                 useTheme={false}
               >
-                <PanelHeading
-                  bsClass="panel"
-                  className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme"
-                  componentClass="div"
+                <div
+                  className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
                   id="assay-properties-hdr"
                   onClick={[Function]}
                 >
-                  <div
-                    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
-                    id="assay-properties-hdr"
-                    onClick={[Function]}
+                  <span
+                    className="domain-panel-title"
                   >
-                    <span
-                      className="domain-panel-title"
-                    >
-                      Assay Properties
-                    </span>
-                  </div>
-                </PanelHeading>
+                    Assay Properties
+                  </span>
+                </div>
               </CollapsiblePanelHeader>
               <PanelBody
                 bsClass="panel"
@@ -2877,25 +2869,17 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                 togglePanel={[Function]}
                 useTheme={false}
               >
-                <PanelHeading
-                  bsClass="panel"
-                  className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme"
-                  componentClass="div"
+                <div
+                  className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
                   id="assay-properties-hdr"
                   onClick={[Function]}
                 >
-                  <div
-                    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
-                    id="assay-properties-hdr"
-                    onClick={[Function]}
+                  <span
+                    className="domain-panel-title"
                   >
-                    <span
-                      className="domain-panel-title"
-                    >
-                      Assay Properties
-                    </span>
-                  </div>
-                </PanelHeading>
+                    Assay Properties
+                  </span>
+                </div>
               </CollapsiblePanelHeader>
               <PanelBody
                 bsClass="panel"
@@ -3986,25 +3970,17 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                 togglePanel={[Function]}
                 useTheme={false}
               >
-                <PanelHeading
-                  bsClass="panel"
-                  className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme"
-                  componentClass="div"
+                <div
+                  className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
                   id="assay-properties-hdr"
                   onClick={[Function]}
                 >
-                  <div
-                    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
-                    id="assay-properties-hdr"
-                    onClick={[Function]}
+                  <span
+                    className="domain-panel-title"
                   >
-                    <span
-                      className="domain-panel-title"
-                    >
-                      Assay Properties
-                    </span>
-                  </div>
-                </PanelHeading>
+                    Assay Properties
+                  </span>
+                </div>
               </CollapsiblePanelHeader>
               <PanelBody
                 bsClass="panel"
@@ -5015,25 +4991,17 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                 togglePanel={[Function]}
                 useTheme={false}
               >
-                <PanelHeading
-                  bsClass="panel"
-                  className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme"
-                  componentClass="div"
+                <div
+                  className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
                   id="assay-properties-hdr"
                   onClick={[Function]}
                 >
-                  <div
-                    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
-                    id="assay-properties-hdr"
-                    onClick={[Function]}
+                  <span
+                    className="domain-panel-title"
                   >
-                    <span
-                      className="domain-panel-title"
-                    >
-                      Assay Properties
-                    </span>
-                  </div>
-                </PanelHeading>
+                    Assay Properties
+                  </span>
+                </div>
               </CollapsiblePanelHeader>
               <PanelBody
                 bsClass="panel"

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.spec.tsx
@@ -112,9 +112,9 @@ describe('DataClassDesigner', () => {
         await waitForLifecycle(wrapped);
 
         const panelHeader = wrapped.find('div#domain-header');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-collapsed')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-collapsed')).toBeTruthy();
         panelHeader.simulate('click');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-expanded')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-expanded')).toBeTruthy();
         expect(wrapped.find(FileAttachmentForm)).toHaveLength(1);
         expect(wrapped.find(SystemFields)).toHaveLength(1);
 

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.spec.tsx
@@ -21,6 +21,7 @@ import { List } from 'immutable';
 
 import getDatasetDesign from '../../../../test/data/dataset-getDatasetDesign.json';
 import { NEW_DATASET_MODEL_WITHOUT_DATASPACE } from '../../../../test/data/constants';
+import { getDomainPropertiesTestAPIWrapper } from '../APIWrapper';
 import { PROPERTIES_PANEL_ERROR_MSG } from '../constants';
 
 import { Alert } from '../../base/Alert';
@@ -38,6 +39,7 @@ describe('Dataset Designer', () => {
     test('New dataset', async () => {
         const designerPanels = shallow(
             <DatasetDesignerPanelImpl
+                api={getDomainPropertiesTestAPIWrapper(jest.fn)}
                 initModel={newDatasetModel}
                 onCancel={jest.fn()}
                 onComplete={jest.fn()}
@@ -62,6 +64,7 @@ describe('Dataset Designer', () => {
     test('Edit existing dataset', async () => {
         const designerPanels = shallow(
             <DatasetDesignerPanels
+                api={getDomainPropertiesTestAPIWrapper(jest.fn)}
                 initModel={populatedDatasetModel}
                 onCancel={jest.fn()}
                 onComplete={jest.fn()}
@@ -78,6 +81,7 @@ describe('Dataset Designer', () => {
     test('for alert/message', async () => {
         const wrapped = mount(
             <DatasetDesignerPanels
+                api={getDomainPropertiesTestAPIWrapper(jest.fn)}
                 initModel={newDatasetModel}
                 onCancel={jest.fn()}
                 onComplete={jest.fn()}
@@ -88,14 +92,14 @@ describe('Dataset Designer', () => {
         await waitForLifecycle(wrapped);
 
         const datasetHeader = wrapped.find('div#dataset-header-id');
-        expect(wrapped.find('#dataset-header-id').at(2).hasClass('domain-panel-header-expanded')).toBeTruthy();
+        expect(wrapped.find('#dataset-header-id').at(1).hasClass('domain-panel-header-expanded')).toBeTruthy();
         datasetHeader.simulate('click');
-        expect(wrapped.find('#dataset-header-id').at(2).hasClass('domain-panel-header-collapsed')).toBeTruthy();
+        expect(wrapped.find('#dataset-header-id').at(1).hasClass('domain-panel-header-collapsed')).toBeTruthy();
 
         const panelHeader = wrapped.find('div#domain-header');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-collapsed')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-collapsed')).toBeTruthy();
         panelHeader.simulate('click');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-expanded')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-expanded')).toBeTruthy();
 
         expect(wrapped.find(Alert)).toHaveLength(2);
         expect(wrapped.find(Alert).at(0).text()).toEqual(PROPERTIES_PANEL_ERROR_MSG);

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { List } from 'immutable';
 
 import { Domain, getServerContext } from '@labkey/api';
 
 import produce, { Draft } from 'immer';
+import { getDefaultAPIWrapper } from '../../../APIWrapper';
+import { DomainPropertiesAPIWrapper } from '../APIWrapper';
 
 import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesigner } from '../BaseDomainDesigner';
 
@@ -52,14 +54,15 @@ const VISIT_DATE_MAPPING_ERROR = 'Your Visit Date Column must not be one of the 
 const ADDITIONAL_KEY_ERROR = 'You must select an Additional Key Field in the dataset properties panel.';
 
 interface Props {
+    api?: DomainPropertiesAPIWrapper;
     initModel?: DatasetModel;
-    onChange?: (model: DatasetModel) => void;
     onCancel: () => void;
+    onChange?: (model: DatasetModel) => void;
     onComplete: (model: DatasetModel) => void;
-    useTheme?: boolean;
     saveBtnText?: string;
     successBsStyle?: string;
     testMode?: boolean;
+    useTheme?: boolean;
 }
 
 interface State {
@@ -76,6 +79,10 @@ interface State {
 export class DatasetDesignerPanelImpl extends React.PureComponent<Props & InjectedBaseDomainDesignerProps, State> {
     private _participantId: string;
     private _sequenceNum: string;
+
+    static defaultProps = {
+        api: getDefaultAPIWrapper().domain,
+    };
 
     constructor(props: Props & InjectedBaseDomainDesignerProps) {
         super(props);
@@ -175,11 +182,11 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         );
     };
 
-    onIndexChange = (keyPropertyIndex?: number, visitDatePropertyIndex?: number) => {
+    onIndexChange = (keyPropertyIndex?: number, visitDatePropertyIndex?: number): void => {
         this.setState(() => ({ keyPropertyIndex, visitDatePropertyIndex }));
     };
 
-    onFinish = () => {
+    onFinish = (): void => {
         const { setSubmitting } = this.props;
         const { model, shouldImportData } = this.state;
         const missingRequiredTimepointMapping = !model.demographicData && !this._sequenceNum;
@@ -207,7 +214,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         this.props.onFinish(model.isValid(), this.saveDomain);
     };
 
-    onDomainChange = (domain: DomainDesign, dirty: boolean, rowIndexChanges: DomainFieldIndexChange[]) => {
+    onDomainChange = (domain: DomainDesign, dirty: boolean, rowIndexChanges: DomainFieldIndexChange[]): void => {
         const { onChange } = this.props;
         const { keyPropertyIndex, visitDatePropertyIndex } = this.state;
 
@@ -281,14 +288,14 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         );
     };
 
-    setFileImportData = (file: File, shouldImportData: boolean) => {
+    setFileImportData = (file: File, shouldImportData: boolean): void => {
         this.setState(state => ({
             file,
             shouldImportData: shouldImportData && !state.model.definitionIsShared,
         }));
     };
 
-    onColumnMappingChange = (participantIdField?: string, timePointField?: string) => {
+    onColumnMappingChange = (participantIdField?: string, timePointField?: string): void => {
         const { model } = this.state;
 
         this._participantId = participantIdField;
@@ -315,7 +322,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         );
     };
 
-    renderColumnMappingSection = () => {
+    renderColumnMappingSection = (): ReactNode => {
         const { model, file } = this.state;
 
         // only show this column mapping section in the file infer fields case when there is at least one field
@@ -363,7 +370,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         this.props.onComplete(this.state.savedModel);
     };
 
-    handleFileImport(participantId, sequenceNum) {
+    handleFileImport(participantId, sequenceNum): void {
         const { setSubmitting } = this.props;
         const { file, savedModel } = this.state;
 
@@ -392,7 +399,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
             });
     }
 
-    saveDomain = () => {
+    saveDomain = (): void => {
         const { setSubmitting } = this.props;
         const { model, shouldImportData } = this.state;
         const participantIdMapCol = this._participantId;
@@ -465,8 +472,9 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
             });
     };
 
-    render() {
+    render(): ReactNode {
         const {
+            api,
             useTheme,
             onTogglePanel,
             visitedPanels,
@@ -516,6 +524,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
                     successBsStyle={successBsStyle}
                 />
                 <DomainForm
+                    api={api}
                     key={model.domain.domainId || 0}
                     domainIndex={0}
                     domain={model.domain}

--- a/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetDesignerPanels.spec.tsx.snap
@@ -2,6 +2,19 @@
 
 exports[`Dataset Designer Edit existing dataset 1`] = `
 <DatasetDesignerPanelImpl
+  api={
+    {
+      "fetchDomainDetails": [MockFunction],
+      "fetchOntologies": [MockFunction],
+      "getDataClassDetails": [MockFunction],
+      "getDomainNamePreviews": [MockFunction],
+      "getGenId": [MockFunction],
+      "getMaxPhiLevel": [Function],
+      "hasExistingDomainData": [MockFunction],
+      "setGenId": [MockFunction],
+      "validateDomainNameExpressions": [MockFunction],
+    }
+  }
   currentPanelIndex={0}
   firstState={true}
   initModel={
@@ -1425,6 +1438,19 @@ exports[`Dataset Designer New dataset 1`] = `
     validate={true}
   />
   <DomainForm
+    api={
+      {
+        "fetchDomainDetails": [MockFunction],
+        "fetchOntologies": [MockFunction],
+        "getDataClassDetails": [MockFunction],
+        "getDomainNamePreviews": [MockFunction],
+        "getGenId": [MockFunction],
+        "getMaxPhiLevel": [Function],
+        "hasExistingDomainData": [MockFunction],
+        "setGenId": [MockFunction],
+        "validateDomainNameExpressions": [MockFunction],
+      }
+    }
     controlledCollapse={true}
     domain={
       Immutable.Record {

--- a/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Dataset Properties Panel Edit existing dataset 1`] = `
   className="domain-form-panel lk-border-theme-light panel panel-default"
 >
   <div
-    className="domain-panel-header domain-heading-collapsible domain-panel-header-expanded labkey-page-nav panel-heading"
+    className="domain-panel-header domain-heading-collapsible domain-panel-header-expanded labkey-page-nav"
     id="dataset-header-id"
     onClick={[Function]}
   >
@@ -601,7 +601,7 @@ exports[`Dataset Properties Panel New dataset 1`] = `
   className="domain-form-panel lk-border-theme-light panel panel-default"
 >
   <div
-    className="domain-panel-header domain-heading-collapsible domain-panel-header-expanded labkey-page-nav panel-heading"
+    className="domain-panel-header domain-heading-collapsible domain-panel-header-expanded labkey-page-nav"
     id="dataset-header-id"
     onClick={[Function]}
   >

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.spec.tsx
@@ -64,9 +64,9 @@ describe('IssuesListDefDesignerPanel', () => {
         await waitForLifecycle(wrapped);
 
         const panelHeader = wrapped.find('div#domain-header');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-collapsed')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-collapsed')).toBeTruthy();
         panelHeader.simulate('click');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-expanded')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-expanded')).toBeTruthy();
 
         expect(wrapped.find(Alert)).toHaveLength(2);
         expect(wrapped.find(Alert).at(0).text()).toEqual(PROPERTIES_PANEL_ERROR_MSG);

--- a/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/issues/__snapshots__/IssuesListDefPropertiesPanel.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`IssuesListDefPropertiesPanel new Issue Def 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="issues-properties-hdr"
     onClick={[Function]}
   >

--- a/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.spec.tsx
@@ -24,6 +24,7 @@ describe('ListDesignerPanel', () => {
             initModel: emptyNewModel,
             onComplete: jest.fn(),
             onCancel: jest.fn(),
+            onChange: jest.fn(),
             testMode: true,
         };
     }
@@ -88,11 +89,11 @@ describe('ListDesignerPanel', () => {
 
         const panelHeader = listDesignerPanels.find('div#domain-header');
 
-        expect(listDesignerPanels.find('#domain-header').at(2).hasClass('domain-panel-header-collapsed')).toBeTruthy();
+        expect(listDesignerPanels.find('#domain-header').at(1).hasClass('domain-panel-header-collapsed')).toBeTruthy();
 
         panelHeader.simulate('click');
 
-        expect(listDesignerPanels.find('#domain-header').at(2).hasClass('domain-panel-header-expanded')).toBeTruthy();
+        expect(listDesignerPanels.find('#domain-header').at(1).hasClass('domain-panel-header-expanded')).toBeTruthy();
 
         expect(listDesignerPanels.find(Alert)).toHaveLength(2);
         expect(listDesignerPanels.find(Alert).at(0).text()).toEqual(PROPERTIES_PANEL_ERROR_MSG);

--- a/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/list/__snapshots__/ListPropertiesPanel.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`ListPropertiesPanel existing list 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="list-properties-hdr"
     onClick={[Function]}
   >
@@ -205,7 +205,7 @@ exports[`ListPropertiesPanel list with error 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="list-properties-hdr"
     onClick={[Function]}
   >
@@ -411,7 +411,7 @@ exports[`ListPropertiesPanel new list 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="list-properties-hdr"
     onClick={[Function]}
   >

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
@@ -164,9 +164,9 @@ describe('SampleTypeDesigner', () => {
         await waitForLifecycle(wrapped);
 
         const panelHeader = wrapped.find('div#domain-header');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-collapsed')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-collapsed')).toBeTruthy();
         panelHeader.simulate('click');
-        expect(wrapped.find('#domain-header').at(2).hasClass('domain-panel-header-expanded')).toBeTruthy();
+        expect(wrapped.find('#domain-header').at(1).hasClass('domain-panel-header-expanded')).toBeTruthy();
         expect(wrapped.find(FileAttachmentForm)).toHaveLength(1);
 
         const alerts = wrapped.find(Alert);

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`SampleTypePropertiesPanel appPropertiesOnly 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="sample-type-properties-hdr"
     onClick={[Function]}
   >
@@ -247,7 +247,7 @@ exports[`SampleTypePropertiesPanel default props 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="sample-type-properties-hdr"
     onClick={[Function]}
   >
@@ -434,7 +434,7 @@ exports[`SampleTypePropertiesPanel include dataclass and use custom labels 1`] =
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="sample-type-properties-hdr"
     onClick={[Function]}
   >
@@ -658,7 +658,7 @@ exports[`SampleTypePropertiesPanel includeMetricUnitProperty 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="sample-type-properties-hdr"
     onClick={[Function]}
   >
@@ -935,7 +935,7 @@ exports[`SampleTypePropertiesPanel metricUnitOptions 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="sample-type-properties-hdr"
     onClick={[Function]}
   >
@@ -1318,7 +1318,7 @@ exports[`SampleTypePropertiesPanel nameExpressionInfoUrl 1`] = `
   className="domain-form-panel domain-panel-no-theme panel panel-default"
 >
   <div
-    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
+    className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
     id="sample-type-properties-hdr"
     onClick={[Function]}
   >
@@ -1789,25 +1789,17 @@ exports[`SampleTypePropertiesPanel with aliquot preview name 1`] = `
                 togglePanel={[Function]}
                 useTheme={false}
               >
-                <PanelHeading
-                  bsClass="panel"
-                  className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme"
-                  componentClass="div"
+                <div
+                  className="domain-panel-header panel-heading domain-panel-header-expanded domain-panel-header-no-theme"
                   id="sample-type-properties-hdr"
                   onClick={[Function]}
                 >
-                  <div
-                    className="domain-panel-header domain-panel-header-expanded domain-panel-header-no-theme panel-heading"
-                    id="sample-type-properties-hdr"
-                    onClick={[Function]}
+                  <span
+                    className="domain-panel-title"
                   >
-                    <span
-                      className="domain-panel-title"
-                    >
-                      Sample Type Properties
-                    </span>
-                  </div>
-                </PanelHeading>
+                    Sample Type Properties
+                  </span>
+                </div>
               </CollapsiblePanelHeader>
               <PanelBody
                 bsClass="panel"

--- a/packages/components/src/test/jest.setup.react.ts
+++ b/packages/components/src/test/jest.setup.react.ts
@@ -1,2 +1,4 @@
 import '@testing-library/jest-dom'; // add custom jest matchers from jest-dom
 require('blob-polyfill');
+
+Object.defineProperty(window, '__react-beautiful-dnd-disable-dev-warnings', { value: true, writable: false });

--- a/packages/components/src/test/jest.setup.ts
+++ b/packages/components/src/test/jest.setup.ts
@@ -24,3 +24,4 @@ configure({ adapter: new Adapter() });
 // is ok, we aren't testing that behavior.
 const noop = () => {};
 Object.defineProperty(window, 'scrollTo', { value: noop, writable: true });
+Object.defineProperty(window, '__react-beautiful-dnd-disable-dev-warnings', { value: true, writable: false });


### PR DESCRIPTION
#### Rationale
The util method updateDomainPanelClassList was manually removing a class from our CollapsiblePanelHeader when useTheme was set to true, this caused test issues as the necessary DOM methods were not available in jsdom. This method is not necessary, instead we can use react to toggle the presence of the class name.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1259
- https://github.com/LabKey/labkey-ui-premium/pull/159
- https://github.com/LabKey/platform/pull/4687
- https://github.com/LabKey/biologics/pull/2295
- https://github.com/LabKey/inventory/pull/978
- https://github.com/LabKey/sampleManagement/pull/2016

#### Changes
- Remove updateDomainPanelClassList
- Update domain designer tests
  - Changing the header to render a div instead of a bootstrap component triggered more render cycles than before, which exposed more issues with components making network requests during our tests
  - Updated enzyme queries to account for the component change
- Disable react-beautiful-dnd warnings in jest tests