### PR TITLE
App header update for listing pages to show details panel content in tooltip

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.3-fb-detailsHeaderPopover.0",
+  "version": "2.366.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.1-fb-detailsHeaderPopover.4",
+  "version": "2.365.1-fb-detailsHeaderPopover.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.3",
+  "version": "2.365.3-fb-detailsHeaderPopover.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.1-fb-detailsHeaderPopover.0",
+  "version": "2.365.1-fb-detailsHeaderPopover.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.1-fb-detailsHeaderPopover.2",
+  "version": "2.365.1-fb-detailsHeaderPopover.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.1-fb-detailsHeaderPopover.1",
+  "version": "2.365.1-fb-detailsHeaderPopover.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.1",
+  "version": "2.365.1-fb-detailsHeaderPopover.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.365.1-fb-detailsHeaderPopover.3",
+  "version": "2.365.1-fb-detailsHeaderPopover.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD September 2023
+### version 2.366.0
+*Released*: 11 September 2023
 - App listing page - move details panel to hover tooltip in header
   - misc styling updates for LabelHelpTip and DetailDisplay
   - add new DesignerDetailTooltip component

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD September 2023
+- App listing page - move details panel to hover tooltip in header
+  - misc styling updates for LabelHelpTip and DetailDisplay
+
 ### version 2.365.1
 *Released*: 4 September 2023
 - Add SamplesTabbedGridPanelComponent to SampleTypeAppContext

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD September 2023
 - App listing page - move details panel to hover tooltip in header
   - misc styling updates for LabelHelpTip and DetailDisplay
+  - add new DesignerDetailTooltip component
 
 ### version 2.365.1
 *Released*: 4 September 2023

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -569,7 +569,7 @@ import { ListDesignerPanels } from './internal/components/domainproperties/list/
 import { DataClassDesigner } from './internal/components/domainproperties/dataclasses/DataClassDesigner';
 import { DataClassModel } from './internal/components/domainproperties/dataclasses/models';
 import { deleteDataClass, fetchDataClass } from './internal/components/domainproperties/dataclasses/actions';
-import { DesignerDetailPanel, DesignerDetailTooltip } from './internal/components/domainproperties/DesignerDetailPanel';
+import { DesignerDetailTooltip } from './internal/components/domainproperties/DesignerDetailPanel';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { RangeValidationOptionsModal } from './internal/components/domainproperties/validation/RangeValidationOptions';
 import { DataTypeProjectsPanel } from './internal/components/domainproperties/DataTypeProjectsPanel';
@@ -1397,7 +1397,6 @@ export {
     setDomainFields,
     DomainDesign,
     DomainField,
-    DesignerDetailPanel,
     DesignerDetailTooltip,
     DomainFieldLabel,
     RangeValidationOptionsModal,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -569,7 +569,7 @@ import { ListDesignerPanels } from './internal/components/domainproperties/list/
 import { DataClassDesigner } from './internal/components/domainproperties/dataclasses/DataClassDesigner';
 import { DataClassModel } from './internal/components/domainproperties/dataclasses/models';
 import { deleteDataClass, fetchDataClass } from './internal/components/domainproperties/dataclasses/actions';
-import { DesignerDetailPanel } from './internal/components/domainproperties/DesignerDetailPanel';
+import { DesignerDetailPanel, DesignerDetailTooltip } from './internal/components/domainproperties/DesignerDetailPanel';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { RangeValidationOptionsModal } from './internal/components/domainproperties/validation/RangeValidationOptions';
 import { DataTypeProjectsPanel } from './internal/components/domainproperties/DataTypeProjectsPanel';
@@ -1398,6 +1398,7 @@ export {
     DomainDesign,
     DomainField,
     DesignerDetailPanel,
+    DesignerDetailTooltip,
     DomainFieldLabel,
     RangeValidationOptionsModal,
     PropertyValidator,

--- a/packages/components/src/internal/components/domainproperties/DesignerDetailPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DesignerDetailPanel.tsx
@@ -21,6 +21,10 @@ export const DesignerDetailPanel: FC<DesignerDetailPanelProps> = memo(props => {
     const { api } = useAppContext();
     const [previews, setPreviews] = useState<Record<string, string>>();
 
+    // don't show description in the panel since it is shown elsewhere in the app header
+    const queryColumns =
+        props.queryColumns ?? props.model?.detailColumns?.filter(col => col.fieldKey.toLowerCase() !== 'description');
+
     useEffect(() => {
         (async () => {
             if (schemaQuery) {
@@ -46,7 +50,7 @@ export const DesignerDetailPanel: FC<DesignerDetailPanelProps> = memo(props => {
         })();
     }, [api, schemaQuery]);
 
-    return <DetailPanel fieldHelpTexts={previews} {...detailDisplayProps} />;
+    return <DetailPanel fieldHelpTexts={previews} queryColumns={queryColumns} {...detailDisplayProps} />;
 });
 
 export const DesignerDetailTooltip: FC<DesignerDetailPanelProps> = memo(props => {

--- a/packages/components/src/internal/components/domainproperties/DesignerDetailPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DesignerDetailPanel.tsx
@@ -7,11 +7,13 @@ import { DetailDisplaySharedProps } from '../forms/detail/DetailDisplay';
 import { RequiresModelAndActions } from '../../../public/QueryModel/withQueryModels';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { DetailPanel } from '../../../public/QueryModel/DetailPanel';
+import { QueryColumn } from '../../../public/QueryColumn';
 import { caseInsensitive } from '../../util/utils';
 import { LabelHelpTip } from '../base/LabelHelpTip';
 
 export interface DesignerDetailPanelProps extends DetailDisplaySharedProps, RequiresModelAndActions {
-    schemaQuery: SchemaQuery;
+    queryColumns?: QueryColumn[];
+    schemaQuery?: SchemaQuery;
 }
 
 export const DesignerDetailPanel: FC<DesignerDetailPanelProps> = memo(props => {
@@ -48,7 +50,7 @@ export const DesignerDetailPanel: FC<DesignerDetailPanelProps> = memo(props => {
 });
 
 export const DesignerDetailTooltip: FC<DesignerDetailPanelProps> = memo(props => {
-    const { actions, model, detailRenderer, schemaQuery } = props;
+    const { model } = props;
     const description = caseInsensitive(model?.getRow(), 'Description')?.value;
 
     return (
@@ -61,12 +63,7 @@ export const DesignerDetailTooltip: FC<DesignerDetailPanelProps> = memo(props =>
             )}
             <LabelHelpTip iconComponent={<span className="header-details-link">Details</span>} placement="bottom">
                 <div className="header-details-hover">
-                    <DesignerDetailPanel
-                        actions={actions}
-                        detailRenderer={detailRenderer}
-                        model={model}
-                        schemaQuery={schemaQuery}
-                    />
+                    <DesignerDetailPanel {...props} />
                 </div>
             </LabelHelpTip>
         </div>

--- a/packages/components/src/internal/components/domainproperties/DesignerDetailPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DesignerDetailPanel.tsx
@@ -7,6 +7,8 @@ import { DetailDisplaySharedProps } from '../forms/detail/DetailDisplay';
 import { RequiresModelAndActions } from '../../../public/QueryModel/withQueryModels';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { DetailPanel } from '../../../public/QueryModel/DetailPanel';
+import { caseInsensitive } from '../../util/utils';
+import { LabelHelpTip } from '../base/LabelHelpTip';
 
 export interface DesignerDetailPanelProps extends DetailDisplaySharedProps, RequiresModelAndActions {
     schemaQuery: SchemaQuery;
@@ -43,4 +45,30 @@ export const DesignerDetailPanel: FC<DesignerDetailPanelProps> = memo(props => {
     }, [api, schemaQuery]);
 
     return <DetailPanel fieldHelpTexts={previews} {...detailDisplayProps} />;
+});
+
+export const DesignerDetailTooltip: FC<DesignerDetailPanelProps> = memo(props => {
+    const { actions, model, detailRenderer, schemaQuery } = props;
+    const description = caseInsensitive(model?.getRow(), 'Description')?.value;
+
+    return (
+        <div>
+            {!!description && (
+                <>
+                    <span className="header-details-description">{description}</span>
+                    <span>&nbsp;</span>
+                </>
+            )}
+            <LabelHelpTip iconComponent={<span className="header-details-link">Details</span>} placement="bottom">
+                <div className="header-details-hover">
+                    <DesignerDetailPanel
+                        actions={actions}
+                        detailRenderer={detailRenderer}
+                        model={model}
+                        schemaQuery={schemaQuery}
+                    />
+                </div>
+            </LabelHelpTip>
+        </div>
+    );
 });

--- a/packages/components/src/internal/components/forms/PageDetailHeader.tsx
+++ b/packages/components/src/internal/components/forms/PageDetailHeader.tsx
@@ -40,7 +40,7 @@ export class PageDetailHeader extends PureComponent<PageDetailHeaderProps> {
 
         return (
             <div className="page-header">
-                <div className={`col-md-${leftColumns} detail__header--container`}>
+                <div className={`col-xs-12 col-md-${leftColumns} detail__header--container`}>
                     {hasIcon && (
                         <div className="detail__header--image-container">
                             {iconUrl ? (

--- a/packages/components/src/internal/components/forms/__snapshots__/PageDetailHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/forms/__snapshots__/PageDetailHeader.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`<PageDetailHeader/> default props 1`] = `
   className="page-header"
 >
   <div
-    className="col-md-6 detail__header--container"
+    className="col-xs-12 col-md-6 detail__header--container"
   >
     <div
       className="detail__header--image-container"
@@ -39,7 +39,7 @@ exports[`<PageDetailHeader/> with additional props 1`] = `
   className="page-header"
 >
   <div
-    className="col-md-5 detail__header--container"
+    className="col-xs-12 col-md-5 detail__header--container"
   >
     <div
       className="detail__header--image-container"
@@ -90,7 +90,7 @@ exports[`<PageDetailHeader/> without icon 1`] = `
   className="page-header"
 >
   <div
-    className="col-md-6 detail__header--container"
+    className="col-xs-12 col-md-6 detail__header--container"
   >
     <div
       className=""

--- a/packages/components/src/internal/components/user/__snapshots__/UserDetailHeader.spec.tsx.snap
+++ b/packages/components/src/internal/components/user/__snapshots__/UserDetailHeader.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`<UserDetailHeader/> default properties 1`] = `
   className="page-header"
 >
   <div
-    className="col-md-9 detail__header--container"
+    className="col-xs-12 col-md-9 detail__header--container"
   >
     <div
       className="detail__header--image-container"
@@ -44,7 +44,7 @@ exports[`<UserDetailHeader/> optional properties 1`] = `
   className="page-header"
 >
   <div
-    className="col-md-9 detail__header--container"
+    className="col-xs-12 col-md-9 detail__header--container"
   >
     <div
       className="detail__header--image-container"

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -222,3 +222,35 @@
 .page-detail-header-title-content {
   padding-right: 5px;
 }
+
+.header-details-link {
+    color: $blue-highlight;
+    cursor: pointer;
+}
+
+.header-details-hover {
+    max-width: 600px;
+}
+
+.header-detail-content {
+    width: 400px;
+
+    .header-detail-info-row {
+        padding: 8px 0;
+        border-bottom: solid $gray-border 1px;
+
+        .row-label, .row-value {
+            display: inline-block;
+            width: 200px;
+            vertical-align: top;
+        }
+    }
+
+    .header-detail-info-row:last-child {
+        border-bottom: none;
+    }
+
+    .horizontal-bar-section {
+        margin-bottom: 8px;
+    }
+}

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -1,6 +1,7 @@
 
 .detail-component--table__fixed {
   table-layout: fixed;
+  border: unset;
 
   tbody tr:first-child td {
       border-top: none;

--- a/packages/components/src/theme/labelHelpTip.scss
+++ b/packages/components/src/theme/labelHelpTip.scss
@@ -26,9 +26,3 @@
 .label-help-arrow-left .arrow {
     left: 55px !important;
 }
-.label-help-shift-right {
-    left: 50px !important;
-    .arrow {
-        left: 260px !important;
-    }
-}

--- a/packages/components/src/theme/labelHelpTip.scss
+++ b/packages/components/src/theme/labelHelpTip.scss
@@ -26,3 +26,9 @@
 .label-help-arrow-left .arrow {
     left: 55px !important;
 }
+.label-help-shift-right {
+    left: 50px !important;
+    .arrow {
+        left: 260px !important;
+    }
+}


### PR DESCRIPTION
#### Rationale
In the apps, many of the listing pages for sample types, sources, registry, media, etc show a "Details" panel at the top of the page. This details is likely not too important for most users and they have to scroll down the page to get to the grid of data they are looking for. This set of PRs removes that details panel from the listing pages and instead adds a "Details" link which will show the content on hover.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1279
- https://github.com/LabKey/labkey-ui-premium/pull/176
- https://github.com/LabKey/sampleManagement/pull/2068
- https://github.com/LabKey/biologics/pull/2345
- https://github.com/LabKey/inventory/pull/1002
- https://github.com/LabKey/testAutomation/pull/1633

#### Changes
- misc styling updates for LabelHelpTip and DetailDisplay
- add new DesignerDetailTooltip component
