### PR TITLE
Plates: Data Field Domain Management

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.0-fb-plate-edit.1",
+  "version": "2.364.0-fb-plate-edit.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.0-fb-plate-edit.0",
+  "version": "2.364.0-fb-plate-edit.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.0-fb-plate-edit.2",
+  "version": "2.365.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.0",
+  "version": "2.364.0-fb-plate-edit.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.365.0
+*Released*: 1 September 2023
+- Add `saveDomain` to `DomainPropertiesAPIWrapper`
+- Add `updateUserDetails` to `SecurityAPIWrapper`
+- Export internal `BaseDomainDesigner`
+- Update `EditableGrid` to account for optional `addControlProps`
+- Removes `UserProvider` in favor of `useUserProperties` hook
+
 ### version 2.364.0
 *Released*: 31 August 2023
 - Issue 47376: User Detail Modal - add className to be able to distinguish modal from others

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -385,6 +385,7 @@ import { AppContextProvider, useAppContext } from './internal/AppContext';
 import { AppContexts } from './internal/AppContexts';
 import { useContainerUser } from './internal/components/container/actions';
 
+import { BaseDomainDesigner } from './internal/components/domainproperties/BaseDomainDesigner';
 import {
     getFilterForSampleOperation,
     getOmittedSampleTypeColumns,
@@ -1387,6 +1388,7 @@ export {
     withNotificationsContext,
     // domain designer related items
     DomainForm,
+    BaseDomainDesigner,
     DomainFieldsDisplay,
     fetchDomain,
     fetchDomainDetails,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -448,7 +448,7 @@ import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
 import { UsersGridPanel } from './internal/components/user/UsersGridPanel';
-import { UserProvider, useUserProperties } from './internal/components/user/UserProvider';
+import { useUserProperties } from './internal/components/user/UserProvider';
 import { UserLink, UserLinkList } from './internal/components/user/UserLink';
 import { AccountSubNav } from './internal/components/user/AccountSubNav';
 import { ProfilePage } from './internal/components/user/ProfilePage';
@@ -1162,7 +1162,6 @@ export {
     SecurityPolicy,
     SecurityRole,
     Principal,
-    UserProvider,
     useUserProperties,
     // sample picklist items
     AddToPicklistMenuItem,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -448,7 +448,7 @@ import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
 import { UsersGridPanel } from './internal/components/user/UsersGridPanel';
-import { useUserProperties } from './internal/components/user/UserProvider';
+import { useUserProperties } from './internal/components/user/hooks';
 import { UserLink, UserLinkList } from './internal/components/user/UserLink';
 import { AccountSubNav } from './internal/components/user/AccountSubNav';
 import { ProfilePage } from './internal/components/user/ProfilePage';

--- a/packages/components/src/internal/components/administration/AccountSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AccountSettingsPage.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { useServerContext } from '../base/ServerContext';
 import { InsufficientPermissionsPage } from '../permissions/InsufficientPermissionsPage';
-import { useUserProperties } from '../user/UserProvider';
+import { useUserProperties } from '../user/hooks';
 import { Page } from '../base/Page';
 import { UserDetailHeader } from '../user/UserDetailHeader';
 import { getUserRoleDisplay } from '../user/actions';

--- a/packages/components/src/internal/components/domainproperties/APIWrapper.ts
+++ b/packages/components/src/internal/components/domainproperties/APIWrapper.ts
@@ -11,6 +11,7 @@ import {
     fetchDomainDetails,
     getMaxPhiLevel,
     fetchOntologies,
+    saveDomain,
 } from './actions';
 import { PHILEVEL_FULL_PHI } from './constants';
 import { getDataClassDetails } from './dataclasses/actions';
@@ -34,6 +35,15 @@ export interface DomainPropertiesAPIWrapper {
         rowId?: number,
         containerPath?: string
     ) => Promise<boolean>;
+    saveDomain: (
+        domain: DomainDesign,
+        kind?: string,
+        options?: any,
+        name?: string,
+        includeWarnings?: boolean,
+        addRowIndexes?: boolean,
+        originalDomain?: DomainDesign
+    ) => Promise<DomainDesign>;
     setGenId: (
         rowId: number,
         kindName: 'SampleSet' | 'DataClass',
@@ -56,6 +66,7 @@ export class DomainPropertiesAPIWrapper implements DomainPropertiesAPIWrapper {
     getGenId = getGenId;
     getMaxPhiLevel = getMaxPhiLevel;
     hasExistingDomainData = hasExistingDomainData;
+    saveDomain = saveDomain;
     setGenId = setGenId;
     validateDomainNameExpressions = validateDomainNameExpressions;
 }
@@ -78,6 +89,7 @@ export function getDomainPropertiesTestAPIWrapper(
         // probably make Jest an explicit dependency since we are actually exporting test utilities.
         getMaxPhiLevel: () => Promise.resolve(PHILEVEL_FULL_PHI),
         hasExistingDomainData: mockFn(),
+        saveDomain: mockFn(),
         setGenId: mockFn(),
         validateDomainNameExpressions: mockFn(),
         ...overrides,

--- a/packages/components/src/internal/components/domainproperties/APIWrapper.ts
+++ b/packages/components/src/internal/components/domainproperties/APIWrapper.ts
@@ -19,9 +19,9 @@ import { DomainDesign, DomainDetails, NameExpressionsValidationResults } from '.
 
 export interface DomainPropertiesAPIWrapper {
     fetchDomainDetails: (
-        domainId: number,
-        schemaName: string,
-        queryName: string,
+        domainId?: number,
+        schemaName?: string,
+        queryName?: string,
         domainKind?: string
     ) => Promise<DomainDetails>;
     fetchOntologies: (containerPath?: string) => Promise<OntologyModel[]>;

--- a/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
@@ -33,90 +33,73 @@ export function withBaseDomainDesigner<Props>(
     ComponentToWrap: ComponentType<Props & InjectedBaseDomainDesignerProps>
 ): ComponentType<Props> {
     class ComponentWithBaseDomainDesigner extends PureComponent<Props, State> {
-        constructor(props: Props) {
-            super(props);
-
-            this.state = {
-                submitting: false,
-                currentPanelIndex: 0,
-                visitedPanels: List<number>(),
-                validatePanel: undefined,
-                firstState: true,
-            };
-        }
+        state: Readonly<State> = {
+            currentPanelIndex: 0,
+            firstState: true,
+            submitting: false,
+            visitedPanels: List<number>(),
+            validatePanel: undefined,
+        };
 
         // TODO: having a child component pass a callback to a parent is a big red flag
-        onTogglePanel = (index: number, collapsed: boolean, callback: () => any): void => {
-            const { visitedPanels, currentPanelIndex } = this.state;
-            const updatedVisitedPanels = getUpdatedVisitedPanelsList(visitedPanels, index);
+        onTogglePanel = (index: number, collapsed: boolean, callback: () => void): void => {
+            const { currentPanelIndex } = this.state;
 
             if (!collapsed) {
                 this.setState(
-                    () => ({
-                        visitedPanels: updatedVisitedPanels,
+                    state => ({
                         currentPanelIndex: index,
                         firstState: false,
-                        validatePanel: currentPanelIndex,
+                        validatePanel: state.currentPanelIndex,
+                        visitedPanels: getUpdatedVisitedPanelsList(state.visitedPanels, index),
                     }),
-                    callback()
+                    callback
+                );
+            } else if (currentPanelIndex === index) {
+                this.setState(
+                    state => ({
+                        currentPanelIndex: undefined,
+                        firstState: false,
+                        validatePanel: state.currentPanelIndex,
+                        visitedPanels: getUpdatedVisitedPanelsList(state.visitedPanels, index),
+                    }),
+                    callback
                 );
             } else {
-                if (currentPanelIndex === index) {
-                    this.setState(
-                        () => ({
-                            visitedPanels: updatedVisitedPanels,
-                            currentPanelIndex: undefined,
-                            firstState: false,
-                            validatePanel: currentPanelIndex,
-                        }),
-                        callback()
-                    );
-                } else {
-                    callback();
-                }
+                callback();
             }
         };
 
         onFinish = (isValid: boolean, save: () => void): void => {
-            const { visitedPanels, currentPanelIndex } = this.state;
-            const updatedVisitedPanels = getUpdatedVisitedPanelsList(visitedPanels, currentPanelIndex);
-
             // This first setState forces the current expanded panel to validate its fields and display and errors
             // the callback setState then sets that to undefined so it doesn't keep validating every render
             this.setState(
-                state => ({ validatePanel: state.currentPanelIndex, visitedPanels: updatedVisitedPanels }),
+                state => {
+                    const { currentPanelIndex, visitedPanels } = state;
+                    return {
+                        validatePanel: currentPanelIndex,
+                        visitedPanels: getUpdatedVisitedPanelsList(visitedPanels, currentPanelIndex),
+                    };
+                },
                 () => {
-                    this.setState(
-                        () => ({ validatePanel: undefined }),
-                        () => {
-                            if (isValid) {
-                                this.setSubmitting(true, save);
-                            }
-                        }
-                    );
+                    const nextState: Partial<State> = { validatePanel: undefined };
+                    if (isValid) {
+                        nextState.submitting = true;
+                    }
+
+                    this.setState(nextState as State, isValid ? save : undefined);
                 }
             );
         };
 
         setSubmitting = (submitting: boolean, callback?: () => void): void => {
-            this.setState(
-                () => ({ submitting }),
-                () => {
-                    callback?.();
-                }
-            );
+            this.setState({ submitting }, callback);
         };
 
         render() {
-            const { submitting, currentPanelIndex, visitedPanels, firstState, validatePanel } = this.state;
-
             return (
                 <ComponentToWrap
-                    submitting={submitting}
-                    currentPanelIndex={currentPanelIndex}
-                    visitedPanels={visitedPanels}
-                    validatePanel={validatePanel}
-                    firstState={firstState}
+                    {...this.state}
                     setSubmitting={this.setSubmitting}
                     onTogglePanel={this.onTogglePanel}
                     onFinish={this.onFinish}
@@ -164,12 +147,8 @@ export class BaseDomainDesigner extends PureComponent<BaseDomainDesignerProps> {
 
         // get a list of the domain names that have errors
         const errorDomains = domains
-            .filter(domain => {
-                return domain.hasException() && domain.domainException.severity === SEVERITY_LEVEL_ERROR;
-            })
-            .map(domain => {
-                return getDomainHeaderName(domain.name, undefined, name);
-            })
+            .filter(domain => domain.hasException() && domain.domainException.severity === SEVERITY_LEVEL_ERROR)
+            .map(domain => getDomainHeaderName(domain.name, undefined, name))
             .toList();
 
         const bottomErrorMsg = getDomainBottomErrorMessage(exception, errorDomains, hasValidProperties, visitedPanels);

--- a/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
@@ -42,7 +42,7 @@ export function withBaseDomainDesigner<Props>(
         };
 
         // TODO: having a child component pass a callback to a parent is a big red flag
-        onTogglePanel = (index: number, collapsed: boolean, callback: () => void): void => {
+        onTogglePanel = (index: number, collapsed: boolean, callback: () => any): void => {
             const { currentPanelIndex } = this.state;
 
             if (!collapsed) {
@@ -53,7 +53,7 @@ export function withBaseDomainDesigner<Props>(
                         validatePanel: state.currentPanelIndex,
                         visitedPanels: getUpdatedVisitedPanelsList(state.visitedPanels, index),
                     }),
-                    callback
+                    callback() // TODO: This is being called immediately and we rely on that fact. Refactor this whole toggling functionality.
                 );
             } else if (currentPanelIndex === index) {
                 this.setState(
@@ -63,7 +63,7 @@ export function withBaseDomainDesigner<Props>(
                         validatePanel: state.currentPanelIndex,
                         visitedPanels: getUpdatedVisitedPanelsList(state.visitedPanels, index),
                     }),
-                    callback
+                    callback() // TODO: This is being called immediately and we rely on that fact. Refactor this whole toggling functionality.
                 );
             } else {
                 callback();

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1420,10 +1420,12 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     }
 }
 
-export default const DomainForm: FC<IDomainFormInput> = memo(props => (
+const DomainForm: FC<IDomainFormInput> = memo(props => (
     <LookupProvider>
         <DomainFormImpl {...props} />
     </LookupProvider>
 ));
 
 DomainForm.displayName = 'DomainForm';
+
+export default DomainForm;

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -221,7 +221,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     }
 
     componentDidMount = async (): Promise<void> => {
-        const { domain, maxPhiLevel, useTheme, onChange, api } = this.props;
+        const { domain, maxPhiLevel, onChange, api } = this.props;
 
         this.setState({ isLoading: true });
 
@@ -1362,7 +1362,8 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                                 </Row>
 
                                 {!summaryViewMode &&
-                                    appDomainHeaderRenderer?.({
+                                    appDomainHeaderRenderer &&
+                                    appDomainHeaderRenderer({
                                         domain,
                                         domainIndex,
                                         modelDomains,

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1420,7 +1420,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     }
 }
 
-export const DomainForm: FC<IDomainFormInput> = memo(props => (
+export default const DomainForm: FC<IDomainFormInput> = memo(props => (
     <LookupProvider>
         <DomainFormImpl {...props} />
     </LookupProvider>

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { FC, memo, ReactNode } from 'react';
 import { List, Map } from 'immutable';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import { Button, Checkbox, Col, Form, FormControl, Panel, Row } from 'react-bootstrap';
@@ -46,6 +46,10 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { InferDomainResponse } from '../../../public/InferDomainResponse';
 
 import { FileAttachmentForm } from '../../../public/files/FileAttachmentForm';
+
+import { LoadingSpinner } from '../base/LoadingSpinner';
+
+import { getDefaultAPIWrapper } from '../../APIWrapper';
 
 import {
     DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS,
@@ -85,7 +89,6 @@ import {
     DomainPanelStatus,
     FieldDetails,
     HeaderRenderer,
-    IAppDomainHeader,
     IDomainField,
     IDomainFormDisplayOptions,
     IFieldChange,
@@ -103,9 +106,7 @@ import {
 } from './propertiesUtil';
 import { DomainPropertiesGrid } from './DomainPropertiesGrid';
 import { SystemFields } from './SystemFields';
-import { LoadingSpinner } from '../base/LoadingSpinner';
 import { DomainPropertiesAPIWrapper } from './APIWrapper';
-import { getDefaultAPIWrapper } from '../../APIWrapper';
 
 interface IDomainFormInput {
     api?: DomainPropertiesAPIWrapper;
@@ -117,7 +118,7 @@ interface IDomainFormInput {
     domain: DomainDesign;
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
     domainIndex?: number;
-    fieldsAdditionalRenderer?: () => any;
+    fieldsAdditionalRenderer?: () => ReactNode;
     headerPrefix?: string; // used as a string to remove from the heading when using the domain.name
     headerTitle?: string;
     helpNoun?: string;
@@ -132,18 +133,18 @@ interface IDomainFormInput {
     modelDomains?: List<DomainDesign>;
     // used to initialize newly added fields
     newFieldConfig?: Partial<IDomainField>;
-    onChange: (newDomain: DomainDesign, dirty: boolean, rowIndexChange?: DomainFieldIndexChange[]) => any;
-    onToggle?: (collapsed: boolean, callback?: () => any) => any;
+    onChange: (newDomain: DomainDesign, dirty: boolean, rowIndexChange?: DomainFieldIndexChange[]) => void;
+    onToggle?: (collapsed: boolean, callback?: () => any) => void;
     panelStatus?: DomainPanelStatus;
     // the queryName to use for text choice distinct value query, overrides schema/query on domain prop
     queryName?: string;
     // the schemaName to use for text choice distinct value query, overrides schema/query on domain prop
     schemaName?: string;
+    // having this prop set is also an indicator that you want to show the file preview grid with the import data option
+    setFileImportData?: (file: File, shouldImportData: boolean) => void;
     showHeader?: boolean;
     successBsStyle?: string;
     systemFields?: SystemField[];
-    // having this prop set is also an indicator that you want to show the file preview grid with the import data option
-    setFileImportData?: (file: File, shouldImportData: boolean) => any;
     testMode?: boolean;
     todoIconHelpMsg?: string;
     useTheme?: boolean;
@@ -171,16 +172,6 @@ interface IDomainFormState {
     summaryViewMode: boolean;
     visibleFieldsCount: number;
     visibleSelection: Set<number>;
-}
-
-export default class DomainForm extends React.PureComponent<IDomainFormInput> {
-    render(): ReactNode {
-        return (
-            <LookupProvider>
-                <DomainFormImpl {...this.props} />
-            </LookupProvider>
-        );
-    }
 }
 
 /**
@@ -232,7 +223,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     componentDidMount = async (): Promise<void> => {
         const { domain, maxPhiLevel, useTheme, onChange, api } = this.props;
 
-        this.setState(() => ({ isLoading: true }));
+        this.setState({ isLoading: true });
 
         if (!maxPhiLevel) {
             try {
@@ -253,11 +244,9 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             }
         }
 
-        if (onChange) {
-            onChange(this.validateDomain(domain), false);
-        }
+        onChange?.(this.validateDomain(domain), false);
 
-        this.setState(() => ({ isLoading: false }));
+        this.setState({ isLoading: false });
     };
 
     UNSAFE_componentWillReceiveProps(nextProps: Readonly<IDomainFormInput>): void {
@@ -269,10 +258,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         }
 
         if (nextProps.validate && validate !== nextProps.validate) {
-            const newDomain = this.validateDomain(nextProps.domain);
-            if (onChange) {
-                onChange(newDomain, false);
-            }
+            onChange?.(this.validateDomain(nextProps.domain), false);
         }
     }
 
@@ -312,9 +298,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                     newDomain = this.getFilteredFields(newDomain);
                 }
 
-                if (onChange) {
-                    onChange(newDomain, false);
-                }
+                onChange?.(newDomain, false);
             }
         );
     };
@@ -362,10 +346,6 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     isExpanded = (): boolean => {
         return this.state.expandedRowIndex !== undefined;
     };
-
-    domainExists(domainDesign: DomainDesign): boolean {
-        return !!domainDesign;
-    }
 
     onFieldExpandToggle = (index: number): void => {
         const { expandedRowIndex } = this.state;
@@ -428,24 +408,24 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             });
         }
 
-        this.setState(() => ({ reservedFieldsMsg: undefined, fieldDetails: updatedDomain.getFieldDetails() }));
-
-        this.props.onChange?.(updatedDomain, dirty !== undefined ? dirty : true, rowIndexChanges);
+        this.setState({ reservedFieldsMsg: undefined, fieldDetails: updatedDomain.getFieldDetails() }, () => {
+            this.props.onChange?.(updatedDomain, dirty !== undefined ? dirty : true, rowIndexChanges);
+        });
     }
 
     clearFilePreviewData = (): void => {
-        const { filePreviewData, file } = this.state;
-        const fieldCount = this.props.domain.fields.size;
-
-        this.setState({
-            filePreviewData: fieldCount === 0 ? undefined : filePreviewData,
-            file: fieldCount === 0 ? undefined : file,
-            filePreviewMsg: undefined,
+        this.setState(state => {
+            const fieldCount = this.props.domain.fields.size;
+            return {
+                filePreviewData: fieldCount === 0 ? undefined : state.filePreviewData,
+                file: fieldCount === 0 ? undefined : state.file,
+                filePreviewMsg: undefined,
+            };
         });
     };
 
     onDeleteConfirm(index: number): void {
-        const rowIndexChange = { originalIndex: index, newIndex: undefined } as DomainFieldIndexChange;
+        const rowIndexChange: DomainFieldIndexChange = { newIndex: undefined, originalIndex: index };
         const updatedDomain = removeFields(this.props.domain, [index]);
         const visibleFieldsCount = getVisibleFieldCount(updatedDomain);
         const visibleSelection = getVisibleSelectedFieldIndexes(updatedDomain.fields);
@@ -461,9 +441,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                 expandedRowIndex: undefined,
                 confirmDeleteRowIndex: undefined,
             },
-            () => {
-                this.clearFilePreviewData();
-            }
+            this.clearFilePreviewData
         );
     }
 
@@ -473,7 +451,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
 
         if (newDesignFields) {
             newDesignFields.forEach(this.applyAddField);
-            this.setState(() => ({ expandedRowIndex: 0 }));
+            this.setState({ expandedRowIndex: 0 });
         } else {
             this.applyAddField();
         }
@@ -488,23 +466,19 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             if (field.visible) {
                 newVisibleSelection = applySetOperation(newVisibleSelection, index, !selectAll);
                 return field.set('selected', !selectAll);
-            } else {
-                return field;
             }
+
+            return field;
         });
 
-        const updatedDomain = domain.merge({
-            fields: toggledFields,
-        }) as DomainDesign;
+        const updatedDomain = domain.merge({ fields: toggledFields }) as DomainDesign;
         this.onDomainChange(updatedDomain, false);
         this.setState(state => ({ selectAll: !state.selectAll, visibleSelection: newVisibleSelection }));
     };
 
     clearAllSelection = (): void => {
         const { domain } = this.props;
-        const fields = domain.fields.map(field => {
-            return field.set('selected', false);
-        });
+        const fields = domain.fields.map(field => field.set('selected', false));
         const updatedDomain = domain.merge({ fields }) as DomainDesign;
         this.onDomainChange(updatedDomain, false);
         this.setState({ selectAll: false, visibleSelection: new Set() });
@@ -513,8 +487,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     onExportFields = (): void => {
         const { domain } = this.props;
         const { visibleSelection } = this.state;
-        const fields = domain.fields;
-        let filteredFields = fields.filter((field: DomainField) => field.visible);
+        let filteredFields = domain.fields.filter(f => f.visible);
         // Respect selection, if any selection exists
         filteredFields =
             visibleSelection.size > 0 ? filteredFields.filter((field: DomainField) => field.selected) : filteredFields;
@@ -528,18 +501,9 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     renderBulkFieldDeleteConfirm = (): ReactNode => {
         const { domain } = this.props;
         const { bulkDeleteConfirmInfo } = this.state;
-        const undeletableNames = bulkDeleteConfirmInfo.undeletableFields.map(i => {
-            return domain.fields.get(i).name;
-        });
-        const { howManyDeleted, undeletableWarning } = generateBulkDeleteWarning(
-            bulkDeleteConfirmInfo,
-            undeletableNames
-        );
+        const deletableSelectedFieldsCount = bulkDeleteConfirmInfo.deletableSelectedFields.length;
 
-        const thisFieldPlural =
-            bulkDeleteConfirmInfo.deletableSelectedFields.length > 1 ? 'these fields' : 'this field';
-
-        if (bulkDeleteConfirmInfo.deletableSelectedFields.length === 0) {
+        if (deletableSelectedFieldsCount === 0) {
             return (
                 <ConfirmModal
                     title="Cannot Delete Required Fields"
@@ -552,6 +516,11 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                 </ConfirmModal>
             );
         }
+
+        const { howManyDeleted, undeletableWarning } = generateBulkDeleteWarning(
+            bulkDeleteConfirmInfo,
+            bulkDeleteConfirmInfo.undeletableFields.map(i => domain.fields.get(i).name)
+        );
 
         return (
             <ConfirmModal
@@ -566,8 +535,9 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                     <p>{howManyDeleted} will be deleted.</p>
                     <p>{undeletableWarning}</p>
                     <p>
-                        Are you sure you want to delete {thisFieldPlural}? All of the related field data will also be
-                        deleted.
+                        Are you sure you want to delete{' '}
+                        {deletableSelectedFieldsCount > 1 ? 'these fields' : 'this field'}? All of the related field
+                        data will also be deleted.
                     </p>
                 </div>
             </ConfirmModal>
@@ -575,28 +545,25 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     };
 
     onBulkDeleteClick = (): void => {
-        const { domain } = this.props;
-        const { visibleSelection } = this.state;
-        const fields = domain.fields;
+        this.setState(state => {
+            const { fields } = this.props.domain;
+            const { visibleSelection } = state;
 
-        const undeletableFields = [];
-        const deletableSelectedFields = [];
+            const undeletableFields: number[] = [];
+            const deletableSelectedFields: number[] = [];
 
-        visibleSelection.forEach(val => {
-            const field = fields.get(val);
+            visibleSelection.forEach(val => {
+                const field = fields.get(val);
 
-            if (field.isSaved() && !isFieldDeletable(field)) {
-                undeletableFields.push(val);
-            } else {
-                deletableSelectedFields.push(val);
-            }
+                if (field.isSaved() && !isFieldDeletable(field)) {
+                    undeletableFields.push(val);
+                } else {
+                    deletableSelectedFields.push(val);
+                }
+            });
+
+            return { bulkDeleteConfirmInfo: { deletableSelectedFields, undeletableFields } };
         });
-
-        const bulkDeleteConfirmInfo = {
-            deletableSelectedFields,
-            undeletableFields,
-        };
-        this.setState({ bulkDeleteConfirmInfo });
     };
 
     onBulkDeleteConfirm = (): void => {
@@ -605,9 +572,10 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         const updatedDomain = removeFields(domain, deletableSelectedFields);
         const visibleFieldsCount = getVisibleFieldCount(updatedDomain);
         const visibleSelection = getVisibleSelectedFieldIndexes(updatedDomain.fields);
-        const rowIndexChanges = deletableSelectedFields.map(i => {
-            return { originalIndex: i, newIndex: undefined } as DomainFieldIndexChange;
-        });
+        const rowIndexChanges = deletableSelectedFields.map<DomainFieldIndexChange>(i => ({
+            newIndex: undefined,
+            originalIndex: i,
+        }));
 
         this.onDomainChange(updatedDomain, true, rowIndexChanges);
         this.setState(
@@ -618,9 +586,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                 selectAll: visibleFieldsCount !== 0 && visibleSelection.size === visibleFieldsCount,
                 bulkDeleteConfirmInfo: undefined,
             },
-            () => {
-                this.clearFilePreviewData();
-            }
+            this.clearFilePreviewData
         );
     };
 
@@ -628,13 +594,16 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         this.applyAddField();
     };
 
+    onFileRemoval = (): void => {
+        this.setState({ filePreviewMsg: undefined });
+    };
+
     applyAddField = (config?: Partial<IDomainField>): void => {
         const { newFieldConfig } = this.props;
         const newConfig = config ? { ...config } : newFieldConfig;
         const newDomain = addDomainField(this.props.domain, newConfig);
         this.onDomainChange(newDomain, true);
-        this.setState({ selectAll: false, visibleFieldsCount: getVisibleFieldCount(newDomain) });
-        this.collapseRow();
+        this.setState({ selectAll: false, visibleFieldsCount: getVisibleFieldCount(newDomain) }, this.collapseRow);
     };
 
     onSystemFieldEnable = (field: string, enable: boolean): void => {
@@ -644,20 +613,28 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
 
     onFieldsChange = (changes: List<IFieldChange>, index: number, expand: boolean): void => {
         const { domain } = this.props;
-        const { visibleFieldsCount } = this.state;
         const firstChange = changes.get(0);
         const rowSelectedChange = getNameFromId(firstChange?.id) === 'selected';
 
         this.onDomainChange(handleDomainUpdates(domain, changes), !rowSelectedChange);
 
         if (rowSelectedChange) {
-            this.setState(state => {
-                const visibleSelection = applySetOperation(state.visibleSelection, index, firstChange.value);
-                const selectAll = visibleFieldsCount !== 0 && visibleSelection.size === visibleFieldsCount;
-                return { visibleSelection, selectAll };
-            });
-        }
-        if (expand) {
+            this.setState(
+                state => {
+                    const { visibleFieldsCount } = state;
+                    const visibleSelection = applySetOperation(state.visibleSelection, index, firstChange.value);
+                    return {
+                        visibleSelection,
+                        selectAll: visibleFieldsCount !== 0 && visibleSelection.size === visibleFieldsCount,
+                    };
+                },
+                () => {
+                    if (expand) {
+                        this.expandRow(index);
+                    }
+                }
+            );
+        } else if (expand) {
             this.expandRow(index);
         }
     };
@@ -669,7 +646,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         if (field) {
             // only show the confirm dialog for saved fields
             if (field.isSaved()) {
-                this.setState(() => ({ confirmDeleteRowIndex: index }));
+                this.setState({ confirmDeleteRowIndex: index });
             } else {
                 this.onDeleteConfirm(index);
             }
@@ -677,11 +654,11 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     };
 
     onConfirmCancel = (): void => {
-        this.setState(() => ({ confirmDeleteRowIndex: undefined }));
+        this.setState({ confirmDeleteRowIndex: undefined });
     };
 
     onConfirmBulkCancel = (): void => {
-        this.setState(() => ({ bulkDeleteConfirmInfo: undefined }));
+        this.setState({ bulkDeleteConfirmInfo: undefined });
     };
 
     onBeforeDragStart = (initial): void => {
@@ -689,7 +666,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         const id = initial.draggableId;
         const idIndex = id ? getIndexFromId(id) : undefined;
 
-        this.setState(() => ({ dragId: idIndex }));
+        this.setState({ dragId: idIndex });
 
         this.onDomainChange(domain, false);
 
@@ -705,7 +682,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         const id = result.draggableId;
         const idIndex = id ? getIndexFromId(id) : undefined;
 
-        this.setState(() => ({ dragId: undefined }));
+        this.setState({ dragId: undefined });
 
         if (result.destination) {
             destIndex = result.destination.index;
@@ -764,16 +741,18 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             }
         });
 
-        // set existing error row indexes with new row indexes
-        const fieldsWithMovedErrorsUpdated = fieldsWithNewIndexesOnErrors.map(error => {
-            return error.merge({
-                rowIndexes: error.newRowIndexes ? error.newRowIndexes : error.rowIndexes,
-                newRowIndexes: undefined, // reset newRowIndexes
-            });
-        });
-
         let domainExceptionWithMovedErrors;
         if (domain.hasException()) {
+            // set existing error row indexes with new row indexes
+            const fieldsWithMovedErrorsUpdated = fieldsWithNewIndexesOnErrors
+                .map(error =>
+                    error.merge({
+                        rowIndexes: error.newRowIndexes ? error.newRowIndexes : error.rowIndexes,
+                        newRowIndexes: undefined, // reset newRowIndexes
+                    })
+                )
+                .toList();
+
             domainExceptionWithMovedErrors = domain.domainException.set('errors', fieldsWithMovedErrorsUpdated);
         }
 
@@ -783,13 +762,15 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         }) as DomainDesign;
 
         if (movedField.selected) {
-            const oldVisibleSelection = applySetOperation(this.state.visibleSelection, srcIndex, false);
-            const visibleSelection = applySetOperation(oldVisibleSelection, destIndex, true);
-            this.setState({ visibleSelection });
+            this.setState(state => {
+                const oldVisibleSelection = applySetOperation(state.visibleSelection, srcIndex, false);
+                return {
+                    visibleSelection: applySetOperation(oldVisibleSelection, destIndex, true),
+                };
+            });
         }
-        const rowIndexChange = { originalIndex: srcIndex, newIndex: destIndex } as DomainFieldIndexChange;
 
-        this.onDomainChange(newDomain, true, [rowIndexChange]);
+        this.onDomainChange(newDomain, true, [{ originalIndex: srcIndex, newIndex: destIndex }]);
 
         this.fastExpand(expanded);
     };
@@ -799,24 +780,24 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         newIndex: number,
         fieldErrors: List<DomainFieldError>
     ): List<DomainFieldError> => {
-        const updatedErrorList = fieldErrors.map(fieldError => {
-            let newRowIndexes;
-            if (fieldError.newRowIndexes === undefined) {
-                newRowIndexes = List<number>().asMutable();
-            } else {
-                newRowIndexes = fieldError.get('newRowIndexes');
-            }
-
-            fieldError.rowIndexes.forEach(val => {
-                if (val === oldIndex) {
-                    newRowIndexes = newRowIndexes.push(newIndex);
+        return fieldErrors
+            .map(fieldError => {
+                let newRowIndexes: List<number>;
+                if (fieldError.newRowIndexes === undefined) {
+                    newRowIndexes = List<number>();
+                } else {
+                    newRowIndexes = fieldError.get('newRowIndexes');
                 }
-            });
 
-            return fieldError.set('newRowIndexes', newRowIndexes.asImmutable());
-        });
+                fieldError.rowIndexes.forEach(val => {
+                    if (val === oldIndex) {
+                        newRowIndexes = newRowIndexes.push(newIndex);
+                    }
+                });
 
-        return updatedErrorList as List<DomainFieldError>;
+                return fieldError.set('newRowIndexes', newRowIndexes) as DomainFieldError;
+            })
+            .toList();
     };
 
     renderAddFieldOption(): ReactNode {
@@ -833,20 +814,20 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                         </ActionButton>
                     </div>
                 );
-            } else {
-                return (
-                    <Row className="domain-add-field-row">
-                        <Col xs={12}>
-                            <AddEntityButton
-                                entity="Field"
-                                buttonClass="domain-form-add-btn"
-                                containerClass="pull-right"
-                                onClick={this.onAddField}
-                            />
-                        </Col>
-                    </Row>
-                );
             }
+
+            return (
+                <Row className="domain-add-field-row">
+                    <Col xs={12}>
+                        <AddEntityButton
+                            entity="Field"
+                            buttonClass="domain-form-add-btn"
+                            containerClass="pull-right"
+                            onClick={this.onAddField}
+                        />
+                    </Col>
+                </Row>
+            );
         }
 
         return null;
@@ -960,9 +941,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                         return resolve(response);
                     } else {
                         const tsFields = response.fields;
-                        if (onChange) {
-                            onChange(mergeDomainFields(domain, tsFields), true);
-                        }
+                        onChange?.(mergeDomainFields(domain, tsFields), true);
                         resolve({ success: true });
                     }
                 } catch (e) {
@@ -1005,12 +984,12 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                 <>
                     <FileAttachmentForm
                         acceptedFormats={acceptedFormats.join(', ')}
-                        showAcceptedFormats={true}
+                        showAcceptedFormats
                         allowDirectories={false}
                         allowMultiple={false}
                         label={label}
                         index={index}
-                        onFileRemoval={() => this.setState(() => ({ filePreviewMsg: undefined }))}
+                        onFileRemoval={this.onFileRemoval}
                         previewGridProps={
                             shouldShowInferFromFile && {
                                 previewCount: 3,
@@ -1026,13 +1005,13 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                     )}
                 </>
             );
-        } else {
-            return (
-                <Panel className="domain-form-no-field-panel">
-                    No fields created yet. Click the 'Add Field' button to get started.
-                </Panel>
-            );
         }
+
+        return (
+            <Panel className="domain-form-no-field-panel">
+                No fields created yet. Click the 'Add Field' button to get started.
+            </Panel>
+        );
     }
 
     onToggleSummaryView = (): void => {
@@ -1062,13 +1041,17 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         const visibleFieldsCount = getVisibleFieldCount(filteredDomain);
         const visibleSelection = getVisibleSelectedFieldIndexes(filteredDomain.fields);
 
-        this.setState(() => ({
-            visibleSelection,
-            visibleFieldsCount,
-            search: value,
-            selectAll: visibleFieldsCount !== 0 && visibleSelection.size === visibleFieldsCount,
-        }));
-        this.onDomainChange(filteredDomain, false);
+        this.setState(
+            {
+                visibleSelection,
+                visibleFieldsCount,
+                search: value,
+                selectAll: visibleFieldsCount !== 0 && visibleSelection.size === visibleFieldsCount,
+            },
+            () => {
+                this.onDomainChange(filteredDomain, false);
+            }
+        );
     };
 
     isPanelExpanded = (): boolean => {
@@ -1083,93 +1066,6 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
     getDomainFields = (): List<DomainField> => {
         return this.props.domain.fields;
     };
-
-    renderPanelHeaderContent(): ReactNode {
-        const { helpTopic } = this.props;
-
-        return (
-            <Row className={helpTopic ? 'domain-form-hdr-margins' : ''}>
-                <Col xs={helpTopic ? 9 : 12} />
-                {helpTopic && (
-                    <Col xs={3}>
-                        <HelpLink topic={helpTopic} className="domain-field-float-right">
-                            Learn more about this tool
-                        </HelpLink>
-                    </Col>
-                )}
-            </Row>
-        );
-    }
-
-    renderToolbar(): ReactNode {
-        const { domain, domainIndex, domainFormDisplayOptions, testMode } = this.props;
-        const { visibleSelection, summaryViewMode } = this.state;
-        const { fields } = domain;
-        const disableExport = fields.size < 1 || fields.filter((field: DomainField) => field.visible).size < 1;
-        const selectedExists = visibleSelection.size > 0;
-
-        return (
-            <Row className="domain-field-toolbar">
-                <Col xs={4}>
-                    {!domainFormDisplayOptions?.hideAddFieldsButton && (
-                        <AddEntityButton
-                            entity="Field"
-                            containerClass="container--toolbar-button"
-                            buttonClass="domain-toolbar-add-btn"
-                            onClick={this.onAddField}
-                        />
-                    )}
-                    <ActionButton
-                        containerClass="container--toolbar-button"
-                        buttonClass="domain-toolbar-delete-btn"
-                        onClick={this.onBulkDeleteClick}
-                        disabled={!selectedExists}
-                    >
-                        <i className="fa fa-trash domain-toolbar-export-btn-icon" /> Delete
-                    </ActionButton>
-                    {this.shouldShowImportExport() && (
-                        <ActionButton
-                            containerClass="container--toolbar-button"
-                            buttonClass="domain-toolbar-export-btn"
-                            onClick={this.onExportFields}
-                            disabled={disableExport}
-                        >
-                            <i className="fa fa-download domain-toolbar-export-btn-icon" /> Export
-                        </ActionButton>
-                    )}
-                </Col>
-                <Col xs={8}>
-                    <div className="pull-right domain-field-toolbar-right-aligned">
-                        {!valueIsEmpty(this.state.search) && (
-                            <span className="domain-search-text">
-                                Showing {fields.filter(f => f.visible).size} of {fields.size} field
-                                {fields.size > 1 ? 's' : ''}.
-                            </span>
-                        )}
-                        <FormControl
-                            id={'domain-search-name-' + domainIndex}
-                            className="domain-search-input"
-                            type="text"
-                            placeholder="Search Fields"
-                            onChange={this.onSearch}
-                        />
-
-                        {!testMode && (
-                            <ToggleWithInputField
-                                active={summaryViewMode}
-                                id={'domain-toggle-summary-' + domainIndex}
-                                onClick={this.onToggleSummaryView}
-                                on="Summary mode"
-                                off="Detail mode"
-                                containerClassName="domain-toolbar-toggle-summary"
-                                style={{ height: '100%', marginLeft: '10px' }} // Inline style necessary for <ReactBootstrapToggle/>
-                            />
-                        )}
-                    </div>
-                </Col>
-            </Row>
-        );
-    }
 
     scrollFunction = (i: number): void => {
         this.setState({ summaryViewMode: false, expandedRowIndex: i }, () => {
@@ -1302,98 +1198,50 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         );
     };
 
-    renderAppDomainHeader = (): ReactNode => {
-        const { appDomainHeaderRenderer, modelDomains, domain, domainIndex } = this.props;
-        const config = {
-            domain,
-            domainIndex,
-            modelDomains,
-            onChange: this.onFieldsChange,
-            onAddField: this.applyAddField,
-        } as IAppDomainHeader;
-
-        return appDomainHeaderRenderer(config);
-    };
-
-    renderForm(): ReactNode {
-        const { domain, appDomainHeaderRenderer, appPropertiesOnly, systemFields } = this.props;
-        const { summaryViewMode, search, selectAll, isLoading } = this.state;
-        const hasFields = domain.fields.size > 0;
-        const actions = {
-            toggleSelectAll: this.toggleSelectAll,
-            scrollFunction: this.scrollFunction,
-            onFieldsChange: this.onFieldsChange,
-        };
-
-        if (isLoading)
-            return <LoadingSpinner />;
-
-        return (
-            <>
-                {systemFields && (
-                    <SystemFields
-                        fields={systemFields}
-                        disabledSystemFields={domain.disabledSystemFields}
-                        onSystemFieldEnable={this.onSystemFieldEnable}
-                    />
-                )}
-
-                {(hasFields || !(this.shouldShowInferFromFile() || this.shouldShowImportExport())) &&
-                    this.renderToolbar()}
-                {this.renderPanelHeaderContent()}
-                {appDomainHeaderRenderer && !summaryViewMode && this.renderAppDomainHeader()}
-
-                {hasFields ? (
-                    summaryViewMode ? (
-                        <div className="domain-form__summary-mode">
-                            <DomainPropertiesGrid
-                                domain={domain}
-                                search={search}
-                                selectAll={selectAll}
-                                actions={actions}
-                                appPropertiesOnly={appPropertiesOnly}
-                                hasOntologyModule={hasModule(ONTOLOGY_MODULE_NAME)}
-                            />
-                        </div>
-                    ) : (
-                        this.renderDetailedFieldView()
-                    )
-                ) : (
-                    this.renderEmptyDomain()
-                )}
-
-                {this.renderAddFieldOption()}
-            </>
-        );
-    }
-
     render(): ReactNode {
         const {
+            appDomainHeaderRenderer,
+            appPropertiesOnly,
             children,
             domain,
-            showHeader,
+            domainIndex,
             collapsible,
             controlledCollapse,
+            domainFormDisplayOptions,
+            fieldsAdditionalRenderer,
             headerTitle,
             headerPrefix,
+            helpNoun,
+            helpTopic,
+            modelDomains,
             panelStatus,
             useTheme,
-            helpNoun,
             setFileImportData,
-            fieldsAdditionalRenderer,
-            domainFormDisplayOptions,
-            todoIconHelpMsg,
+            showHeader,
             systemFields,
+            testMode,
+            todoIconHelpMsg,
         } = this.props;
-        const { collapsed, confirmDeleteRowIndex, filePreviewData, file, bulkDeleteConfirmInfo } = this.state;
-        const title = getDomainHeaderName(domain.name, headerTitle, headerPrefix);
+        const {
+            bulkDeleteConfirmInfo,
+            collapsed,
+            confirmDeleteRowIndex,
+            filePreviewData,
+            file,
+            isLoading,
+            search,
+            selectAll,
+            summaryViewMode,
+            visibleSelection,
+        } = this.state;
+        const { fields } = domain;
         const headerDetails =
-            domain.fields.size > 0
-                ? '' + domain.fields.size + ' Field' + (domain.fields.size > 1 ? 's' : '') + ' Defined'
-                : undefined;
-        const hasFields = domain.fields.size > 0;
+            fields.size > 0 ? '' + fields.size + ' Field' + (fields.size > 1 ? 's' : '') + ' Defined' : undefined;
+        const hasFields = fields.size > 0;
         const styleToolbar =
             !hasFields && !systemFields && (this.shouldShowInferFromFile() || this.shouldShowImportExport());
+        const disableExport = !hasFields || fields.filter(f => f.visible).size < 1;
+        const hasException = domain.hasException();
 
         return (
             <>
@@ -1407,7 +1255,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                     {showHeader && (
                         <CollapsiblePanelHeader
                             id={getDomainPanelHeaderId(domain)}
-                            title={title}
+                            title={getDomainHeaderName(domain.name, headerTitle, headerPrefix)}
                             collapsed={!(this.isPanelExpanded() && controlledCollapse)}
                             collapsible={collapsible}
                             controlledCollapse={controlledCollapse}
@@ -1416,8 +1264,8 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                             panelStatus={panelStatus}
                             togglePanel={this.togglePanel}
                             useTheme={useTheme}
-                            isValid={!domain.hasException()}
-                            iconHelpMsg={domain.hasException() ? domain.domainException.exception : undefined}
+                            isValid={!hasException}
+                            iconHelpMsg={hasException ? domain.domainException.exception : undefined}
                         >
                             {children}
                         </CollapsiblePanelHeader>
@@ -1426,9 +1274,128 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                         className={classNames({ 'domain-field-top-noBuffer': !styleToolbar })}
                         collapsible={collapsible || controlledCollapse}
                     >
-                        {this.domainExists(domain) ? this.renderForm() : <Alert>Invalid domain design.</Alert>}
+                        {isLoading && <LoadingSpinner />}
 
-                        {fieldsAdditionalRenderer && fieldsAdditionalRenderer()}
+                        {!isLoading && (
+                            <>
+                                {systemFields && (
+                                    <SystemFields
+                                        fields={systemFields}
+                                        disabledSystemFields={domain.disabledSystemFields}
+                                        onSystemFieldEnable={this.onSystemFieldEnable}
+                                    />
+                                )}
+
+                                {(hasFields || !(this.shouldShowInferFromFile() || this.shouldShowImportExport())) && (
+                                    <Row className="domain-field-toolbar">
+                                        <Col xs={4}>
+                                            {!domainFormDisplayOptions?.hideAddFieldsButton && (
+                                                <AddEntityButton
+                                                    entity="Field"
+                                                    containerClass="container--toolbar-button"
+                                                    buttonClass="domain-toolbar-add-btn"
+                                                    onClick={this.onAddField}
+                                                />
+                                            )}
+                                            <ActionButton
+                                                containerClass="container--toolbar-button"
+                                                buttonClass="domain-toolbar-delete-btn"
+                                                onClick={this.onBulkDeleteClick}
+                                                disabled={visibleSelection.size === 0}
+                                            >
+                                                <i className="fa fa-trash domain-toolbar-export-btn-icon" /> Delete
+                                            </ActionButton>
+
+                                            {this.shouldShowImportExport() && (
+                                                <ActionButton
+                                                    containerClass="container--toolbar-button"
+                                                    buttonClass="domain-toolbar-export-btn"
+                                                    onClick={this.onExportFields}
+                                                    disabled={disableExport}
+                                                >
+                                                    <i className="fa fa-download domain-toolbar-export-btn-icon" />{' '}
+                                                    Export
+                                                </ActionButton>
+                                            )}
+                                        </Col>
+                                        <Col xs={8}>
+                                            <div className="pull-right domain-field-toolbar-right-aligned">
+                                                {!valueIsEmpty(search) && (
+                                                    <span className="domain-search-text">
+                                                        Showing {fields.filter(f => f.visible).size} of {fields.size}{' '}
+                                                        field {fields.size > 1 ? 's' : ''}.
+                                                    </span>
+                                                )}
+                                                <FormControl
+                                                    id={'domain-search-name-' + domainIndex}
+                                                    className="domain-search-input"
+                                                    type="text"
+                                                    placeholder="Search Fields"
+                                                    onChange={this.onSearch}
+                                                />
+
+                                                {!testMode && (
+                                                    <ToggleWithInputField
+                                                        active={summaryViewMode}
+                                                        id={'domain-toggle-summary-' + domainIndex}
+                                                        onClick={this.onToggleSummaryView}
+                                                        on="Summary mode"
+                                                        off="Detail mode"
+                                                        containerClassName="domain-toolbar-toggle-summary"
+                                                        style={{ height: '100%', marginLeft: '10px' }} // Inline style necessary for <ReactBootstrapToggle/>
+                                                    />
+                                                )}
+                                            </div>
+                                        </Col>
+                                    </Row>
+                                )}
+
+                                <Row className={helpTopic ? 'domain-form-hdr-margins' : ''}>
+                                    <Col xs={helpTopic ? 9 : 12} />
+                                    {helpTopic && (
+                                        <Col xs={3}>
+                                            <HelpLink topic={helpTopic} className="domain-field-float-right">
+                                                Learn more about this tool
+                                            </HelpLink>
+                                        </Col>
+                                    )}
+                                </Row>
+
+                                {!summaryViewMode &&
+                                    appDomainHeaderRenderer?.({
+                                        domain,
+                                        domainIndex,
+                                        modelDomains,
+                                        onChange: this.onFieldsChange,
+                                        onAddField: this.applyAddField,
+                                    })}
+
+                                {hasFields && summaryViewMode && (
+                                    <div className="domain-form__summary-mode">
+                                        <DomainPropertiesGrid
+                                            domain={domain}
+                                            search={search}
+                                            selectAll={selectAll}
+                                            actions={{
+                                                toggleSelectAll: this.toggleSelectAll,
+                                                scrollFunction: this.scrollFunction,
+                                                onFieldsChange: this.onFieldsChange,
+                                            }}
+                                            appPropertiesOnly={appPropertiesOnly}
+                                            hasOntologyModule={hasModule(ONTOLOGY_MODULE_NAME)}
+                                        />
+                                    </div>
+                                )}
+
+                                {hasFields && !summaryViewMode && this.renderDetailedFieldView()}
+
+                                {!hasFields && this.renderEmptyDomain()}
+
+                                {this.renderAddFieldOption()}
+                            </>
+                        )}
+
+                        {fieldsAdditionalRenderer?.()}
 
                         {filePreviewData && !domainFormDisplayOptions?.hideImportData && (
                             <ImportDataFilePreview
@@ -1440,7 +1407,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                         )}
                     </Panel.Body>
                 </Panel>
-                {domain.hasException() && domain.domainException.severity === SEVERITY_LEVEL_ERROR && (
+                {hasException && domain.domainException.severity === SEVERITY_LEVEL_ERROR && (
                     <div
                         onClick={this.togglePanel}
                         className={getDomainAlertClasses(collapsed, controlledCollapse, useTheme)}
@@ -1452,3 +1419,11 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         );
     }
 }
+
+export const DomainForm: FC<IDomainFormInput> = memo(props => (
+    <LookupProvider>
+        <DomainFormImpl {...props} />
+    </LookupProvider>
+));
+
+DomainForm.displayName = 'DomainForm';

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -178,9 +178,9 @@ export function fetchDomain(
  * @return Promise wrapped Domain API call.
  */
 export function fetchDomainDetails(
-    domainId: number,
-    schemaName: string,
-    queryName: string,
+    domainId?: number,
+    schemaName?: string,
+    queryName?: string,
     domainKind?: string
 ): Promise<DomainDetails> {
     return new Promise((resolve, reject) => {

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.spec.tsx.snap
@@ -231,6 +231,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -382,6 +383,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -533,6 +535,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -1428,6 +1431,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -1821,6 +1825,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -2745,6 +2750,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -2896,6 +2902,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -3047,6 +3054,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -3422,6 +3430,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain for new assay 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -3573,6 +3582,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain for new assay 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -4431,6 +4441,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -5799,6 +5810,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -6192,6 +6204,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.spec.tsx.snap
@@ -124,6 +124,7 @@ exports[`DataClassDesigner custom properties 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -380,6 +381,7 @@ exports[`DataClassDesigner default properties 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -1161,6 +1163,7 @@ exports[`DataClassDesigner initModel 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }

--- a/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetDesignerPanels.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetDesignerPanels.spec.tsx.snap
@@ -11,6 +11,7 @@ exports[`Dataset Designer Edit existing dataset 1`] = `
       "getGenId": [MockFunction],
       "getMaxPhiLevel": [Function],
       "hasExistingDomainData": [MockFunction],
+      "saveDomain": [MockFunction],
       "setGenId": [MockFunction],
       "validateDomainNameExpressions": [MockFunction],
     }
@@ -1447,6 +1448,7 @@ exports[`Dataset Designer New dataset 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.spec.tsx
@@ -185,7 +185,7 @@ describe('SampleTypeDesigner', () => {
         panelHeader.simulate('click');
         const alerts = wrapped.find(Alert);
         // still expect to have only two alerts.  We don't show the Barcode header in the file import panel.
-        // Jest doesn't wnat to switch to that panel.
+        // Jest doesn't want to switch to that panel.
         expect(alerts).toHaveLength(2);
         expect(alerts.at(0).text()).toEqual(PROPERTIES_PANEL_ERROR_MSG);
         expect(alerts.at(1).text()).toEqual('Please correct errors in the properties panel before saving.');

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypeDesigner.spec.tsx.snap
@@ -160,6 +160,7 @@ exports[`SampleTypeDesigner custom properties 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -411,6 +412,7 @@ exports[`SampleTypeDesigner default properties 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }
@@ -903,6 +905,7 @@ exports[`SampleTypeDesigner initModel with name URL props 1`] = `
         "getGenId": [MockFunction],
         "getMaxPhiLevel": [Function],
         "hasExistingDomainData": [MockFunction],
+        "saveDomain": [MockFunction],
         "setGenId": [MockFunction],
         "validateDomainNameExpressions": [MockFunction],
       }

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1161,7 +1161,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             processBulkData,
             queryInfo,
         } = this.props;
-        const { nounPlural } = addControlProps;
+        const nounPlural = addControlProps?.nounPlural;
         // numItems is a string because we rely on Formsy to grab the value for us (See QueryInfoForm for details). We
         // need to parseInt the value because we add this variable to other numbers, if it's a string we'll add more
         // rows than we want because 1 + "1" is "11" in JavaScript.
@@ -1249,23 +1249,22 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         onChange(changes.editorModel, changes.dataKeys, changes.data);
     };
 
-    getAddControlProps = (): Partial<AddRowsControlProps> => {
-        const { addControlProps, editorModel, maxRows } = this.props;
-        if (maxRows && editorModel.rowCount + addControlProps.maxCount > maxRows) {
-            return { ...addControlProps, maxTotalCount: maxRows, maxCount: maxRows - editorModel.rowCount };
-        } else {
-            return { ...addControlProps, maxTotalCount: maxRows };
-        }
-    };
-
     renderAddRowsControl = (placement: PlacementType): ReactNode => {
-        const { editorModel, isSubmitting, maxRows } = this.props;
+        const { addControlProps, editorModel, isSubmitting, maxRows } = this.props;
+        let maxCount = addControlProps?.maxCount;
+
+        if (maxRows && editorModel.rowCount + (addControlProps?.maxCount ?? 0) > maxRows) {
+            maxCount = maxRows - editorModel.rowCount;
+        }
+
         return (
             <AddRowsControl
-                {...this.getAddControlProps()}
-                placement={placement}
+                {...addControlProps}
                 disable={isSubmitting || (maxRows && editorModel.rowCount >= maxRows)}
+                maxCount={maxCount}
+                maxTotalCount={maxRows}
                 onAdd={this.addRows}
+                placement={placement}
             />
         );
     };
@@ -1324,7 +1323,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                     )}
                     {allowExport && (
                         <span className="control-right pull-right">
-                            <EditableGridExportMenu id={editorModel.id} hasData={true} exportHandler={exportHandler} />
+                            <EditableGridExportMenu id={editorModel.id} hasData exportHandler={exportHandler} />
                         </span>
                     )}
                 </div>
@@ -1343,7 +1342,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 asModal
                 checkRequiredFields={false}
                 showLabelAsterisk
-                submitForEditText={`Add ${capitalizeFirstChar(addControlProps.nounPlural)} to Grid`}
+                submitForEditText={`Add ${capitalizeFirstChar(addControlProps?.nounPlural)} to Grid`}
                 maxCount={maxToAdd}
                 onHide={this.toggleBulkAdd}
                 operation={forUpdate ? Operation.update : Operation.insert}
@@ -1484,10 +1483,10 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                     operation={forUpdate ? Operation.update : Operation.insert}
                     onSubmitForEdit={this.bulkUpdate}
                     onSuccess={this.toggleBulkUpdate}
-                    pluralNoun={addControlProps.nounPlural}
+                    pluralNoun={addControlProps?.nounPlural}
                     queryInfo={queryInfo}
                     selectedRowIndexes={this.getSelectedRowIndices()}
-                    singularNoun={addControlProps.nounSingular}
+                    singularNoun={addControlProps?.nounSingular}
                     warning={bulkUpdateProps?.warning}
                 />
             </>

--- a/packages/components/src/internal/components/user/ProfilePage.tsx
+++ b/packages/components/src/internal/components/user/ProfilePage.tsx
@@ -29,7 +29,7 @@ import { getUserRoleDisplay } from './actions';
 import { UserProfile } from './UserProfile';
 import { ChangePasswordModal } from './ChangePasswordModal';
 
-import { useUserProperties } from './UserProvider';
+import { useUserProperties } from './hooks';
 
 interface Props extends WithRouterProps {
     updateUserDisplayName: (displayName: string) => any;

--- a/packages/components/src/internal/components/user/ProfilePage.tsx
+++ b/packages/components/src/internal/components/user/ProfilePage.tsx
@@ -32,7 +32,7 @@ import { ChangePasswordModal } from './ChangePasswordModal';
 import { useUserProperties } from './hooks';
 
 interface Props extends WithRouterProps {
-    updateUserDisplayName: (displayName: string) => any;
+    updateUserDisplayName: (displayName: string) => void;
 }
 
 const TITLE = 'User Profile';
@@ -44,10 +44,6 @@ const ProfilePageImpl: FC<Props> = props => {
     const { moduleContext, user } = useServerContext();
     const userProperties = useUserProperties(user);
     const { createNotification } = useNotificationsContext();
-
-    if (!user.isSignedIn) {
-        return <InsufficientPermissionsPage title={TITLE} />;
-    }
 
     const navigate = useCallback(
         (result: any, shouldReload: boolean): void => {
@@ -83,6 +79,10 @@ const ProfilePageImpl: FC<Props> = props => {
     const toggleChangePassword = useCallback((): void => {
         setShowChangePassword(!showChangePassword);
     }, [showChangePassword]);
+
+    if (!user.isSignedIn) {
+        return <InsufficientPermissionsPage title={TITLE} />;
+    }
 
     const allowChangePassword = !isLoginAutoRedirectEnabled(moduleContext);
 

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -24,7 +24,7 @@ import { GroupsList } from '../permissions/GroupsList';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
-import { getUserDetailsRowData, updateUserDetails } from './actions';
+import { getUserDetailsRowData } from './actions';
 
 const FIELDS_TO_EXCLUDE = List<string>([
     'userid',
@@ -139,7 +139,7 @@ export class UserProfile extends PureComponent<Props, State> {
     };
 
     submitUserDetails = (data: OrderedMap<string, any>): Promise<any> => {
-        const { user } = this.props;
+        const { api, user } = this.props;
         const avatar = this.state.avatar || (this.state.removeCurrentAvatar ? null : undefined);
 
         // Issue 39225: don't submit empty string for required DisplayName
@@ -153,7 +153,7 @@ export class UserProfile extends PureComponent<Props, State> {
             this.setState(() => ({ reloadRequired: true }));
         }
 
-        return updateUserDetails(SCHEMAS.CORE_TABLES.USERS, getUserDetailsRowData(user, data, avatar));
+        return api.security.updateUserDetails(SCHEMAS.CORE_TABLES.USERS, getUserDetailsRowData(user, data, avatar));
     };
 
     onSuccess = (result: {}): void => {

--- a/packages/components/src/internal/components/user/UserProvider.tsx
+++ b/packages/components/src/internal/components/user/UserProvider.tsx
@@ -6,62 +6,7 @@ import React, { useEffect, useState } from 'react';
 
 import { User } from '../base/models/User';
 
-import { LoadingPage } from '../base/LoadingPage';
-
 import { getUserProperties } from './actions';
-
-interface Props {
-    user: User;
-}
-
-interface State {
-    userProperties: Record<string, any>;
-}
-
-const Context = React.createContext<State>(undefined);
-const UserContextProvider = Context.Provider;
-export const UserContextConsumer = Context.Consumer;
-
-/** @deprecated Consider calling getUserProperties() or using useUserProperties hook instead. */
-export const UserProvider = (Component: React.ComponentType) => {
-    return class UserProviderImpl extends React.Component<Props, State> {
-        constructor(props: Props) {
-            super(props);
-
-            this.state = {
-                userProperties: undefined,
-            };
-        }
-
-        componentDidMount = async (): Promise<void> => {
-            const { user } = this.props;
-
-            if (!user.isGuest) {
-                try {
-                    const response = await getUserProperties(user.id);
-                    this.setState({ userProperties: response.props });
-                    return;
-                } catch (e) {
-                    console.error('Failed to load user properties', e);
-                }
-            }
-
-            this.setState({ userProperties: {} });
-        };
-
-        render() {
-            if (this.state.userProperties) {
-                return (
-                    <UserContextProvider value={this.state}>
-                        <Component {...this.props} {...this.state} />
-                    </UserContextProvider>
-                );
-            } else {
-                return <LoadingPage />;
-            }
-        }
-    };
-};
 
 export function useUserProperties(user: User): Record<string, any> {
     const { id, isGuest } = user;

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -2,12 +2,9 @@ import moment from 'moment';
 import { OrderedMap } from 'immutable';
 import { Ajax, PermissionRoles, PermissionTypes, Security, Utils } from '@labkey/api';
 
-import { processRequest } from '../../query/api';
-
 import { buildURL } from '../../url/AppURL';
 import { hasAllPermissions, User } from '../base/models/User';
 import { caseInsensitive } from '../../util/utils';
-import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SHARED_CONTAINER_PATH } from '../../constants';
 
 import { APPLICATION_SECURITY_ROLES, SITE_SECURITY_ROLES } from '../administration/constants';
@@ -118,23 +115,6 @@ export function getUserDetailsRowData(user: User, data: OrderedMap<string, any>,
     }
 
     return formData;
-}
-
-export function updateUserDetails(schemaQuery: SchemaQuery, data: FormData): Promise<any> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: buildURL('user', 'updateUserDetails.api'),
-            method: 'POST',
-            form: data,
-            success: Utils.getCallbackWrapper((response, request) => {
-                if (processRequest(response, request, reject)) return;
-                resolve(response);
-            }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
-        });
-    });
 }
 
 export function changePassword(model: ChangePasswordModel): Promise<any> {

--- a/packages/components/src/internal/components/user/hooks.ts
+++ b/packages/components/src/internal/components/user/hooks.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { User } from '../base/models/User';
 

--- a/packages/components/src/internal/components/user/hooks.ts
+++ b/packages/components/src/internal/components/user/hooks.ts
@@ -5,10 +5,9 @@
 import { useEffect, useState } from 'react';
 
 import { User } from '../base/models/User';
+import { getDefaultAPIWrapper } from '../../APIWrapper';
 
-import { getUserProperties } from './actions';
-
-export function useUserProperties(user: User): Record<string, any> {
+export function useUserProperties(user: User, api = getDefaultAPIWrapper()): Record<string, any> {
     const { id, isGuest } = user;
     const [userProperties, setUserProperties] = useState<Record<string, any>>();
 
@@ -18,14 +17,14 @@ export function useUserProperties(user: User): Record<string, any> {
         } else {
             (async () => {
                 try {
-                    const response = await getUserProperties(id);
+                    const response = await api.security.getUserProperties(id);
                     setUserProperties(response.props);
                 } catch (e) {
                     console.error('Failed to load user properties', e);
                 }
             })();
         }
-    }, [isGuest, id]);
+    }, [api, isGuest, id]);
 
     return userProperties;
 }


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-ui-premium/pull/171 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1273
- https://github.com/LabKey/labkey-ui-premium/pull/171
- https://github.com/LabKey/biologics/pull/2335
- https://github.com/LabKey/sampleManagement/pull/2056
- https://github.com/LabKey/inventory/pull/996
- https://github.com/LabKey/platform/pull/4716

#### Changes
- Add `saveDomain` to `DomainPropertiesAPIWrapper`
- Add `updateUserDetails` to `SecurityAPIWrapper`
- Export internal `BaseDomainDesigner`
- Update `EditableGrid` to account for optional `addControlProps`
- Removes `UserProvider` in favor of `useUserProperties` hook
