### PR TITLE
Use standard password when creating integration test users

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.3.0-createUserPassword.0",
+  "version": "1.3.0",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.2.0",
+  "version": "1.3.0-createUserPassword.0",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/releaseNotes/test.md
+++ b/packages/test/releaseNotes/test.md
@@ -2,7 +2,7 @@
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
 ### version 1.3.0
-*Released*: TBD
+*Released*: 7 Sept 2023
 * Use standard password for `integrationUtils.createUser()`
 
 ### version 1.2.0

--- a/packages/test/releaseNotes/test.md
+++ b/packages/test/releaseNotes/test.md
@@ -1,6 +1,10 @@
 # @labkey/test
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
+### version 1.3.0
+*Released*: TBD
+* Use standard password for `integrationUtils.createUser()`
+
 ### version 1.2.0
 *Released*: 17 July 2023
 * Remove `SecurityRole`. Use `PermissionRoles` provided by `@labkey/api` instead.

--- a/packages/test/src/integrationUtils.ts
+++ b/packages/test/src/integrationUtils.ts
@@ -87,7 +87,7 @@ export interface IntegrationTestServer {
      * Create a new user account on the server with the specified credentials. If the account already exists, then
      * the account will be deleted and re-created to ensure credentials and permissions are configured as expected.
      */
-    createUser: (email: string, password: string) => Promise<TestUser>;
+    createUser: (email: string) => Promise<TestUser>;
     /** Make a GET request against the server. */
     get: (controller: string, action: string, params?: any, options?: RequestOptions) => Test;
     /** Initializes the server for the test run. This is required to be called prior to any tests running. */
@@ -149,10 +149,12 @@ const createTestContainer = async (ctx: ServerContext, containerOptions?: any /*
     return await _createContainer(ctx, ctx.projectPath, Utils.generateUUID(), containerOptions);
 };
 
-const createUser = async (ctx: ServerContext, email: string, password: string): Promise<TestUser> => {
+const createUser = async (ctx: ServerContext, email: string): Promise<TestUser> => {
     // Delete user (if the account already exists)
     // This ensures the given user's password and subsequent permissions are as expected
     await deleteUser(ctx, email);
+
+    const password = ctx.defaultContext.password;
 
     // Create the user
     const createUserResponse = await postRequest(ctx, 'security', 'createNewUser.api', {

--- a/packages/test/src/test/example.ispec.ts
+++ b/packages/test/src/test/example.ispec.ts
@@ -59,8 +59,8 @@ describe('query-executeSql.api', () => {
         const testContainer = await server.createTestContainer();
 
         // Create two users
-        const noPermissionsUser = await server.createUser('hasnopermissions@lktestuser.com', 'pwSuper1Awesome!');
-        const readerUser = await server.createUser('reader@lktestuser.com', 'pwSuper2Awesome!');
+        const noPermissionsUser = await server.createUser('hasnopermissions@lktestuser.com');
+        const readerUser = await server.createUser('reader@lktestuser.com');
 
         // Assign permissions to a user in the test container
         await server.addUserToRole('reader@lktestuser.com', PermissionRoles.Reader, testContainer.path);


### PR DESCRIPTION
#### Rationale
A recent change increased the default password complexity which broke many integration tests that weren't using complex passwords. There isn't any reason for integration tests to set a specific password. They can just use the same password as the primary test user.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4707

#### Changes
- Use standard password for `integrationUtils.createUser()`