### PR TITLE
Issues 48594, 48596, and 48607: Fix for admin settings page for starter and ResponsiveMenuButtonGroup

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.1-settingsAndMenuFixes.0",
+  "version": "2.364.1-settingsAndMenuFixes.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.0",
+  "version": "2.364.1-settingsAndMenuFixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.1-settingsAndMenuFixes.1",
+  "version": "2.364.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 - Issue 48596: ResponsiveMenuButtonGroup fix for empty button group
 - Issue 48594: Show project look and feel form for starter edition too
+- Issue 48607: Don't use spread operator for array construction to avoid javascript error
 
 ### version 2.364.0
 *Released*: 31 August 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - Issue 48596: ResponsiveMenuButtonGroup fix for empty button group
-- Issue 48594: Fix AdminSettingsPage for starter product
+- Issue 48594: Show project look and feel form for starter edition too
 
 ### version 2.364.0
 *Released*: 31 August 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48596: ResponsiveMenuButtonGroup fix for empty button group
+- Issue 48594: Fix AdminSettingsPage for starter product
+
 ### version 2.364.0
 *Released*: 31 August 2023
 - Issue 47376: User Detail Modal - add className to be able to distinguish modal from others

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.364.1
+*Released*: 6 September 2023
 - Issue 48596: ResponsiveMenuButtonGroup fix for empty button group
 - Issue 48594: Show project look and feel form for starter edition too
 - Issue 48607: Don't use spread operator for array construction to avoid javascript error

--- a/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
+++ b/packages/components/src/internal/components/administration/AdminSettingsPage.tsx
@@ -82,12 +82,13 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
         );
     }, [moduleContext]);
 
-    const projectSettings = useMemo((): React.ReactNode => {
-        if (!isProductProjectsEnabled(moduleContext)) return null;
-
+    const commonSettings = useMemo((): React.ReactNode => {
         return (
             <>
-                <ProjectSettings onChange={onSettingsChange} onSuccess={onSettingsSuccess} onPageError={onError} />
+                <ActiveUserLimit />
+                {isProductProjectsEnabled(moduleContext) && (
+                    <ProjectSettings onChange={onSettingsChange} onSuccess={onSettingsSuccess} onPageError={onError} />
+                )}
                 {isAppHomeFolder(container, moduleContext) && (
                     <ProjectLookAndFeelForm
                         api={api.folder}
@@ -95,7 +96,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
                         onSuccess={onSettingsSuccess}
                     />
                 )}
-                {!isAppHomeFolder(container, moduleContext) && (
+                {isProductProjectsEnabled(moduleContext) && !isAppHomeFolder(container, moduleContext) && (
                     <>
                         <ProjectDataTypeSelections
                             entityDataTypes={projectDataTypes}
@@ -116,6 +117,18 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
                         )}
                     </>
                 )}
+                {biologicsIsPrimaryApp(moduleContext) && isELNEnabled(moduleContext) && (
+                    <NotebookProjectSettingsComponent />
+                )}
+                <BarTenderSettingsForm
+                    onChange={onSettingsChange}
+                    onSuccess={onBarTenderSuccess}
+                    setIsDirty={setIsDirty}
+                    getIsDirty={getIsDirty}
+                />
+                <NameIdSettings {...props} />
+                {isSampleStatusEnabled(moduleContext) && <ManageSampleStatusesPanel {...props} />}
+                {children}
             </>
         );
     }, [moduleContext, projectDataTypes, disabledTypesMap, container]);
@@ -138,16 +151,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
                 disableRemoveSelf
                 lkVersion={lkVersion}
             >
-                <ActiveUserLimit />
-                {projectSettings}
-                <BarTenderSettingsForm
-                    onChange={onSettingsChange}
-                    onSuccess={onBarTenderSuccess}
-                    setIsDirty={setIsDirty}
-                    getIsDirty={getIsDirty}
-                />
-                <NameIdSettings {...props} />
-                {isSampleStatusEnabled(moduleContext) && <ManageSampleStatusesPanel {...props} />}
+                {commonSettings}
             </BasePermissions>
         );
     }
@@ -162,20 +166,7 @@ export const AdminSettingsPageImpl: FC<InjectedRouteLeaveProps> = props => {
                 hasPermission={user.isAdmin}
                 renderButtons={lkVersion}
             >
-                <ActiveUserLimit />
-                {projectSettings}
-                {biologicsIsPrimaryApp(moduleContext) && isELNEnabled(moduleContext) && (
-                    <NotebookProjectSettingsComponent />
-                )}
-                <BarTenderSettingsForm
-                    onChange={onSettingsChange}
-                    onSuccess={onBarTenderSuccess}
-                    setIsDirty={setIsDirty}
-                    getIsDirty={getIsDirty}
-                />
-                <NameIdSettings {...props} />
-                {isSampleStatusEnabled(moduleContext) && <ManageSampleStatusesPanel {...props} />}
-                {children}
+                {commonSettings}
             </BasePermissionsCheckPage>
         </>
     );

--- a/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
+++ b/packages/components/src/internal/components/buttons/ResponsiveMenuButtonGroup.tsx
@@ -118,7 +118,7 @@ export const ResponsiveMenuButtonGroup: FC<Props> = memo(props => {
     useEffect(() => {
         // Don't attempt to compute widths when we're in tests, or we'll fall over
         if (navigator.userAgent.includes('jsdom')) return;
-        const itemEls = elRef.current.childNodes;
+        const itemEls = elRef.current?.childNodes ?? [];
         // childNodes is a nodeList which does not have the map method
         const widths = Array.from(itemEls).map((element: HTMLElement) => element.getBoundingClientRect().width);
         setItemWidths(widths);

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -206,7 +206,7 @@ export function getOrderedSelectedPicklistSamples(queryModel: QueryModel, saveSn
     const { queryName, queryParameters, selections, sortString, viewName, selectionKey } = queryModel;
     return getSelectedPicklistSamples(
         queryName,
-        Array.of(...selections),
+        Array.from(selections),
         saveSnapshot,
         selectionKey,
         sortString,
@@ -248,7 +248,7 @@ export function getOrderedSelectedMappedKeys(
         getSelectedData(
             schemaName,
             queryName,
-            Array.of(...selections),
+            Array.from(selections),
             toColumn ? [fromColumn, toColumn].join(',') : fromColumn,
             sortString,
             queryParameters,


### PR DESCRIPTION
#### Rationale
[Issue 48594](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48594) - The look and feel settings panel was inadvertently hidden by a check for product projects being enabled, which caused it to not show up for Starter edition clients
[Issue 48596](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48596) - It can happen (particularly for a read-only user) that a grid has its set of buttons reduced to an empty set, so we need to accommodate that.
[Issue 48607](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48607) - Don't use the spread operator when creating arrays from selections as it can cause "Maximum call stack size exceeded" errors.

#### Related Pull Requests

- https://github.com/LabKey/labkey-ui-premium/pull/173
- https://github.com/LabKey/inventory/pull/998
- https://github.com/LabKey/sampleManagement/pull/2060
- https://github.com/LabKey/biologics/pull/2340

#### Changes
- Refactor in `AdminSettingsPage` to share more and localize checks for product-projects being enabled
- Update `ResponsiveMenuButtonGroup` to account for no buttons.
