### PR TITLE
SVGChart: Inject containerFilter into queryConfig

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.362.1",
+  "version": "2.362.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.362.?
+*Released*: ?? August 2023
+- SVGChart: Inject containerFilter into query config returned from server
+
 ### version 2.362.1
 *Released*: 29 August 2023
 - Issue 47763: Remove unnecessary DataFileUrl column from requiredColumns in Assay Runs grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.362.?
-*Released*: ?? August 2023
+### version 2.362.2
+*Released*: 30 August 2023
 - SVGChart: Inject containerFilter into query config returned from server
 - RReport: use containerFilterName query arg
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.362.?
 *Released*: ?? August 2023
 - SVGChart: Inject containerFilter into query config returned from server
+- RReport: use containerFilterName query arg
 
 ### version 2.362.1
 *Released*: 29 August 2023

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -20,6 +20,7 @@ import { isLoading, LoadingState } from '../../../public/LoadingState';
 import { DataViewInfoTypes, LABKEY_VIS } from '../../constants';
 
 import { DataViewInfo } from '../../DataViewInfo';
+import { getContainerFilter } from '../../query/api';
 import { generateId } from '../../util/utils';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
@@ -70,9 +71,10 @@ interface Props {
     filters?: Filter.IFilter[];
 }
 
-export const SVGChart: FC<Props> = memo(({ api, chart, filters }) => {
+export const SVGChart: FC<Props> = memo(({ api, chart, container, filters }) => {
     const { error, reportId } = chart;
     const divId = useMemo(() => generateId('chart-'), []);
+    const containerFilter = useMemo(() => getContainerFilter(container), [container]);
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [queryConfig, setQueryConfig] = useState<ChartQueryConfig>(undefined);
     const [chartConfig, setChartConfig] = useState<ChartConfig>(undefined);
@@ -88,6 +90,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, filters }) => {
                 ...computeDimensions(ref.current.offsetWidth),
             };
             const queryConfig_ = visualizationConfig.queryConfig;
+            queryConfig_.containerFilter = containerFilter;
             setChartConfig(chartConfig_);
 
             if (filters) {
@@ -102,7 +105,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, filters }) => {
         }
         // We purposely don't use filters as a dep, see note in computeFilterKey
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [api, reportId, filterKey]);
+    }, [api, containerFilter, reportId, filterKey]);
 
     const updateChartSize = useCallback(() => {
         setChartConfig(currentChartConfig => {
@@ -138,7 +141,6 @@ export const SVGChart: FC<Props> = memo(({ api, chart, filters }) => {
                 // updated in the future to use the underlying VIS library to separate fetching of data from rendering
                 // the chart. We should only be fetching data when the reportId or filterArray change.
                 LABKEY_VIS.GenericChartHelper.renderChartSVG(divId, queryConfig, chartConfig);
-                console.log(chartConfig);
             }
         };
         // Debounce the call to render because we may trigger many resize events back to back, which will produce many

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -69,6 +69,7 @@ interface Props {
     chart: DataViewInfo;
     container?: string;
     filters?: Filter.IFilter[];
+    urlPrefix?: string;
 }
 
 export const SVGChart: FC<Props> = memo(({ api, chart, container, filters }) => {
@@ -160,7 +161,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, container, filters }) => 
 });
 SVGChart.displayName = 'SVGChart';
 
-const RReport: FC<Props> = memo(({ api, chart, container, filters }) => {
+const RReport: FC<Props> = memo(({ api, chart, container, filters, urlPrefix }) => {
     const { error, reportId } = chart;
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [reportHtml, setReportHtml] = useState<string>(undefined);
@@ -171,7 +172,7 @@ const RReport: FC<Props> = memo(({ api, chart, container, filters }) => {
         setLoadError(undefined);
 
         try {
-            const html = await api.fetchRReport(reportId, container, filters);
+            const html = await api.fetchRReport(reportId, urlPrefix, container, filters);
             setReportHtml(html);
         } catch (e) {
             setLoadError(e.exception);
@@ -229,9 +230,9 @@ const RReport: FC<Props> = memo(({ api, chart, container, filters }) => {
 });
 RReport.displayName = 'RReport';
 
-export const Chart: FC<Props> = memo(({ api = DEFAULT_API_WRAPPER, chart, container, filters }) => {
+export const Chart: FC<Props> = memo(({ api = DEFAULT_API_WRAPPER, chart, container, filters, urlPrefix }) => {
     if (chart.type === DataViewInfoTypes.RReport) {
-        return <RReport api={api} chart={chart} container={container} filters={filters} />;
+        return <RReport api={api} chart={chart} container={container} filters={filters} urlPrefix={urlPrefix} />;
     }
 
     return <SVGChart api={api} chart={chart} container={container} filters={filters} />;

--- a/packages/components/src/internal/components/chart/api.ts
+++ b/packages/components/src/internal/components/chart/api.ts
@@ -3,7 +3,7 @@ import { getContainerFilter } from '../../query/api';
 import { buildURL } from '../../url/AppURL';
 import { VisualizationConfigModel } from './models';
 
-export function fetchVisualizationConfig(reportId: string): Promise<VisualizationConfigModel> {
+function fetchVisualizationConfig(reportId: string): Promise<VisualizationConfigModel> {
     return new Promise((resolve, reject) => {
         Query.Visualization.get({
             reportId,
@@ -18,7 +18,7 @@ export function fetchVisualizationConfig(reportId: string): Promise<Visualizatio
     });
 }
 
-export function fetchRReport(reportId: string, container?: string, filters?: Filter.IFilter[]): Promise<string> {
+function fetchRReport(reportId: string, container?: string, filters?: Filter.IFilter[]): Promise<string> {
     return new Promise((resolve, reject) => {
         const params = { reportId, 'webpart.name': 'report', containerFilter: getContainerFilter(container) };
         if (filters) {

--- a/packages/components/src/internal/components/chart/api.ts
+++ b/packages/components/src/internal/components/chart/api.ts
@@ -1,6 +1,8 @@
 import { Ajax, Filter, Query, Utils } from '@labkey/api';
+
 import { getContainerFilter } from '../../query/api';
 import { buildURL } from '../../url/AppURL';
+
 import { VisualizationConfigModel } from './models';
 
 function fetchVisualizationConfig(reportId: string): Promise<VisualizationConfigModel> {
@@ -18,17 +20,19 @@ function fetchVisualizationConfig(reportId: string): Promise<VisualizationConfig
     });
 }
 
-function fetchRReport(reportId: string, container?: string, filters?: Filter.IFilter[]): Promise<string> {
+function fetchRReport(
+    reportId: string,
+    urlPrefix = 'query',
+    container?: string,
+    filters?: Filter.IFilter[]
+): Promise<string> {
     return new Promise((resolve, reject) => {
-        const params = { reportId, 'webpart.name': 'report', containerFilter: getContainerFilter(container) };
-        if (filters) {
-            filters.forEach(filter => {
-                params[filter.getURLParameterName()] = filter.getURLParameterValue();
-            });
-        }
-        const url = buildURL('project', 'getWebPart.view', params, { container });
+        // The getWebPart API honors containerFilterName, not containerFilter.
+        const containerFilterPrefix = `${urlPrefix}.containerFilterName`;
+        const params = { reportId, 'webpart.name': 'report', [containerFilterPrefix]: getContainerFilter(container) };
+        if (filters) filters.forEach(filter => (params[filter.getURLParameterName()] = filter.getURLParameterValue()));
         Ajax.request({
-            url,
+            url: buildURL('project', 'getWebPart.view', params, { container }),
             success: Utils.getCallbackWrapper(response => {
                 resolve(response.html);
             }),
@@ -40,7 +44,12 @@ function fetchRReport(reportId: string, container?: string, filters?: Filter.IFi
 }
 
 export interface ChartAPIWrapper {
-    fetchRReport: (reportId: string, container?: string, filters?: Filter.IFilter[]) => Promise<string>;
+    fetchRReport: (
+        reportId: string,
+        urlPrefix?: string,
+        container?: string,
+        filters?: Filter.IFilter[]
+    ) => Promise<string>;
     fetchVisualizationConfig: (reportId: string) => Promise<VisualizationConfigModel>;
 }
 

--- a/packages/components/src/internal/components/chart/models.ts
+++ b/packages/components/src/internal/components/chart/models.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Filter } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { AppURL } from '../../url/AppURL';
 import { SchemaQuery } from '../../../public/SchemaQuery';
@@ -49,7 +49,7 @@ export interface ChartConfig {
 
 export interface ChartQueryConfig {
     columns: string[];
-    containerFilter: string;
+    containerFilter: Query.ContainerFilter;
     containerPath: string;
     // dataRegionName: string;
     filterArray: Filter.IFilter[];

--- a/packages/components/src/internal/components/chart/models.ts
+++ b/packages/components/src/internal/components/chart/models.ts
@@ -49,6 +49,7 @@ export interface ChartConfig {
 
 export interface ChartQueryConfig {
     columns: string[];
+    containerFilter: string;
     containerPath: string;
     // dataRegionName: string;
     filterArray: Filter.IFilter[];

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -23,7 +23,12 @@ export const ChartPanel: FC<RequiresModelAndActions> = memo(({ actions, model })
                     <span className="fa fa-close" /> Close
                 </button>
             </div>
-            <Chart chart={selectedChart} container={containerPath} filters={model.filters} />
+            <Chart
+                chart={selectedChart}
+                container={containerPath}
+                filters={model.filters}
+                urlPrefix={model.urlPrefix}
+            />
         </div>
     );
 });


### PR DESCRIPTION
#### Rationale
This PR fixes [Issue 48581](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48581) and [Issue 48517](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48517)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1269
- https://github.com/LabKey/labkey-ui-premium/pull/166
- https://github.com/LabKey/biologics/pull/2328
- https://github.com/LabKey/sampleManagement/pull/2046
- https://github.com/LabKey/inventory/pull/991

#### Changes
- SVGChart: Inject containerFilter into queryConfig
- RReport: Use containerFilterName query arg