### PR TITLE
Issue 48364: Sample assay report SQL syntax error in WHERE clause for sample field with space in name

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.361.2-fb-sampleAssaySQL48364.0",
+  "version": "2.361.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.361.2",
+  "version": "2.361.2-fb-sampleAssaySQL48364.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48364: Sample assay report SQL syntax error in WHERE clause for sample field with space in name
+
 ### version 2.361.2
 *Released*: 24 August 2023
 - Rename `parseTimeFormat` to `parseDateFNSTimeFormat`

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.361.3
+*Released*: 28 August 2023
 - Issue 48364: Sample assay report SQL syntax error in WHERE clause for sample field with space in name
 
 ### version 2.361.2

--- a/packages/components/src/internal/AssayDefinitionModel.spec.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.spec.ts
@@ -85,7 +85,17 @@ describe('AssayDefinitionModel', () => {
         const filter = model.createSampleFilter(List.of('a', 'b'), [1, 2], Filter.Types.IN);
         expect(filter.getURLParameterName()).toBe('query.*~where');
         expect(filter.getURLParameterValue()).toBe(
-            'RowId IN (SELECT RowId FROM Data WHERE a.RowId IN (1,2) UNION SELECT RowId FROM Data WHERE b.RowId IN (1,2))'
+            'RowId IN (SELECT RowId FROM Data WHERE "a"."RowId" IN (1,2) UNION SELECT RowId FROM Data WHERE "b"."RowId" IN (1,2))'
+        );
+    });
+
+    // Issue 48364
+    test('createSampleFilter, multiple columns with space in name', () => {
+        const model = new AssayDefinitionModel();
+        const filter = model.createSampleFilter(List.of('sample result', 'b'), [1, 2], Filter.Types.IN);
+        expect(filter.getURLParameterName()).toBe('query.*~where');
+        expect(filter.getURLParameterValue()).toBe(
+            'RowId IN (SELECT RowId FROM Data WHERE "sample result"."RowId" IN (1,2) UNION SELECT RowId FROM Data WHERE "b"."RowId" IN (1,2))'
         );
     });
 });

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -273,7 +273,10 @@ export class AssayDefinitionModel extends Record({
                 'RowId IN (' +
                 sampleColumns
                     .map(sampleCol => {
-                        const fieldKey = (sampleCol + keyCol).replace(/\//g, '.');
+                        const fieldKey = (sampleCol + keyCol)
+                            .split('/')
+                            .map(token => '"' + token + '"')
+                            .join('.');
                         return `SELECT RowId FROM Data WHERE ${fieldKey} IN (${value.join(',')})`;
                     })
                     .join(' UNION ') +


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48364

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1267
- https://github.com/LabKey/labkey-ui-premium/pull/164
- https://github.com/LabKey/sampleManagement/pull/2040
- https://github.com/LabKey/biologics/pull/2320

#### Changes
- encode sample column name in quotes for WHERE clause
