### PR TITLE
Issue 48300: ReactDatePicker supply safe dateFNS time formats

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.361.1",
+  "version": "2.361.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.361.2
+*Released*: 24 August 2023
+- Rename `parseTimeFormat` to `parseDateFNSTimeFormat`
+- Return constant time formats for 12-hour and 24-hour time formats.
+
 ### version 2.361.1
 *Released*: 24 August 2023
 - EditableGrid change to allow for tabAdditionalBtn prop instead of cancelBtnProps

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -3,7 +3,12 @@ import moment from 'moment';
 import classNames from 'classnames';
 import Formsy from 'formsy-react';
 
-import { getColDateFormat, getMomentDateFormat, getJsonDateTimeFormatString, parseDateFNSTimeFormat } from '../util/Date';
+import {
+    getColDateFormat,
+    getMomentDateFormat,
+    getJsonDateTimeFormatString,
+    parseDateFNSTimeFormat,
+} from '../util/Date';
 import { Key, useEnterEscape } from '../../public/useEnterEscape';
 
 import { QueryColumn } from '../../public/QueryColumn';

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import classNames from 'classnames';
 import Formsy from 'formsy-react';
 
-import { getColDateFormat, getMomentDateFormat, getJsonDateTimeFormatString, parseTimeFormat } from '../util/Date';
+import { getColDateFormat, getMomentDateFormat, getJsonDateTimeFormatString, parseDateFNSTimeFormat } from '../util/Date';
 import { Key, useEnterEscape } from '../../public/useEnterEscape';
 
 import { QueryColumn } from '../../public/QueryColumn';
@@ -175,7 +175,7 @@ export const EditInlineField: FC<Props> = memo(props => {
                     selected={dateValue}
                     showTimeSelect={!!column}
                     dateFormat={dateInputDateFormat}
-                    timeFormat={parseTimeFormat(dateInputDateFormat)}
+                    timeFormat={parseDateFNSTimeFormat(dateInputDateFormat)}
                 />
             )}
             {state.editing && isTextArea && (

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.spec.tsx
@@ -52,10 +52,10 @@ describe('DatePickerInput', () => {
     });
 
     test('with time-formatted dateFormat', () => {
-        const wrapper = mount(<DatePickerInputImpl {...DEFAULT_PROPS} dateFormat="yyyy-MM-dd kk:mm" />);
+        const wrapper = mount(<DatePickerInputImpl {...DEFAULT_PROPS} dateFormat="yyyy-MM-dd kk:mm a" />);
         const datePicker = wrapper.find(DatePicker);
-        expect(datePicker.prop('dateFormat')).toBe('yyyy-MM-dd kk:mm');
-        expect(datePicker.prop('timeFormat')).toBe('kk:mm');
+        expect(datePicker.prop('dateFormat')).toBe('yyyy-MM-dd kk:mm a');
+        expect(datePicker.prop('timeFormat')).toBe('HH:mm');
         wrapper.unmount();
     });
 

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -24,7 +24,7 @@ import {
     isDateTimeCol,
     isRelativeDateFilterValue,
     parseDate,
-    parseTimeFormat,
+    parseDateFNSTimeFormat,
 } from '../../../util/Date';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
@@ -196,7 +196,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
                 placeholderText={placeholderText ?? `Select ${queryColumn.caption.toLowerCase()}`}
                 selected={selectedDate}
                 showTimeSelect={!hideTime && isDateTimeCol(queryColumn)}
-                timeFormat={parseTimeFormat(dateFormat)}
+                timeFormat={parseDateFNSTimeFormat(dateFormat)}
                 value={allowRelativeInput && isRelativeDateFilterValue(value) ? value : undefined}
                 wrapperClassName={inputWrapperClassName}
             />

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -30,7 +30,7 @@ import {
     isDateTimeInPast,
     isRelativeDateFilterValue,
     parseDate,
-    parseTimeFormat,
+    parseDateFNSTimeFormat,
 } from './Date';
 
 describe('Date Utilities', () => {
@@ -149,14 +149,16 @@ describe('Date Utilities', () => {
         });
     });
 
-    describe('parseTimeFormat', () => {
+    describe('parseDateFNSTimeFormat', () => {
         test('various formats', () => {
-            expect(parseTimeFormat('yyyy-MM HH')).toBeUndefined();
-            expect(parseTimeFormat('yyyy-MM HH HH:mm')).toBeUndefined();
-            expect(parseTimeFormat('yyyy-MM-DD HHmm')).toBeUndefined();
-            expect(parseTimeFormat('yyyy:MM:DD kk:mm YY')).toBeUndefined();
-            expect(parseTimeFormat('yyyy-MM-DD HH:mm')).toBe('HH:mm');
-            expect(parseTimeFormat('yyyy:MM:DD kk:mm')).toBe('kk:mm');
+            expect(parseDateFNSTimeFormat('yyyy-MM HH')).toBeUndefined();
+            expect(parseDateFNSTimeFormat('yyyy-MM-DD HHmm')).toBeUndefined();
+            expect(parseDateFNSTimeFormat('yyyy-MM HH HH:mm')).toBeUndefined();
+            expect(parseDateFNSTimeFormat('yyyy:MM:DD kk:mm aa')).toBe('HH:mm');
+            expect(parseDateFNSTimeFormat('yyyy-MM-DD HH:mm')).toBe('HH:mm');
+            expect(parseDateFNSTimeFormat('yyyy:MM:DD kk:mm')).toBe('HH:mm');
+            expect(parseDateFNSTimeFormat('yyyy:MM:DD hh:mm')).toBe('h:mm a');
+            expect(parseDateFNSTimeFormat('yyyy:MM:DD KK:mm')).toBe('h:mm a');
         });
     });
 

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -87,17 +87,27 @@ export function getColDateFormat(queryColumn: QueryColumn, dateFormat?: string, 
 }
 
 // Issue 48300: Respect 12-hour vs 24-hour time display format
-// This method intends to parse out the time portion of the format from the date portion of the format.
+// This method attempts to determine if the time portion of date format is in either 12-hour or 24-hour format.
+// If the time format can be determined, then it will return a constant dateFNS time format.
 // NK: That said, this is a far-reaching over simplification / contrived implementation which presumes the time
 // format follows the date format. For a more precise implementation we would search for time-specific portions within
 // the string (or use some more grand date format parsing library utility), however, there are so many different
 // formats (Java, Moment, Date-FNS, JavaScript, etc) and a seemingly infinite number of ways to configure a date/time
 // format that I've elected to just assume the second part of a space-split string that contains a ":" is the time
-// format (e.g. it supports formats similar to "yyyy-MM-dd hh:mm").
-export function parseTimeFormat(dateFormat: string): string {
+// format (e.g. it supports formats similar to "yyyy-MM-dd hh:mm" or "yyyy-MM-dd hh:mm aa").
+export function parseDateFNSTimeFormat(dateFormat: string): string {
     if (!dateFormat) return undefined;
     const parts = dateFormat.split(' ');
-    if (parts.length === 2 && parts[1].indexOf(':') > -1) return parts[1];
+
+    if (parts.length > 1 && parts[1].indexOf(':') > -1) {
+        const timePart = parts[1];
+        if (timePart.indexOf('H') > -1 || timePart.indexOf('k') > -1) {
+            return 'HH:mm'; // 13:30
+        } else if (timePart.indexOf('h') > -1 || timePart.indexOf('K') > -1) {
+            return 'h:mm a'; // 1:30 PM
+        }
+    }
+
     return undefined;
 }
 

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -94,7 +94,7 @@ export function getColDateFormat(queryColumn: QueryColumn, dateFormat?: string, 
 // the string (or use some more grand date format parsing library utility), however, there are so many different
 // formats (Java, Moment, Date-FNS, JavaScript, etc) and a seemingly infinite number of ways to configure a date/time
 // format that I've elected to just assume the second part of a space-split string that contains a ":" is the time
-// format (e.g. it supports formats similar to "yyyy-MM-dd hh:mm" or "yyyy-MM-dd hh:mm aa").
+// format (e.g. it supports formats similar to "yyyy-MM-dd hh:mm" or "yyyy-MM-dd hh:mm a").
 export function parseDateFNSTimeFormat(dateFormat: string): string {
     if (!dateFormat) return undefined;
     const parts = dateFormat.split(' ');


### PR DESCRIPTION
#### Rationale
While shoring up some tests related to a [previous fix](https://github.com/LabKey/labkey-ui-components/pull/1262) for [Issue 48300](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48300) I came to the realization that simply handing through the server's time format is an unstable and in the end an untenable solution. As such, rather than passing it through I've elected to return explicit DateFNS formats for 12-hour and 24-hour formats when parsing. For 12-hour the time format is `h:mm a` (e.g. 1:30pm) and for 24-hour the time format is `HH:mm` (e.g. 13:30). These formats will not crash the ReactDatePicker and will give reasonable displays for the time format based on what has been parsed from the server's time format.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1265
- https://github.com/LabKey/biologics/pull/2311
- https://github.com/LabKey/sampleManagement/pull/2030
- https://github.com/LabKey/inventory/pull/983
- https://github.com/LabKey/testAutomation/pull/1613

#### Changes
- Rename `parseTimeFormat` to `parseDateFNSTimeFormat`
- Return constant time formats for 12-hour and 24-hour time formats.
