### PR TITLE
Issue 48300: Respect date/time display in date selector

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.360.1",
+  "version": "2.360.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.360.2
+*Released*: 22 August 2023
+- Added a `parseTimeFormat` method to determine the time format portion of a date format.
+- Supply `timeFormat` parsed from the `dateFormat` for usages of `DatePicker`.
+
 ### version 2.360.1
 *Released*: 21 August 2023
 - Remove updateDomainPanelClassList

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import classNames from 'classnames';
 import Formsy from 'formsy-react';
 
-import { getColDateFormat, getMomentDateFormat, getJsonDateTimeFormatString } from '../util/Date';
+import { getColDateFormat, getMomentDateFormat, getJsonDateTimeFormatString, parseTimeFormat } from '../util/Date';
 import { Key, useEnterEscape } from '../../public/useEnterEscape';
 
 import { QueryColumn } from '../../public/QueryColumn';
@@ -157,6 +157,11 @@ export const EditInlineField: FC<Props> = memo(props => {
         }
     }, []);
 
+    const dateInputDateFormat = useMemo<string>(
+        () => (isDate ? getColDateFormat(column, column ? undefined : getMomentDateFormat()) : undefined),
+        [column, isDate]
+    );
+
     return (
         <div className={className}>
             {state.editing && isDate && (
@@ -169,7 +174,8 @@ export const EditInlineField: FC<Props> = memo(props => {
                     placeholderText={placeholder}
                     selected={dateValue}
                     showTimeSelect={!!column}
-                    dateFormat={getColDateFormat(column, column ? undefined : getMomentDateFormat())}
+                    dateFormat={dateInputDateFormat}
+                    timeFormat={parseTimeFormat(dateInputDateFormat)}
                 />
             )}
             {state.editing && isTextArea && (

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.spec.tsx
@@ -51,12 +51,28 @@ describe('DatePickerInput', () => {
         wrapper.unmount();
     });
 
+    test('with time-formatted dateFormat', () => {
+        const wrapper = mount(<DatePickerInputImpl {...DEFAULT_PROPS} dateFormat="yyyy-MM-dd kk:mm" />);
+        const datePicker = wrapper.find(DatePicker);
+        expect(datePicker.prop('dateFormat')).toBe('yyyy-MM-dd kk:mm');
+        expect(datePicker.prop('timeFormat')).toBe('kk:mm');
+        wrapper.unmount();
+    });
+
+    test('without time-formatted dateFormat', () => {
+        const wrapper = mount(<DatePickerInputImpl {...DEFAULT_PROPS} dateFormat="yyyy-MM-dd" />);
+        const datePicker = wrapper.find(DatePicker);
+        expect(datePicker.prop('dateFormat')).toBe('yyyy-MM-dd');
+        expect(datePicker.prop('timeFormat')).toBeUndefined();
+        wrapper.unmount();
+    });
+
     test('renderFieldLabel', () => {
         const wrapper = mount(
             <DatePickerInputImpl
                 {...DEFAULT_PROPS}
                 labelClassName="labelClassName"
-                renderFieldLabel={() => 'renderFieldLabel'}
+                renderFieldLabel={jest.fn().mockReturnValue('renderFieldLabel')}
             />
         );
         validate(wrapper, false);

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -30,6 +30,7 @@ import {
     isDateTimeInPast,
     isRelativeDateFilterValue,
     parseDate,
+    parseTimeFormat,
 } from './Date';
 
 describe('Date Utilities', () => {
@@ -145,6 +146,17 @@ describe('Date Utilities', () => {
             expect(getColDateFormat(col, 'DateTime')).toBe('yyyy-MM-dd HH:mm');
             expect(getColDateFormat(col, 'DateTime', true)).toBe('yyyy-MM-dd HH:mm');
             expect(getColDateFormat(col, 'Time')).toBe('HH:mm:ss');
+        });
+    });
+
+    describe('parseTimeFormat', () => {
+        test('various formats', () => {
+            expect(parseTimeFormat('yyyy-MM HH')).toBeUndefined();
+            expect(parseTimeFormat('yyyy-MM HH HH:mm')).toBeUndefined();
+            expect(parseTimeFormat('yyyy-MM-DD HHmm')).toBeUndefined();
+            expect(parseTimeFormat('yyyy:MM:DD kk:mm YY')).toBeUndefined();
+            expect(parseTimeFormat('yyyy-MM-DD HH:mm')).toBe('HH:mm');
+            expect(parseTimeFormat('yyyy:MM:DD kk:mm')).toBe('kk:mm');
         });
     });
 


### PR DESCRIPTION
#### Rationale
This work seeks to address [Issue 48300](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48300) by parsing for the `timeFormat` portion of a date format string and passing that to the underlying `DatePicker` component. In turn, the `DatePicker` will respect the supplied `timeFormat` resulting in the capability to display both 12-hour based and 24-hour based time selection.

<img width="308" alt="image" src="https://github.com/LabKey/labkey-ui-components/assets/3926239/14a1782c-7415-4425-b233-b3eef9a74764">

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1262
- https://github.com/LabKey/biologics/pull/2299
- https://github.com/LabKey/sampleManagement/pull/2020
- https://github.com/LabKey/inventory/pull/981

#### Changes
- Added a `parseTimeFormat` method to determine the time format portion of a date format (caveats abound -- see inline comments).
- Supply `timeFormat` parsed from the `dateFormat` for usages of `DatePicker`.
- Encapsulated format translations into `dateFNSToMoment` and `momentToDateFNS` utilities.
