### PR TITLE
Issue 47197: Add 'Cancel' button on the group management and permissions pages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.362.1",
+  "version": "2.362.1-fb-misc239AppCory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.363.0",
+  "version": "2.364.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 47376: User Detail Modal - add className to be able to distinguish modal from others
+- Issue 47197: Add 'Cancel' button on the group management and permissions pages
+
 ### version 2.362.1
 *Released*: 29 August 2023
 - Issue 47763: Remove unnecessary DataFileUrl column from requiredColumns in Assay Runs grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.364.0
+*Released*: 31 August 2023
 - Issue 47376: User Detail Modal - add className to be able to distinguish modal from others
 - Issue 47197: Add 'Cancel' button on the group management and permissions pages
 

--- a/packages/components/src/internal/components/administration/GroupAssignments.tsx
+++ b/packages/components/src/internal/components/administration/GroupAssignments.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, FC, memo, useCallback, useMemo, useState } from 'react';
 import { Button, Col, Panel, Row } from 'react-bootstrap';
 import { List, Map } from 'immutable';
+import { InjectedRouter } from 'react-router';
 
 import { Alert } from '../base/Alert';
 
@@ -29,6 +30,7 @@ export interface GroupAssignmentsProps {
     principalsById: Map<number, Principal>;
     removeMember: (groupId: string, memberId: number) => void;
     rolesByUniqueName: Map<string, SecurityRole>;
+    router?: InjectedRouter;
     save: () => Promise<void>;
     setErrorMsg: (e: string) => void;
     setIsDirty: (isDirty: boolean) => void;
@@ -54,12 +56,18 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
         save,
         setErrorMsg,
         setIsDirty,
+        router,
     } = props;
     const { user } = useServerContext();
     const [submitting, setSubmitting] = useState<boolean>(false);
     const [selectedPrincipalId, setSelectedPrincipalId] = useState<number>();
     const [newGroupName, setNewGroupName] = useState<string>('');
     const initExpandedGroup = getLocation().query?.get('expand');
+
+    const onCancel = useCallback(() => {
+        setIsDirty(false);
+        router.goBack();
+    }, [router, setIsDirty]);
 
     const onSave = useCallback(async () => {
         setSubmitting(true);
@@ -68,19 +76,6 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
         setIsDirty(false);
         setSubmitting(false);
     }, [save, setErrorMsg, setIsDirty]);
-
-    const saveButton = useMemo(() => {
-        return (
-            <Button
-                className="pull-right alert-button group-management-save-btn"
-                bsStyle="success"
-                disabled={submitting || !getIsDirty()}
-                onClick={onSave}
-            >
-                Save
-            </Button>
-        );
-    }, [getIsDirty, onSave, submitting]);
 
     const showDetails = useCallback((principalId: number) => {
         setSelectedPrincipalId(principalId);
@@ -191,7 +186,15 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
 
                         <div className="group-assignment-panel__footer">
                             {errorMsg && <Alert>{errorMsg}</Alert>}
-                            {saveButton}
+                            <Button
+                                className="pull-right alert-button group-management-save-btn"
+                                bsStyle="success"
+                                disabled={submitting || !getIsDirty()}
+                                onClick={onSave}
+                            >
+                                Save
+                            </Button>
+                            {router && <Button onClick={onCancel}>Cancel</Button>}
                         </div>
                     </Panel.Body>
                 </Panel>

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -31,12 +31,13 @@ import { AUDIT_EVENT_TYPE_PARAM, GROUP_AUDIT_QUERY } from '../auditlog/constants
 
 import { AUDIT_KEY } from '../../app/constants';
 
+import { NotFound } from '../base/NotFound';
+
 import { GroupAssignments } from './GroupAssignments';
 
 import { showPremiumFeatures } from './utils';
 import { GroupMembership, MemberType } from './models';
 import { fetchGroupMembership } from './actions';
-import { NotFound } from '../base/NotFound';
 
 export type GroupManagementPageProps = InjectedRouteLeaveProps & InjectedPermissionsPage & WithRouterProps;
 
@@ -253,8 +254,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
         return showPremiumFeatures(moduleContext) ? container.path : undefined;
     }, [container, moduleContext]);
 
-    if (isProductProjectsEnabled() && !container.isProject)
-        return <NotFound />;
+    if (isProductProjectsEnabled() && !container.isProject) return <NotFound />;
 
     return (
         <BasePermissionsCheckPage

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -41,7 +41,7 @@ import { NotFound } from '../base/NotFound';
 export type GroupManagementPageProps = InjectedRouteLeaveProps & InjectedPermissionsPage & WithRouterProps;
 
 export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props => {
-    const { setIsDirty, getIsDirty, inactiveUsersById, principalsById, rolesByUniqueName, principals } = props;
+    const { setIsDirty, getIsDirty, inactiveUsersById, principalsById, rolesByUniqueName, principals, router } = props;
     const [error, setError] = useState<string>();
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [savedGroupMembership, setSavedGroupMembership] = useState<GroupMembership>();
@@ -283,6 +283,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
                     setIsDirty={setIsDirty}
                     getIsDirty={getIsDirty}
                     getAuditLogData={api.security.getAuditLogData}
+                    router={router}
                 />
             )}
         </BasePermissionsCheckPage>

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -5,6 +5,7 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import { Button, Checkbox, Col, Row } from 'react-bootstrap';
 import { List } from 'immutable';
+import { InjectedRouter } from 'react-router';
 import { Security } from '@labkey/api';
 
 import { UserDetailsPanel } from '../user/UserDetailsPanel';
@@ -43,6 +44,7 @@ export interface PermissionAssignmentsProps extends InjectedPermissionsPage, Inj
     policy: SecurityPolicy;
     /** Subset list of role uniqueNames to show in this component usage */
     rolesToShow?: List<string>;
+    router?: InjectedRouter;
     showDetailsPanel?: boolean;
     title?: string;
     /** Specific principal type (i.e. 'u' for users and 'g' for groups) to show in this component usage */
@@ -66,6 +68,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         setIsDirty,
         showDetailsPanel = true,
         title = 'Security Roles and Assignments',
+        router,
     } = props;
     const [inherited, setInherited] = useState<boolean>(() => policy.isInheritFromParent());
     const [rootPolicy, setRootPolicy] = useState<SecurityPolicy>();
@@ -140,6 +143,11 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         onSuccess();
         loadGroupMembership();
     }, [onSuccess, loadGroupMembership]);
+
+    const onCancel = useCallback(() => {
+        setIsDirty(false);
+        router.goBack();
+    }, [router, setIsDirty]);
 
     const onSavePolicy = useCallback(() => {
         const wasInherited = policy.isInheritFromParent();
@@ -232,17 +240,6 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
     const isSubfolder = !isProjectContainer(container.path);
     const projectsEnabled = isProductProjectsEnabled(moduleContext);
 
-    const saveButton = (
-        <Button
-            className="pull-right alert-button permissions-assignment-save-btn"
-            bsStyle="success"
-            disabled={submitting || !getIsDirty()}
-            onClick={onSavePolicy}
-        >
-            Save
-        </Button>
-    );
-
     return (
         <Row>
             <Col xs={12} md={showDetailsPanel ? 8 : 12}>
@@ -287,7 +284,15 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                         ))}
                         <br />
                         {saveErrorMsg && <Alert>{saveErrorMsg}</Alert>}
-                        {saveButton}
+                        <Button
+                            className="pull-right alert-button permissions-assignment-save-btn"
+                            bsStyle="success"
+                            disabled={submitting || !getIsDirty()}
+                            onClick={onSavePolicy}
+                        >
+                            Save
+                        </Button>
+                        {router && <Button onClick={onCancel}>Cancel</Button>}
                     </div>
                 </div>
             </Col>

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -315,7 +315,7 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
 
         if (toggleDetailsModal) {
             return (
-                <Modal onHide={toggleDetailsModal} show={true}>
+                <Modal onHide={toggleDetailsModal} show={true} className="user-detail-modal">
                     <Modal.Header closeButton>
                         <Modal.Title>{this.renderHeader()}</Modal.Title>
                     </Modal.Header>


### PR DESCRIPTION
#### Rationale
Issue [47197](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47197): Add 'Cancel' button on the group management and permissions pages

also included in this PR is the small fix for this issue:
Issue [47376](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47376): User Detail Modal triggers navigation in ELN Home

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1272
- https://github.com/LabKey/labkey-ui-premium/pull/170
- https://github.com/LabKey/sampleManagement/pull/2054
- https://github.com/LabKey/biologics/pull/2334
- https://github.com/LabKey/inventory/pull/995

#### Changes
- add cancel button to app group and permissions admin page
- for for notebooks home listing page click on row vs user details modal
