### PR TITLE
Issue 48608: suppress 'Z' in date-fns format translation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.1-fb-issue-48608.0",
+  "version": "2.364.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.364.1",
+  "version": "2.364.1-fb-issue-48608.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.364.2
+*Released*: 11 September 2023
+- Issue 48608: Replace `/Z+/gi` characters with `xxx` when translating moment format to date-fns format
+- Support partial reverse translation of `xxx` from date-fns to moment
+
 ### version 2.364.1
 *Released*: 6 September 2023
 - Issue 48596: ResponsiveMenuButtonGroup fix for empty button group

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -138,10 +138,13 @@ describe('Date Utilities', () => {
             const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
             expect(getColDateFormat(col, 'YYYY-MM-DD')).toBe('yyyy-MM-dd');
             expect(getColDateFormat(col, 'YY-MM-dd')).toBe('yy-MM-dd');
+            expect(getColDateFormat(col, 'YY-MM-dd z')).toBe('yy-MM-dd xxx');
             expect(getColDateFormat(col, 'YY-MM-dd Z')).toBe('yy-MM-dd xxx');
+            expect(getColDateFormat(col, 'YY-MM-dd zz')).toBe('yy-MM-dd xxx');
             expect(getColDateFormat(col, 'ZZ YY-MM-dd ZZ')).toBe('xxx yy-MM-dd xxx');
             expect(getColDateFormat(col, 'xxx YY-MM-dd ZZ')).toBe('xxx yy-MM-dd xxx');
             expect(getColDateFormat(col, 'YY-MM-dd ZZZZ')).toBe('yy-MM-dd xxx');
+            expect(getColDateFormat(col, 'zzzz YY-MM-dd')).toBe('xxx yy-MM-dd');
         });
 
         test('shortcut formats', () => {

--- a/packages/components/src/internal/util/Date.spec.ts
+++ b/packages/components/src/internal/util/Date.spec.ts
@@ -138,6 +138,10 @@ describe('Date Utilities', () => {
             const col = new QueryColumn({ shortCaption: 'DateCol', rangeURI: DATETIME_TYPE.rangeURI });
             expect(getColDateFormat(col, 'YYYY-MM-DD')).toBe('yyyy-MM-dd');
             expect(getColDateFormat(col, 'YY-MM-dd')).toBe('yy-MM-dd');
+            expect(getColDateFormat(col, 'YY-MM-dd Z')).toBe('yy-MM-dd xxx');
+            expect(getColDateFormat(col, 'ZZ YY-MM-dd ZZ')).toBe('xxx yy-MM-dd xxx');
+            expect(getColDateFormat(col, 'xxx YY-MM-dd ZZ')).toBe('xxx yy-MM-dd xxx');
+            expect(getColDateFormat(col, 'YY-MM-dd ZZZZ')).toBe('yy-MM-dd xxx');
         });
 
         test('shortcut formats', () => {

--- a/packages/components/src/internal/util/jDateFormatParser.spec.ts
+++ b/packages/components/src/internal/util/jDateFormatParser.spec.ts
@@ -168,6 +168,7 @@ describe('jDateFormatParser', () => {
             expect(toMomentFormatString('z')).toBe('ZZ');
             expect(toMomentFormatString('zzzz')).toBe('Z');
             expect(toMomentFormatString('Z')).toBe('ZZ');
+            expect(toMomentFormatString('ZZZZ')).toBe('ZZ');
             expect(toMomentFormatString('X')).toBe('ZZ');
             expect(toMomentFormatString('XX')).toBe('ZZ');
             expect(toMomentFormatString('XXX')).toBe('Z');

--- a/packages/components/src/internal/util/jDateFormatParser.ts
+++ b/packages/components/src/internal/util/jDateFormatParser.ts
@@ -43,6 +43,7 @@ const javaToMomentFormatMapping: FormatMapping = {
     z: 'ZZ',
     zzzz: 'Z',
     Z: 'ZZ',
+    ZZZZ: 'ZZ',
     X: 'ZZ',
     XX: 'ZZ',
     XXX: 'Z',


### PR DESCRIPTION
#### Rationale
This addresses [Issue 48608](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48608) by suppressing the `Z` and `z` characters when translating moment format to date-fns format. Additionally, this prevents duplicate rendering of timezone offset when the `ZZZZ` Java format is translated to moment.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1281
- https://github.com/LabKey/labkey-ui-premium/pull/179
- https://github.com/LabKey/biologics/pull/2350
- https://github.com/LabKey/sampleManagement/pull/2074
- https://github.com/LabKey/inventory/pull/1005

#### Changes
- Replace `/Z+/gi` characters with `xxx` when translating moment format to date-fns format
- Support partial reverse translation of `xxx` from date-fns to moment
- Add regression test coverage
