### PR TITLE
Only query for a single column during loadTotalCount

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.2",
+  "version": "2.365.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.2-fb-storageLocationPerf.2",
+  "version": "2.365.2-fb-storageLocationPerf.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.2-fb-storageLocationPerf.4",
+  "version": "2.365.2-fb-storageLocationPerf.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.2-fb-storageLocationPerf.3",
+  "version": "2.365.2-fb-storageLocationPerf.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.2-fb-storageLocationPerf.1",
+  "version": "2.365.2-fb-storageLocationPerf.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.1",
+  "version": "2.365.2-fb-storageLocationPerf.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.0",
+  "version": "2.365.1-fb-storageLocationPerf.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.X
+*Released*: X September 2023
+- Issue 48329: LKSM: Sample Finder query performance issues
+  - Only query for a single column during loadTotalCount
+
 ### version 2.365.0
 *Released*: 1 September 2023
 - Add `saveDomain` to `DomainPropertiesAPIWrapper`

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -139,14 +139,11 @@ export function getSelectRowCountColumnsStr(
         if (qFilter) return rawColumns;
     }
 
+    if (pkCols?.length > 0)
+        return pkCols[0].fieldKey;
+
     const columns: string[] =
         typeof rawColumns === 'string' ? rawColumns.split(',').map(col => col.trim()) : rawColumns;
 
-    if (columns.length <= 1) return columns[0];
-
-    const columnsPkLc = pkCols?.map(col => col.fieldKey.toLowerCase());
-    const columnsLc = columns.map(col => col.toLowerCase());
-
-    const pkCol: string = columnsPkLc.find(col => columnsLc.indexOf(col) > -1);
-    return pkCol ? pkCol : columns[0];
+    return columns[0];
 }

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -127,23 +127,26 @@ export function getQueryModelExportParams(
     return getExportParams(type, schemaQuery, exportOptions, advancedOptions);
 }
 
-export function getSelectRowCountColumnsStr(rawColumns?: string | string[], filterArray?: Filter.IFilter[]): string | string[] {
+export function getSelectRowCountColumnsStr(
+    rawColumns?: string | string[],
+    filterArray?: Filter.IFilter[],
+    pkCols?: QueryColumn[]
+): string | string[] {
+    if (!rawColumns || rawColumns === '*') return rawColumns;
+
     if (filterArray?.length > 0) {
         const qFilter = filterArray.some(filter => filter.getColumnName() === '*');
-        if (qFilter)
-            return rawColumns;
+        if (qFilter) return rawColumns;
     }
-
-    if (!rawColumns || rawColumns === '*') return rawColumns === null ? null : '*';
 
     const columns: string[] =
         typeof rawColumns === 'string' ? rawColumns.split(',').map(col => col.trim()) : rawColumns;
 
     if (columns.length <= 1) return columns[0];
 
+    const columnsPkLc = pkCols?.map(col => col.fieldKey.toLowerCase());
     const columnsLc = columns.map(col => col.toLowerCase());
-    if (columnsLc.indexOf('rowid') > -1) return 'rowid';
-    if (columnsLc.indexOf('name') > -1) return 'name';
 
-    return columns[0];
+    const pkCol: string = columnsPkLc.find(col => columnsLc.indexOf(col) > -1);
+    return pkCol ? pkCol : columns[0];
 }

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -127,7 +127,13 @@ export function getQueryModelExportParams(
     return getExportParams(type, schemaQuery, exportOptions, advancedOptions);
 }
 
-export function getSelectRowCountColumnsStr(rawColumns?: string | string[]): string {
+export function getSelectRowCountColumnsStr(rawColumns?: string | string[], filterArray?: Filter.IFilter[]): string | string[] {
+    if (filterArray?.length > 0) {
+        const qFilter = filterArray.some(filter => filter.getColumnName() === '*');
+        if (qFilter)
+            return rawColumns;
+    }
+
     if (!rawColumns || rawColumns === '*') return rawColumns === null ? null : '*';
 
     const columns: string[] =

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -127,20 +127,17 @@ export function getQueryModelExportParams(
     return getExportParams(type, schemaQuery, exportOptions, advancedOptions);
 }
 
-export function getSelectRowCountColumnsStr(rawColumns?: string | string[]) : string {
-    if (!rawColumns || rawColumns === '*')
-        return rawColumns === null ? null : '*';
+export function getSelectRowCountColumnsStr(rawColumns?: string | string[]): string {
+    if (!rawColumns || rawColumns === '*') return rawColumns === null ? null : '*';
 
-    const columns : string[] = typeof rawColumns === 'string' ? rawColumns.split(',').map(col => col.trim()) : rawColumns;
+    const columns: string[] =
+        typeof rawColumns === 'string' ? rawColumns.split(',').map(col => col.trim()) : rawColumns;
 
-    if (columns.length <= 1)
-        return columns[0];
+    if (columns.length <= 1) return columns[0];
 
     const columnsLc = columns.map(col => col.toLowerCase());
-    if (columnsLc.indexOf('rowid') > -1)
-        return 'rowid';
-    if (columnsLc.indexOf('name') > -1)
-        return 'name';
+    if (columnsLc.indexOf('rowid') > -1) return 'rowid';
+    if (columnsLc.indexOf('name') > -1) return 'name';
 
     return columns[0];
 }

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -126,3 +126,21 @@ export function getQueryModelExportParams(
     };
     return getExportParams(type, schemaQuery, exportOptions, advancedOptions);
 }
+
+export function getSelectRowCountColumnsStr(rawColumns?: string | string[]) : string {
+    if (!rawColumns || rawColumns === '*')
+        return rawColumns === null ? null : '*';
+
+    const columns : string[] = typeof rawColumns === 'string' ? rawColumns.split(',').map(col => col.trim()) : rawColumns;
+
+    if (columns.length <= 1)
+        return columns[0];
+
+    const columnsLc = columns.map(col => col.toLowerCase());
+    if (columnsLc.indexOf('rowid') > -1)
+        return 'rowid';
+    if (columnsLc.indexOf('name') > -1)
+        return 'name';
+
+    return columns[0];
+}

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -569,6 +569,7 @@ export function withQueryModels<Props>(
 
             try {
                 const loadRowsConfig = this.state.queryModels[id].loadRowsConfig;
+                const queryInfo = this.state.queryModels[id].queryInfo;
                 const { rowCount } = await selectRows({
                     ...loadRowsConfig,
                     sort: undefined,
@@ -578,7 +579,7 @@ export function withQueryModels<Props>(
                     includeUpdateColumn: false,
                     // includeMetadata: false, // TODO don't require metadata in selectRows response processing
                     includeTotalCount: true,
-                    columns: getSelectRowCountColumnsStr(loadRowsConfig.columns, loadRowsConfig.filterArray),
+                    columns: getSelectRowCountColumnsStr(loadRowsConfig.columns, loadRowsConfig.filterArray, queryInfo?.getPkCols()),
                 });
 
                 this.setState(

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -16,7 +16,7 @@ import { resolveErrorMessage } from '../../internal/util/messaging';
 
 import { selectRows } from '../../internal/query/selectRows';
 
-import { filterArraysEqual, sortArraysEqual } from './utils';
+import { filterArraysEqual, getSelectRowCountColumnsStr, sortArraysEqual } from './utils';
 import { DefaultQueryModelLoader, QueryModelLoader } from './QueryModelLoader';
 import { QueryConfig, QueryModel } from './QueryModel';
 
@@ -568,8 +568,9 @@ export function withQueryModels<Props>(
             );
 
             try {
+                const loadRowsConfig = this.state.queryModels[id].loadRowsConfig;
                 const { rowCount } = await selectRows({
-                    ...this.state.queryModels[id].loadRowsConfig,
+                    ...loadRowsConfig,
                     sort: undefined,
                     maxRows: 1,
                     offset: 0,
@@ -577,6 +578,7 @@ export function withQueryModels<Props>(
                     includeUpdateColumn: false,
                     // includeMetadata: false, // TODO don't require metadata in selectRows response processing
                     includeTotalCount: true,
+                    columns: getSelectRowCountColumnsStr(loadRowsConfig.columns),
                 });
 
                 this.setState(

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -578,7 +578,7 @@ export function withQueryModels<Props>(
                     includeUpdateColumn: false,
                     // includeMetadata: false, // TODO don't require metadata in selectRows response processing
                     includeTotalCount: true,
-                    columns: getSelectRowCountColumnsStr(loadRowsConfig.columns),
+                    columns: getSelectRowCountColumnsStr(loadRowsConfig.columns, loadRowsConfig.filterArray),
                 });
 
                 this.setState(


### PR DESCRIPTION
#### Rationale
The query to load grid total row count was separated from the main getQuery for rows data a while back. The set of columns the loadTotalCount query for is the same as the grid data query, which often is not necessary.  

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1276
- https://github.com/LabKey/labkey-ui-premium/pull/174
- https://github.com/LabKey/platform/pull/4717
- https://github.com/LabKey/inventory/pull/999
- https://github.com/LabKey/sampleManagement/pull/2064
- https://github.com/LabKey/biologics/pull/2341

#### Changes
- modify loadTotalCount to query for a single column instead of full set of columns for certain scenarios
